### PR TITLE
Added DB Prefix to Migrations

### DIFF
--- a/app/database/migrations/2013_11_18_164423_set_nullvalues_for_user.php
+++ b/app/database/migrations/2013_11_18_164423_set_nullvalues_for_user.php
@@ -9,12 +9,13 @@ class SetNullvaluesForUser extends Migration
      *
      * @return void
      */
+	
     public function up()
     {
         //
-
-        DB::statement('ALTER TABLE users MODIFY phone varchar(20) null');
-        DB::statement('ALTER TABLE users MODIFY jobtitle varchar(50) null');
+		$prefix = DB::getTablePrefix();
+        DB::statement('ALTER TABLE '.$prefix.'users MODIFY phone varchar(20) null');
+        DB::statement('ALTER TABLE '.$prefix.'users MODIFY jobtitle varchar(50) null');
 
     }
 

--- a/app/database/migrations/2013_11_19_061409_edit_added_on_asset_logs_table.php
+++ b/app/database/migrations/2013_11_19_061409_edit_added_on_asset_logs_table.php
@@ -11,7 +11,7 @@ class EditAddedOnAssetLogsTable extends Migration
      */
     public function up()
     {
-        DB::statement('ALTER TABLE asset_logs MODIFY added_on timestamp null');
+        DB::statement('ALTER TABLE  ' . DB::getTablePrefix() . 'asset_logs MODIFY added_on timestamp null');
 
     }
 

--- a/app/database/migrations/2013_11_19_062250_edit_location_id_asset_logs_table.php
+++ b/app/database/migrations/2013_11_19_062250_edit_location_id_asset_logs_table.php
@@ -11,8 +11,9 @@ class EditLocationIdAssetLogsTable extends Migration
      */
     public function up()
     {
-        DB::statement('ALTER TABLE asset_logs MODIFY location_id int(11) null');
-        DB::statement('ALTER TABLE asset_logs MODIFY added_on timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP');
+		$prefix=DB::getTablePrefix();
+        DB::statement('ALTER TABLE '.$prefix.'asset_logs MODIFY location_id int(11) null');
+        DB::statement('ALTER TABLE '.$prefix.'asset_logs MODIFY added_on timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP');
 
     }
 

--- a/app/database/migrations/2013_11_25_104343_alter_warranty_column_on_assets.php
+++ b/app/database/migrations/2013_11_25_104343_alter_warranty_column_on_assets.php
@@ -11,7 +11,7 @@ class AlterWarrantyColumnOnAssets extends Migration
      */
     public function up()
     {
-        DB::statement('ALTER TABLE assets CHANGE warrantee_months warranty_months int (3)');
+        DB::statement('ALTER TABLE ' . DB::getTablePrefix() . 'assets CHANGE warrantee_months warranty_months int (3)');
     }
 
     /**

--- a/app/database/migrations/2013_12_06_094618_add_nullable_to_licenses_table.php
+++ b/app/database/migrations/2013_12_06_094618_add_nullable_to_licenses_table.php
@@ -11,11 +11,11 @@ class AddNullableToLicensesTable extends Migration
      */
     public function up()
     {
-        //
-        DB::statement('ALTER TABLE licenses MODIFY order_number varchar(50) null');
-        DB::statement('ALTER TABLE licenses MODIFY notes varchar(255) null');
-        DB::statement('ALTER TABLE licenses MODIFY license_name varchar(100) null');
-        DB::statement('ALTER TABLE licenses MODIFY license_email varchar(120) null');
+        $prefix = DB::getTablePrefix();
+        DB::statement('ALTER TABLE ' . $prefix . 'licenses MODIFY order_number varchar(50) null');
+        DB::statement('ALTER TABLE ' . $prefix . 'licenses MODIFY notes varchar(255) null');
+        DB::statement('ALTER TABLE ' . $prefix . 'licenses MODIFY license_name varchar(100) null');
+        DB::statement('ALTER TABLE ' . $prefix . 'licenses MODIFY license_email varchar(120) null');
     }
 
     /**

--- a/app/database/migrations/2014_05_24_093839_alter_default_license_depreciation_id.php
+++ b/app/database/migrations/2014_05_24_093839_alter_default_license_depreciation_id.php
@@ -13,7 +13,7 @@ class AlterDefaultLicenseDepreciationId extends Migration
     public function up()
     {
         //
-        DB::statement('ALTER TABLE licenses MODIFY column depreciation_id tinyint(1) NOT NULL DEFAULT "0"');
+        DB::statement('ALTER TABLE '.DB::getTablePrefix().'licenses MODIFY column depreciation_id tinyint(1) NOT NULL DEFAULT "0"');
 
     }
 

--- a/app/database/migrations/2014_05_27_231658_alter_default_values_licenses.php
+++ b/app/database/migrations/2014_05_27_231658_alter_default_values_licenses.php
@@ -13,7 +13,7 @@ class AlterDefaultValuesLicenses extends Migration
     public function up()
     {
         //
-        DB::statement('ALTER TABLE license_seats MODIFY column notes text NULL');
+        DB::statement('ALTER TABLE ' . DB::getTablePrefix() . 'license_seats MODIFY column notes text NULL');
     }
 
     /**

--- a/app/database/migrations/2014_06_20_004847_make_asset_log_checkedout_to_nullable.php
+++ b/app/database/migrations/2014_06_20_004847_make_asset_log_checkedout_to_nullable.php
@@ -13,7 +13,7 @@ class MakeAssetLogCheckedoutToNullable extends Migration
     public function up()
     {
         //
-        DB::statement('ALTER TABLE asset_logs MODIFY column checkedout_to int(11) NULL');
+        DB::statement('ALTER TABLE ' . DB::getTablePrefix() . 'asset_logs MODIFY column checkedout_to int(11) NULL');
     }
 
     /**

--- a/app/database/migrations/2014_06_20_005050_make_asset_log_purchasedate_to_nullable.php
+++ b/app/database/migrations/2014_06_20_005050_make_asset_log_purchasedate_to_nullable.php
@@ -13,7 +13,7 @@ class MakeAssetLogPurchasedateToNullable extends Migration
     public function up()
     {
         //
-        DB::statement('ALTER TABLE licenses MODIFY column purchase_date date NULL');
+        DB::statement('ALTER TABLE ' . DB::getTablePrefix() . 'licenses MODIFY column purchase_date date NULL');
     }
 
     /**

--- a/app/database/migrations/2014_07_17_161625_make_asset_id_in_logs_nullable.php
+++ b/app/database/migrations/2014_07_17_161625_make_asset_id_in_logs_nullable.php
@@ -13,7 +13,7 @@ class MakeAssetIdInLogsNullable extends Migration {
 	public function up()
 	{
 		//
-		DB::statement('ALTER TABLE asset_logs MODIFY column asset_id int NULL');
+		DB::statement('ALTER TABLE ' . DB::getTablePrefix() . 'asset_logs MODIFY column asset_id int NULL');
 	}
 
 	/**

--- a/app/database/migrations/2014_08_12_053504_alpha_0_4_2_release.php
+++ b/app/database/migrations/2014_08_12_053504_alpha_0_4_2_release.php
@@ -12,21 +12,22 @@ class Alpha042Release extends Migration {
 	 */
 	public function up()
 	{
+		$prefix = DB::getTablePrefix();
 		Schema::table('assets', function(Blueprint $table)
 		{
 			//
 		});
                 
-                DB::statement('UPDATE assets SET status_id="0" where status_id is null');
-                DB::statement('UPDATE assets SET purchase_cost=0 where purchase_cost is null');
-                DB::statement('UPDATE models SET eol=0 where eol is null');
-                DB::statement('UPDATE users SET location_id=0 where location_id is null');
-                DB::statement('UPDATE assets SET asset_tag=" " WHERE asset_tag is null');
-                DB::statement('UPDATE locations SET state=" " where state is null');
-                DB::statement('UPDATE models SET manufacturer_id="0" where manufacturer_id is null');
-                DB::statement('UPDATE models SET category_id="0" where category_id is null');
+                DB::statement('UPDATE '.$prefix.'assets SET status_id="0" where status_id is null');
+                DB::statement('UPDATE '.$prefix.'assets SET purchase_cost=0 where purchase_cost is null');
+                DB::statement('UPDATE '.$prefix.'models SET eol=0 where eol is null');
+                DB::statement('UPDATE '.$prefix.'users SET location_id=0 where location_id is null');
+                DB::statement('UPDATE '.$prefix.'assets SET asset_tag=" " WHERE asset_tag is null');
+                DB::statement('UPDATE '.$prefix.'locations SET state=" " where state is null');
+                DB::statement('UPDATE '.$prefix.'models SET manufacturer_id="0" where manufacturer_id is null');
+                DB::statement('UPDATE '.$prefix.'models SET category_id="0" where category_id is null');
 
-                DB::statement('ALTER TABLE assets '
+                DB::statement('ALTER TABLE '.$prefix.'assets '
                     . 'MODIFY COLUMN name VARCHAR(255) NULL , '
                     . 'MODIFY COLUMN asset_tag VARCHAR(255) NOT NULL , '
                     . 'MODIFY COLUMN purchase_cost DECIMAL(13,4) NOT NULL DEFAULT "0" , '
@@ -36,26 +37,26 @@ class Alpha042Release extends Migration {
                     . 'MODIFY COLUMN archived TINYINT(1) NOT NULL DEFAULT "0" , '
                     . 'MODIFY COLUMN depreciate TINYINT(1) NOT NULL DEFAULT "0"');
 
-                DB::statement('ALTER TABLE licenses '
+                DB::statement('ALTER TABLE '.$prefix.'licenses '
                     . 'MODIFY COLUMN purchase_cost DECIMAL(13,4) NULL , '
                     . 'MODIFY COLUMN depreciate TINYINT(1) NULL DEFAULT "0"');
 
-                DB::statement('ALTER TABLE license_seats '
+                DB::statement('ALTER TABLE '.$prefix.'license_seats '
                     . 'MODIFY COLUMN assigned_to INT(11) NULL ');
 
-                DB::statement('ALTER TABLE locations '
+                DB::statement('ALTER TABLE '.$prefix.'locations '
                     . 'MODIFY COLUMN state VARCHAR(255) NOT NULL ,'
                     . 'MODIFY COLUMN address2 VARCHAR(255) NULL ,'
                     . 'MODIFY COLUMN zip VARCHAR(10) NULL ');
 
-                DB::statement('ALTER TABLE models '
+                DB::statement('ALTER TABLE '.$prefix.'models '
                     . 'MODIFY COLUMN modelno VARCHAR(255) NULL , '
                     . 'MODIFY COLUMN manufacturer_id INT(11) NOT NULL , '
                     . 'MODIFY COLUMN category_id INT(11) NOT NULL , '
                     . 'MODIFY COLUMN depreciation_id INT(11) NOT NULL DEFAULT "0" , '
                     . 'MODIFY COLUMN eol INT(11) NULL DEFAULT "0"');
 
-                DB::statement('ALTER TABLE users '
+                DB::statement('ALTER TABLE '.$prefix.'users '
                     . 'MODIFY COLUMN first_name VARCHAR(255) NOT NULL , '
                     . 'MODIFY COLUMN last_name VARCHAR(255) NOT NULL , '
                     . 'MODIFY COLUMN location_id INT(11) NOT NULL');

--- a/app/database/migrations/2014_08_17_083523_make_location_id_nullable.php
+++ b/app/database/migrations/2014_08_17_083523_make_location_id_nullable.php
@@ -13,7 +13,7 @@ class MakeLocationIdNullable extends Migration {
 	public function up()
 	{
 		//
-		DB::statement('ALTER TABLE users MODIFY column location_id int NULL');
+		DB::statement('ALTER TABLE ' . DB::getTablePrefix() . 'users MODIFY column location_id int NULL');
 	}
 
 	/**


### PR DESCRIPTION
Added DB::getTablePrefix(); to migrations to fix #284

Not sure if there is another way to achieve this but if there is please disregard this pull request
