### PR TITLE
Docker image requires ubuntu trusty, not latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:trusty
 MAINTAINER Brady Wetherington <uberbrady@gmail.com>
 
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Hi,

With recent Ubuntu Xenial release, ubuntu:latest docker image changed its content. Xenial doesn't contain the packages we are installing - see build error at https://hub.docker.com/r/samepagelabs/snipe-it/builds/b9c4s9modak6ieu8klxbsy9/ .

We should either fix the install rules or explicitly require Ubuntu Trusty. I've done the latter.

Petr.