### PR TITLE
Fix 1531

### DIFF
--- a/app/controllers/admin/AssetsController.php
+++ b/app/controllers/admin/AssetsController.php
@@ -576,6 +576,9 @@ class AssetsController extends AdminController
         // Update the asset data to null, since it's being checked in
         $asset->assigned_to            		= NULL;
         $asset->accepted                  = NULL;
+        
+        $asset->expected_checkin = NULL;
+        $asset->last_checkout = NULL;
 
 
         // Was the asset updated?

--- a/app/controllers/admin/UsersController.php
+++ b/app/controllers/admin/UsersController.php
@@ -536,7 +536,12 @@ class UsersController extends AdminController {
                 unset($user_raw_array[$key]);
             }
 
-            if (!Config::get('app.lock_passwords')) {
+            if (!Sentry::getUser()->isSuperUser()) {
+                // Redirect to the user management page
+                return Redirect::route('users')->with('error', 'Insufficient permissions!');
+            } else if (Config::get('app.lock_passwords')) {
+                return Redirect::route('users')->with('error', 'Bulk delete is not enabled in this installation');
+            } else {
 
                 $assets = Asset::whereIn('assigned_to', $user_raw_array)->get();
                 $accessories = DB::table('accessories_users')->whereIn('assigned_to', $user_raw_array)->get();
@@ -583,8 +588,6 @@ class UsersController extends AdminController {
 
 
                 return Redirect::route('users')->with('success', 'Your selected users have been deleted and their assets have been updated.');
-            } else {
-                return Redirect::route('users')->with('error', 'Bulk delete is not enabled in this installation');
             }
 
             return Redirect::route('users')->with('error', 'An error has occurred');

--- a/app/views/backend/users/index.blade.php
+++ b/app/views/backend/users/index.blade.php
@@ -79,9 +79,12 @@
                    </th>
                    <th data-sortable="false" data-field="groups">{{ Lang::get('general.groups') }}</th>
                    <th data-sortable="true" data-field="notes">{{ Lang::get('general.notes') }}</th>
-                   <th data-switchable="false" data-searchable="false" data-sortable="false" data-field="actions" >{{ Lang::get('table.actions') }}</th>
+                   @if (Input::get('status')!='deleted')
+                    <th data-switchable="false" data-searchable="false" data-sortable="false" data-field="actions" >{{ Lang::get('table.actions') }}</th>
+                   @endif
                </tr>
            </thead>
+           @if (Input::get('status')!='deleted')
            <tfoot>
                <tr>
                    <td colspan="12">
@@ -92,6 +95,7 @@
                    </td>
                </tr>
            </tfoot>
+           @endif
        </table>
 
     {{ Form::close() }}


### PR DESCRIPTION
This clears the last checkout and expected checkin date fields when checking an asset back in.  The information is still stored in the log long term.