### PR TITLE
Fix Settings Table for Sqlite

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -178,8 +178,6 @@ class SettingsController extends Controller
         $settings->brand = 1;
         $settings->default_currency = 'USD';
         $settings->user_id = 1;
-        $settings->option_name = '135';
-        $settings->option_value = '1356';
 
         if ((!$user->isValid('initial')) && (!$settings->isValid('initial'))) {
             return redirect()->back()->withInput()->withErrors($user->getErrors())->withErrors($settings->getErrors());

--- a/database/migrations/2016_05_20_024859_remove_option_keys_from_settings_table.php
+++ b/database/migrations/2016_05_20_024859_remove_option_keys_from_settings_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class RemoveOptionKeysFromSettingsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            //
+            $table->dropColumn('option_name');
+            $table->dropColumn('option_value');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('Settings', function (Blueprint $table) {
+            //
+        });
+    }
+}


### PR DESCRIPTION
This gets rid of my dummy code that snuck into SettingsController and adds a migration to drop the option_name and option_value columns.  