### PR TITLE
views: Added old tag to placeholder when cloning

### DIFF
--- a/app/views/backend/hardware/clone.blade.php
+++ b/app/views/backend/hardware/clone.blade.php
@@ -26,7 +26,7 @@
             <div class="form-group {{ $errors->has('asset_tag') ? 'error' : '' }}">
                 <label class="control-label" for="asset_tag">@lang('admin/hardware/form.tag')</label>
                 <div class="controls">
-                    <input class="col-md-4" type="text" name="asset_tag" id="asset_tag" value="{{{ Input::old('asset_tag') }}}" />
+                    <input class="col-md-4" type="text" name="asset_tag" id="asset_tag" value="{{{ Input::old('asset_tag') }}}" placeholder="{{{ Input::old('asset_tag', $asset->asset_tag) }}}" />
                     {{ $errors->first('asset_tag', '<span class="help-inline"><i class="icon-remove-sign"></i> :message</span>') }}
                 </div>
             </div>


### PR DESCRIPTION
- Added the old tag to the placeholder attribute of the `asset_tag` input to improve the UX.

--8<--

When adding multiple assets one might want to keep a common naming scheme for their tags. While using the old `asset_tag` just does not do the trick (since the tags should be unique) setting it as the placeholder helps to come up with a new tag easily.  
