### PR TITLE
fix typo: artisand -> artisan

### DIFF
--- a/app/config/local/app.example.php
+++ b/app/config/local/app.example.php
@@ -37,7 +37,7 @@ return array(
     | to a random, 32 character string, otherwise these encrypted strings
     | will not be safe. Please do this before deploying an application!
     |
-    | Run a php artisand key:generate --env=staging to create a random one
+    | Run a php artisan key:generate --env=staging to create a random one
     */
 
     'key' => 'Change_this_key_or_snipe_will_get_ya',

--- a/app/config/production/app.example.php
+++ b/app/config/production/app.example.php
@@ -37,7 +37,7 @@ return array(
     | to a random, 32 character string, otherwise these encrypted strings
     | will not be safe. Please do this before deploying an application!
     |
-    | Run a php artisand key:generate --env=staging to create a random one
+    | Run a php artisan key:generate --env=staging to create a random one
     */
 
     'key' => 'Change_this_key_or_snipe_will_get_ya',

--- a/app/config/staging/app.example.php
+++ b/app/config/staging/app.example.php
@@ -37,7 +37,7 @@ return array(
     | to a random, 32 character string, otherwise these encrypted strings
     | will not be safe. Please do this before deploying an application!
     |
-    | Run a php artisand key:generate --env=staging to create a random one
+    | Run a php artisan key:generate --env=staging to create a random one
     */
 
     'key' => 'Change_this_key_or_snipe_will_get_ya',

--- a/app/config/testing/app.example.php
+++ b/app/config/testing/app.example.php
@@ -37,7 +37,7 @@ return array(
     | to a random, 32 character string, otherwise these encrypted strings
     | will not be safe. Please do this before deploying an application!
     |
-    | Run a php artisand key:generate --env=staging to create a random one
+    | Run a php artisan key:generate --env=staging to create a random one
     */
 
     'key' => 'Change_this_key_or_snipe_will_get_ya',


### PR DESCRIPTION
In few app.example.php config files was artisand instead artisan.
