### PR TITLE
Fix integrity constraint violation on sqlite.

### DIFF
--- a/app/Http/Controllers/AssetsController.php
+++ b/app/Http/Controllers/AssetsController.php
@@ -352,16 +352,13 @@ class AssetsController extends Controller
             $asset->supplier_id =  null;
         }
 
-        if ($request->has('requestable')) {
-            $asset->requestable = e($request->input('requestable'));
-        } else {
-            $asset->requestable =  null;
-        }
+        // If the box isn't checked, it's not in the request at all.
+        $asset->requestable = $request->has('requestable');
 
         if ($request->has('rtd_location_id')) {
             $asset->rtd_location_id = e($request->input('rtd_location_id'));
         } else {
-            $asset->requestable =  null;
+            $asset->rtd_location_id =  null;
         }
 
         if ($request->has('image_delete')) {


### PR DESCRIPTION
If the requestable checkbox was not checked, it did not exist in the request.
Setting requestable to null in such a case would cause a violation because it should be 0/1.

Also fix a copy/paste where we reset requestable after checking for rtd_location_id.