### PR TITLE
Images for devices on the Assets datatable page.

### DIFF
--- a/app/controllers/admin/AssetsController.php
+++ b/app/controllers/admin/AssetsController.php
@@ -171,17 +171,6 @@ class AssetsController extends AdminController
             $asset->physical            		= '1';
             $asset->depreciate          		= '0';
 
-	    // Create the image (if one was chosen.)
-            if (Input::file('image')) {
-                $image = Input::file('image');
-                $file_name = str_random(25).".".$image->getClientOriginalExtension();
-                $path = public_path('uploads/assets/'.$file_name);
-                Image::make($image->getRealPath())->resize(300, null, function ($constraint) {
-                    $constraint->aspectRatio();
-                    $constraint->upsize();
-                })->save($path);
-                $asset->image = $file_name;
-
 
             // Was the asset created?
             if($asset->save()) {
@@ -195,6 +184,17 @@ class AssetsController extends AdminController
 					$logaction->note = e(Input::get('note'));
 					$log = $logaction->logaction('checkout');
 				}
+	    // Create the image (if one was chosen.)
+            if (Input::file('image')) {
+                $image = Input::file('image');
+                $file_name = str_random(25).".".$image->getClientOriginalExtension();
+                $path = public_path('uploads/assets/'.$file_name);
+                Image::make($image->getRealPath())->resize(300, null, function ($constraint) {
+                    $constraint->aspectRatio();
+                    $constraint->upsize();
+                })->save($path);
+                $asset->image = $file_name;
+
             }
                 // Redirect to the asset listing page
                 return Redirect::to("hardware")->with('success', Lang::get('admin/hardware/message.create.success'));

--- a/app/controllers/admin/AssetsController.php
+++ b/app/controllers/admin/AssetsController.php
@@ -171,6 +171,18 @@ class AssetsController extends AdminController
             $asset->physical            		= '1';
             $asset->depreciate          		= '0';
 
+	    // Create the image (if one was chosen.)
+            if (Input::file('image')) {
+                $image = Input::file('image');
+                $file_name = str_random(25).".".$image->getClientOriginalExtension();
+                $path = public_path('uploads/assets/'.$file_name);
+                Image::make($image->getRealPath())->resize(300, null, function ($constraint) {
+                    $constraint->aspectRatio();
+                    $constraint->upsize();
+                })->save($path);
+                $asset->image = $file_name;
+
+            }
 
             // Was the asset created?
             if($asset->save()) {
@@ -184,18 +196,6 @@ class AssetsController extends AdminController
 					$logaction->note = e(Input::get('note'));
 					$log = $logaction->logaction('checkout');
 				}
-	    // Create the image (if one was chosen.)
-            if (Input::file('image')) {
-                $image = Input::file('image');
-                $file_name = str_random(25).".".$image->getClientOriginalExtension();
-                $path = public_path('uploads/assets/'.$file_name);
-                Image::make($image->getRealPath())->resize(300, null, function ($constraint) {
-                    $constraint->aspectRatio();
-                    $constraint->upsize();
-                })->save($path);
-                $asset->image = $file_name;
-
-            }
                 // Redirect to the asset listing page
                 return Redirect::to("hardware")->with('success', Lang::get('admin/hardware/message.create.success'));
             }

--- a/app/controllers/admin/AssetsController.php
+++ b/app/controllers/admin/AssetsController.php
@@ -2,6 +2,7 @@
 
 use AdminController;
 use Input;
+use Image;
 use Lang;
 use Asset;
 use Supplier;
@@ -29,6 +30,7 @@ use Paginator;
 use Manufacturer; //for embedded-create
 use Artisan;
 use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\HttpFoundation\JsonResponse;
 
 
 class AssetsController extends AdminController
@@ -169,6 +171,18 @@ class AssetsController extends AdminController
             $asset->physical            		= '1';
             $asset->depreciate          		= '0';
 
+	    // Create the image (if one was chosen.)
+            if (Input::file('image')) {
+                $image = Input::file('image');
+                $file_name = str_random(25).".".$image->getClientOriginalExtension();
+                $path = public_path('uploads/assets/'.$file_name);
+                Image::make($image->getRealPath())->resize(300, null, function ($constraint) {
+                    $constraint->aspectRatio();
+                    $constraint->upsize();
+                })->save($path);
+                $asset->image = $file_name;
+
+
             // Was the asset created?
             if($asset->save()) {
 
@@ -181,7 +195,7 @@ class AssetsController extends AdminController
 					$logaction->note = e(Input::get('note'));
 					$log = $logaction->logaction('checkout');
 				}
-
+            }
                 // Redirect to the asset listing page
                 return Redirect::to("hardware")->with('success', Lang::get('admin/hardware/message.create.success'));
             }
@@ -307,6 +321,20 @@ class AssetsController extends AdminController
             $asset->asset_tag           	= e(Input::get('asset_tag'));
             $asset->notes            		= e(Input::get('notes'));
             $asset->physical            	= '1';
+
+	    // Update the image
+            if (Input::file('image')) {
+                $image = Input::file('image');
+		  $file_name = str_random(25).".".$image->getClientOriginalExtension();
+                $path = public_path('uploads/assets/'.$file_name);
+                Image::make($image->getRealPath())->resize(300, null, function ($constraint) {
+                    $constraint->aspectRatio();
+                    $constraint->upsize();
+                })->save($path);
+                $asset->image = $file_name;
+            }
+
+
 
             // Was the asset updated?
             if($asset->save()) {
@@ -1208,6 +1236,7 @@ class AssetsController extends AdminController
         $rows[] = array(
             'checkbox'      =>'<div class="text-center"><input type="checkbox" name="edit_asset['.$asset->id.']" class="one_required"></div>',
             'id'        => $asset->id,
+            'image'          => ($asset->image!='') ? '<img src="/uploads/assets/'.$asset->image.'" height=50 width=50></img>' : (($asset->model->image!='') ? '<img src="/uploads/models/'.$asset->model->image.'" height=40 width=50></img>' : ''),
             'name'          => '<a title="'.$asset->name.'" href="hardware/'.$asset->id.'/view">'.$asset->name.'</a>',
             'asset_tag'     => '<a title="'.$asset->asset_tag.'" href="hardware/'.$asset->id.'/view">'.$asset->asset_tag.'</a>',
             'serial'        => $asset->serial,

--- a/app/database/migrations/2015_11_05_183749_image.php
+++ b/app/database/migrations/2015_11_05_183749_image.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class Image extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::table('assets', function(Blueprint $table)
+		{
+			$table->text('image')->after('notes')->nullable();
+			//
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::table('assets', function(Blueprint $table)
+		{
+			//
+		});
+	}
+
+}

--- a/app/lang/en/admin/hardware/table.php
+++ b/app/lang/en/admin/hardware/table.php
@@ -18,6 +18,7 @@ return array(
     'serial'   		=> 'Serial',
     'status'   		=> 'Status',
     'title'      	=> 'Asset ',
+    'image'		=> 'Device Image',
     'days_without_acceptance' => 'Days Without Acceptance'
 
 );

--- a/app/lang/en/general.php
+++ b/app/lang/en/general.php
@@ -140,4 +140,5 @@
     'years'					=> 'years',
     'yes' 					=> 'Yes',
     'zip'  					=> 'Zip',
+    'noimage'					=> 'No image uploaded or image not found.',
     ];

--- a/app/views/backend/hardware/edit.blade.php
+++ b/app/views/backend/hardware/edit.blade.php
@@ -113,9 +113,9 @@
             <div class="col-md-12 column">
 
 			 @if ($asset->id)
-				 <form class="form-horizontal" method="post" action="{{ route('update/hardware',$asset->id) }}" autocomplete="off" role="form">
+				 <form class="form-horizontal" method="post" action="{{ route('update/hardware',$asset->id) }}" autocomplete="off" role="form" enctype="multipart/form-data" >
 			 @else
-				 <form class="form-horizontal" method="post" action="{{ route('savenew/hardware') }}" autocomplete="off" role="form">
+				 <form class="form-horizontal" method="post" action="{{ route('savenew/hardware') }}" autocomplete="off" role="form" enctype="multipart/form-data">
 			 @endif
 
             <!-- CSRF Token -->
@@ -300,11 +300,33 @@
 		  	</div>
 
 
+            <!-- Image -->
+            @if ($asset->image)
+                <div class="form-group {{ $errors->has('image_delete') ? 'has-error' : '' }}">
+                    <label class="col-md-2 control-label" for="image_delete">@lang('general.image_delete')</label>
+                    <div class="col-md-5">
+                        {{ Form::checkbox('image_delete') }}
+                        <img src="/uploads/assets/{{{ $asset->image }}}" />
+                        {{ $errors->first('image_delete', '<br><span class="alert-msg">:message</span>') }}
+                    </div>
+                </div>
+            @endif
+
+            <div class="form-group {{ $errors->has('image') ? 'has-error' : '' }}">
+                <label class="col-md-2 control-label" for="image">@lang('general.image_upload')</label>
+                <div class="col-md-5">
+                    {{ Form::file('image') }}
+                    {{ $errors->first('image', '<br><span class="alert-msg">:message</span>') }}
+                </div>
+            </div>
+
+
+
             <!-- Form actions -->
                 <div class="form-group">
                 <label class="col-md-2 control-label"></label>
                     <div class="col-md-7 col-sm-12">
-                        <a class="btn btn-link" href="{{ URL::previous() }}">@lang('button.cancel')</a>
+                        <a class="btn btn-link" href="{{ URL::previous() }}" method="post" enctype="multipart/form-data">@lang('button.cancel')</a>
                         <button type="submit" class="btn btn-success"><i class="fa fa-check icon-white"></i> @lang('general.save')</button>
                     </div>
                 </div>

--- a/app/views/backend/hardware/index.blade.php
+++ b/app/views/backend/hardware/index.blade.php
@@ -67,6 +67,7 @@
 
                 <th data-class="hidden-xs" data-switchable="false" data-searchable="false" data-sortable="false" data-field="checkbox"><div class="text-center"><input type="checkbox" id="checkAll" style="padding-left: 0px;"></div></th>
                 <th data-sortable="true" data-field="id" data-visible="false">@lang('general.id')</th>
+                <th data-sortable="true" data-field="image"  data-visible="false">@lang('admin/hardware/table.image')</th>
                 <th data-sortable="true" data-field="name"  data-visible="false">@lang('admin/hardware/form.name')</th>
                 <th data-sortable="true" data-field="asset_tag">@lang('admin/hardware/table.asset_tag')</th>
                 <th data-sortable="true" data-field="serial">@lang('admin/hardware/table.serial')</th>

--- a/app/views/backend/hardware/view.blade.php
+++ b/app/views/backend/hardware/view.blade.php
@@ -38,8 +38,6 @@
                 <li role="presentation"><a href="{{ route('clone/hardware', $asset->id) }}">@lang('admin/hardware/general.clone')</a></li>
             </ul>
         </div>
-
-
     </div>
 </div>
 </div>
@@ -47,7 +45,6 @@
 <div class="user-profile">
 <div class="row profile">
 <div class="col-md-9 bio">
-
 		@if ($asset->model->deleted_at!='')
             <div class="alert alert-warning alert-block">
 				<i class="fa fa-warning"></i>
@@ -144,6 +141,7 @@
         @endif
 
 
+
         @if ($asset->model->eol)
             <div class="col-md-12" style="padding-bottom: 5px;">
             <strong>@lang('admin/hardware/form.eol_rate'): </strong>
@@ -178,10 +176,11 @@
 
 
 <div class="col-md-12">
+
   		<!-- Licenses assets table -->
         <h6>Software Assigned </h6>
-		<br>
-		<!-- checked out assets table -->
+
+
 		@if (count($asset->licenses) > 0)
 		<table class="table table-hover">
 			<thead>
@@ -295,8 +294,6 @@
                          @else
                               {{{ $file->filename }}}
                          @endif
-
-
                     </td>
                     <td>
                         @if ($file->filename)
@@ -408,6 +405,14 @@
             </ul>
             @endif
 
+		<!-- Is there an image to show? -->
+                 @if ($asset->image)
+                     <h6><img src="{{ Config::get('app.url') }}/uploads/assets/{{{ $asset->image }}}"</img></h6>
+		 @else
+		     <h6><br/><p>@lang('general.noimage')<p></h6></br>
+                 @endif
+
+		<!-- checked out assets table -->
 
             @if (($asset->assigneduser) && ($asset->assigned_to > 0) && ($asset->deleted_at==''))
                 <h6><br>@lang('admin/hardware/form.checkedout_to')</h6>
@@ -415,6 +420,8 @@
 
                     <li><img src="{{{ $asset->assigneduser->gravatar() }}}" class="img-circle" style="width: 100px; margin-right: 20px;" /><br /><br /></li>
                     <li><a href="{{ route('view/user', $asset->assigned_to) }}">{{ $asset->assigneduser->fullName() }}</a></li>
+		<br>
+
 
 
                     @if (isset($asset->userloc))


### PR DESCRIPTION
Hey there, hoping the powers that be can help me out here:

This PR is my current progress for adding images for each asset per device on the datatable.

A user can upload an image for a model and use that as the generic image for the asset on the asset datatable page, OR they can override the model image by uploading their own for that particular device

I have one major problem that I cannot figure out for the life of me:

Inserting images works as intended, except that if you create an asset and upload an image at the same time, it will only use the model image. No file is uploaded and no entry is made for the image column of the asset (in the assets table.) 

However, If you go back in and edit that same asset, upload an image, it comes up with the correct (uploaded) image. I'm at a loss because I don't know where else to look.
I'm going to keep playing around, but If @snipe / @uberbrady or anyone else can point me in the right direction, that'd be greatly appreciated. Bear with me as I learn this stuff :P