### PR TITLE
Removed debugbar:publish

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,11 +47,9 @@
 
 		],
 		"post-update-cmd": [
-			"php artisan optimize",
-			"php artisan debugbar:publish"
+			"php artisan optimize"
 		],
 		"post-install-cmd": [
-			"php artisan debugbar:publish"
 		],
 		"post-create-project-cmd": [
 			"php artisan key:generate"


### PR DESCRIPTION
As per:
```
NOTICE: Since laravel-debugbar 1.7.x, publishing assets is no longer necessary. The assets in public/packages/barryvdh/laravel-debugbar and maximebf/php-debugbar can be safely removed.
```