### PR TITLE
Fix #723 - Add view to list users of group

### DIFF
--- a/app/lang/en/admin/groups/table.php
+++ b/app/lang/en/admin/groups/table.php
@@ -5,5 +5,7 @@ return array(
     'id'         => 'Id',
     'name'       => 'Name',
     'users'      => '# of Users',
+    'update'	 => 'Update Group',
+    'view'		 => 'View Group',
 
 );

--- a/app/routes.php
+++ b/app/routes.php
@@ -281,6 +281,7 @@ Route::group(array('prefix' => 'admin', 'before' => 'admin-auth', 'namespace' =>
         Route::post('{groupId}/edit', 'GroupsController@postEdit');
         Route::get('{groupId}/delete', array('as' => 'delete/group', 'uses' => 'GroupsController@getDelete'));
         Route::get('{groupId}/restore', array('as' => 'restore/group', 'uses' => 'GroupsController@getRestore'));
+        Route::get('{groupId}/view', array('as' => 'view/group', 'uses' => 'GroupsController@getView'));
     });
 
     # Dashboard

--- a/app/views/backend/groups/view.blade.php
+++ b/app/views/backend/groups/view.blade.php
@@ -12,7 +12,7 @@
 
 <div class="row header">
     <div class="col-md-12">
-        <a href="{{ route('view/supplier', $group->id) }}" class="btn-flat white pull-right">
+        <a href="{{ route('update/group', $group->id) }}" class="btn-flat white pull-right">
         @lang('admin/groups/table.update')</a>
         <a href="{{ URL::to('admin/groups') }}" class="btn-flat gray pull-right" style="margin-right:5px;"><i class="fa fa-arrow-left icon-white"></i> @lang('general.back')</a>
         <h3 class="name"> @lang('admin/groups/titles.group_management') - {{{ $group->name }}}</h3>

--- a/app/views/backend/groups/view.blade.php
+++ b/app/views/backend/groups/view.blade.php
@@ -1,0 +1,53 @@
+@extends('backend/layouts/default')
+
+{{-- Page title --}}
+@section('title')
+@lang('admin/groups/table.view') -
+{{{ $group->name }}} ::
+@parent
+@stop
+
+{{-- Page content --}}
+@section('content')
+
+<div class="row header">
+    <div class="col-md-12">
+        <a href="{{ route('view/supplier', $group->id) }}" class="btn-flat white pull-right">
+        @lang('admin/groups/table.update')</a>
+        <a href="{{ URL::to('admin/groups') }}" class="btn-flat gray pull-right" style="margin-right:5px;"><i class="fa fa-arrow-left icon-white"></i> @lang('general.back')</a>
+        <h3 class="name"> @lang('admin/groups/titles.group_management') - {{{ $group->name }}}</h3>
+    </div>
+</div>
+
+<div class="user-profile">
+    <div class="row profile">
+        <div class="col-md-12 bio">
+            @if (count($users) > 0)
+           <table id="example">
+            <thead>
+                <tr role="row">
+                        <th class="col-md-3">@lang('admin/groups/table.name')</th>
+                    </tr>
+                </thead>
+                <tbody>
+
+                    @foreach ($users as $user)
+                    <tr>
+                        <td><a href="{{ route('view/user', $user->id) }}">{{{ $user->first_name }}} {{{ $user->last_name }}}</a></td>
+                    </tr>
+                    @endforeach
+
+
+                </tbody>
+            </table>
+
+            @else
+            <div class="col-md-12">
+                <div class="alert alert-info alert-block">
+                    <i class="fa fa-info-circle"></i>
+                    @lang('general.no_results')
+                </div>
+            </div>
+            @endif
+        </div>
+@stop


### PR DESCRIPTION
Added the ability to click on a group name in the 'Group Management' Section to view all users attached to that group.

Based on feature suggestion #723 