### PR TITLE
Change to using route in error message

### DIFF
--- a/app/views/error/500.blade.php
+++ b/app/views/error/500.blade.php
@@ -117,7 +117,7 @@
             </p>
 
             <p>
-                Perhaps you would like to go to our <a href="{{ URL::to('home'); }}">home page</a>?
+                Perhaps you would like to go to our <a href="{{ URL::route('home'); }}">home page</a>?
             </p>
         </div>
     </div>


### PR DESCRIPTION
When I've broken things and wound up with a 500 error the link back to home
produces a 404 error. I believe its because it uses 'to' instead of 'route' but
I'm not familiar enough with php to be sure of my theory.

These are the three files that return to 'home', only 500 uses 'to'.

https://github.com/snipe/snipe-it/blob/5a6fe6ccf8aa9af8ab09f0cb2fa79130b8ab81ee/app/views/error/500.blade.php#L120
https://github.com/snipe/snipe-it/blob/5a6fe6ccf8aa9af8ab09f0cb2fa79130b8ab81ee/app/views/error/404.blade.php
https://github.com/snipe/snipe-it/blob/5a6fe6ccf8aa9af8ab09f0cb2fa79130b8ab81ee/app/views/error/403.blade.php