### PR TITLE
Enhance further install without dummy data

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,3 @@ Whenever you pull down a new version from master or develop, when you grab the [
 	php artisan migrate
 
 Forgetting to do this can mean your DB might end up out of sync with the new files you just pulled, or you may have some funky cached autoloader values. It's a good idea to get into the habit of running these every time you pull anything new down. If there are no database changes to migrate, it won't hurt anything to run migrations anyway.
-
-
-[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/snipe/snipe-it/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
-

--- a/README.md
+++ b/README.md
@@ -65,3 +65,7 @@ Whenever you pull down a new version from master or develop, when you grab the [
 	php artisan migrate
 
 Forgetting to do this can mean your DB might end up out of sync with the new files you just pulled, or you may have some funky cached autoloader values. It's a good idea to get into the habit of running these every time you pull anything new down. If there are no database changes to migrate, it won't hurt anything to run migrations anyway.
+
+
+[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/snipe/snipe-it/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
+

--- a/app/commands/AppCommand.php
+++ b/app/commands/AppCommand.php
@@ -100,12 +100,16 @@ class AppCommand extends Command
         // Seed the tables with dummy data
 		if( $this->dummyData === true )
 		{
-			$this->call('db:seed');
+			$this->call('db:seed', array('--force'=>true));
 		}
 		else
 		{	
 			// Seeding Settings table is mandatory
-			$this->call('db:seed', array('--class' => 'SettingsSeeder'));
+			$this->call('db:seed', array('--class' => 'SettingsSeeder', '--force'=>true));
+			// Seeding Statuslabels is strongly recommended
+			$this->call('db:seed', array('--class' => 'StatuslabelsSeeder', '--force'=>true));
+			// Seeding Categories is good to have
+			$this->call('db:seed', array('--class' => 'CategoriesSeeder', '--force'=>true));
 		}
     }
 


### PR DESCRIPTION
Use --force to prevent user unnecessary user interactions.
Seed StatusLabels even when dummy datas chose to not be seeded because
snipe-it heavily builds on those table.
Seed Categories, because it is very common and goot to have, also.