### PR TITLE
Missing mysql client in docker image #1908

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ php5-gd \
 patch \
 curl \
 vim \
-git 
+git \
+mysql-client
 
 RUN php5enmod mcrypt
 RUN php5enmod gd


### PR DESCRIPTION
This patch fixes missing mysql client and consequently backup functionality in docker image.