### PR TITLE
Configuration Volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,9 @@ RUN sed -i 's/return $app;/$env="production";\nreturn $app;/' bootstrap/start.ph
 
 #copy all configuration files
 COPY docker/*.php /var/www/html/app/config/production/
+RUN mkdir /opt/snipe-it && cd /opt/snipe-it && ln -s -T /var/www/html/app/config/production/ config
+# Create a volume for attaching to from outside the container, if desired.
+VOLUME /opt/snipe-it/config
 
 RUN chown -R docker /var/www/html
 


### PR DESCRIPTION
Having the ability to optionally store config outside of the container is desirable - this means that when a new version of the container is released, the existing container can be removed and replaced without any configuration data being lost.

In particular, this means that a container like watchtower (https://github.com/CenturyLinkLabs/watchtower) can do this automatically when a new container is pushed (although running migrations automatically when the new container is launched may be required in that case)

Proposed is a volume bound to /opt/snipe-it/config which links to /var/www/html/app/config/production/ in the container.

This volume would then be used with the -v command line switch, e.g:

sudo docker run --restart=always -d -p 8080:80 --name="snipe-it" --link snipe-it-mysql:mysql -v /path/to/config/files:/opt/snipe-it/config --env-file=/home/snipe-it/docker.env snipe/snipe-it