### PR TITLE
Check boxes in settings not showing correct settings

### DIFF
--- a/app/views/backend/settings/edit.blade.php
+++ b/app/views/backend/settings/edit.blade.php
@@ -46,7 +46,7 @@
 										</label>
 										<div class="controls">
 
-											<input class="col-md-1" type="checkbox" name="display_asset_name" id="display_asset_name" value="1" {{{ $setting->display_asset_name === '1' ? 'checked' : '' }}} />
+											<input class="col-md-1" type="checkbox" name="display_asset_name" id="display_asset_name" value="1" {{{ $setting->display_asset_name == '1' ? 'checked' : '' }}} />
 
 											{{ $errors->first('display_asset_name', '<span class="help-inline">:message</span>') }}
 											</div>
@@ -68,7 +68,7 @@
 										Display QR Codes</label>
 										<div class="controls">
 									@if ($is_gd_installed)
-											<input class="col-md-1" type="checkbox" name="qr_code" id="qr_code" value="1" {{ $setting->qr_code === '1' ? 'checked' : '' }} />
+											<input class="col-md-1" type="checkbox" name="qr_code" id="qr_code" value="1" {{ $setting->qr_code == '1' ? 'checked' : '' }} />
 									@else
 											<span class="help-inline">
 												@lang('admin/settings/general.php_gd_warning')
@@ -83,7 +83,7 @@
 									<div class="form-group {{ $errors->has('qr_text') ? 'error' : '' }}">
 										<label class="control-label" for="qr_text"> @lang('admin/settings/general.qr_text')</label>
 										<div class="controls">
-									@if ($setting->qr_code === '1')
+									@if ($setting->qr_code == '1')
 											<input class="col-md-9" type="text" name="qr_text" id="qr_text" value="{{{ Input::old('qr_text', $setting->qr_text) }}}" />
 									@else
 											<span class="help-inline">

--- a/app/views/backend/settings/index.blade.php
+++ b/app/views/backend/settings/index.blade.php
@@ -43,7 +43,7 @@ Settings ::
 									<td>@lang('admin/settings/general.display_asset_name')</td>
 
 
-									@if ($setting->display_asset_name === '1')
+									@if ($setting->display_asset_name == '1')
 										<td>Yes</td>
 									@else
 										<td>No</td>
@@ -56,7 +56,7 @@ Settings ::
 								</tr>
 								<tr>
 									<td>Display QR Codes</td>
-										@if ($setting->qr_code === '1')
+										@if ($setting->qr_code == '1')
 											<td>Yes</td>
 										@else
 											<td>No</td>


### PR DESCRIPTION
I noticed that despite the display asset name and display qr code were set to 1 in the database the check boxes and text view of the settings page did not reflect that
