### PR TITLE
LDAP active flag

### DIFF
--- a/app/config/production/ldap.example.php
+++ b/app/config/production/ldap.example.php
@@ -75,6 +75,12 @@ return array(
     'result.last.name'  => "",
     'result.first.name' => "",
     'result.email' => "",
+    
+    /*
+    | This field is optional as not all LDAP directories will have it.  If yours
+    | does not have it, just leave this field blank and the extra check will
+    | be omitted.
+    */
     'result.active.flag' => "",
     
     /*

--- a/app/controllers/admin/UsersController.php
+++ b/app/controllers/admin/UsersController.php
@@ -1112,7 +1112,7 @@ class UsersController extends AdminController {
 
         $summary = array();
         for ($i = 0; $i < $results["count"]; $i++) {
-            if ($results[$i][$ldap_result_active_flag][0] == "TRUE") {
+            if (empty($ldap_result_active_flag) || $results[$i][$ldap_result_active_flag][0] == "TRUE") {
 
                 $item = array();
                 $item["username"] = isset( $results[$i][$ldap_result_username][0] ) ? $results[$i][$ldap_result_username][0] : "";

--- a/app/controllers/admin/UsersController.php
+++ b/app/controllers/admin/UsersController.php
@@ -1068,7 +1068,7 @@ class UsersController extends AdminController {
     /**
      * LDAP form processing.
      *
-     * @Auther Aldin Alaily
+     * @author Aldin Alaily
      * @return Redirect
      */
     public function postLDAP() {
@@ -1166,11 +1166,7 @@ class UsersController extends AdminController {
 
                 array_push($summary, $item);
             }
-            /* Easy break in the loop */
-            /*
-            if ($i >= 1)
-                break;
-            */
+
         }
 
 


### PR DESCRIPTION
I just realized that although the "ldap.result.active.flag" is optional (since not all LDAP implementation will have it), I never checked for the case where the flag wasn't set.  Failure to make this check will cause the implementation that do not have this flag implemented to never create users. 