### PR TITLE
fix: Use the old asset tag when cloning

### DIFF
--- a/app/views/backend/hardware/clone.blade.php
+++ b/app/views/backend/hardware/clone.blade.php
@@ -26,7 +26,7 @@
             <div class="form-group {{ $errors->has('asset_tag') ? 'error' : '' }}">
                 <label class="control-label" for="asset_tag">@lang('admin/hardware/form.tag')</label>
                 <div class="controls">
-                    <input class="col-md-4" type="text" name="asset_tag" id="asset_tag" value="{{{ Input::old('asset_tag') }}}" placeholder="{{{ Input::old('asset_tag', $asset->asset_tag) }}}" />
+                    <input class="col-md-4" type="text" name="asset_tag" id="asset_tag" value="{{{ Input::old('asset_tag', $asset->asset_tag) }}}" />
                     {{ $errors->first('asset_tag', '<span class="help-inline"><i class="icon-remove-sign"></i> :message</span>') }}
                 </div>
             </div>


### PR DESCRIPTION
- Removed previous use of placeholder, added code to set the old asset tag as the new one since it is being checked for uniqueness.
- For more rationale see our discussion with @technogenus in #241

--8<--

I became convinced that @technogenus's view over how this should work is the correct one. This PR implements it.
