### PR TITLE
Use the model validation trait to validate asset maintences

### DIFF
--- a/app/Models/AssetMaintenance.php
+++ b/app/Models/AssetMaintenance.php
@@ -15,6 +15,7 @@ class AssetMaintenance extends Model implements ICompanyableChild
 {
     use SoftDeletes;
     use CompanyableChildTrait;
+    use ValidatingTrait;
 
 
     protected $dates = [ 'deleted_at' ];


### PR DESCRIPTION
A form request for this might still be necessary, but this at least makes the model validation occur.  Fixes #2170