### PR TITLE
Prevent users without a company from changing the company

### DIFF
--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -110,7 +110,7 @@ final class Company extends Model
     public static function isCurrentUserAuthorized()
     {
 
-        return ((!static::isFullMultipleCompanySupportEnabled()) || (Auth::user()->company_id == null) || (Auth::user()->isSuperUser()));
+        return ((!static::isFullMultipleCompanySupportEnabled()) || (Auth::user()->isSuperUser()));
     }
 
     public static function canManageUsersCompanies()


### PR DESCRIPTION
Don't allow users without a company to change the company of items if full company support is enabled.