### PR TITLE
Fix insecure content warnings

### DIFF
--- a/app/views/backend/layouts/default.blade.php
+++ b/app/views/backend/layouts/default.blade.php
@@ -41,13 +41,13 @@
 
 
 		<!-- open sans font -->
-		<link href='http://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800' rel='stylesheet' type='text/css'>
+		<link href='//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800' rel='stylesheet' type='text/css'>
 
 		<!-- lato font -->
-		<link href='http://fonts.googleapis.com/css?family=Lato:300,400,700,900,300italic,400italic,700italic,900italic' rel='stylesheet' type='text/css'>
+		<link href='//fonts.googleapis.com/css?family=Lato:300,400,700,900,300italic,400italic,700italic,900italic' rel='stylesheet' type='text/css'>
 
 		<!--[if lt IE 9]>
-		  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+		  <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
 		<![endif]-->
 
 		<style>
@@ -281,7 +281,7 @@
 
 
 	<!-- scripts -->
-    <script src="http://code.jquery.com/jquery-latest.js"></script>
+    <script src="//code.jquery.com/jquery-latest.js"></script>
     <script src="{{ asset('assets/js/bootstrap.min.js') }}"></script>
     <script src="{{ asset('assets/js/jquery-ui-1.10.2.custom.min.js') }}"></script>
     <!-- knob -->


### PR DESCRIPTION
Remove protocol from Google and jQuery CDN URLs, to fix insecure content warnings in SSL-only environments.
