### PR TITLE
Category Acceptance Test Fix

### DIFF
--- a/tests/acceptance/CategoriesCept.php
+++ b/tests/acceptance/CategoriesCept.php
@@ -23,6 +23,7 @@ $I->see('Create Category', 'h1.pull-left');
 $I->dontSee('&lt;span class=&quot;');
 
 $I->fillField('name', 'testcategory');
+$I->selectOption('form select[name=category_type]', 'Asset');
 $I->click('Save');
 $I->dontSee('&lt;span class=&quot;');
-$I->dontSee('.alert-danger');
+$I->dontSeeElement('.alert-danger');


### PR DESCRIPTION
Fix categories acceptance test as it stands. 
$I->see('.alert-danger'); just checked for that text, we needed $I->seeElement.  Fixing this also revealed that the test was failing, because we never selected a category type and validation failed.

I have a few additions to this test as well, but I need to play with how we seed the data to make those additions more reliable and useful, so it will be a few days before I can get to that.  I can just keep adding to this PR if you'd like, or we can start a new one when I get to it :)