### PR TITLE
on forget password, show error message if user not found with email

### DIFF
--- a/app/controllers/AuthController.php
+++ b/app/controllers/AuthController.php
@@ -332,6 +332,7 @@ class AuthController extends BaseController
             }
 
         } catch (Cartalyst\Sentry\Users\UserNotFoundException $e) {
+            return Redirect::route('forgot-password')->withInput()->with('error', $e->getMessage());
             // Even though the username was not found, we will pretend
             // we have sent the password reset code through username,
             // this is a security measure against hackers.


### PR DESCRIPTION
If the user not found, then there is no indication of that. Instead of showing error, it shows success message. For this, I've added the error message.