### PR TITLE
If the move of the uploaded import file fails, return an error message. 

### DIFF
--- a/app/Http/Controllers/AssetsController.php
+++ b/app/Http/Controllers/AssetsController.php
@@ -840,6 +840,9 @@ class AssetsController extends Controller
                     $file->move($path, $date.'-'.$fixed_filename);
                 } catch (\Symfony\Component\HttpFoundation\File\Exception\FileException $exception) {
                         $results['error']=trans('admin/hardware/message.upload.error');
+                        if( config('app.debug')) {
+                            $results['error'].= ' ' . $exception->getMessage();
+                        }
                         return $results;
                 }
                 $name = date('Y-m-d-his').'-'.$fixed_filename;

--- a/app/Http/Controllers/AssetsController.php
+++ b/app/Http/Controllers/AssetsController.php
@@ -836,7 +836,12 @@ class AssetsController extends Controller
 
                 $date = date('Y-m-d-his');
                 $fixed_filename = str_replace(' ', '-', $file->getClientOriginalName());
-                $file->move($path, $date.'-'.$fixed_filename);
+                try {
+                    $file->move($path, $date.'-'.$fixed_filename);
+                } catch (\Symfony\Component\HttpFoundation\File\Exception\FileException $exception) {
+                        $results['error']=trans('admin/hardware/message.upload.error');
+                        return $results;
+                }
                 $name = date('Y-m-d-his').'-'.$fixed_filename;
                 $filesize = Setting::fileSizeConvert(filesize($path.'/'.$name));
                 $results[] = compact('name', 'filesize');
@@ -850,7 +855,6 @@ class AssetsController extends Controller
 
 
         } else {
-
             $results['error']=trans('general.feature_disabled');
             return $results;
         }


### PR DESCRIPTION
 Fixes an issue reported on gitter today where bad permissions on the upload directory didn't provide any feedback.

Currently it just gives a generic error message.  I can display the error from the exception, but I'm not sure if we want to do that and potentially reveal technical debug information on a production server (paths and all of that).