### PR TITLE
Fixes Purchase Cost not showing up on custom reports

### DIFF
--- a/app/controllers/admin/ReportsController.php
+++ b/app/controllers/admin/ReportsController.php
@@ -405,7 +405,7 @@ class ReportsController extends AdminController
         if (e( Input::get( 'purchase_date' ) ) == '1') {
             $header[] = 'Purchase Date';
         }
-        if (( e( Input::get( 'purchase_cost' ) ) == '1' ) && ( e( Input::get( 'depreciation' ) ) == '0' )) {
+        if (( e( Input::get( 'purchase_cost' ) ) == '1' ) && ( e( Input::get( 'depreciation' ) ) != '1' )) {
             $header[] = 'Purchase Cost';
         }
         if (e( Input::get( 'order' ) ) == '1') {
@@ -461,7 +461,7 @@ class ReportsController extends AdminController
             if (e( Input::get( 'purchase_date' ) ) == '1') {
                 $row[] = $asset->purchase_date;
             }
-            if (e( Input::get( 'purchase_cost' ) ) == '1') {
+            if (e( Input::get( 'purchase_cost' ) ) == '1' && ( e( Input::get( 'depreciation' ) ) != '1' )) {
                 $row[] = '"' . number_format( $asset->purchase_cost ) . '"';
             }
             if (e( Input::get( 'order' ) ) == '1') {


### PR DESCRIPTION
Fixes #1226. The code was looking for the 'depreciation' input to be '0' when not checked, but `Input::get` was returning null. Added the same check to where the actual value is inputted which was causing the headers to be misaligned when Purchase Cost and Depreciation were both checked.