### PR TITLE
Set replace for http on url in app.php

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -148,7 +148,7 @@ if [[ $distro == "u" ]]; then
 	replace "            'password'  => ''," "            'password'  => '$mysqluserpw'," -- $dir/app/config/production/database.php
 	replace "'http://production.yourserver.com'," "'http://$fqdn'," -- $dir/app/config/production/database.php
 	cp $dir/app/config/production/app.example.php $dir/app/config/production/app.php
-	replace "'https://production.yourserver.com'," "'https://$fqdn'," -- $dir/app/config/production/app.php
+	replace "'http://production.yourserver.com'," "'http://$fqdn'," -- $dir/app/config/production/app.php
 	replace "'Change_this_key_or_snipe_will_get_ya'," "'$random32'," -- $dir/app/config/production/app.php
 	replace "'false'," "true," -- $dir/app/config/production/app.php
 	cp $dir/app/config/production/mail.example.php $dir/app/config/production/mail.php


### PR DESCRIPTION
The script keeps the "url" variable set as https in $dir/app/config/production/app.php but the script sets up the apache for http. The only problem this caused for me was the "Dashboard" and "Snipe-IT" button's href was set to https.