### PR TITLE
Fix more number_format madness.

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -43,7 +43,7 @@ class Helper
         return array_walk($emails_array, 'trim_value');
     }
 
-    public static function parseCurrencyString($cost)
+    public static function formatCurrencyOutput($cost)
     {
         // The importer has formatted number strings since v3, so the value might be a string, or an integer.
         // If it's a number, format it as a string

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -43,6 +43,17 @@ class Helper
         return array_walk($emails_array, 'trim_value');
     }
 
+    public static function parseCurrencyString($cost)
+    {
+        // The importer has formatted number strings since v3, so the value might be a string, or an integer.
+        // If it's a number, format it as a string
+        if (is_numeric($cost)) {
+            return number_format($cost, 2, '.', '');
+        }
+        // It's already been parsed.
+        return $cost;
+    }
+
     // This doesn't do anything yet
     public static function trim_value(&$value)
     {

--- a/app/Http/Controllers/AccessoriesController.php
+++ b/app/Http/Controllers/AccessoriesController.php
@@ -617,7 +617,7 @@ class AccessoriesController extends Controller
             'min_amt'  => e($accessory->min_amt),
             'location'      => ($accessory->location) ? e($accessory->location->name): '',
             'purchase_date' => e($accessory->purchase_date),
-            'purchase_cost' => Helper::parseCurrencyString($accessory->purchase_cost),
+            'purchase_cost' => Helper::formatCurrencyOutput($accessory->purchase_cost),
             'numRemaining'  => $accessory->numRemaining(),
             'actions'       => $actions,
             'companyName'   => is_null($company) ? '' : e($company->name)

--- a/app/Http/Controllers/AccessoriesController.php
+++ b/app/Http/Controllers/AccessoriesController.php
@@ -617,7 +617,7 @@ class AccessoriesController extends Controller
             'min_amt'  => e($accessory->min_amt),
             'location'      => ($accessory->location) ? e($accessory->location->name): '',
             'purchase_date' => e($accessory->purchase_date),
-            'purchase_cost' => number_format($accessory->purchase_cost, 2),
+            'purchase_cost' => Helper::parseCurrencyString($accessory->purchase_cost),
             'numRemaining'  => $accessory->numRemaining(),
             'actions'       => $actions,
             'companyName'   => is_null($company) ? '' : e($company->name)

--- a/app/Http/Controllers/AssetsController.php
+++ b/app/Http/Controllers/AssetsController.php
@@ -354,7 +354,7 @@ class AssetsController extends Controller
         }
 
         if ($request->has('purchase_cost')) {
-            $asset->purchase_cost = e(Helper::parseCurrencyString($request->input('purchase_cost')));
+            $asset->purchase_cost = e(Helper::formatCurrencyOutput($request->input('purchase_cost')));
         } else {
             $asset->purchase_cost =  null;
         }
@@ -1741,7 +1741,7 @@ class AssetsController extends Controller
                 }
             }
 
-            $purchase_cost = Helper::parseCurrencyString($asset->purchase_cost);
+            $purchase_cost = Helper::formatCurrencyOutput($asset->purchase_cost);
 
             $row = array(
             'checkbox'      =>'<div class="text-center"><input type="checkbox" name="edit_asset['.$asset->id.']" class="one_required"></div>',

--- a/app/Http/Controllers/AssetsController.php
+++ b/app/Http/Controllers/AssetsController.php
@@ -354,7 +354,7 @@ class AssetsController extends Controller
         }
 
         if ($request->has('purchase_cost')) {
-            $asset->purchase_cost = e(number_format($request->input('purchase_cost'), 2, '.', ''));
+            $asset->purchase_cost = e(Helper::parseCurrencyString($request->input('purchase_cost')));
         } else {
             $asset->purchase_cost =  null;
         }
@@ -1741,11 +1741,7 @@ class AssetsController extends Controller
                 }
             }
 
-            // Lots going on here.  Importer has parsed numbers before importing, so we need to check and see if it's a number before trying to parse.
-            $purchase_cost = $asset->purchase_cost ?: '';
-            if (is_numeric($purchase_cost)) {
-                $purchase_cost = number_format($purchase_cost, 2);
-            }
+            $purchase_cost = Helper::parseCurrencyString($asset->purchase_cost);
 
             $row = array(
             'checkbox'      =>'<div class="text-center"><input type="checkbox" name="edit_asset['.$asset->id.']" class="one_required"></div>',

--- a/app/Http/Controllers/ComponentsController.php
+++ b/app/Http/Controllers/ComponentsController.php
@@ -484,7 +484,7 @@ class ComponentsController extends Controller
                 'category'           => ($component->category) ? e($component->category->name) : 'Missing category',
                 'order_number'  => e($component->order_number),
                 'purchase_date'  => e($component->purchase_date),
-                'purchase_cost'  => Helper::parseCurrencyString($component->purchase_cost),
+                'purchase_cost'  => Helper::formatCurrencyOutput($component->purchase_cost),
                 'numRemaining'  => $component->numRemaining(),
                 'actions'       => $actions,
                 'companyName'   => is_null($company) ? '' : e($company->name),

--- a/app/Http/Controllers/ComponentsController.php
+++ b/app/Http/Controllers/ComponentsController.php
@@ -484,7 +484,7 @@ class ComponentsController extends Controller
                 'category'           => ($component->category) ? e($component->category->name) : 'Missing category',
                 'order_number'  => e($component->order_number),
                 'purchase_date'  => e($component->purchase_date),
-                'purchase_cost'  => ($component->purchase_cost!='') ? number_format($component->purchase_cost, 2): '' ,
+                'purchase_cost'  => Helper::parseCurrencyString($component->purchase_cost),
                 'numRemaining'  => $component->numRemaining(),
                 'actions'       => $actions,
                 'companyName'   => is_null($company) ? '' : e($company->name),

--- a/app/Http/Controllers/ConsumablesController.php
+++ b/app/Http/Controllers/ConsumablesController.php
@@ -476,7 +476,7 @@ class ConsumablesController extends Controller
                 'category'           => ($consumable->category) ? e($consumable->category->name) : 'Missing category',
                 'order_number'  => e($consumable->order_number),
                 'purchase_date'  => e($consumable->purchase_date),
-                'purchase_cost'  => ($consumable->purchase_cost!='') ? number_format($consumable->purchase_cost, 2): '' ,
+                'purchase_cost'  => Helper::parseCurrencyString($consumable->purchase_cost),
                 'numRemaining'  => $consumable->numRemaining(),
                 'actions'       => $actions,
                 'companyName'   => is_null($company) ? '' : e($company->name),

--- a/app/Http/Controllers/ConsumablesController.php
+++ b/app/Http/Controllers/ConsumablesController.php
@@ -476,7 +476,7 @@ class ConsumablesController extends Controller
                 'category'           => ($consumable->category) ? e($consumable->category->name) : 'Missing category',
                 'order_number'  => e($consumable->order_number),
                 'purchase_date'  => e($consumable->purchase_date),
-                'purchase_cost'  => Helper::parseCurrencyString($consumable->purchase_cost),
+                'purchase_cost'  => Helper::formatCurrencyOutput($consumable->purchase_cost),
                 'numRemaining'  => $consumable->numRemaining(),
                 'actions'       => $actions,
                 'companyName'   => is_null($company) ? '' : e($company->name),

--- a/app/Http/Controllers/LicensesController.php
+++ b/app/Http/Controllers/LicensesController.php
@@ -1015,7 +1015,7 @@ class LicensesController extends Controller
                 'license_email'      => e($license->license_email),
                 'purchase_date'     => ($license->purchase_date) ? $license->purchase_date : '',
                 'expiration_date'     => ($license->expiration_date) ? $license->expiration_date : '',
-                'purchase_cost'     => Helper::parseCurrencyString($license->purchase_cost),
+                'purchase_cost'     => Helper::formatCurrencyOutput($license->purchase_cost),
                 'purchase_order'     => ($license->purchase_order) ? e($license->purchase_order) : '',
                 'order_number'     => ($license->order_number) ? e($license->order_number) : '',
                 'notes'     => ($license->notes) ? e($license->notes) : '',

--- a/app/Http/Controllers/LicensesController.php
+++ b/app/Http/Controllers/LicensesController.php
@@ -1015,7 +1015,7 @@ class LicensesController extends Controller
                 'license_email'      => e($license->license_email),
                 'purchase_date'     => ($license->purchase_date) ? $license->purchase_date : '',
                 'expiration_date'     => ($license->expiration_date) ? $license->expiration_date : '',
-                'purchase_cost'     => ($license->purchase_cost) ? number_format($license->purchase_cost, 2) : '',
+                'purchase_cost'     => Helper::parseCurrencyString($license->purchase_cost),
                 'purchase_order'     => ($license->purchase_order) ? e($license->purchase_order) : '',
                 'order_number'     => ($license->order_number) ? e($license->order_number) : '',
                 'notes'     => ($license->notes) ? e($license->notes) : '',

--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -309,9 +309,9 @@ class ReportsController extends Controller
             }
 
             $row[] = $asset->purchase_date;
-            $row[] = $currency . Helper::parseCurrencyString($asset->purchase_cost);
-            $row[] = $currency . Helper::parseCurrencyString($asset->getDepreciatedValue());
-            $row[] = $currency . Helper::parseCurrencyString(( $asset->purchase_cost - $asset->getDepreciatedValue() ));
+            $row[] = $currency . Helper::formatCurrencyOutput($asset->purchase_cost);
+            $row[] = $currency . Helper::formatCurrencyOutput($asset->getDepreciatedValue());
+            $row[] = $currency . Helper::formatCurrencyOutput(( $asset->purchase_cost - $asset->getDepreciatedValue() ));
             $csv->insertOne($row);
         }
 
@@ -393,7 +393,7 @@ class ReportsController extends Controller
             $row[] = $license->remaincount();
             $row[] = $license->expiration_date;
             $row[] = $license->purchase_date;
-            $row[] = '"' . Helper::parseCurrencyString($license->purchase_cost) . '"';
+            $row[] = '"' . Helper::formatCurrencyOutput($license->purchase_cost) . '"';
 
             $rows[] = implode($row, ',');
         }
@@ -529,7 +529,7 @@ class ReportsController extends Controller
                 $row[] = e($asset->purchase_date);
             }
             if (e(Input::get('purchase_cost')) == '1' && ( e(Input::get('depreciation')) != '1' )) {
-                $row[] = '"' . Helper::parseCurrencyString($asset->purchase_cost) . '"';
+                $row[] = '"' . Helper::formatCurrencyOutput($asset->purchase_cost) . '"';
             }
             if (e(Input::get('order')) == '1') {
                 if ($asset->order_number) {
@@ -606,9 +606,9 @@ class ReportsController extends Controller
             }
             if (e(Input::get('depreciation')) == '1') {
                 $depreciation = $asset->getDepreciatedValue();
-                $row[]        = '"' . Helper::parseCurrencyString($asset->purchase_cost) . '"';
-                $row[]        = '"' . Helper::parseCurrencyString($depreciation) . '"';
-                $row[]        = '"' . Helper::parseCurrencyString($asset->purchase_cost) . '"';
+                $row[]        = '"' . Helper::formatCurrencyOutput($asset->purchase_cost) . '"';
+                $row[]        = '"' . Helper::formatCurrencyOutput($depreciation) . '"';
+                $row[]        = '"' . Helper::formatCurrencyOutput($asset->purchase_cost) . '"';
             }
 
             foreach ($customfields as $customfield) {
@@ -699,7 +699,7 @@ class ReportsController extends Controller
                 $improvementTime = intval($assetMaintenance->asset_maintenance_time);
             }
             $row[]  = $improvementTime;
-            $row[]  = trans('general.currency') . Helper::parseCurrencyString($assetMaintenance->cost);
+            $row[]  = trans('general.currency') . Helper::formatCurrencyOutput($assetMaintenance->cost);
             $rows[] = implode($row, ',');
         }
 

--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -1,25 +1,26 @@
 <?php
 namespace App\Http\Controllers;
 
+use App\Helpers\Helper;
 use App\Models\Accessory;
 use App\Models\Actionlog;
 use App\Models\Asset;
 use App\Models\AssetMaintenance;
-use Carbon\Carbon;
+use App\Models\AssetModel;
 use App\Models\Company;
+use App\Models\CustomField;
+use App\Models\License;
+use App\Models\Location;
+use App\Models\Setting;
+use App\Models\User;
+use Carbon\Carbon;
 use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Response;
 use Illuminate\Support\Facades\View;
 use Input;
 use League\Csv\Reader;
-use App\Models\License;
-use App\Models\Location;
-use App\Models\AssetModel;
-use App\Models\CustomField;
 use Redirect;
-use App\Models\Setting;
-use App\Models\User;
 
 /**
  * This controller handles all actions related to Reports for
@@ -166,7 +167,7 @@ class ReportsController extends Controller
                 $row[] = '';
             }
             $row[] = $asset->purchase_date;
-            $row[] = '"' . number_format($asset->purchase_cost, 2) . '"';
+            $row[] = '"' . Helper::parsePurchasedCost($asset->purchase_cost) . '"';
             if ($asset->order_number) {
                 $row[] = e($asset->order_number);
             } else {
@@ -308,9 +309,9 @@ class ReportsController extends Controller
             }
 
             $row[] = $asset->purchase_date;
-            $row[] = $currency . number_format($asset->purchase_cost, 2);
-            $row[] = $currency . number_format($asset->getDepreciatedValue(), 2);
-            $row[] = $currency . number_format(( $asset->purchase_cost - $asset->getDepreciatedValue() ), 2);
+            $row[] = $currency . Helper::parseCurrencyString($asset->purchase_cost);
+            $row[] = $currency . Helper::parseCurrencyString($asset->getDepreciatedValue());
+            $row[] = $currency . Helper::parseCurrencyString(( $asset->purchase_cost - $asset->getDepreciatedValue() ));
             $csv->insertOne($row);
         }
 
@@ -392,7 +393,7 @@ class ReportsController extends Controller
             $row[] = $license->remaincount();
             $row[] = $license->expiration_date;
             $row[] = $license->purchase_date;
-            $row[] = '"' . number_format($license->purchase_cost, 2) . '"';
+            $row[] = '"' . Helper::parseCurrencyString($license->purchase_cost) . '"';
 
             $rows[] = implode($row, ',');
         }
@@ -416,7 +417,7 @@ class ReportsController extends Controller
     public function getCustomReport()
     {
         $customfields = CustomField::get();
-        return View::make('reports/custom')->with('customfields',$customfields);
+        return View::make('reports/custom')->with('customfields', $customfields);
     }
 
     /**
@@ -528,7 +529,7 @@ class ReportsController extends Controller
                 $row[] = e($asset->purchase_date);
             }
             if (e(Input::get('purchase_cost')) == '1' && ( e(Input::get('depreciation')) != '1' )) {
-                $row[] = '"' . number_format($asset->purchase_cost, 2) . '"';
+                $row[] = '"' . Helper::parseCurrencyString($asset->purchase_cost) . '"';
             }
             if (e(Input::get('order')) == '1') {
                 if ($asset->order_number) {
@@ -605,9 +606,9 @@ class ReportsController extends Controller
             }
             if (e(Input::get('depreciation')) == '1') {
                 $depreciation = $asset->getDepreciatedValue();
-                $row[]        = '"' . number_format($asset->purchase_cost, 2) . '"';
-                $row[]        = '"' . number_format($depreciation, 2) . '"';
-                $row[]        = '"' . number_format($asset->purchase_cost - $depreciation, 2) . '"';
+                $row[]        = '"' . Helper::parseCurrencyString($asset->purchase_cost) . '"';
+                $row[]        = '"' . Helper::parseCurrencyString($depreciation) . '"';
+                $row[]        = '"' . Helper::parseCurrencyString($asset->purchase_cost) . '"';
             }
 
             foreach ($customfields as $customfield) {
@@ -698,7 +699,7 @@ class ReportsController extends Controller
                 $improvementTime = intval($assetMaintenance->asset_maintenance_time);
             }
             $row[]  = $improvementTime;
-            $row[]  = trans('general.currency') . number_format($assetMaintenance->cost, 2);
+            $row[]  = trans('general.currency') . Helper::parseCurrencyString($assetMaintenance->cost);
             $rows[] = implode($row, ',');
         }
 

--- a/resources/views/accessories/edit.blade.php
+++ b/resources/views/accessories/edit.blade.php
@@ -132,7 +132,7 @@
                     <span class="input-group-addon">
                         {{ \App\Models\Setting::first()->default_currency }}
                     </span>
-                    <input class="col-md-3 form-control" type="text" name="purchase_cost" id="purchase_cost" value="{{ Input::old('purchase_cost', \App\Helpers\Helper::parseCurrencyString($accessory->purchase_cost)) }}" />
+                    <input class="col-md-3 form-control" type="text" name="purchase_cost" id="purchase_cost" value="{{ Input::old('purchase_cost', \App\Helpers\Helper::formatCurrencyOutput($accessory->purchase_cost)) }}" />
                     {!! $errors->first('purchase_cost', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
                 </div>
             </div>

--- a/resources/views/accessories/edit.blade.php
+++ b/resources/views/accessories/edit.blade.php
@@ -132,7 +132,7 @@
                     <span class="input-group-addon">
                         {{ \App\Models\Setting::first()->default_currency }}
                     </span>
-                    <input class="col-md-3 form-control" type="text" name="purchase_cost" id="purchase_cost" value="{{ Input::old('purchase_cost', number_format($accessory->purchase_cost,2)) }}" />
+                    <input class="col-md-3 form-control" type="text" name="purchase_cost" id="purchase_cost" value="{{ Input::old('purchase_cost', \App\Helpers\Helper::parseCurrencyString($accessory->purchase_cost)) }}" />
                     {!! $errors->first('purchase_cost', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
                 </div>
             </div>

--- a/resources/views/asset_maintenances/edit.blade.php
+++ b/resources/views/asset_maintenances/edit.blade.php
@@ -122,7 +122,7 @@
               <div class="col-md-2">
                   <div class="input-group">
                       <span class="input-group-addon">{{ \App\Models\Setting::first()->default_currency }}</span>
-                      <input class="col-md-2 form-control" type="text" name="cost" id="cost" value="{{ Input::old('cost', number_format($assetMaintenance->cost,2)) }}" />
+                      <input class="col-md-2 form-control" type="text" name="cost" id="cost" value="{{ Input::old('cost', \App\Helpers\Helper::parseCurrencyString($assetMaintenance->cost)) }}" />
                       {!! $errors->first('cost', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
                   </div>
               </div>

--- a/resources/views/asset_maintenances/edit.blade.php
+++ b/resources/views/asset_maintenances/edit.blade.php
@@ -122,7 +122,7 @@
               <div class="col-md-2">
                   <div class="input-group">
                       <span class="input-group-addon">{{ \App\Models\Setting::first()->default_currency }}</span>
-                      <input class="col-md-2 form-control" type="text" name="cost" id="cost" value="{{ Input::old('cost', \App\Helpers\Helper::parseCurrencyString($assetMaintenance->cost)) }}" />
+                      <input class="col-md-2 form-control" type="text" name="cost" id="cost" value="{{ Input::old('cost', \App\Helpers\Helper::formatCurrencyOutput($assetMaintenance->cost)) }}" />
                       {!! $errors->first('cost', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
                   </div>
               </div>

--- a/resources/views/components/edit.blade.php
+++ b/resources/views/components/edit.blade.php
@@ -156,7 +156,7 @@
                      <span class="input-group-addon">
                          {{ \App\Models\Setting::first()->default_currency }}
                      </span>
-                     <input class="col-md-2 form-control" type="text" name="purchase_cost" id="purchase_cost" value="{{ Input::old('purchase_cost', number_format($component->purchase_cost,2)) }}" />
+                     <input class="col-md-2 form-control" type="text" name="purchase_cost" id="purchase_cost" value="{{ Input::old('purchase_cost', \App\Helpers\Helper::parseCurrencyString($component->purchase_cost)) }}" />
                      {!! $errors->first('purchase_cost', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
                  </div>
              </div>

--- a/resources/views/components/edit.blade.php
+++ b/resources/views/components/edit.blade.php
@@ -156,7 +156,7 @@
                      <span class="input-group-addon">
                          {{ \App\Models\Setting::first()->default_currency }}
                      </span>
-                     <input class="col-md-2 form-control" type="text" name="purchase_cost" id="purchase_cost" value="{{ Input::old('purchase_cost', \App\Helpers\Helper::parseCurrencyString($component->purchase_cost)) }}" />
+                     <input class="col-md-2 form-control" type="text" name="purchase_cost" id="purchase_cost" value="{{ Input::old('purchase_cost', \App\Helpers\Helper::formatCurrencyOutput($component->purchase_cost)) }}" />
                      {!! $errors->first('purchase_cost', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
                  </div>
              </div>

--- a/resources/views/components/view.blade.php
+++ b/resources/views/components/view.blade.php
@@ -83,7 +83,7 @@
         <div class="col-md-12" style="padding-bottom: 5px;"><strong>{{ trans('admin/components/general.cost') }}:</strong>
         {{ \App\Models\Setting::first()->default_currency }}
 
-        {{ number_format($component->purchase_cost,2) }} </div>
+        {{ \App\Helpers\Helper::parseCurrencyString($component->purchase_cost) }} </div>
     @endif
 
     @if ($component->order_number)

--- a/resources/views/components/view.blade.php
+++ b/resources/views/components/view.blade.php
@@ -83,7 +83,7 @@
         <div class="col-md-12" style="padding-bottom: 5px;"><strong>{{ trans('admin/components/general.cost') }}:</strong>
         {{ \App\Models\Setting::first()->default_currency }}
 
-        {{ \App\Helpers\Helper::parseCurrencyString($component->purchase_cost) }} </div>
+        {{ \App\Helpers\Helper::formatCurrencyOutput($component->purchase_cost) }} </div>
     @endif
 
     @if ($component->order_number)

--- a/resources/views/consumables/edit.blade.php
+++ b/resources/views/consumables/edit.blade.php
@@ -159,7 +159,7 @@
                      <span class="input-group-addon">
                          {{ \App\Models\Setting::first()->default_currency }}
                      </span>
-                     <input class="col-md-2 form-control" type="text" name="purchase_cost" id="purchase_cost" value="{{ Input::old('purchase_cost', \App\Helpers\Helper::parseCurrencyString($consumable->purchase_cost)) }}" />
+                     <input class="col-md-2 form-control" type="text" name="purchase_cost" id="purchase_cost" value="{{ Input::old('purchase_cost', \App\Helpers\Helper::formatCurrencyOutput($consumable->purchase_cost)) }}" />
                      {!! $errors->first('purchase_cost', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
                  </div>
              </div>

--- a/resources/views/consumables/edit.blade.php
+++ b/resources/views/consumables/edit.blade.php
@@ -159,7 +159,7 @@
                      <span class="input-group-addon">
                          {{ \App\Models\Setting::first()->default_currency }}
                      </span>
-                     <input class="col-md-2 form-control" type="text" name="purchase_cost" id="purchase_cost" value="{{ Input::old('purchase_cost', number_format($consumable->purchase_cost,2)) }}" />
+                     <input class="col-md-2 form-control" type="text" name="purchase_cost" id="purchase_cost" value="{{ Input::old('purchase_cost', \App\Helpers\Helper::parseCurrencyString($consumable->purchase_cost)) }}" />
                      {!! $errors->first('purchase_cost', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
                  </div>
              </div>

--- a/resources/views/consumables/view.blade.php
+++ b/resources/views/consumables/view.blade.php
@@ -72,7 +72,7 @@
         <div class="col-md-12" style="padding-bottom: 5px;"><strong>{{ trans('admin/consumables/general.cost') }}:</strong>
         {{ \App\Models\Setting::first()->default_currency }}
 
-        {{ number_format($consumable->purchase_cost,2) }} </div>
+        {{ \App\Helpers\Helper::parseCurrencyString($consumable->purchase_cost) }} </div>
     @endif
 
     @if ($consumable->item_no)

--- a/resources/views/consumables/view.blade.php
+++ b/resources/views/consumables/view.blade.php
@@ -72,7 +72,7 @@
         <div class="col-md-12" style="padding-bottom: 5px;"><strong>{{ trans('admin/consumables/general.cost') }}:</strong>
         {{ \App\Models\Setting::first()->default_currency }}
 
-        {{ \App\Helpers\Helper::parseCurrencyString($consumable->purchase_cost) }} </div>
+        {{ \App\Helpers\Helper::formatCurrencyOutput($consumable->purchase_cost) }} </div>
     @endif
 
     @if ($consumable->item_no)

--- a/resources/views/hardware/edit.blade.php
+++ b/resources/views/hardware/edit.blade.php
@@ -215,7 +215,7 @@
 
 
                                </span>
-                               <input class="col-md-2 form-control" type="text" name="purchase_cost" id="purchase_cost" value="{{ Input::old('purchase_cost', number_format($asset->purchase_cost,2, '.', '')) }}" />
+                               <input class="col-md-2 form-control" type="text" name="purchase_cost" id="purchase_cost" value="{{ Input::old('purchase_cost', \App\Helpers\Helper::parseCurrencyString($asset->purchase_cost)) }}" />
                                {!! $errors->first('purchase_cost', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
                         </div>
                 </div>

--- a/resources/views/hardware/edit.blade.php
+++ b/resources/views/hardware/edit.blade.php
@@ -215,7 +215,7 @@
 
 
                                </span>
-                               <input class="col-md-2 form-control" type="text" name="purchase_cost" id="purchase_cost" value="{{ Input::old('purchase_cost', \App\Helpers\Helper::parseCurrencyString($asset->purchase_cost)) }}" />
+                               <input class="col-md-2 form-control" type="text" name="purchase_cost" id="purchase_cost" value="{{ Input::old('purchase_cost', \App\Helpers\Helper::formatCurrencyOutput($asset->purchase_cost)) }}" />
                                {!! $errors->first('purchase_cost', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
                         </div>
                 </div>

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -154,7 +154,7 @@
                           @else
                             {{ \App\Models\Setting::first()->default_currency }}
                           @endif
-                          {{ number_format($asset->purchase_cost,2) }}
+                          {{ \App\Helpers\Helper::parseCurrencyString($asset->purchase_cost)}}
 
                           @if ($asset->order_number)
                               (Order #{{ $asset->order_number }})

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -154,7 +154,7 @@
                           @else
                             {{ \App\Models\Setting::first()->default_currency }}
                           @endif
-                          {{ \App\Helpers\Helper::parseCurrencyString($asset->purchase_cost)}}
+                          {{ \App\Helpers\Helper::formatCurrencyOutput($asset->purchase_cost)}}
 
                           @if ($asset->order_number)
                               (Order #{{ $asset->order_number }})

--- a/resources/views/licenses/edit.blade.php
+++ b/resources/views/licenses/edit.blade.php
@@ -139,7 +139,7 @@
                   <div class="col-md-3">
                       <div class="input-group">
                           <span class="input-group-addon">{{ \App\Models\Setting::first()->default_currency }}</span>
-                          <input class="col-md-3 form-control" type="text" name="purchase_cost" id="purchase_cost" value="{{ Input::old('purchase_cost', \App\Helpers\Helper::parseCurrencyString($license->purchase_cost)) }}" />
+                          <input class="col-md-3 form-control" type="text" name="purchase_cost" id="purchase_cost" value="{{ Input::old('purchase_cost', \App\Helpers\Helper::formatCurrencyOutput($license->purchase_cost)) }}" />
                           {!! $errors->first('purchase_cost', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
                        </div>
                    </div>

--- a/resources/views/licenses/edit.blade.php
+++ b/resources/views/licenses/edit.blade.php
@@ -139,7 +139,7 @@
                   <div class="col-md-3">
                       <div class="input-group">
                           <span class="input-group-addon">{{ \App\Models\Setting::first()->default_currency }}</span>
-                          <input class="col-md-3 form-control" type="text" name="purchase_cost" id="purchase_cost" value="{{ Input::old('purchase_cost', number_format($license->purchase_cost,2)) }}" />
+                          <input class="col-md-3 form-control" type="text" name="purchase_cost" id="purchase_cost" value="{{ Input::old('purchase_cost', \App\Helpers\Helper::parseCurrencyString($license->purchase_cost)) }}" />
                           {!! $errors->first('purchase_cost', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
                        </div>
                    </div>

--- a/resources/views/licenses/view.blade.php
+++ b/resources/views/licenses/view.blade.php
@@ -246,7 +246,7 @@
                       </td>
                       <td>
                         {{ \App\Models\Setting::first()->default_currency }}
-                        {{ \App\Helpers\Helper::parseCurrencyString($license->purchase_cost) }}
+                        {{ \App\Helpers\Helper::formatCurrencyOutput($license->purchase_cost) }}
                       </td>
                     </tr>
                     @endif

--- a/resources/views/licenses/view.blade.php
+++ b/resources/views/licenses/view.blade.php
@@ -246,7 +246,7 @@
                       </td>
                       <td>
                         {{ \App\Models\Setting::first()->default_currency }}
-                        {{ number_format($license->purchase_cost,2) }}
+                        {{ \App\Helpers\Helper::parseCurrencyString($license->purchase_cost) }}
                       </td>
                     </tr>
                     @endif

--- a/resources/views/reports/asset.blade.php
+++ b/resources/views/reports/asset.blade.php
@@ -77,7 +77,7 @@
             </td>
             <td>{{ $asset->purchase_date }}</td>
             <td class="align-right">{{ $settings->default_currency }}
-                {{ \App\Helpers\Helper::parseCurrencyString($asset->purchase_cost) }}
+                {{ \App\Helpers\Helper::formatCurrencyOutput($asset->purchase_cost) }}
             </td>
             <td>
                 @if ($asset->order_number)

--- a/resources/views/reports/asset.blade.php
+++ b/resources/views/reports/asset.blade.php
@@ -77,7 +77,7 @@
             </td>
             <td>{{ $asset->purchase_date }}</td>
             <td class="align-right">{{ $settings->default_currency }}
-                {{ number_format($asset->purchase_cost) }}
+                {{ \App\Helpers\Helper::parseCurrencyString($asset->purchase_cost) }}
             </td>
             <td>
                 @if ($asset->order_number)

--- a/resources/views/reports/depreciation.blade.php
+++ b/resources/views/reports/depreciation.blade.php
@@ -111,7 +111,7 @@
                 @else
                     {{ \App\Models\Setting::first()->default_currency }}
                 @endif
-                {{ \App\Helpers\Helper::parseCurrencyString($asset->purchase_cost) }}</td>
+                {{ \App\Helpers\Helper::formatCurrencyOutput($asset->purchase_cost) }}</td>
             <td class="align-right">
                 @if ($asset->assetloc )
                     {{ $asset->assetloc->currency }}
@@ -119,7 +119,7 @@
                     {{ \App\Models\Setting::first()->default_currency }}
                 @endif
 
-                {{ \App\Helpers\Helper::parseCurrencyString($asset->getDepreciatedValue()) }}</td>
+                {{ \App\Helpers\Helper::formatCurrencyOutput($asset->getDepreciatedValue()) }}</td>
             <td class="align-right">
                 @if ($asset->assetloc)
                     {{ $asset->assetloc->currency }}
@@ -127,7 +127,7 @@
                     {{ \App\Models\Setting::first()->default_currency }}
                 @endif
 
-                -{{ \App\Helpers\Helper::parseCurrencyString(($asset->purchase_cost - $asset->getDepreciatedValue())) }}</td>
+                -{{ \App\Helpers\Helper::formatCurrencyOutput(($asset->purchase_cost - $asset->getDepreciatedValue())) }}</td>
             @else
 	            <td></td>
 	            <td></td>

--- a/resources/views/reports/depreciation.blade.php
+++ b/resources/views/reports/depreciation.blade.php
@@ -111,7 +111,7 @@
                 @else
                     {{ \App\Models\Setting::first()->default_currency }}
                 @endif
-            	{{ number_format($asset->purchase_cost) }}</td>
+                {{ \App\Helpers\Helper::parseCurrencyString($asset->purchase_cost) }}</td>
             <td class="align-right">
                 @if ($asset->assetloc )
                     {{ $asset->assetloc->currency }}
@@ -119,7 +119,7 @@
                     {{ \App\Models\Setting::first()->default_currency }}
                 @endif
 
-            	{{ number_format($asset->getDepreciatedValue()) }}</td>
+                {{ \App\Helpers\Helper::parseCurrencyString($asset->getDepreciatedValue()) }}</td>
             <td class="align-right">
                 @if ($asset->assetloc)
                     {{ $asset->assetloc->currency }}
@@ -127,7 +127,7 @@
                     {{ \App\Models\Setting::first()->default_currency }}
                 @endif
 
-            	-{{ number_format(($asset->purchase_cost - $asset->getDepreciatedValue())) }}</td>
+                -{{ \App\Helpers\Helper::parseCurrencyString(($asset->purchase_cost - $asset->getDepreciatedValue())) }}</td>
             @else
 	            <td></td>
 	            <td></td>

--- a/resources/views/reports/index.blade.php
+++ b/resources/views/reports/index.blade.php
@@ -74,7 +74,7 @@
             @if ($asset->purchase_cost > 0)
             <td class="align-right">
               {{ \App\Models\Setting::first()->default_currency }}
-              {{ number_format($asset->purchase_cost) }}
+              {{ \App\Helpers\Helper::parseCurrencyString($asset->purchase_cost) }}
             </td>
             <td class="align-right">
               {{ \App\Models\Setting::first()->default_currency }}

--- a/resources/views/reports/index.blade.php
+++ b/resources/views/reports/index.blade.php
@@ -74,7 +74,7 @@
             @if ($asset->purchase_cost > 0)
             <td class="align-right">
               {{ \App\Models\Setting::first()->default_currency }}
-              {{ \App\Helpers\Helper::parseCurrencyString($asset->purchase_cost) }}
+              {{ \App\Helpers\Helper::formatCurrencyOutput($asset->purchase_cost) }}
             </td>
             <td class="align-right">
               {{ \App\Models\Setting::first()->default_currency }}


### PR DESCRIPTION
This does two main things:
1) The importer now imports as numbers, not parsed strings.  This allows
is to format values on output instead of input, which is what was
happening in most places.

2) Add a Helper::parseCurrencyString method and port everything to use
this.  This checks to see if the value is numeric or empty, and returns
the appropriate value in all cases.  Should fix all known occurances of
number_format expections.