### PR TITLE
Fixes composer formatting issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,8 @@
 		"chumper/datatable": "dev-master"
 	},
 	"require-dev": {
-        "phpunit/phpunit": "*"
-    },
-
+		"phpunit/phpunit": "*"
+	},
 	"autoload": {
 		"classmap": [
 			"app/commands",
@@ -27,11 +26,11 @@
 			"php artisan clear-compiled"
 		],
 		"post-update-cmd": [
-			"php artisan optimize"
-		    "php artisan debugbar:publish"
+			"php artisan optimize",
+			"php artisan debugbar:publish"
 		],
 		"post-install-cmd": [
-		    "php artisan debugbar:publish"
+			"php artisan debugbar:publish"
 		],
 		"post-create-project-cmd": [
 			"php artisan key:generate"


### PR DESCRIPTION
Issue #99 introduces a breaking change the composer.json file.  There was a missing comma after the first item in the "post-update-cmd" array.

This commit also fixes indentation inconsistencies as well as replaces spaces with tabs (as per the default composer.json file provided by Laravel)
