### PR TITLE
On install, force debug on in the middle ware until setup is complete

### DIFF
--- a/app/Console/Commands/ObjectImportCommand.php
+++ b/app/Console/Commands/ObjectImportCommand.php
@@ -455,6 +455,9 @@ class ObjectImportCommand extends Command
         }
         $status = new Statuslabel();
         $status->name = $asset_statuslabel_name;
+        $status->deployable = 1;
+        $status->pending = 0;
+        $status->archived = 0;
 
 
         if (!$this->option('testrun')) {

--- a/app/Http/Middleware/CheckForSetup.php
+++ b/app/Http/Middleware/CheckForSetup.php
@@ -23,6 +23,9 @@ class CheckForSetup
             }
 
         } else {
+            // Force debug until the setup happens.
+            // Should catch a lot of the early 500 errors that lead to "Turn on Debug"
+            config(['app.debug' => true]);
             if (!$request->is('setup*')) {
                 return redirect(config('app.url').'/setup')->with('Request', $request);
             }


### PR DESCRIPTION
This should make debugging easier in general I hope.  Tested with APP_DEBUG=false and true, before and after setup.