### PR TITLE
Fix hardware creation error making old input disappear.  

### DIFF
--- a/app/Http/Requests/AssetRequest.php
+++ b/app/Http/Requests/AssetRequest.php
@@ -55,8 +55,7 @@ class AssetRequest extends Request
     {
         $this->session()->flash('errors', Session::get('errors', new \Illuminate\Support\ViewErrorBag)
             ->put('default', new \Illuminate\Support\MessageBag($errors)));
-
+        \Input::flash();
         return parent::response($errors);
-    //     return $this->redirector->back()->withInput()->withErrors($errors, $this->errorBag);
     }
 }

--- a/resources/views/hardware/edit.blade.php
+++ b/resources/views/hardware/edit.blade.php
@@ -515,7 +515,7 @@ $(function () {
       },
       error: function(data) {
         // AssetRequest Validator will flash all errors to session, this just refreshes to see them.
-        window.location.reload();
+        window.location.reload(true);
       }
     });
 


### PR DESCRIPTION
This should be redone to dynamically update on the client side based on a JSON response instead of flashing and reloading, but that's a lot of change for v3 at this point.

It seems to work locally, but It was a little finnicky when I was first playing with it so please give it some testing before believing it's good :)