### PR TITLE
Center 1D Barcode and include Custom CSS in barcodes view

### DIFF
--- a/resources/views/hardware/labels.blade.php
+++ b/resources/views/hardware/labels.blade.php
@@ -49,6 +49,11 @@
     width: 100%;
     height: 100%;
   }
+  img.barcode {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+  }
 
  .qr_text {
     width: {{ $qr_txt_size }}in;
@@ -88,6 +93,9 @@
     }
   }
 
+  @if (\App\Models\Setting::getSettings()->custom_css)
+    {{ \App\Models\Setting::getSettings()->show_custom_css() }}
+  @endif
 
   </style>
 


### PR DESCRIPTION
Eventually I think that it would be nice to have discreet settings for barcode text font and width. But this is a small change that allows for any customization to the barcodes via CSS.