### PR TITLE
Mobile-Friendly image capture/upload + Ajax rewrite of asset create

### DIFF
--- a/app/Http/Controllers/AssetsController.php
+++ b/app/Http/Controllers/AssetsController.php
@@ -218,12 +218,10 @@ class AssetsController extends Controller
             $path = public_path('uploads/assets/'.$file_name);
 
             //Currently resizing happens on Client.  Maybe use this for thumbnails in the future?
-            Image::make($image)
-            ->resize(500, 500, function ($constraint) {
+            Image::make($image)->resize(500, 500, function ($constraint) {
                 $constraint->aspectRatio();
                 $constraint->upsize();
-            })
-            ->save($path);
+            })->save($path);
             $asset->image = $file_name;
 
         }
@@ -370,11 +368,17 @@ class AssetsController extends Controller
         $asset->physical     = '1';
 
            // Update the image
-        if (Input::file('image')) {
-            $image = Input::file('image');
-            $file_name = str_random(25).".".$image->getClientOriginalExtension();
+          if (Input::has('image')) {
+            $image = Input::get('image');
+            $header = explode(';', $image, 2)[0];
+            $extension = substr( $header, strpos($header, '/')+1);
+            $image = substr( $image, strpos($image, ',')+1);
+
+            $file_name = str_random(25).".".$extension;
             $path = public_path('uploads/assets/'.$file_name);
-            Image::make($image->getRealPath())->resize(500, null, function ($constraint) {
+
+
+            Image::make($image)->resize(500, 500, function ($constraint) {
                 $constraint->aspectRatio();
                 $constraint->upsize();
             })->save($path);

--- a/app/Http/Requests/AssetRequest.php
+++ b/app/Http/Requests/AssetRequest.php
@@ -4,7 +4,7 @@ namespace App\Http\Requests;
 
 use App\Http\Requests\Request;
 use App\Models\AssetModel;
-
+use Session;
 class AssetRequest extends Request
 {
     /**
@@ -53,6 +53,10 @@ class AssetRequest extends Request
 
     public function response(array $errors)
     {
-        return $this->redirector->back()->withInput()->withErrors($errors, $this->errorBag);
+        $this->session()->flash('errors', Session::get('errors', new \Illuminate\Support\ViewErrorBag)
+            ->put('default', new \Illuminate\Support\MessageBag($errors)));
+
+        return parent::response($errors);
+    //     return $this->redirector->back()->withInput()->withErrors($errors, $this->errorBag);
     }
 }

--- a/app/Http/Requests/Request.php
+++ b/app/Http/Requests/Request.php
@@ -13,9 +13,9 @@ abstract class Request extends FormRequest
         return $this->rules;
     }
 
-    public function response(array $errors)
-    {
-        $this->session->flash('errorMessages', $errors);
-        return $this->redirector->back()->withErrors($errors)->withInput();
-    }
+    // public function response(array $errors)
+    // {
+    //     $this->session->flash('errorMessages', $errors);
+    //     return $this->redirector->back()->withErrors($errors)->withInput();
+    // }
 }

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -162,7 +162,6 @@ Route::group([ 'prefix' => 'api', 'middleware' => 'auth' ], function () {
         );
     });
 
-
 });
 
 /*

--- a/resources/views/hardware/edit.blade.php
+++ b/resources/views/hardware/edit.blade.php
@@ -373,7 +373,7 @@
            <label class="col-md-3 control-label" for="image">{{ trans('general.image_upload') }}</label>
            <div class="col-md-5">
                <!-- {{ Form::file('image') }} -->
-               <input type="file" id="file-upload" accept="image/*" capture="camera" name="image">
+               <input type="file" id="file-upload" accept="image/*" name="image">
                {!! $errors->first('image', '<span class="alert-msg">:message</span>') !!}
            </div>
        </div>
@@ -561,7 +561,7 @@ $(function () {
         newWidth = maxWidth;
       } else {
         newWidth = width * (maxHeight/height);
-        newHeight = height;
+        newHeight = maxHeight;
       }
       var canvas = document.createElement('canvas');
 

--- a/resources/views/hardware/edit.blade.php
+++ b/resources/views/hardware/edit.blade.php
@@ -15,7 +15,6 @@
   {{ trans('general.back') }}</a>
 @stop
 
-
 {{-- Some room for the modals --}}
 <div class="modal fade" id="createModal">
   <div class="modal-dialog">
@@ -112,9 +111,9 @@
 <div class="row">
   <div class="col-md-8 col-md-offset-2">
     @if ($asset->id)
-     <form class="form-horizontal" method="post" action="{{ route('update/hardware',$asset->id) }}" autocomplete="off" role="form" enctype="multipart/form-data" >
+     <form id="create-form" class="form-horizontal" method="post" action="{{ route('update/hardware',$asset->id) }}" autocomplete="off" role="form" enctype="multipart/form-data" >
    @else
-     <form class="form-horizontal" method="post" action="{{ route('savenew/hardware') }}" autocomplete="off" role="form" enctype="multipart/form-data">
+     <form id="create-form" class="form-horizontal" method="post" action="{{ route('savenew/hardware') }}" autocomplete="off" role="form" enctype="multipart/form-data">
    @endif
 
 
@@ -373,7 +372,8 @@
        <div class="form-group {{ $errors->has('image') ? 'has-error' : '' }}">
            <label class="col-md-3 control-label" for="image">{{ trans('general.image_upload') }}</label>
            <div class="col-md-5">
-               {{ Form::file('image') }}
+               <!-- {{ Form::file('image') }} -->
+               <input type="file" id="file-upload" accept="image/*" capture="camera" name="image">
                {!! $errors->first('image', '<span class="alert-msg">:message</span>') !!}
            </div>
        </div>
@@ -383,7 +383,7 @@
       </div><!-- /.box-body -->
       <div class="box-footer text-right">
         <a class="btn btn-link" href="{{ URL::previous() }}" method="post" enctype="multipart/form-data">{{ trans('button.cancel') }}</a>
-        <button type="submit" class="btn btn-success"><i class="fa fa-check icon-white"></i> {{ trans('general.save') }}</button>
+        <button type="submit" class="btn btn-success" id="submit-button"><i class="fa fa-check icon-white"></i> {{ trans('general.save') }}</button>
       </div><!-- /.box-footer -->
     </div><!-- /.box -->
 
@@ -427,7 +427,6 @@
     	    $.ajax({
     	        url: "{{config('app.url') }}/api/statuslabels/"+status_id+"/deployable",
     	        success: function(data) {
-                    //console.log(data);
                     $(".status_spinner").css("display", "none");
 
     	            if(data == true){
@@ -435,7 +434,7 @@
     	            } else {
     	                 $("#assigned_user").css("display", "none");
     	            }
-    	        }
+                }
     	    });
         }
 	};
@@ -490,6 +489,124 @@ $(function () {
 
     //console.warn("The Model is: "+model+" and the select is: "+select);
   });
+
+   $("form").submit( function(event) {
+    event.preventDefault();
+    return sendForm();
+  });
+
+  // Resize Files when chosen
+
+
+
+    //First check to see if there is a file before doing anything else
+
+    var imageData = "";
+    var $fileInput = $('#file-upload'); 
+    $fileInput.on('change', function(e) {
+      if( $fileInput != '' ) {
+        if(window.File && window.FileReader && window.FormData) {
+          var file = e.target.files[0];
+          if(file) {
+            if(/^image\//i.test(file.type)) {
+              readFile(file);
+            } else {
+              alert('Invalid Image File :(');
+            }
+          }
+        }
+        else {
+          console.log("File API not supported, not resizing");
+        } 
+      }
+    });
+
+
+  function readFile(file) {
+    var reader = new FileReader();
+
+    reader.onloadend = function() {
+      processFile(reader.result, file.type);
+    }
+
+    reader.onerror = function() { 
+      alert("Unable to read file");
+    }
+
+    reader.readAsDataURL(file);
+  }
+
+  function processFile(dataURL, fileType) {
+    var maxWidth = 800;
+    var maxHeight = 800;
+
+    var image = new Image();
+    image.src = dataURL;
+
+    image.onload = function() {
+      var width = image.width;
+      var height = image.height;
+      var shouldResize = (width > maxWidth) || (height > maxHeight);
+
+      if(!shouldResize) {
+        imageData = dataURL;
+        return;
+      }
+
+      var newWidth;
+      var newHeight;
+
+      if( width > height) {
+        newHeight = height * (maxWidth/width);
+        newWidth = maxWidth;
+      } else {
+        newWidth = width * (maxHeight/height);
+        newHeight = height;
+      }
+      var canvas = document.createElement('canvas');
+
+      canvas.width = newWidth;
+      canvas.height = newHeight;
+
+      var context = canvas.getContext('2d');
+
+      context.drawImage(this, 0, 0, newWidth, newHeight);
+
+      dataURL = canvas.toDataURL( fileType );
+
+      imageData = dataURL;
+
+    };
+
+    image.onerror = function () {
+      alert('Unable to process file :(');
+    }
+  }
+
+  function sendForm() {
+    var form = $("#create-form").get(0);
+    var successRoute = "{{route('hardware')}}";
+    var formData = $('#create-form').serializeArray();
+    formData.push({name:'image', value:imageData});
+    $.ajax({
+      type: 'POST',
+      url: form.action,
+      headers:{"X-Requested-With": 'XMLHttpRequest'},
+      data: formData,
+      dataType: 'json',
+      success: function(data) {
+        // AssetController flashes success to session, redirect to hardware page.
+        window.location.href = successRoute;
+      },
+      error: function(data) {
+        // AssetRequest Validator will flash all errors to session, this just refreshes to see them.
+        window.location.reload();
+      }
+    });
+
+    return false;
+  }
+
 
   $('#modal-save').on('click',function () {
     var data={};


### PR DESCRIPTION
This PR rewrites the Asset creation/editing to allow for mobile uploading (one line of code) + resizing of images (many lines of code) before posting to the server.  It also rewrites the creation page to use an AJAX form to prevent a long delay while uploading.  Tested with android, ipad, and computer.  

This also boosts the image maximum to 800x800, but that could easily be reverted back to the current 300x300.  Once v3 comes out I want to look at making a  prescaled "thumbnail" version of each image, but that will make more sense with one of my other branches.  I may look at scaling the images clientside in the view/edit asset page.