### PR TITLE
Clear checkout and checkin fields when returning an asset.

### DIFF
--- a/app/controllers/admin/AssetsController.php
+++ b/app/controllers/admin/AssetsController.php
@@ -577,6 +577,8 @@ class AssetsController extends AdminController
         $asset->assigned_to            		= NULL;
         $asset->accepted                  = NULL;
 
+        $asset->expected_checkin = NULL;
+        $asset->last_checkout = NULL;
 
         // Was the asset updated?
         if($asset->save()) {


### PR DESCRIPTION
This clears the last checkout and expected checkin fields when checking an asset back in. The data is still preserved in the log. Fixes #1531 (this time based on the proper HEAD) Third time is the charm?