### PR TITLE
Use app.url for password reset instead of hard coded one.

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -51,7 +51,7 @@
                       <button class="btn btn-lg btn-primary btn-block">{{ trans('auth/general.login')  }}</button>
                     </div>
                     <div class="col-md-12 col-sm-12 col-xs-12 text-right" style="padding-top: 10px;">
-                          <a href="../password/reset">{{ trans('auth/general.forgot_password')  }}</a>
+                          <a href="{{ config('app.url') }}/password/reset">{{ trans('auth/general.forgot_password')  }}</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Since the password reset link was hard coded to be `../password/reset` it was failing when the application was hosted under a folder like `domain.com/snipe-it/`.

I changed it to use config('app.url') that way it doesn't fail in any case.