### PR TITLE
Fix license Checkout.

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -208,6 +208,13 @@ class Helper
         return $assets_list;
     }
 
+    public static function detailedAssetList()
+    {
+
+        $assets = array('' => trans('general.select_asset')) + Company::scopeCompanyables(Asset::all(), 'assets.company_id')->lists('detailed_name', 'id')->toArray();
+        return $assets;
+    }
+
 
     public static function customFieldsetList()
     {

--- a/app/Http/Controllers/ComponentsController.php
+++ b/app/Http/Controllers/ComponentsController.php
@@ -287,7 +287,7 @@ class ComponentsController extends Controller
         }
 
         // Get the dropdown of assets and then pass it to the checkout view
-        $assets_list = Helper::assetsList();
+        $assets_list = Helper::detailedAssetList();
 
         return View::make('components/checkout', compact('component'))->with('assets_list', $assets_list);
 

--- a/app/Http/Controllers/LicensesController.php
+++ b/app/Http/Controllers/LicensesController.php
@@ -439,8 +439,7 @@ class LicensesController extends Controller
         // Get the dropdown of users and then pass it to the checkout view
         $users_list = Helper::usersList();
 
-        $assets = Company::scopeCompanyables(Asset::all(), 'assets.company_id')->lists('detailed_name', 'id');
-
+        $assets = Helper::detailedAssetList();
         return View::make('licenses/checkout', compact('licenseseat'))
         ->with('users_list', $users_list)
         ->with('asset_list', $assets);

--- a/resources/views/components/checkout.blade.php
+++ b/resources/views/components/checkout.blade.php
@@ -32,7 +32,7 @@
           @if ($component->name)
           <!-- consumable name -->
           <div class="form-group">
-          <label class="col-sm-3 control-label">{{ trans('admin/consumables/general.consumable_name') }}</label>
+          <label class="col-sm-3 control-label">{{ trans('admin/components/general.component_name') }}</label>
               <div class="col-md-6">
                 <p class="form-control-static">{{ $component->name }}</p>
               </div>


### PR DESCRIPTION
A mistake in the sqlite porting led to "Please select an asset"
disappearing.  This centralizes that code in Helper, and uses the code
in Licensescontroller and componentscontroller.

Also use the proper name on the components checkout page.

AssetMaintencesController reuses the same underlying code as
licensescontroller, but we don't want "Please select an asset" to be an
option there, so I'm not changing that code.