### PR TITLE
Paveit: Add a space to the signature to make the --soft option work.

### DIFF
--- a/app/Console/Commands/PaveIt.php
+++ b/app/Console/Commands/PaveIt.php
@@ -29,7 +29,7 @@ class PaveIt extends Command
      * @var string
      */
     protected $signature = 'snipeit:pave
-              {--soft: Perform a "Soft" Delete, leaving all migrations, table structure, and the first user in place.}';
+              {--soft : Perform a "Soft" Delete, leaving all migrations, table structure, and the first user in place.}';
 
     /**
      * The console command description.


### PR DESCRIPTION
It was parsing the option as --soft:, which is terribly unhelpful.