### PR TITLE
Fix #896 - Only show Checkout/Checkin if deployable

### DIFF
--- a/app/controllers/admin/AssetsController.php
+++ b/app/controllers/admin/AssetsController.php
@@ -1039,15 +1039,16 @@ class AssetsController extends AdminController
 
 	        });
 
-	    $inout = new \Chumper\Datatable\Columns\FunctionColumn('inout', function ($assets)
-        	{
-	       	 	if (($assets->assigned_to !='') && ($assets->assigned_to > 0)) {
-					return '<a href="'.route('checkin/hardware', $assets->id).'" class="btn btn-primary btn-sm">'.Lang::get('general.checkin').'</a>';
-				} else {
-					return '<a href="'.route('checkout/hardware', $assets->id).'" class="btn btn-info btn-sm">'.Lang::get('general.checkout').'</a>';
-				}
-	        });
-
+	   $inout = new \Chumper\Datatable\Columns\FunctionColumn('inout', function ($assets)
+      	{
+            if ($assets->assetstatus->deployable != 0) {
+                if (($assets->assigned_to !='') && ($assets->assigned_to > 0)) {
+                    return '<a href="'.route('checkin/hardware', $assets->id).'" class="btn btn-primary btn-sm">'.Lang::get('general.checkin').'</a>';
+                } else {
+                    return '<a href="'.route('checkout/hardware', $assets->id).'" class="btn btn-info btn-sm">'.Lang::get('general.checkout').'</a>';
+                }
+            }
+        });
 
 
         return Datatable::collection($assets)


### PR DESCRIPTION
Assuming that only deployable assets should see this button