### PR TITLE
Add LDAP support to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,14 +54,8 @@ COPY docker/mail.php /var/www/html/app/config/production/mail.php
 #change DB file user
 #RUN sed -i s/travis/snipe_it/ /var/www/html/app/config/production/database.php
 
-#init app config file (DO NOT overwrite!)
-RUN cp -n /var/www/html/app/config/production/app.example.php /var/www/html/app/config/production/app.php
-
-# Change default hostname to blank...I guess?
-RUN sed -i s%http://staging.yourserver.com%% /var/www/html/app/config/production/app.php
-
-# turn off the toolbar
-RUN sed -i 's%\x27debug\x27 => true%\x27debug\x27 => false%' /var/www/html/app/config/production/app.php
+#init app config file
+COPY docker/app.php /var/www/html/app/config/production/app.php
 
 RUN chown -R docker /var/www/html
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && apt-get install -y \
 apache2-bin \
 libapache2-mod-php5 \
 php5-curl \
+php5-ldap \
 php5-mysql \
 php5-mcrypt \
 php5-gd \
@@ -39,23 +40,8 @@ WORKDIR /var/www/html
 #Patch bootstrap file
 RUN patch -p1 < /tmp/app_start.patch
 
-#DB create?
-# mysqladmin -u root  create snipeit_laravel
-
-#DB create user, grant access to new DB?
-# grant all privileges on snipeit_laravel.* TO snipeit;
-
-#DB config file init? (NEVER overwrite!)
-#RUN cp -n /var/www/html/app/config/production/database.example.php /var/www/html/app/config/production/database.php
-COPY docker/database.php /var/www/html/app/config/production/database.php
-
-COPY docker/mail.php /var/www/html/app/config/production/mail.php
-
-#change DB file user
-#RUN sed -i s/travis/snipe_it/ /var/www/html/app/config/production/database.php
-
-#init app config file
-COPY docker/app.php /var/www/html/app/config/production/app.php
+#copy all configuration files
+COPY docker/*.php /var/www/html/app/config/production/
 
 RUN chown -R docker /var/www/html
 

--- a/docker/app.php
+++ b/docker/app.php
@@ -1,0 +1,45 @@
+<?php
+
+return array(
+
+    /*
+    |--------------------------------------------------------------------------
+    | Application Debug Mode
+    |--------------------------------------------------------------------------
+    |
+    | When your application is in debug mode, detailed error messages with
+    | stack traces will be shown on every error that occurs within your
+    | application. If disabled, a simple generic error page is shown.
+    |
+    */
+
+    'debug' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Application URL
+    |--------------------------------------------------------------------------
+    |
+    | This URL is used by the console to properly generate URLs when using
+    | the Artisan command line tool. You should set this to the root of
+    | your application so that it is used when running Artisan tasks.
+    |
+    */
+
+    'url' => isset($_ENV['SERVER_URL']) ? $_ENV['SERVER_URL'] : 'https://production.yourserver.com',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Encryption Key
+    |--------------------------------------------------------------------------
+    |
+    | This key is used by the Illuminate encrypter service and should be set
+    | to a random, 32 character string, otherwise these encrypted strings
+    | will not be safe. Please do this before deploying an application!
+    |
+    | Run a php artisan key:generate --env=staging to create a random one
+    */
+
+    'key' => 'Change_this_key_or_snipe_will_get_ya',
+
+);

--- a/docker/ldap.php
+++ b/docker/ldap.php
@@ -1,0 +1,112 @@
+<?php
+
+return array(
+
+    /*
+    |--------------------------------------------------------------------------
+    | URL
+    |--------------------------------------------------------------------------
+    |
+    | URL for the LDAP server. This should start with ldap://, for example:
+    | ldap://ldap.yourserver.com
+    |
+    */
+    'url' => isset($_ENV['LDAP_URL']) ? $_ENV['LDAP_URL'] : "",
+
+
+    /*
+    |--------------------------------------------------------------------------
+    | Username
+    |--------------------------------------------------------------------------
+    |
+    | Username to use to connect authenticate to LDAP, for example:
+    | cn=read-only-admin,dc=example,dc=com
+    |
+    */
+	'username' => isset($_ENV['LDAP_USERNAME']) ? $_ENV['LDAP_USERNAME'] : "",
+
+	/*
+    |--------------------------------------------------------------------------
+    | Password
+    |--------------------------------------------------------------------------
+    |
+    | Password to use when authenticating to LDAP.
+    |
+    */
+	'password' => isset($_ENV['LDAP_PASSWORD']) ? $_ENV['LDAP_PASSWORD'] : "",
+
+	/*
+    |--------------------------------------------------------------------------
+    | Basedn
+    |--------------------------------------------------------------------------
+    |
+    | The base where the search for users will be executed, for example:
+    | dc=example,dc=com
+    |
+    */
+	'basedn' => isset($_ENV['LDAP_BASEDN']) ? $_ENV['LDAP_BASEDN'] : "",
+
+
+	/*
+    |--------------------------------------------------------------------------
+    | Filter
+    |--------------------------------------------------------------------------
+    |
+    | The search filter for the LDAP query. This probably does not have to be
+    | changed.
+    |
+    */
+	'filter' => isset($_ENV['LDAP_FILTER']) ? $_ENV['LDAP_FILTER'] : "&(cn=*)",
+
+
+	/*
+    |--------------------------------------------------------------------------
+    | LDAP field names that will be retrieved to create a user.
+    |
+    | Using the username as an example:
+    | If I set 'result.username' => 'my-org-username', the code will connect to
+    | LDAP as follows (where $results[$i] represents a row in the LDAP query:
+    | $username-to-insert-in-snipe-it = $results[$i]["my-org-username"][0]
+    |
+    | Note: all these fields are required.
+    |--------------------------------------------------------------------------
+    |
+    | The search filter for the LDAP query.
+    |
+    */
+    'result.username' => isset($_ENV['LDAP_RESULT_USERNAME']) ? $_ENV['LDAP_RESULT_USERNAME'] : "",
+    'result.last.name' => isset($_ENV['LDAP_RESULT_LAST_NAME']) ? $_ENV['LDAP_RESULT_LAST_NAME'] : "",
+    'result.first.name' => isset($_ENV['LDAP_RESULT_FIRST_NAME']) ? $_ENV['LDAP_RESULT_FIRST_NAME'] : "",
+
+    /*
+    | These fields are optional as not all LDAP directories will have it.  If yours
+    | does not have them, just leave these blank and the extra check will
+    | be omitted.
+    */
+    'result.active.flag' => isset($_ENV['LDAP_RESULT_ACTIVE_FLAG']) ? $_ENV['LDAP_RESULT_ACTIVE_FLAG'] : "",
+    'result.emp.num' => isset($_ENV['LDAP_RESULT_EMP_NUM']) ? $_ENV['LDAP_RESULT_EMP_NUM'] : "",
+    'result.email' => isset($_ENV['LDAP_RESULT_EMAIL']) ? $_ENV['LDAP_RESULT_EMAIL'] : "",
+
+    /*
+    |--------------------------------------------------------------------------
+    | LDAP filter query for authentication
+    |--------------------------------------------------------------------------
+    |
+    | The LDAP query that we want to execute when authenticating a user. This
+    | should not have to be changed.
+    |
+    */
+    'authentication.filter.query' => isset($_ENV['LDAP_AUTHENTICATION_FILTER_QUERY']) ? $_ENV['LDAP_AUTHENTICATION_FILTER_QUERY'] : "uid=",
+
+    /*
+    |--------------------------------------------------------------------------
+    | LDAP Version
+    |--------------------------------------------------------------------------
+    |
+    | Version of LDAP you are using.
+    |
+    */
+    'version' => 3,
+
+
+);


### PR DESCRIPTION
The current Docker image works great, but it doesn't support the recently added LDAP features. I have added support for LDAP, and made it configurable using environment variables, just like the other features. I intentionally left LDAP disabled if it is not configured.

Additionally, I made a second commit adding support for specifying the server URL (as used for the dashboard URL, as well as in emails). Now the user doesn't have to hand-edit a file inside the container anymore.

Another pull request will be sent with the corresponding documentation updates.