### PR TITLE
Remove hardcoded location in favour of a selection dropdown

### DIFF
--- a/app/lang/en/admin/users/general.php
+++ b/app/lang/en/admin/users/general.php
@@ -10,7 +10,7 @@ return array(
     'filetype_info'     => 'Allowed filetypes are png, gif, jpg, jpeg, doc, docx, pdf, txt, zip, and rar.',
     'history_user'      => 'History for :name',
     'last_login'        => 'Last Login',
-    'ldap_config_text'  => 'LDAP configuration settings can be found in the app/config folder in a file called ldap.php',
+    'ldap_config_text'  => 'LDAP configuration settings can be found in the app/config folder in a file called ldap.php. The selected location will be set for all imported users. You will need to have at least one location set to use this feature.',
     'ldap_text'         => 'Connect to LDAP and create users.  Passwords will be auto-generated.',
     'software_user'     => 'Software Checked out to :name',
     'view_user'         => 'View User :name',

--- a/app/views/backend/users/ldap.blade.php
+++ b/app/views/backend/users/ldap.blade.php
@@ -46,9 +46,20 @@ Create a User ::
         <!-- CSRF Token -->
         <input type="hidden" name="_token" value="{{ csrf_token() }}" />
 
+        <div class="form-group {{ $errors->has('location_id') ? 'has-error' : '' }}">
+                <label class="col-md-3 control-label" for="location_id">@lang('admin/users/table.location')
+                    </label>
+                <div class="col-md-7">
+                    {{ Form::select('location_id', $location_list, array('class'=>'select2', 'style'=>'width:350px')) }}
+                    {{ $errors->first('location_id', '<br><span class="alert-msg">:message</span>') }}
+                </div>
+            </div>
+        
         <button type="submit" class="btn btn-warning" id="sync">
             <i id="sync-button-icon" class="fa fa-refresh icon-white"></i> <span id="sync-button-text">Synchronize</span>
         </button>
+        
+
     </form>
     @if (Session::get('summary'))
     <h3>Synchronization Results</h3>


### PR DESCRIPTION
This merge request is to remove the hardcoded location (which is currently hardcoded to 1) in favour of letting the user select a location that already exists in the system.  It will ensure that the system will not crash (as described here #1101), if a location with id = 1 has been deleted.  This fix can also act as a springboard to incorporating a location_id field in the LDAP config file, thus covering all cases (users that have location set in LDAP and those that do not).