### PR TITLE
Importer improvements

### DIFF
--- a/app/Console/Commands/ObjectImportCommand.php
+++ b/app/Console/Commands/ObjectImportCommand.php
@@ -563,8 +563,9 @@ class ObjectImportCommand extends Command {
 		if (!empty($user_username)) {
 			if ($user = User::MatchEmailOrUsername($user_username, $user_email)
 				->whereNotNull('username')->first()) {
+
 				$this->log('User '.$user_username.' already exists');
-			} else {
+			} else if(( $first_name != '') && ($last_name != '') && ($user_username != '')) {
                 $user = new \App\Models\User;
                 $password  = substr(str_shuffle("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"), 0, 20);
 
@@ -580,6 +581,8 @@ class ObjectImportCommand extends Command {
                     $this->error('User: ' . $user->getErrors());
                 }
 
+			} else {
+				$user = new User;
 			}
 		} else {
 			$user = new User;

--- a/app/Console/Commands/ObjectImportCommand.php
+++ b/app/Console/Commands/ObjectImportCommand.php
@@ -347,24 +347,25 @@ class ObjectImportCommand extends Command {
 			return;
 		foreach ($this->status_labels as $tempstatus) {
 			if ($tempstatus->name === $asset_statuslabel_name) {
-				$this->comment('A matching Status ' . $asset_statuslabel_name . ' already exists');
+				$this->log('A matching Status ' . $asset_statuslabel_name . ' already exists');
 				return $tempstatus;
 			}
 		}
-
 		$status = new Statuslabel();
 		$status->name = $asset_statuslabel_name;
-		$this->status_labels->add($status);
+
 
 		if(!$this->option('testrun')) {
 			if ($status->save()) {
-				$this->comment('Status ' . $asset_statuslabel_name . ' was created');
+				$this->status_labels->add($status);
+				$this->log('Status ' . $asset_statuslabel_name . ' was created');
 				return $status;
 			} else {
-				$this->comment('Something went wrong! Status ' . $asset_statuslabel_name . ' was NOT created');
+                $this->error('Status: ' . $status->getErrors());
 				return $status;
 			}
 		} else {
+			$this->status_labels->add($status);
 			return $status;
 		}
 	}
@@ -602,6 +603,10 @@ class ObjectImportCommand extends Command {
         $asset_serial = $this->array_smart_fetch($row, "serial number");
         $asset_tag = $this->array_smart_fetch($row, "asset tag");
         $asset_image = $this->array_smart_fetch($row, "image");
+        $asset_warranty_months = intval($this->array_smart_fetch($row, "warranty months"));
+        if(empty($asset_warranty_months)) {
+        	$asset_warranty_months = NULL;
+        }
         // Check for the asset model match and create it if it doesn't exist
         $asset_model = $this->createOrFetchAssetModel($row, $item["category"], $item["manufacturer"]);
 		$supplier = $this->createOrFetchSupplier($row);
@@ -621,7 +626,7 @@ class ObjectImportCommand extends Command {
 		}
 
 		if(empty($item["status_label"])) {
-			$this->comment("No status field found, defaulting to id 1.");
+			$this->log("No status field found, defaulting to id 1.");
 			$status_id = 1;
 		} else {
 			$status_id = $item["status_label"]->id;

--- a/app/Console/Commands/ObjectImportCommand.php
+++ b/app/Console/Commands/ObjectImportCommand.php
@@ -14,6 +14,7 @@ use App\Models\Company;
 use App\Models\Consumable;
 use App\Models\Location;
 use App\Models\Manufacturer;
+use App\Models\Statuslabel;
 use App\Models\Supplier;
 use App\Models\User;
 use DB;
@@ -90,6 +91,7 @@ class ObjectImportCommand extends Command {
 		$this->suppliers = Supplier::All(['name']);
 		$this->accessories = Accessory::All(['name']);
 		$this->consumables = Consumable::All(['name']);
+		$this->status_labels = Statuslabel::All(['name']);
 		// Loop through the records
 		DB::transaction(function() use (&$newarray){
 		$item_type = strtolower($this->option('item-type'));
@@ -104,6 +106,8 @@ class ObjectImportCommand extends Command {
 			$item_company_name = $this->array_smart_fetch($row, "company");
 			$item_location = $this->array_smart_fetch($row, "location");
 
+			$item_status_name = $this->array_smart_fetch($row, "status");
+
 			$item["item_name"] = $this->array_smart_fetch($row, "item name");
 			$item["purchase_date"] = date("Y-m-d 00:00:01", strtotime($this->array_smart_fetch($row, "purchase date")));
 			$item["purchase_cost"] = $this->array_smart_fetch($row, "purchase cost");
@@ -111,6 +115,7 @@ class ObjectImportCommand extends Command {
 			$item["notes"] = $this->array_smart_fetch($row, "notes");
 			$item["quantity"] = $this->array_smart_fetch($row, "quantity");
 			$item["requestable"] = $this->array_smart_fetch($row, "requestable");
+			
 
 
 			$this->current_assetId = $item["item_name"];
@@ -126,6 +131,8 @@ class ObjectImportCommand extends Command {
 			$item["category"] = $this->createOrFetchCategory($item_category, $item_type);
 			$item["manufacturer"] = $this->createOrFetchManufacturer($row);
 			$item["company"] = $this->createOrFetchCompany($item_company_name);
+
+			$item["status_label"] = $this->createOrFetchStatusLabel($item_status_name);
 
 			switch ($item_type) {
 				case "asset":
@@ -329,7 +336,38 @@ class ObjectImportCommand extends Command {
 			return $company;
 		}
 	}
+	private $status_labels;
+	/**
+	 * @param string $asset_statuslabel_name 
+	 * @return Company
+	 */
+	public function createOrFetchStatusLabel($asset_statuslabel_name)
+	{
+		if(empty($asset_statuslabel_name))
+			return;
+		foreach ($this->status_labels as $tempstatus) {
+			if ($tempstatus->name === $asset_statuslabel_name) {
+				$this->comment('A matching Status ' . $asset_statuslabel_name . ' already exists');
+				return $tempstatus;
+			}
+		}
 
+		$status = new Statuslabel();
+		$status->name = $asset_statuslabel_name;
+		$this->status_labels->add($status);
+
+		if(!$this->option('testrun')) {
+			if ($status->save()) {
+				$this->comment('Status ' . $asset_statuslabel_name . ' was created');
+				return $status;
+			} else {
+				$this->comment('Something went wrong! Status ' . $asset_statuslabel_name . ' was NOT created');
+				return $status;
+			}
+		} else {
+			return $status;
+		}
+	}
 
 	private $manufacturers;
 
@@ -557,7 +595,7 @@ class ObjectImportCommand extends Command {
 	 */
 	public function createAssetIfNotExists(array $row, array $item )
 	{
-		$status_id = 1;
+
         $asset_serial = $this->array_smart_fetch($row, "serial number");
         $asset_tag = $this->array_smart_fetch($row, "asset tag");
         $asset_image = $this->array_smart_fetch($row, "image");
@@ -577,6 +615,13 @@ class ObjectImportCommand extends Command {
 				$this->comment('A matching Asset ' . $asset_tag . ' already exists');
 				return;
 			}
+		}
+
+		if(empty($item["status_label"])) {
+			$this->comment("No status field found, defaulting to id 1.");
+			$status_id = 1;
+		} else {
+			$status_id = $item["status_label"]->id;
 		}
 
 		$asset = new Asset();

--- a/app/Http/Controllers/AssetsController.php
+++ b/app/Http/Controllers/AssetsController.php
@@ -744,6 +744,9 @@ class AssetsController extends Controller
             return redirect()->to('hardware')->with('error', trans('general.insufficient_permissions'));
         }
 
+        // Check if the uploads directory exists.  If not, try to create it.
+        if(!file_exists($path))
+            mkdir($path, 0755);
         if ($handle = opendir($path)) {
 
             /* This is the correct way to loop over the directory. */
@@ -841,7 +844,7 @@ class AssetsController extends Controller
         }
 
         $output = new BufferedOutput;
-        Artisan::call('asset-import:csv', ['filename'=> config('app.private_uploads').'/imports/assets/'.$filename, '--email_format'=>'firstname.lastname', '--username_format'=>'firstname.lastname'], $output);
+        Artisan::call('snipeit:import', ['filename'=> config('app.private_uploads').'/imports/assets/'.$filename, '--email_format'=>'firstname.lastname', '--username_format'=>'firstname.lastname'], $output);
         $display_output =  $output->fetch();
         $file = config('app.private_uploads').'/imports/assets/'.str_replace('.csv', '', $filename).'-output-'.date("Y-m-d-his").'.txt';
         file_put_contents($file, $display_output);

--- a/resources/lang/en/admin/hardware/message.php
+++ b/resources/lang/en/admin/hardware/message.php
@@ -36,6 +36,12 @@ return array(
         'invalidfiles' => 'One or more of your files is too large or is a filetype that is not allowed. Allowed filetypes are png, gif, jpg, doc, docx, pdf, and txt.',
     ),
 
+    'import' => array(
+        'error'         => 'Some Items did not import Correctly.',
+        'errorDetail'   => 'The Following Items were not imported because of errors.',
+        'success'       => "Your File has been imported",
+    ),
+
 
     'delete' => array(
         'confirm'   	=> 'Are you sure you wish to delete this asset?',

--- a/resources/views/hardware/import.blade.php
+++ b/resources/views/hardware/import.blade.php
@@ -66,7 +66,38 @@
                     </div>
                 </div>
             </div>
+ 
         </div>
+        @if (session()->has('import_errors'))
+        <div class="errors-table">
+        <div class="alert alert-warning">
+            <strong>Warning</strong> {{trans('admin/hardware/message.import.errorDetail')}}
+        </div>
+        <table class="table table-striped" id="errors-table">
+            <thead>
+                <th>Asset</th>
+                <th colspan="1">Field</th>
+                <th colspan ="1">Parameter</th>
+                <th colspan ="1">Errors</th>
+            </thead>
+            <tbody>
+                @foreach (session('import_errors') as $asset => $error)
+                <tr>
+                    <td> {{ $asset }}</td>
+
+                    @foreach ($error as $field => $values )
+                        <td> {{ $field }} </td>
+                        @foreach( $values as $fieldName=>$errorString)
+                                <td>{{$fieldName}}</td>
+                                <td>{{$errorString[0]}}</td>
+                        @endforeach
+                    @endforeach
+                </tr>
+                @endforeach
+            </tbody>
+        </table>
+        </div>
+        @endif
     </div>
 </div>
 @section('moar_scripts')


### PR DESCRIPTION
This series of commits rewrites the output parts of the importer to write most information to a log  (configured with --logfile) instead of STDOUT.  At the end of the import, any and all items that failed validation are printed to the screen with associated errors.  This also changes Importing accessories/consumables to be done via a command line option rather than reading a field in the csv, which should make it accessible without complicating anything.  Tested with a few different mock csvs and personal exports.  