### PR TITLE
Explicitly set the favicon in the basic and default layout templates

### DIFF
--- a/resources/views/layouts/basic.blade.php
+++ b/resources/views/layouts/basic.blade.php
@@ -8,6 +8,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Snipe-IT</title>
 
+    <!-- Favicon -->
+    <link rel="shortcut icon" type="image/ico" href="{{ asset('favicon.ico') }}">
     <!-- CSS -->
     <link rel="stylesheet" href="{{ asset('assets/css/bootstrap.min.css') }}">
     <!-- Font Awesome -->

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -24,6 +24,8 @@
     <!-- iCheck for checkboxes and radio inputs -->
     <link rel="stylesheet" href="{{ asset('assets/js/plugins/iCheck/all.css') }}">
 
+    <!-- Favicon -->
+    <link rel="shortcut icon" type="image/ico" href="{{ asset('favicon.ico') }}">
     <!-- Theme style -->
     <link rel="stylesheet" href="{{ asset('assets/css/skins/skin-blue.css') }}">
 
@@ -111,7 +113,7 @@
                       </a>
                   @endif
               </li>
-            </ul> 
+            </ul>
 
           <!-- Navbar Right Menu -->
             <div class="navbar-custom-menu">
@@ -379,7 +381,7 @@
       </a>
        <!-- Sidebar toggle button-->
       </header>
-     
+
       <!-- Left side column. contains the logo and sidebar -->
       <aside class="main-sidebar">
         <!-- sidebar: style can be found in sidebar.less -->


### PR DESCRIPTION
This is a temporary workaround to solve the issue of using the included favicon.ico file when installing to a subdirectory rather than to the root of the domain.  If you install to a subdirectory and the root domain already includes a favicon, that will be used rather than the included favicon.

A better approach would be to allow users to upload their own favicon in the same fashion as is done with logos.

*sorry for the auto whitespace cleanup that my editor did when I saved the default layout file