### PR TITLE
If a category has items in it, disable changing the category type

### DIFF
--- a/resources/views/categories/edit.blade.php
+++ b/resources/views/categories/edit.blade.php
@@ -55,7 +55,7 @@
           <i class='fa fa-asterisk'></i>
         </div>
           <div class="col-md-7">
-              {{ Form::select('category_type', $category_types , Input::old('category_type', $category->category_type), array('class'=>'select2', 'style'=>'min-width:350px')) }}
+              {{ Form::select('category_type', $category_types , Input::old('category_type', $category->category_type), array('class'=>'select2', 'style'=>'min-width:350px', $category->itemCount() > 0 ? 'disabled' : '')) }}
               {!! $errors->first('category_type', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
           </div>
       </div>


### PR DESCRIPTION
This is only client side at the moment.  Might require server side checking down the road, or maybe some sort of hint about why it's disabled?  Not sure the best way to communicate that..