### PR TITLE
Style the notes field so that it shows newlines.

### DIFF
--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -247,7 +247,7 @@
                    @endif
                    <tr>
                       <td>{{ trans('admin/hardware/form.notes') }}</td>
-                      <td>{{ $asset->notes }}</td>
+                      <td style="white-space:pre-wrap; word-wrap:break-word;">{{ $asset->notes }}</td>
                     </tr>
                    @if ($asset->created_at)
                       <tr>

--- a/resources/views/licenses/view.blade.php
+++ b/resources/views/licenses/view.blade.php
@@ -258,10 +258,14 @@
                     </tr>
 
                     @if ($license->notes)
-                       <tr><td>
-                         {{ trans('admin/licenses/form.notes') }}:
-                         </td><td>
-                        {{ nl2br(e($license->notes)) }}</td></tr>
+                     <tr>
+                        <td>
+                          {{ trans('admin/licenses/form.notes') }}:
+                        </td>
+                        <td style="white-space:pre-wrap; word-wrap:break-word;">
+                          {{ $license->notes }}
+                        </td>
+                      </tr>
                     @endif
 
 


### PR DESCRIPTION
The other option would be to use nl2br as we render it, but that would involve not escaping any html in the notes field, which seems risky to me...

Fixes Bug #2283