### PR TITLE
Custom Fields - shouldn't be able to add the same field twice to the same fieldset

### DIFF
--- a/app/controllers/admin/CustomFieldsController.php
+++ b/app/controllers/admin/CustomFieldsController.php
@@ -53,8 +53,19 @@ class CustomFieldsController extends \BaseController {
 	
 	public function associate($id)
 	{
-		print "ID is: $id";
+		//print "ID is: $id";
 		$set=CustomFieldset::find($id);
+		//print_r($set->fields());
+		foreach($set->fields AS $field) {
+			//print_r($field);
+			//print "Field ID of this particular field is:".$field->id.", and we are checking for: ".Input::get('field_id');
+			if($field->id == Input::get('field_id')) {
+				//print "I want to redirect back in failure";
+				//exit(-2);
+				return Redirect::route("admin.custom_fields.show",[$id])->withInput()->withErrors(['field_id' => "Field already added"]);
+			}
+		}
+		exit(-1);
 		$results=$set->fields()->attach(Input::get('field_id'),["required" => (Input::get('required') == "on"),"order" => Input::get('order')]);
 		//return "I assoced it. Results: $results";
 		return Redirect::route("admin.custom_fields.show",[$id]); //redirect(["asdf" => "alskdjf"]);
@@ -101,13 +112,21 @@ class CustomFieldsController extends \BaseController {
 		
 		//print_r($parameters);
 		//
+		$custom_fields_list=["" => "Add New Field to Fieldset"] + CustomField::lists("name","id");
+		// print_r($custom_fields_list);
 		$maxid=0;
 		foreach($cfset->fields AS $field) {
+			// print "Looking for: ".$field->id;
 			if($field->pivot->order > $maxid) {
 				$maxid=$field->pivot->order;
 			}
+			if(isset($custom_fields_list[$field->id])) {
+				// print "Found ".$field->id.", so removing it.<br>";
+				unset($custom_fields_list[$field->id]);
+			}
 		}
-		return View::make("backend.custom_fields.show")->with("custom_fieldset",$cfset)->with("maxid",$maxid+1);
+		
+		return View::make("backend.custom_fields.show")->with("custom_fieldset",$cfset)->with("maxid",$maxid+1)->with("custom_fields_list",$custom_fields_list);
 	}
 
 

--- a/app/controllers/admin/CustomFieldsController.php
+++ b/app/controllers/admin/CustomFieldsController.php
@@ -1,4 +1,4 @@
-<?php
+<?php namespace Controllers\Admin;
 
 class CustomFieldsController extends \BaseController {
 

--- a/app/controllers/admin/CustomFieldsController.php
+++ b/app/controllers/admin/CustomFieldsController.php
@@ -1,5 +1,12 @@
 <?php namespace Controllers\Admin;
 
+use View;
+use CustomFieldset;
+use CustomField;
+use Input;
+use Validator;
+use Redirect;
+
 class CustomFieldsController extends \BaseController {
 
 	/**
@@ -7,7 +14,7 @@ class CustomFieldsController extends \BaseController {
 	 *
 	 * @return Response
 	 */
-	public function getIndex()
+	public function index()
 	{
 		//
 		return View::make("backend.custom_fields.index")->with("custom_fieldsets",CustomFieldset::all())->with("custom_fields",CustomField::all());
@@ -19,7 +26,7 @@ class CustomFieldsController extends \BaseController {
 	 *
 	 * @return Response
 	 */
-	public function getCreate()
+	public function create()
 	{
 		//
 		return View::make("backend.custom_fields.create");
@@ -31,34 +38,34 @@ class CustomFieldsController extends \BaseController {
 	 *
 	 * @return Response
 	 */
-	public function postIndex()
+	public function store()
 	{
 		//
 		$cfset=new CustomFieldset(["name" => Input::get("name")]);
 		$validator=Validator::make(Input::all(),$cfset->rules);
 		if($validator->passes()) {
 			$cfset->save();
-			return Redirect::to("/custom_fieldsets/".$cfset->id); //redirect(["asdf" => "alskdjf"]);
+			return Redirect::route("admin.custom_fields.show",[$cfset->id]); //redirect(["asdf" => "alskdjf"]);
 		} else {
 			return Redirect::back()->withInput()->withErrors($validator);
 		}
 	}
 	
-	public function postAssociate($id)
+	public function associate($id)
 	{
 		print "ID is: $id";
 		$set=CustomFieldset::find($id);
 		$results=$set->fields()->attach(Input::get('field_id'),["required" => (Input::get('required') == "on"),"order" => Input::get('order')]);
 		//return "I assoced it. Results: $results";
-		return Redirect::to("/custom_fieldsets/".$id); //redirect(["asdf" => "alskdjf"]);
+		return Redirect::route("admin.custom_fields.show",[$id]); //redirect(["asdf" => "alskdjf"]);
 	}
 	
-	public function getCreateField()
+	public function createField()
 	{
 		return View::make("backend.custom_fields.create_field");
 	}
 	
-	public function postCreateField()
+	public function storeField()
 	{
 		$field=new CustomField(["name" => Input::get("name"),"element" => Input::get("element")]);
 		if(!in_array(Input::get('format'),["ALPHA","NUMERIC","MAC","IP"])) {
@@ -72,7 +79,7 @@ class CustomFieldsController extends \BaseController {
 			$results=$field->save();
 			//return "postCreateField: $results";
 			if ($results) {
-				return Redirect::to("/custom_fieldsets/");
+				return Redirect::route("admin.custom_fields.index");
 			} else {
 				return Redirect::back()->withInput()->withErrors(['message' => "Failed to save?"]);
 			}
@@ -87,9 +94,9 @@ class CustomFieldsController extends \BaseController {
 	 * @param  int  $id
 	 * @return Response
 	 */
-	public function missingMethod($parameters = array())
+	public function show($id)
 	{
-		$id=$parameters[0];
+		//$id=$parameters[0];
 		$cfset=CustomFieldset::find($id);
 		
 		//print_r($parameters);

--- a/app/routes.php
+++ b/app/routes.php
@@ -140,13 +140,6 @@
         } );
     } );
 
-    
-    # Custom fieldset
-    //Route::get('/custom_fieldsets/{id}','CustomFieldsController@show');
-    //Route::get('/custom_fieldsets/create','CustomFieldsController@getCreate');
-    Route::post('/custom_fieldsets/{id}/associate','CustomFieldsController@postAssociate');
-    Route::controller('/custom_fieldsets','CustomFieldsController' );
-
     /*
     |--------------------------------------------------------------------------
     | Asset Routes
@@ -467,6 +460,12 @@
             } );
 
         } );
+
+        # Custom fieldset
+        //Route::get('/custom_fieldsets/{id}','CustomFieldsController@show');
+        //Route::get('/custom_fieldsets/create','CustomFieldsController@getCreate');
+        // Route::post(['prefix' => 'custom_fieldsets/{id}/associate','CustomFieldsController@postAssociate');
+        Route::controller('custom_fieldsets','CustomFieldsController');
 
         # User Management
         Route::group( [ 'prefix' => 'users' ], function () {

--- a/app/routes.php
+++ b/app/routes.php
@@ -465,7 +465,11 @@
         //Route::get('/custom_fieldsets/{id}','CustomFieldsController@show');
         //Route::get('/custom_fieldsets/create','CustomFieldsController@getCreate');
         // Route::post(['prefix' => 'custom_fieldsets/{id}/associate','CustomFieldsController@postAssociate');
-        Route::controller('custom_fieldsets','CustomFieldsController');
+        Route::get('custom_fields/create-field',['uses' =>'CustomFieldsController@createField','as' => 'admin.custom_fields.create-field']); //['prefix' => 'custom_fields',]
+        Route::post('custom_fields/create-field',['uses' => 'CustomFieldsController@storeField','as' => 'admin.custom_fields.store-field']);
+        Route::post('custom_fields/{id}/associate',['uses' => 'CustomFieldsController@associate','as' => 'admin.custom_fields.associate']);
+        Route::resource('custom_fields','CustomFieldsController');
+        //Route::controller('custom_fields','CustomFieldsController');
 
         # User Management
         Route::group( [ 'prefix' => 'users' ], function () {

--- a/app/views/backend/custom_fields/create.blade.php
+++ b/app/views/backend/custom_fields/create.blade.php
@@ -1,9 +1,9 @@
 @extends('backend/layouts/default')
 @section('content')
 
-<?= Form::open(['url' => '/custom_fieldsets']) ?>
+<?= Form::open(['route' => 'admin.custom_fields.store']) ?>
   Name: {{Form::text("name",Input::old('name'))}}<span class="alert-msg"><?= $errors->first('name'); ?></span><br />
   <input type='submit'>
 </form>
-<br><a href='/custom_fieldsets'>Back to Custom Fieldset List</a>
+<br>{{ link_to_route('admin.custom_fields.index',"Back to Custom Fieldset List")}}
 @stop

--- a/app/views/backend/custom_fields/create_field.blade.php
+++ b/app/views/backend/custom_fields/create_field.blade.php
@@ -1,13 +1,15 @@
 @extends('backend/layouts/default')
 @section('content')
 
-
-{{ Form::open(["url" =>"/custom_fieldsets/create-field"])}}
+{{-- 
+['url' => '/admin/custom_fields/create-field']
+--}}
+{{ Form::open(["route" => 'admin.custom_fields.store-field'] )}}
 Name: {{ Form::text("name")}}<span class="alert-msg"><?= $errors->first('name'); ?></span><br>
 type: {{ Form::select("element",["text" => "Text Box"])}}<span class="alert-msg"><?= $errors->first('element'); ?></span><br>
 format: {{ Form::select("format",predefined_formats(),"ANY") }}<span class="alert-msg"><?= $errors->first('format'); ?></span>
 Custom Format (if selected): {{ Form::text("custom_format") }}<br>
 <input type='submit'>
 {{ Form::close() }}
-<br><a href='/custom_fieldsets'>Back to Custom Fieldset List</a>
+<br>{{ link_to_route('admin.custom_fields.index',"Back to Custom Fieldset List") }}
 @stop

--- a/app/views/backend/custom_fields/index.blade.php
+++ b/app/views/backend/custom_fields/index.blade.php
@@ -1,21 +1,19 @@
 @extends('backend/layouts/default')
 @section('content')
-<?
-?>
-
 <h2>Fieldsets</h2>
 <ul>
 @foreach($custom_fieldsets AS $fieldset)
-<li><a href='/custom_fieldsets/{{$fieldset->id}}'>{{{$fieldset->name}}}</li>
+{{-- FIXME - should we be using a 'Resource' instead of 'Controller' here? --}}
+<li>{{link_to_route("admin.custom_fields.show",$fieldset->name,['id' => $fieldset->id])}}</li>
 @endforeach
 </ul>
 
-<a href='/custom_fieldsets/create'>New Fieldset</a><br>
+{{link_to_route("admin.custom_fields.create","New Fieldset")}}<br>
 <h2>Custom Field Definitions</h2>
 <ul>
   @foreach($custom_fields AS $field) 
   <li>{{{$field->name}}}, {{{$field->format}}}</li>
   @endforeach
 </ul>
-<a href='/custom_fieldsets/create-field'>New Field</a>
+{{link_to_route("admin.custom_fields.create-field","New Field")}}
 @stop

--- a/app/views/backend/custom_fields/show.blade.php
+++ b/app/views/backend/custom_fields/show.blade.php
@@ -8,9 +8,9 @@
 <li>{{$field->pivot->order}}) {{$field->name}}, {{$field->format}}, {{$field->pivot->required ? "REQUIRED" : "OPTIONAL"}}</li>
 @endforeach
 </ul>
-{{ Form::open(['url' => '/custom_fieldsets/'.$custom_fieldset->id.'/associate']) }}
+{{ Form::open(['route' => ["admin.custom_fields.associate",$custom_fieldset->id]]) }}
 {{ Form::checkbox("required","on") }}Required?
 {{ Form::text("order",$maxid)}}
 {{ Form::select("field_id",["" => "Add New Field to Fieldset"] + CustomField::lists("name","id"),"",["onchange" => "document.forms[0].submit()"]) }}
-<br><a href='/custom_fieldsets'>Back to Custom Fieldset List</a>
+<br>{{link_to_route("admin.custom_fields.index","Back to Custom Fieldset List")}}
 @stop

--- a/app/views/backend/custom_fields/show.blade.php
+++ b/app/views/backend/custom_fields/show.blade.php
@@ -11,6 +11,7 @@
 {{ Form::open(['route' => ["admin.custom_fields.associate",$custom_fieldset->id]]) }}
 {{ Form::checkbox("required","on") }}Required?
 {{ Form::text("order",$maxid)}}
-{{ Form::select("field_id",["" => "Add New Field to Fieldset"] + CustomField::lists("name","id"),"",["onchange" => "document.forms[0].submit()"]) }}
+{{ Form::select("field_id",$custom_fields_list,"",["onchange" => "document.forms[0].submit()"]) }}
+<span class="alert-msg"><?= $errors->first('field_id'); ?></span>
 <br>{{link_to_route("admin.custom_fields.index","Back to Custom Fieldset List")}}
 @stop

--- a/app/views/backend/layouts/default.blade.php
+++ b/app/views/backend/layouts/default.blade.php
@@ -249,9 +249,9 @@
                                 <i class="fa fa-download fa-fw"></i> @lang('admin/settings/general.backups')
                             </a>
                         </li>
-                        <li{{ (Request::is('custom_fieldsets*') ? ' class="active"' : '') }}>
-                            <a href="{{ URL::to('custom_fieldsets') }}">
-                                <i class="fa fa-wrench fa-fw"></i> Custom Fields?
+                        <li{{ (Request::is('admin/custom_fields*') ? ' class="active"' : '') }}>
+                            <a href="{{ route('admin.custom_fields.index') }}">
+                                <i class="fa fa-wrench fa-fw"></i> Custom Fields
                             </a>
                         </li>
                         <li class="divider"></li>


### PR DESCRIPTION
Helps with another checkbox on #1397 - the one where you can add the same field twice to a fieldset. Now the back end will disallow it, and the front end won't prompt you with it to start with (so the back-end piece should never fire. But better to be safe than sorry.)

Requires PR #1408 to be merged first.