### PR TITLE
Removed post-install-cmd php artisan optimize. 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,6 @@
 		]
 	},
 	"scripts": {
-		"post-install-cmd": [
-			"php artisan optimize"
-		],
 		"pre-update-cmd": [
 			"php artisan clear-compiled"
 		],


### PR DESCRIPTION
 Causes initial install to fail due to lack of required config (mail.php).
