### PR TITLE
Update default.blade.php

### DIFF
--- a/app/views/backend/layouts/default.blade.php
+++ b/app/views/backend/layouts/default.blade.php
@@ -109,11 +109,11 @@
 
 
 	            @if (Setting::getSettings()->logo)
-	            	<a class="navbar-brand" href="{{ Config::get('app.url') }}" style="padding: 5px;">
+	            	<a class="navbar-brand" href="{{ URL::to('') }}" style="padding: 5px;">
 	            	<img src="/uploads/{{{ Setting::getSettings()->logo }}}">
 	            	</a>
 	            @else
-	            	<a class="navbar-brand" href="{{ Config::get('app.url') }}">
+	            	<a class="navbar-brand" href="{{ URL::to('') }}">
 	            	{{{ Setting::getSettings()->site_name }}}
 	            	</a>
 	            @endif
@@ -249,7 +249,7 @@
         <ul id="dashboard-menu">
 			@if(Sentry::getUser()->hasAccess('admin'))
 			<li{{ (Request::is('*/') ? ' class="active"><div class="pointer"><div class="arrow"></div><div class="arrow_border"></div></div>' : '>') }}
-                <a href="{{ Config::get('app.url') }}"><i class="fa fa-dashboard"></i><span>Dashboard</span></a>
+                <a href="{{ URL::to('') }}"><i class="fa fa-dashboard"></i><span>Dashboard</span></a>
             </li>
             <li{{ (Request::is('hardware*') ? ' class="active"><div class="pointer"><div class="arrow"></div><div class="arrow_border"></div></div>' : '>') }}
                 <a href="{{ URL::to('hardware') }}" class="dropdown-toggle">


### PR DESCRIPTION
The URLs to which the Dashboard and 'Snipe IT Asset Management'/logo hyperlinks linked were inconsistent across pages and sometimes linked to pages that didn't exist, causing 404 errors. See https://github.com/snipe/snipe-it/issues/848.

This edit solves that by making these hyperlinks link to the index page from anywhere on the site.