### PR TITLE
Small fixes

### DIFF
--- a/app/Http/Controllers/AssetsController.php
+++ b/app/Http/Controllers/AssetsController.php
@@ -626,12 +626,12 @@ class AssetsController extends Controller
         if ($asset->save()) {
 
             if ($request->input('checkin_at') == Carbon::now()->format('Y-m-d')) {
-                $checkout_at = Carbon::now();
+                $checkin_at = Carbon::now();
             } else {
-                $checkout_at = $request->input('checkin_at').' 00:00:00';
+                $checkin_at = $request->input('checkin_at').' 00:00:00';
             }
-            //$checkout_at = e(Input::get('checkin_at'));
-            $logaction = $asset->createLogRecord('checkin', $asset, $admin, $user, null, e(Input::get('note')), $checkout_at);
+            //$checkin_at = e(Input::get('checkin_at'));
+            $logaction = $asset->createLogRecord('checkin', $asset, $admin, $user, null, e(Input::get('note')), $checkin_at);
 
 
             $settings = Setting::getSettings();

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -55,7 +55,7 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
 
         $user_permissions = json_decode($this->permissions, true);
 
-        //If the user is explicitly granted, return false
+        //If the user is explicitly granted, return true
         if (($user_permissions!='') && ((array_key_exists($section, $user_permissions)) && ($user_permissions[$section]=='1'))) {
             return true;
         }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -205,7 +205,7 @@ class AuthServiceProvider extends ServiceProvider
         # Components
         # -----------------------------------------
         $gate->define('components.view', function ($user) {
-            if (($user->hasAccess('components.create')) || ($user->hasAccess('admin'))) {
+            if (($user->hasAccess('components.view')) || ($user->hasAccess('admin'))) {
                 return true;
             }
         });

--- a/resources/views/licenses/view.blade.php
+++ b/resources/views/licenses/view.blade.php
@@ -119,21 +119,21 @@
                     @if (!is_null($license->serial))
                     <tr>
                       <td>{{ trans('admin/licenses/form.license_key') }}</td>
-                      <td style="word-wrap: break-word;overflow-wrap: break-word;word-break: break-word;">{{ nl2br(e($license->serial)) }}</td>
+                      <td style="word-wrap: break-word;overflow-wrap: break-word;word-break: break-word;">{!! nl2br(e($license->serial)) !!}</td>
                     </tr>
                     @endif
 
                     @if (!is_null($license->license_name))
                     <tr>
                       <td>{{ trans('admin/licenses/form.to_name') }}</td>
-                      <td>{{ nl2br(e($license->license_name)) }}</td>
+                      <td>{{ $license->license_name }}</td>
                     </tr>
                     @endif
 
                     @if (!is_null($license->license_email))
                     <tr>
                       <td>{{ trans('admin/licenses/form.to_email') }}</td>
-                      <td>{{ nl2br(e($license->license_email)) }}</td>
+                      <td>{{ $license->license_email }}</td>
                     </tr>
                     @endif
 


### PR DESCRIPTION
I know you hate grab-bag pull requests, but these are all one liners that fix little things I've encountered, and creating that many pull requests sounds exhausting.  

This does the following:

* Allows uses with the components:view permission to actually see components.
* Adjusts a comment that indicates the code does the opposite of what it actually does.
* Renames a variable that indiciates the code does the opposite of what it does.
* Renders line breaks in license keys, as well as removing nl2br() from a few fields where it makes no sense.  Fixes #2344 