### PR TITLE
Allow new Unicode character class to alpha_space

### DIFF
--- a/app/validators.php
+++ b/app/validators.php
@@ -1,5 +1,9 @@
 <?php
 
 Validator::extend('alpha_space', function ($attribute,$value,$parameters) {
-    return preg_match("/^[\s\n\-+:?#~'\/\(\)_,!.a-zA-Z0-9\pL\pN_-]+$/um",$value);
+    return preg_match("/^[\s\n\-+:?#~'\/\(\)_,!.a-zA-Z0-9\pL\pN\pM_-]+$/um",$value);
+    // whitespace, newline, -, +, :, ?, #, ~, ', /, (, ), _, ',', !, ., a-z, A-Z, 0-9, 
+    //   Unicode Letter (\pL), Unicode Number (\pN), Unicode Spacing Combining Mark (\p{Mc} (eastern language vowels)), _ (again?), - (again?)
+    // patterm must be matched at least once (empty strings will not pass)
+    // (ungreedy?!) ,multiline 
 });


### PR DESCRIPTION
Fixes #568 - permit Unicode 'marks' in addition to unicode 'letters'.

Several eastern languages require this for vowels (vowels are represented as an additional 'mark' over a consonant or multiple consonants).