### PR TITLE
Returning the hyphen to this pattern

### DIFF
--- a/app/validators.php
+++ b/app/validators.php
@@ -2,5 +2,5 @@
 
 Validator::extend('alpha_space', function($attribute,$value,$parameters)
 {
-	return preg_match("/^[\n-+:?#~'\/\(\)_,!. a-zA-Z0-9]+$/m",$value);
+	return preg_match("/^[\n-+:?#~'\/\(\)-_,!. a-zA-Z0-9]+$/m",$value);
 });


### PR DESCRIPTION
It appears the hyphen was dropped in the last commit to this file. The result is that fields which should permit hyphens/dashes (like the License Serial Number) do not allow them, contrary to even the error message on the field.

I fixed it by adding the hyphen back to the pattern, I'm not sure if I'm doing this pull request correctly though, so please let me know if this is the wrong process.

![screen shot 2014-02-10 at 21 47 54](https://f.cloud.github.com/assets/5559124/2133701/c7ead8b8-92cb-11e3-8d3a-8732a618d08b.png)
