### PR TITLE
Add bin directory to gitignore so vendor assets don't get committed.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ public/packages/*
 /app/storage/views/*
 /app/storage/logs/*
 /app/storage/debugbar/
+/bin/


### PR DESCRIPTION
Composer install/update adds a bin/ directory. This makes sure it doesn't get committed accidentally.
