### PR TITLE
Change v3 installer to fetch v3 master.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,6 @@
 if [ "$(id -u)" != "0" ]; then
   exec sudo "$0" "$@"
 fi
-wget https://raw.githubusercontent.com/snipe/snipe-it/master/snipeit.sh
+wget https://raw.githubusercontent.com/snipe/snipe-it/v3/snipeit.sh
 chmod 744 snipeit.sh
 sudo ./snipeit.sh 2>&1 | sudo tee -a /var/log/snipeit-install.log

--- a/snipeit.sh
+++ b/snipeit.sh
@@ -27,7 +27,7 @@ hostname="$(hostname)"
 fqdn="$(hostname --fqdn)"
 ans=default
 hosts=/etc/hosts
-file=v3.0-alpha2.zip #CHANGE THIS WHEN MASTER IS V3 AGAIN
+file=v3-master.zip #CHANGE THIS WHEN MASTER IS V3 AGAIN
 tmp=/tmp/$name
 fileName=snipe-it-3.0-alpha2
 


### PR DESCRIPTION
This also updates v3's install.sh to fetch the v3 snipeit.sh with all the details.  If/when the merges to v3-master, it might make sense to pull the v3-master/snipeit.sh on that branch.  Or maybe we just rename snipeit.sh install.sh and simplify things, but that would probably break something.