### PR TITLE
Fix asset creation errors when asset tag already exists

### DIFF
--- a/app/Http/Controllers/AssetsController.php
+++ b/app/Http/Controllers/AssetsController.php
@@ -254,8 +254,8 @@ class AssetsController extends Controller
             \Session::flash('success', trans('admin/hardware/message.create.success'));
             return response()->json(['redirect_url' => route('hardware')]);
         }
-
-        return response()->json(['errors' => $asset->getErrors()]);
+        \Session::flash('errors', $asset->getErrors());
+        return response()->json(['errors' => $asset->getErrors()], 500);
     }
 
     /**

--- a/app/Http/Controllers/AssetsController.php
+++ b/app/Http/Controllers/AssetsController.php
@@ -417,8 +417,8 @@ class AssetsController extends Controller
             \Session::flash('success', trans('admin/hardware/message.update.success'));
             return response()->json(['redirect_url' => route("view/hardware", $assetId)]);
         }
-
-        return response()->json(['errors' => $asset->getErrors()]);
+        \Session::flash('errors', $asset->getErrors());
+        return response()->json(['errors' => $asset->getErrors()], 500);
 
     }
 


### PR DESCRIPTION
Make sure the formrequest checks uniqueness of the asset tag. Fixes trying to create an asset with a duplicate asset tag.