### PR TITLE
Fix updates from v2

### DIFF
--- a/database/migrations/2016_05_20_143758_remove_option_value_from_settings_table.php
+++ b/database/migrations/2016_05_20_143758_remove_option_value_from_settings_table.php
@@ -3,7 +3,7 @@
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class RemoveOptionKeysFromSettingsTable extends Migration
+class RemoveOptionValueFromSettingsTable extends Migration
 {
     /**
      * Run the migrations.
@@ -14,8 +14,8 @@ class RemoveOptionKeysFromSettingsTable extends Migration
     {
         Schema::table('settings', function (Blueprint $table) {
             //
-            if(Schema::hasColumn('option_name', 'settings'))
-                $table->dropColumn('option_name');
+            if(Schema::hasColumn('option_value', 'settings'))
+                $table->dropColumn('option_value');
         });
     }
 
@@ -26,9 +26,9 @@ class RemoveOptionKeysFromSettingsTable extends Migration
      */
     public function down()
     {
-        Schema::table('Settings', function (Blueprint $table) {
-            //
-            $table->string('option_name')->nullable();
+        //
+        Schema::table('settings', function (Blueprint $table) {
+            $table->string('option_value')->nullable();
         });
     }
 }


### PR DESCRIPTION
Doing some investigation after #2058 popped up, it looks like the migration file 2013_11_22_213400_edits_to_settings_table.php differs between master and v3.  In master it dropped option_name and option_value.  In v3, this code is commented out (which explains the setup issues I saw when doing a fresh install, but not issues on a migrate).  That means my PR last night was flawed.

This commit checks to ensure the column exists before dropping it.  The other solution would be to uncomment the code in the migration, but that feels more unpredictable to me (It's still alpha though, so maybe easier).

This also breaks the migration up into two files because apparentlly with sqlite things behavior is undefined if dropping multiple columns in one migration.