### PR TITLE
Fix to issue with depreciation not returning correct value

### DIFF
--- a/app/models/Depreciable.php
+++ b/app/models/Depreciable.php
@@ -48,7 +48,7 @@ class Depreciable extends Elegant
         }
 
         // fraction of value left
-        $months_remaining = $this->time_until_depreciated()->m + $this->time_until_depreciated()->y; //UGlY
+        $months_remaining = $this->time_until_depreciated()->m + 12*$this->time_until_depreciated()->y; //UGlY
         $current_value = round(($months_remaining/ $this->get_depreciation()->months) * $this->purchase_cost, 2);
 
         if ($current_value < 0) {


### PR DESCRIPTION
Fixes #733 - we weren't doing the depreciation math exactly right - the months remaining weren't being calculated correctly with respect to 'years' - they were being treated the same as months.

Ouch, sorry.