### PR TITLE
Fix Asset Maintenance date and consumable counts

### DIFF
--- a/app/controllers/admin/AssetMaintenancesController.php
+++ b/app/controllers/admin/AssetMaintenancesController.php
@@ -107,7 +107,7 @@
                  'cost'          => $maintenance_cost,
                  'asset_maintenance_type'          => e($maintenance->asset_maintenance_type),
                  'start_date'         => $maintenance->start_date,
-                 'time'          => $maintenance->asset_maintenance_time,
+                 'asset_maintenance_time'          => $maintenance->asset_maintenance_time,
                  'completion_date'     => $maintenance->completion_date,
                  'actions'       => $actions,
                  'companyName'   => is_null($company) ? '' : $company->name
@@ -231,6 +231,16 @@
                     || ( $assetMaintenance->completion_date == "0000-00-00" )
                 ) {
                     $assetMaintenance->completion_date = null;
+                }
+
+                if (( $assetMaintenance->completion_date !== "" )
+                    && ( $assetMaintenance->completion_date !== "0000-00-00" )
+                    && ( $assetMaintenance->start_date !== "" )
+                    && ( $assetMaintenance->start_date !== "0000-00-00" )
+                ) {
+                    $startDate                                = Carbon::parse( $assetMaintenance->start_date );
+                    $completionDate                           = Carbon::parse( $assetMaintenance->completion_date );
+                    $assetMaintenance->asset_maintenance_time = $completionDate->diffInDays( $startDate );
                 }
 
                 // Was the asset maintenance created?

--- a/app/controllers/admin/CategoriesController.php
+++ b/app/controllers/admin/CategoriesController.php
@@ -250,12 +250,11 @@ class CategoriesController extends AdminController
 
         foreach ($categories as $category) {
             $actions = '<a href="'.route('update/category', $category->id).'" class="btn btn-warning btn-sm" style="margin-right:5px;"><i class="fa fa-pencil icon-white"></i></a><a data-html="false" class="btn delete-asset btn-danger btn-sm" data-toggle="modal" href="'.route('delete/category', $category->id).'" data-content="'.Lang::get('admin/categories/message.delete.confirm').'" data-title="'.Lang::get('general.delete').' '.htmlspecialchars($category->name).'?" onClick="return false;"><i class="fa fa-trash icon-white"></i></a>';
-
             $rows[] = array(
                 'id'      => $category->id,
                 'name'  => link_to('/admin/settings/categories/'.$category->id.'/view', $category->name) ,
                 'category_type' => ucwords($category->category_type),
-                'count'         => ($category->category_type=='asset') ?  $category->assetscount() : $category->accessoriescount(),
+                'count'         => $category->itemCount(),
                 'acceptance'    => ($category->require_acceptance=='1') ? '<i class="fa fa-check"></i>' : '',
                 //EULA is still not working correctly
                 'eula'          => ($category->getEula()) ? '<i class="fa fa-check"></i>' : '',

--- a/app/models/Category.php
+++ b/app/models/Category.php
@@ -35,6 +35,28 @@ class Category extends Elegant
         return $this->hasMany('Accessory');
     }
 
+    public function consumablesCount()
+    {
+        return $this->hasMany('Consumable')->count();
+    }
+
+    public function consumables()
+    {
+        return $this->hasMany('Consumable');
+    }
+
+    public function itemCount()
+    {
+        switch ($this->category_type) {
+            case 'asset':
+                return $this->assetscount();
+            case 'accessory':
+                return $this->accessoriescount();
+            case 'consumable':
+                return $this->consumablesCount();
+        }
+        return '0';
+    }
 
     public function assets()
     {

--- a/app/views/backend/asset_maintenances/view.blade.php
+++ b/app/views/backend/asset_maintenances/view.blade.php
@@ -68,19 +68,12 @@ use Carbon\Carbon;
                     </div>
                     <div class="col-md-3 col-sm-3" style="padding-bottom: 10px; margin-left: 15px; word-wrap: break-word;">
                         <strong>@lang('admin/asset_maintenances/form.completion_date'): </strong>
-                        <?php if (is_null($assetMaintenance->completion_date)) {
-                            $calculationEndDate = Carbon::now();
-                            $completionDate = NULL;
-                        } else {
-                            $completionDate = Carbon::parse($assetMaintenance->completion_date);
-                            $calculationEndDate = $completionDate;
-                        }
-                        ?>
-                        {{{ $completionDate ? $completionDate->toDateString() : Lang::get('admin/asset_maintenances/message.asset_maintenance_incomplete') }}}
+			{{ $completionDate = $assetMaintenance->completion_date }}
+                        {{{ $completionDate ? $completionDate : Lang::get('admin/asset_maintenances/message.asset_maintenance_incomplete') }}}
                     </div>
                     <div class="col-md-3 col-sm-3" style="padding-bottom: 10px; margin-left: 15px; word-wrap: break-word;">
                         <strong>@lang('admin/asset_maintenances/form.asset_maintenance_time'): </strong>
-                        {{ $calculationEndDate->diffInDays($startDate) }}
+                        {{ $assetMaintenance->asset_maintenance_time }}
                     </div>
                 </div>
                 <!-- 3rd Row End -->


### PR DESCRIPTION
This fixes a few separate things, but git is hard.

1)  Adds consumables() and consumablesCount() to CategoriesController and refactors to use this.  Fixes counts of Consumables Categories in the category display.

2) At present, Asset Maintenance would not set asset_maintenance_time if the start and end date were set on creation, rather than on edit.  This fixes that.  This also fixes a bug that would prevent showing the length of maintenance in the table.  We might want to do some sort of DB migration to insert asset_maintenance_time for any asset maintenances that have a begin and end date but a time of null, to fix any current existing issues of this, but I'm not certain thats the correct fix.

Thanks!