### PR TITLE
Change LDAP auth to better handle no user found

### DIFF
--- a/app/controllers/AuthController.php
+++ b/app/controllers/AuthController.php
@@ -45,7 +45,7 @@ class AuthController extends BaseController
             if ($connection) {
                 // binding to ldap server
                 $ldapbind = ldap_bind($connection, $ldaprdn, $ldappass);
-                if ( ($results = @ldap_search($connection, $baseDn, $filterQuery)) !==false ) {
+                if ( ($results = @ldap_search($connection, $baseDn, $filterQuery)) != false ) {
                     $entry = ldap_first_entry($connection, $results);
                     if ( ($userDn = @ldap_get_dn($connection, $entry)) !== false ) {
                         if( ($isBound = ldap_bind($connection, $userDn, $password)) == "true") {


### PR DESCRIPTION
Changing the comparison to not care about type allows for auth to fail when no user is found in the LDAP directory. When a user is not found, `ldap_first_entry` returns `null`, `null !== false` evaluates to `true` while `null != false` evaluates to `false`.

This prevents Snipe-IT from trying to do an Anonymous Bind against the LDAP directory when trying to validate credentials used by a user to login to Snipe-IT. It also prevents the issue raised in #1251 from happening.