### PR TITLE
Fix what appears to be a copy/paste error when user creation fails.

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -130,10 +130,8 @@ class UsersController extends Controller
             }
             return redirect::route('users')->with('success', trans('admin/users/message.success.create'));
         } else {
-            redirect()->back()->withInput()->withInput()->withErrors($user->getErrors())->withErrors($settings->getErrors());
+            return redirect()->back()->withInput()->withInput()->withErrors($user->getErrors());
         }
-
-        return redirect()->route('create/user')->withInput()->with('error', $error);
     }
 
     /**


### PR DESCRIPTION
At present, if model validation failed while creating a user it would try to redirect to a faulty URL.  This should remedy that.