### PR TITLE
Fix a regression in Helper::usersList and ::managerList()

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -164,10 +164,11 @@ class Helper
 
     public static function managerList()
     {
-        $manager_list = User::where('deleted_at', '=', null)
-        ->orderBy('last_name', 'asc')
-        ->orderBy('first_name', 'asc')->get()
-        ->lists('full_name', 'id');
+        $manager_list = array('' => '') +
+                        User::where('deleted_at', '=', null)
+                        ->orderBy('last_name', 'asc')
+                        ->orderBy('first_name', 'asc')->get()
+                        ->lists('complete_name', 'id')->toArray();
 
         return $manager_list;
     }
@@ -187,12 +188,13 @@ class Helper
 
     public static function usersList()
     {
-        $users_list = User::where('deleted_at', '=', null)
-        ->where('show_in_list','=',1)
-        ->orderBy('last_name', 'asc')
-        ->orderBy('first_name', 'asc')->get()
-        ->lists('full_name', 'id');
-        
+        $users_list =   array( '' => trans('general.select_user')) +
+                        User::where('deleted_at', '=', null)
+                        ->where('show_in_list','=',1)
+                        ->orderBy('last_name', 'asc')
+                        ->orderBy('first_name', 'asc')->get()
+                        ->lists('complete_name', 'id')->toArray();
+
         return $users_list;
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -123,6 +123,11 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
       return $this->first_name . " " . $this->last_name;
     }
 
+    public function getCompleteNameAttribute()
+    {
+      return $this->last_name . ", " . $this->first_name . " (" . $this->username . ")";
+    }
+
   /**
    * Returns the user Gravatar image url.
    *


### PR DESCRIPTION
In making everything sqlite friendly I omitted the "Select a User" option.  The names were also formatted differently.  This should restore the original behavior.