### PR TITLE
Reduce Import error warnings in importer.

### DIFF
--- a/app/Console/Commands/ObjectImportCommand.php
+++ b/app/Console/Commands/ObjectImportCommand.php
@@ -286,7 +286,7 @@ class ObjectImportCommand extends Command {
 	/**
 	 * Finds a category with the same name and item type in the database, otherwise creates it
 	 * @param $asset_category string
-	 * @param $item_type stringI
+	 * @param $item_type string
 	 * @return Category
 	 */
 	public function createOrFetchCategory($asset_category, $item_type)

--- a/app/Console/Commands/ObjectImportCommand.php
+++ b/app/Console/Commands/ObjectImportCommand.php
@@ -286,7 +286,7 @@ class ObjectImportCommand extends Command {
 	/**
 	 * Finds a category with the same name and item type in the database, otherwise creates it
 	 * @param $asset_category string
-	 * @param $item_type string
+	 * @param $item_type stringI
 	 * @return Category
 	 */
 	public function createOrFetchCategory($asset_category, $item_type)
@@ -348,7 +348,7 @@ class ObjectImportCommand extends Command {
 				$this->log('Company ' . $asset_company_name . ' was created');
 				return $company;
 			} else {
-                $this->jsonError('Company', $company->getErrors());
+                $this->log('Company', $company->getErrors());
 			}
 		} else {
 			$this->companies->add($company);
@@ -470,7 +470,7 @@ class ObjectImportCommand extends Command {
 					$this->log('Location ' . $asset_location . ' was created');
 					return $location;
 				} else {
-					$this->jsonError('Location', $location->getErrors()) ;
+					$this->log('Location', $location->getErrors()) ;
 					return $location;
 				}
 			} else {
@@ -512,7 +512,7 @@ class ObjectImportCommand extends Command {
 				$this->log('Supplier ' . $supplier_name . ' was created');
 				return $supplier;
 			} else {
-                $this->jsonError('Supplier', $supplier->getErrors());
+                $this->log('Supplier', $supplier->getErrors());
                 return $supplier;
 			}
 		} else {

--- a/resources/views/hardware/import.blade.php
+++ b/resources/views/hardware/import.blade.php
@@ -73,24 +73,21 @@
         <div class="alert alert-warning">
             <strong>Warning</strong> {{trans('admin/hardware/message.import.errorDetail')}}
         </div>
-        <table class="table table-striped" id="errors-table">
+        <table class="table table-striped table-bordered" id="errors-table">
             <thead>
                 <th>Asset</th>
-                <th colspan="1">Field</th>
-                <th colspan ="1">Parameter</th>
-                <th colspan ="1">Errors</th>
+                <th>Errors</th>
             </thead>
             <tbody>
                 @foreach (session('import_errors') as $asset => $error)
                 <tr>
                     <td> {{ $asset }}</td>
-
                     @foreach ($error as $field => $values )
-                        <td> {{ $field }} </td>
-                        @foreach( $values as $fieldName=>$errorString)
-                                <td>{{$fieldName}}</td>
-                                <td>{{$errorString[0]}}</td>
-                        @endforeach
+                        <td> <span><b>{{ $field }}:</b>
+                            @foreach( $values as $errorString)
+                                    <span>{{$errorString[0]}} </span>
+                            @endforeach
+                        </td>
                     @endforeach
                 </tr>
                 @endforeach


### PR DESCRIPTION
This reduces the amount of items that make it into the error table when importing by only triggering errors if they directly effect the creation of an asset.  Also clean up the table layout some.