### PR TITLE
Adding escape to the dash so that it is a literal rather than a range

### DIFF
--- a/app/validators.php
+++ b/app/validators.php
@@ -2,5 +2,5 @@
 
 Validator::extend('alpha_space', function($attribute,$value,$parameters)
 {
-	return preg_match("/^[\n-+:?#~'\/\(\)_,!. a-zA-Z0-9]+$/m",$value);
+	return preg_match("/^[\n\-+:?#~'\/\(\)_,!. a-zA-Z0-9]+$/m",$value);
 });


### PR DESCRIPTION
This seems to fix up the field validation for the serial numbers and asset names in my limited testing.
