### PR TITLE
Added Code128 Label Compatibility

### DIFF
--- a/app/controllers/admin/AssetsController.php
+++ b/app/controllers/admin/AssetsController.php
@@ -21,6 +21,7 @@ use Response;
 use Config;
 use Location;
 use Log;
+use Dns1D;
 use DNS2D;
 use Mail;
 use Datatable;
@@ -30,6 +31,7 @@ use Slack;
 class AssetsController extends AdminController
 {
     protected $qrCodeDimensions = array( 'height' => 3.5, 'width' => 3.5);
+    protected $barCodeDimensions = array( 'height' => 3, 'width' => 33);
 
     /**
      * Show a list of all the assets.
@@ -660,9 +662,15 @@ class AssetsController extends AdminController
 
             if (isset($asset->id,$asset->asset_tag)) {
 
+                if ($settings->barcode_type == 'C128'){
+                $content = DNS1D::getBarcodePNG(route('view/hardware', $asset->id), $settings->barcode_type,
+                    $this->barCodeDimensions['height'],$this->barCodeDimensions['width']);
+                }
+
+                else{
                 $content = DNS2D::getBarcodePNG(route('view/hardware', $asset->id), $settings->barcode_type,
                     $this->qrCodeDimensions['height'],$this->qrCodeDimensions['width']);
-
+                }
                 $img = imagecreatefromstring(base64_decode($content));
                 imagepng($img);
                 imagedestroy($img);

--- a/app/controllers/admin/AssetsController.php
+++ b/app/controllers/admin/AssetsController.php
@@ -21,7 +21,7 @@ use Response;
 use Config;
 use Location;
 use Log;
-use Dns1D;
+use DNS1D;
 use DNS2D;
 use Mail;
 use Datatable;
@@ -662,15 +662,15 @@ class AssetsController extends AdminController
 
             if (isset($asset->id,$asset->asset_tag)) {
 
-                if ($settings->barcode_type == 'C128'){
-                $content = DNS1D::getBarcodePNG(route('view/hardware', $asset->id), $settings->barcode_type,
+		if ($settings->barcode_type == 'C128'){
+		$content = DNS1D::getBarcodePNG(route('view/hardware', $asset->id), $settings->barcode_type,
                     $this->barCodeDimensions['height'],$this->barCodeDimensions['width']);
-                }
+		}
 
-                else{
+		else{
                 $content = DNS2D::getBarcodePNG(route('view/hardware', $asset->id), $settings->barcode_type,
                     $this->qrCodeDimensions['height'],$this->qrCodeDimensions['width']);
-                }
+		}
                 $img = imagecreatefromstring(base64_decode($content));
                 imagepng($img);
                 imagedestroy($img);

--- a/app/macros.php
+++ b/app/macros.php
@@ -284,7 +284,7 @@ Form::macro('barcode_types', function ($name = "barcode_type", $selected = null,
     $barcode_types = array(
     'QRCODE'=>"QR Code",
     'PDF417'=>'PDF417',
-    'DATAMATRIX'=>'DATAMATRIX'
+    'DATAMATRIX'=>'DATAMATRIX',
     'C128' => 'Code 128'
     );
 

--- a/app/macros.php
+++ b/app/macros.php
@@ -285,6 +285,7 @@ Form::macro('barcode_types', function ($name = "barcode_type", $selected = null,
     'QRCODE'=>"QR Code",
     'PDF417'=>'PDF417',
     'DATAMATRIX'=>'DATAMATRIX'
+    'C128' => 'Code 128'
     );
 
     $select = '<select name="'.$name.'" class="'.$class.'">';


### PR DESCRIPTION
Helps with #973 by adding code128 compatibility to labels. Just enable qr codes and select Code128 in settings, and it should work.