### PR TITLE
Fix adding an image to an asset when public/uploads/assets does not exist

### DIFF
--- a/app/Http/Controllers/AssetsController.php
+++ b/app/Http/Controllers/AssetsController.php
@@ -210,20 +210,36 @@ class AssetsController extends Controller
 
         // Create the image (if one was chosen.)
         if (Input::has('image')) {
+
+
+
             $image = Input::get('image');
             $header = explode(';', $image, 2)[0];
             $extension = substr($header, strpos($header, '/')+1);
             $image = substr($image, strpos($image, ',')+1);
 
             $file_name = str_random(25).".".$extension;
-            $path = public_path('uploads/assets/'.$file_name);
 
-            //Currently resizing happens on Client.  Maybe use this for thumbnails in the future?
-            Image::make($image)->resize(500, 500, function ($constraint) {
-                $constraint->aspectRatio();
-                $constraint->upsize();
-            })->save($path);
-            $asset->image = $file_name;
+            $directory= public_path('uploads/assets/');
+            // Check if the uploads directory exists.  If not, try to create it.
+            if (!file_exists($directory)) {
+                mkdir($directory, 0755);
+            }
+            $path = public_path('uploads/assets/'.$file_name);
+            try {
+                Image::make($image)->resize(500, 500, function ($constraint) {
+                    $constraint->aspectRatio();
+                    $constraint->upsize();
+                })->save($path);
+                $asset->image = $file_name;
+            } catch(\Exception $e) {
+                \Input::flash();
+                $messageBag = new \Illuminate\Support\MessageBag();
+                $messageBag->add('image', $e->getMessage());
+                \Session()->flash('errors', \Session::get('errors', new \Illuminate\Support\ViewErrorBag)
+                    ->put('default', $messageBag));
+                return response()->json(['image' => $e->getMessage()], 422);
+            }
 
         }
 
@@ -384,13 +400,28 @@ class AssetsController extends Controller
             $extension = substr($header, strpos($header, '/')+1);
             $image = substr($image, strpos($image, ',')+1);
 
+            $directory= public_path('uploads/assets/');
+            // Check if the uploads directory exists.  If not, try to create it.
+            if (!file_exists($directory)) {
+                mkdir($directory, 0755);
+            }
+
             $file_name = str_random(25).".".$extension;
             $path = public_path('uploads/assets/'.$file_name);
-
-            Image::make($image)->resize(500, 500, function ($constraint) {
-                $constraint->aspectRatio();
-                $constraint->upsize();
-            })->save($path);
+            try {
+                Image::make($image)->resize(500, 500, function ($constraint) {
+                    $constraint->aspectRatio();
+                    $constraint->upsize();
+                })->save($path);
+                $asset->image = $file_name;
+            } catch(\Exception $e) {
+                \Input::flash();
+                $messageBag = new \Illuminate\Support\MessageBag();
+                $messageBag->add('image', $e->getMessage());
+                \Session()->flash('errors', \Session::get('errors', new \Illuminate\Support\ViewErrorBag)
+                    ->put('default', $messageBag));
+                return response()->json(['image' => $e->getMessage()], 422);
+            }
             $asset->image = $file_name;
         }
 

--- a/app/Http/Controllers/AssetsController.php
+++ b/app/Http/Controllers/AssetsController.php
@@ -214,8 +214,13 @@ class AssetsController extends Controller
 
 
             $image = Input::get('image');
+
+            // After modification, the image is prefixed by mime info like the following:
+            // data:image/jpeg;base64,; This causes the image library to be unhappy, so we need to remove it.
             $header = explode(';', $image, 2)[0];
+            // Grab the image type from the header while we're at it.
             $extension = substr($header, strpos($header, '/')+1);
+            // Start reading the image after the first comma, postceding the base64.
             $image = substr($image, strpos($image, ',')+1);
 
             $file_name = str_random(25).".".$extension;
@@ -396,6 +401,7 @@ class AssetsController extends Controller
         // Update the image
         if (Input::has('image')) {
             $image = $request->input('image');
+            // See postCreate for more explaination of the following.
             $header = explode(';', $image, 2)[0];
             $extension = substr($header, strpos($header, '/')+1);
             $image = substr($image, strpos($image, ',')+1);

--- a/resources/views/hardware/edit.blade.php
+++ b/resources/views/hardware/edit.blade.php
@@ -512,13 +512,14 @@ $(function () {
       success: function(data) {
         // AssetController flashes success to session, redirect to hardware page.
          window.location.href = data.redirect_url;
-       //   console.dir(data);
-       //   console.log('submit was successful');
+         // console.dir(data);
+         // console.log('submit was successful');
       },
       error: function(data) {
         // AssetRequest Validator will flash all errors to session, this just refreshes to see them.
         window.location.reload(true);
-        //  console.log('error submitting');
+        // console.log(JSON.stringify(data));
+         // console.log('error submitting');
       }
     });
 


### PR DESCRIPTION
 First check to see if we can create directory and do so.  If any errors occur, display the error string as an error on the page.

I'm not sure if we want to create the public/uploads/assets directory in the default git tree or not.  Thoughts?
