### PR TITLE
Reassignable License Setting

### DIFF
--- a/app/controllers/admin/LicensesController.php
+++ b/app/controllers/admin/LicensesController.php
@@ -22,6 +22,7 @@ use Response;
 use Datatable;
 use Slack;
 use Config;
+use Session;
 
 class LicensesController extends AdminController
 {
@@ -229,6 +230,7 @@ class LicensesController extends AdminController
             $license->depreciation_id   = e(Input::get('depreciation_id'));
             $license->purchase_order    = e(Input::get('purchase_order'));
             $license->maintained        = e(Input::get('maintained'));
+            $license->reassignable      = e(Input::get('reassignable'));
 
             if ( e(Input::get('supplier_id')) == '') {
                 $license->supplier_id = NULL;
@@ -267,6 +269,12 @@ class LicensesController extends AdminController
                 $license->maintained = 0;
             } else {
                 $license->maintained = e(Input::get('maintained'));
+            }
+
+            if ( e(Input::get('reassignable')) == '') {
+                $license->reassignable = 0;
+            } else {
+                $license->reassignable = e(Input::get('reassignable'));
             }
 
             if ( e(Input::get('purchase_order')) == '') {
@@ -607,6 +615,12 @@ class LicensesController extends AdminController
         
         $license = License::find($licenseseat->license_id);
 
+        if(!$license->reassignable) {
+            // Not allowed to checkin
+            Session::flash('error', 'License not reassignable.');
+            return Redirect::back()->withInput();
+        }
+        
         // Declare the rules for the form validation
         $rules = array(
             'note'   => 'alpha_space',

--- a/app/database/migrations/2015_05_22_124421_add_reassignable_to_licenses.php
+++ b/app/database/migrations/2015_05_22_124421_add_reassignable_to_licenses.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddReassignableToLicenses extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::table('licenses', function(Blueprint $table)
+		{
+			$table->boolean('reassignable')->default(true);
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::table('licenses', function(Blueprint $table)
+		{
+			//
+			$table->dropColumn('reassignable');
+		});
+	}
+
+}

--- a/app/lang/en/admin/licenses/form.php
+++ b/app/lang/en/admin/licenses/form.php
@@ -10,6 +10,7 @@ return array(
     'depreciation'      => 'Depreciation',
     'expiration'        => 'Expiration Date',
     'maintained'        => 'Maintained',
+    'reassignable'      => 'Reassignable',
     'name'              => 'Software Name',
     'no_depreciation'   => 'Do Not Depreciate',
     'notes'             => 'Notes',

--- a/app/views/backend/licenses/edit.blade.php
+++ b/app/views/backend/licenses/edit.blade.php
@@ -84,6 +84,15 @@
                     </div>
             </div>
 
+    <!-- Reassignable -->
+    <div class="form-group {{ $errors->has('reassignable') ? ' has-error' : '' }}">
+        <label for="reassignable" class="col-md-3 control-label">@lang('admin/licenses/form.reassignable')</label>
+        <div class="col-md-7 input-group">
+            {{ Form::Checkbox('reassignable', '1', Input::old('reassignable', $license->reassignable)) }}
+            @lang('general.yes')
+        </div>
+    </div>
+
             <!-- Supplier -->
             <div class="form-group {{ $errors->has('supplier_id') ? ' has-error' : '' }}">
                 <label for="supplier_id" class="col-md-3 control-label">@lang('admin/licenses/form.supplier')</label>

--- a/app/views/backend/licenses/view.blade.php
+++ b/app/views/backend/licenses/view.blade.php
@@ -134,8 +134,13 @@
                                 </td>
                                 <td>
                                     @if (($licensedto->assigned_to) || ($licensedto->asset_id))
-                                        <a href="{{ route('checkin/license', $licensedto->id) }}" class="btn btn-primary btn-sm">
-                                        @lang('general.checkin')</a>
+                                        @if ($license->reassignable)
+                                            <a href="{{ route('checkin/license', $licensedto->id) }}" class="btn btn-primary btn-sm">
+                                            @lang('general.checkin')
+                                            </a>
+                                        @else
+                                            <span>Assigned</span>
+                                        @endif
                                     @else
                                         <a href="{{ route('checkout/license', $licensedto->id) }}" class="btn btn-info btn-sm">
                                         @lang('general.checkout')</a>
@@ -332,6 +337,10 @@
                     <li><strong>@lang('admin/licenses/form.seats'):</strong>
                     {{{ $license->seats }}} </li>
                     @endif
+
+                    <li><strong>@lang('admin/licenses/form.reassignable'):</strong>
+                                {{ $license->reassignable ? 'Yes' : 'No' }}
+                    </li>
 
                     @if ($license->notes)
                     	 <li><strong>@lang('admin/licenses/form.notes'):</strong>


### PR DESCRIPTION
Hi @snipe - firstly thanks for this awesome project!

I needed to represent OEM licenses which are not reassignable - for example OEM Windows 7 or Microsoft Office licenses which come with a PC and are only valid for that Asset (or User). I wanted to stop the system allowing these types of License to be checked-in once assigned. These licenses are checked-out once, and then remain associated with that Asset or User.

I deliberated about how to do this, including adding a new table and section to the Asset form, but in the end I decided the most flexible approach was actually to add a boolean property to a License called "reassignable". This also was simple to implement, and allows us to continue to benefit from the existing License features.

As you will see in the PR, if you set a License as `!reassignable` then once checked-out a License can no longer be Checked-in. In the occasional circumstances where an admin needs to manually override this (if a mistake is made for example), then the License can temporarily be set back to reassignable.

Thanks!