### PR TITLE
Scope to company when viewing assets

### DIFF
--- a/app/Http/Controllers/AccessoriesController.php
+++ b/app/Http/Controllers/AccessoriesController.php
@@ -549,7 +549,7 @@ class AccessoriesController extends Controller
     **/
     public function getDatatable(Request $request)
     {
-        $accessories = Accessory::select('accessories.*')->with('category', 'company')
+        $accessories = Company::scopeCompanyables(Accessory::select('accessories.*')->with('category', 'company'))
         ->whereNull('accessories.deleted_at');
 
         if (Input::has('search')) {

--- a/app/Http/Controllers/AssetsController.php
+++ b/app/Http/Controllers/AssetsController.php
@@ -1408,7 +1408,7 @@ class AssetsController extends Controller
     {
 
 
-        $assets = Asset::select('assets.*')->with('model', 'assigneduser', 'assigneduser.userloc', 'assetstatus', 'defaultLoc', 'assetlog', 'model', 'model.category', 'model.manufacturer', 'model.fieldset', 'assetstatus', 'assetloc', 'company')
+        $assets = Company::scopeCompanyables(Asset::select('assets.*'))->with('model', 'assigneduser', 'assigneduser.userloc', 'assetstatus', 'defaultLoc', 'assetlog', 'model', 'model.category', 'model.manufacturer', 'model.fieldset', 'assetstatus', 'assetloc', 'company')
         ->Hardware();
 
         if (Input::has('search')) {

--- a/app/Http/Controllers/ComponentsController.php
+++ b/app/Http/Controllers/ComponentsController.php
@@ -410,8 +410,8 @@ class ComponentsController extends Controller
     **/
     public function getDatatable()
     {
-        $components = Component::select('components.*')->whereNull('components.deleted_at')
-            ->with('company', 'location', 'category');
+        $components = Company::scopeCompanyables(Component::select('components.*')->whereNull('components.deleted_at')
+            ->with('company', 'location', 'category'));
 
         if (Input::has('search')) {
             $components = $components->TextSearch(Input::get('search'));

--- a/app/Http/Controllers/ConsumablesController.php
+++ b/app/Http/Controllers/ConsumablesController.php
@@ -397,8 +397,8 @@ class ConsumablesController extends Controller
     */
     public function getDatatable()
     {
-        $consumables = Consumable::select('consumables.*')->whereNull('consumables.deleted_at')
-            ->with('company', 'location', 'category', 'users');
+        $consumables = Company::scopeCompanyables(Consumable::select('consumables.*')->whereNull('consumables.deleted_at')
+            ->with('company', 'location', 'category', 'users'));
 
         if (Input::has('search')) {
             $consumables = $consumables->TextSearch(e(Input::get('search')));

--- a/app/Http/Controllers/LicensesController.php
+++ b/app/Http/Controllers/LicensesController.php
@@ -965,7 +965,7 @@ class LicensesController extends Controller
     */
     public function getDatatable()
     {
-        $licenses = License::with('company');
+        $licenses = Company::scopeCompanyables(License::with('company'));
 
         if (Input::has('search')) {
             $licenses = $licenses->TextSearch(Input::get('search'));

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -328,7 +328,7 @@ class Asset extends Depreciable
     public static function assetcount()
     {
 
-        return Asset::where('physical', '=', '1')
+        return Company::scopeCompanyables(Asset::where('physical', '=', '1'))
                ->whereNull('deleted_at', 'and')
                ->count();
     }

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -137,7 +137,7 @@ final class Company extends Model
     {
         if (count($companyable_names) == 0) {
             throw new Exception('No Companyable Children to scope');
-        } elseif (!static::isFullMultipleCompanySupportEnabled()) {
+        } elseif (!static::isFullMultipleCompanySupportEnabled() || (Auth::check() && Auth::user()->isSuperUser())) {
             return $query;
         } else {
             $f = function ($q) {

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -55,11 +55,7 @@ final class Company extends Model
             $company_id = null;
         }
 
-        if ($company_id == null) {
-            return $query;
-        } else {
-            return $query->where($column, '=', $company_id);
-        }
+        return $query->where($column, '=', $company_id);
     }
 
     public static function getSelectList()


### PR DESCRIPTION
This should fix #2206, I've tested a little locally with users, but I don't have the same range of data to confirm everything is behaving. 

One behavioral change this makes (after discussion in gitter) is that when a user doesn't belong to a company, rather than showing all items from all companies, we only show items that don't belong to companies.

This changes licenses, assets, accessories, consumables, and components.  Users was already done.  Did I forget anywhere?