### PR TITLE
Fix (for real this time?) the settings table option_name/option_value

### DIFF
--- a/database/migrations/2016_05_20_024859_remove_option_keys_from_settings_table.php
+++ b/database/migrations/2016_05_20_024859_remove_option_keys_from_settings_table.php
@@ -14,7 +14,7 @@ class RemoveOptionKeysFromSettingsTable extends Migration
     {
         Schema::table('settings', function (Blueprint $table) {
             //
-            if(Schema::hasColumn('option_name', 'settings'))
+            if(Schema::hasColumn('settings', 'option_name'))
                 $table->dropColumn('option_name');
         });
     }

--- a/database/migrations/2016_05_20_143758_remove_option_value_from_settings_table.php
+++ b/database/migrations/2016_05_20_143758_remove_option_value_from_settings_table.php
@@ -14,7 +14,7 @@ class RemoveOptionValueFromSettingsTable extends Migration
     {
         Schema::table('settings', function (Blueprint $table) {
             //
-            if(Schema::hasColumn('option_value', 'settings'))
+            if(Schema::hasColumn('settings', 'option_value'))
                 $table->dropColumn('option_value');
         });
     }


### PR DESCRIPTION
So...

It looks like I mixed up the order of Schema::hasColumn(), which led to this migration doing nothing.  I haven't seen anyone else encounter this issue, so I'm suspecting there are not many people creating a new install of v3 without migrating an existing database currently, so I've just modified the migration directly.  it could easily become another migration though if we want to make sure everythings fixed for everyone.