### PR TITLE
Make limit/offset work in getDataView

### DIFF
--- a/app/Http/Controllers/CategoriesController.php
+++ b/app/Http/Controllers/CategoriesController.php
@@ -326,7 +326,7 @@ class CategoriesController extends Controller
         $allowed_columns = ['id','name','serial','asset_tag'];
         $sort = in_array(Input::get('sort'), $allowed_columns) ? Input::get('sort') : 'created_at';
         $count = $category_assets->count();
-
+        $category_assets = $category_assets->skip($offset)->take($limit)->get();
         $rows = array();
 
         foreach ($category_assets as $asset) {


### PR DESCRIPTION
It looks like when getDataViewAssets() got added limit and offset were not respected.  This fixes that.