### PR TITLE
Fixed AutoIncrement Bug with no Assets and cleaned up logic

### DIFF
--- a/app/models/Asset.php
+++ b/app/models/Asset.php
@@ -182,17 +182,11 @@ class Asset extends Depreciable
     {
         $settings = Setting::getSettings();
 
-        if (isset($asset_tag->id)) {
-        	$asset_id = $asset_tag->id;
-        } else {
-        	$asset_id = 1;
-        }
 		if ($settings->auto_increment_assets == '1') {
 			$asset_tag = DB::table('assets')
-                    ->where('physical', '=', '1')
-                    ->orderBy('created_at','desc')
-                    ->first();
-			return $settings->auto_increment_prefix.($asset_tag->id + 1);
+				->where('physical', '=', '1')
+				->max('id');
+			return $settings->auto_increment_prefix.($asset_tag + 1);
 		} else {
 			return false;
 		}


### PR DESCRIPTION
Fixed a bug when no assets are in table that the autoincrement method blows up. Also optimized the logic to get max id instead of popping top off creation date.