### PR TITLE
Importer: Implement item update and interface improvments

### DIFF
--- a/app/Console/Commands/ObjectImportCommand.php
+++ b/app/Console/Commands/ObjectImportCommand.php
@@ -1,25 +1,26 @@
 <?php
 namespace App\Console\Commands;
 
-use Illuminate\Console\Command;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputArgument;
-use League\Csv\Reader;
+use App\Helpers\Helper;
 use App\Models\Accessory;
 use App\Models\Asset;
 use App\Models\AssetModel;
 use App\Models\Category;
 use App\Models\Company;
 use App\Models\Consumable;
+use App\Models\CustomField;
 use App\Models\Location;
 use App\Models\Manufacturer;
+use App\Models\Setting;
 use App\Models\Statuslabel;
 use App\Models\Supplier;
 use App\Models\User;
-use App\Models\CustomField;
 use DB;
-use App\Models\Setting;
+use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Model;
+use League\Csv\Reader;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 
 ini_set('max_execution_time', 600); //600 seconds = 10 minutes
 ini_set('memory_limit', '500M');
@@ -795,7 +796,8 @@ class ObjectImportCommand extends Command
         if (!empty($item["purchase_cost"])) {
             //TODO How to generalize this for not USD?
             $purchase_cost = substr($item["purchase_cost"], 0, 1) === '$' ? substr($item["purchase_cost"], 1) : $item["purchase_cost"];
-            $asset->purchase_cost = number_format($purchase_cost, 2, '.', '');
+            // $asset->purchase_cost = number_format($purchase_cost, 2, '.', '');
+            $asset->purchase_cost = Helper::ParseFloat($purchase_cost);
             $this->log("Asset cost parsed: " . $asset->purchase_cost);
         } else {
             $asset->purchase_cost = 0.00;

--- a/app/Console/Commands/ObjectImportCommand.php
+++ b/app/Console/Commands/ObjectImportCommand.php
@@ -886,7 +886,7 @@ class ObjectImportCommand extends Command
                     return;
                 }
                 $this->log('Updating matching accessory with new values');
-                $editingAsset = true;
+                $editingAccessory = true;
                 $accessory = $tempaccessory;
             }
         }

--- a/app/Http/Controllers/AssetsController.php
+++ b/app/Http/Controllers/AssetsController.php
@@ -948,7 +948,7 @@ class AssetsController extends Controller
     * @since [v2.0]
     * @return Redirect
     */
-    public function getProcessImportFile()
+    public function postProcessImportFile()
     {
         // php artisan asset-import:csv path/to/your/file.csv --domain=yourdomain.com --email_format=firstname.lastname
         $filename = Input::get('filename');

--- a/app/Http/Controllers/AssetsController.php
+++ b/app/Http/Controllers/AssetsController.php
@@ -948,23 +948,28 @@ class AssetsController extends Controller
     * @since [v2.0]
     * @return Redirect
     */
-    public function getProcessImportFile($filename)
+    public function getProcessImportFile()
     {
         // php artisan asset-import:csv path/to/your/file.csv --domain=yourdomain.com --email_format=firstname.lastname
+        $filename = Input::get('filename');
+        $itemType = Input::get('import-type');
+        $updateItems  = Input::get('import-update');
 
         if (!Company::isCurrentUserAuthorized()) {
             return redirect()->to('hardware')->with('error', trans('general.insufficient_permissions'));
         }
-
-        $return = Artisan::call(
-            'snipeit:import',
-            ['filename'=> config('app.private_uploads').'/imports/assets/'.$filename,
+        $importOptions =    ['filename'=> config('app.private_uploads').'/imports/assets/'.$filename,
                                 '--email_format'=>'firstname.lastname',
                                 '--username_format'=>'firstname.lastname',
                                 '--web-importer' => true,
-                                '--user_id' => Auth::user()->id
-                                ]
-        );
+                                '--user_id' => Auth::user()->id,
+                                '--item-type' => $itemType,
+                            ];
+        if ($updateItems) {
+            $importOptions['--update'] = true;
+        }
+
+        $return = Artisan::call('snipeit:import', $importOptions);
         $display_output =  Artisan::output();
         $file = config('app.private_uploads').'/imports/assets/'.str_replace('.csv', '', $filename).'-output-'.date("Y-m-d-his").'.txt';
         file_put_contents($file, $display_output);

--- a/app/Http/Controllers/AssetsController.php
+++ b/app/Http/Controllers/AssetsController.php
@@ -973,8 +973,22 @@ class AssetsController extends Controller
         $display_output =  Artisan::output();
         $file = config('app.private_uploads').'/imports/assets/'.str_replace('.csv', '', $filename).'-output-'.date("Y-m-d-his").'.txt';
         file_put_contents($file, $display_output);
+        // We use hardware instead of asset in the url
+        $redirectTo = "hardware";
+        switch($itemType) {
+            case "asset":
+                $redirectTo = "hardware";
+                break;
+            case "accessory":
+                $redirectTo = "accessories";
+                break;
+            case "consumable":
+                $redirectTo = "consumables";
+                break;
+        }
+
         if ($return === 0) { //Success
-            return redirect()->to('hardware')->with('success', trans('admin/hardware/message.import.success'));
+            return redirect()->to(route($redirectTo))->with('success', trans('admin/hardware/message.import.success'));
         } elseif ($return === 1) { // Failure
             return redirect()->back()->with('import_errors', json_decode($display_output))->with('error', trans('admin/hardware/message.import.error'));
         }

--- a/app/Http/Controllers/AssetsController.php
+++ b/app/Http/Controllers/AssetsController.php
@@ -927,6 +927,18 @@ class AssetsController extends Controller
 
     }
 
+    public function getDeleteImportFile($filename)
+    {
+        if (!Company::isCurrentUserAuthorized()) {
+            return redirect()->to('hardware')->with('error', trans('general.insufficient_permissions'));
+        }
+
+        if (unlink(config('app.private_uploads').'/imports/assets/'.$filename)) {
+            return redirect()->back()->with('success', trans('admin/hardware/message.import.file_delete_success'));
+        }
+        return redirect()->back()->with('error', trans('admin/hardware/message.import.file_delete_error'));
+    }
+
 
     /**
     * Process the uploaded file

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -295,7 +295,7 @@ Route::group(
 
         Route::post( 'import/process/', [ 'as' => 'assets/import/process-file',
                 'middleware' => 'authorize:assets.create',
-                'uses' => 'AssetsController@getProcessImportFile'
+                'uses' => 'AssetsController@postProcessImportFile'
         ]);
         Route::get( 'import/delete/{filename}', [ 'as' => 'assets/import/delete-file',
                 'middleware' => 'authorize:assets.create', // TODO What permissions should this require?

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -297,6 +297,10 @@ Route::group(
                 'middleware' => 'authorize:assets.create',
                 'uses' => 'AssetsController@getProcessImportFile'
         ]);
+        Route::get( 'import/delete/{filename}', [ 'as' => 'assets/import/delete-file',
+                'middleware' => 'authorize:assets.create', // TODO What permissions should this require?
+                'uses' => 'AssetsController@getDeleteImportFile'
+        ]);
 
         Route::get('import',[
                 'as' => 'assets/import',

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -293,7 +293,7 @@ Route::group(
                 'uses' => 'AssetsController@getDeleteImportFile'
         ]);
 
-        Route::get( 'import/process/{filename}', [ 'as' => 'assets/import/process-file',
+        Route::post( 'import/process/', [ 'as' => 'assets/import/process-file',
                 'middleware' => 'authorize:assets.create',
                 'uses' => 'AssetsController@getProcessImportFile'
         ]);

--- a/resources/lang/en/admin/hardware/message.php
+++ b/resources/lang/en/admin/hardware/message.php
@@ -37,9 +37,11 @@ return array(
     ),
 
     'import' => array(
-        'error'         => 'Some items did not import correctly.',
-        'errorDetail'   => 'The following Items were not imported because of errors.',
-        'success'       => "Your file has been imported",
+        'error'                 => 'Some items did not import correctly.',
+        'errorDetail'           => 'The following Items were not imported because of errors.',
+        'success'               => "Your file has been imported",
+        'file_delete_success'   => "Your file has been been successfully deleted",
+        'file_delete_error'      => "The file was unable to be deleted",
     ),
 
 

--- a/resources/views/hardware/import.blade.php
+++ b/resources/views/hardware/import.blade.php
@@ -9,6 +9,49 @@
 {{-- Page content --}}
 @section('content')
 
+
+{{-- Modal import dialog --}}
+
+<div class="modal fade" id="importModal">
+    <form id="import-modal-form" class="form-horizontal" method="post" action="{{ route('assets/import/process-file') }}" autocomplete="off" role="form">
+        {{ csrf_field()}}
+        <input type="hidden" id="modal-filename" name="filename" value="">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <h4 class="modal-title">Import File:</h4>
+                </div>
+                <div class="modal-body">
+
+                    <div class="dynamic-form-row">
+                        <div class="col-md-4 col-xs-12">
+                            <label for="import-type">Import Type:</label>
+                        </div>
+                        <div class="col-md-8 col-xs-12">
+                            {{ Form::select('import-type', array('asset' => 'Assets', 'accessory' => "Accessories", 'consumable' => "Consumables") , 'asset', array('class'=>'select2 parent', 'style'=>'width:100%','id' =>'import-type')) }}
+                        </div>
+                    </div>
+                    <div class="dynamic-form-row">
+                        <div class="col-md-4 col-xs-12">
+                            <label for="import-update">Update Existing Values?:</label>
+                        </div>
+                        <div class="col-md-8 col-xs-12">
+                            {{ Form::checkbox('import-update') }}
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">{{ trans('button.cancel') }}</button>
+                    <!-- <button type="button" class="btn btn-primary" id="modal-save">{{ trans('general.save') }}</button> -->
+                    {{Form::submit(trans('general.save'))}}
+                </div>
+            </div>
+        </div>
+    </form>
+</div>
+
+
 <div class="row">
   <div class="col-md-12">
         <div class="box">
@@ -40,8 +83,6 @@
                 <div class="row">
                     <div class="col-md-12">
 
-
-
                         <table class="table table-striped" id="upload-table">
                             <thead>
                                 <th>File</th>
@@ -56,9 +97,7 @@
                                     <td>{{ date("M d, Y g:i A", $file['modified']) }} </td>
                                     <td>{{ $file['filesize'] }}</td>
                                     <td>
-                                        <a class="btn btn-info btn-sm" href="import/process/{{ $file['filename'] }}">
-                                            <i class="fa fa-spinner process"></i> Process
-                                        </a>
+                                        <a href="#" data-toggle="modal" data-target="#importModal" data-filename={{$file['filename']}} class="btn btn-sm btn-info"><i class="fa fa-spinner process"></i> Process</a>
                                         <a class="btn btn-danger btn-sm" href="import/delete/{{ $file['filename'] }}"><i class="fa fa-trash icon-white"></i></a>
                                     </td>
                                 </tr>
@@ -68,8 +107,8 @@
                     </div>
                 </div>
             </div>
- 
         </div>
+
         @if (session()->has('import_errors'))
         <div class="errors-table">
         <div class="alert alert-warning">
@@ -151,8 +190,7 @@
                         $('.progress-bar-text').html('Finished!');
                         $('.progress-checkmark').fadeIn('fast').html('<i class="fa fa-check fa-3x icon-white" style="color: green"></i>');
                         $.each(data.result.files, function (index, file) {
-                            $('<tr><td>' + file.name + '</td><td>Just now</td><td>' + file.filesize + '</td><td><a class="btn btn-info btn-sm" href="import/process/' + file.name + '"><i class="fa fa-spinner process"></i> Process</a></td></tr>').prependTo("#upload-table > tbody");
-                            //$('<tr><td>').text(file.name).appendTo(document.body);
+                            $('<tr><td>' + file.name + '</td><td>Just now</td><td>' + file.filesize + '</td><td><a class="btn btn-info btn-sm" href="#" data-toggle="modal" data-target="#importModal" data-filename='+ file.name + '><i class="fa fa-spinner process"></i> Process</a><a class="btn btn-danger btn-sm" href="import/delete/' +file.name + '"><i class="fa fa-trash icon-white"></i></a></td></tr>').prependTo("#upload-table > tbody");
                         });
                     }
                     $('#progress').removeClass('active');
@@ -160,6 +198,14 @@
 
                 }
             });
+        });
+
+        // Modal Import options handling
+        $('#importModal').on("show.bs.modal", function(event) {
+            var link = $(event.relatedTarget);
+            var filename = link.data('filename');
+            $(this).find('.modal-title').text("Import File: " + filename );
+            $("#modal-filename").val(filename);
         });
         </script>
 @stop

--- a/resources/views/hardware/import.blade.php
+++ b/resources/views/hardware/import.blade.php
@@ -57,7 +57,9 @@
                                     <td>{{ $file['filesize'] }}</td>
                                     <td>
                                         <a class="btn btn-info btn-sm" href="import/process/{{ $file['filename'] }}">
-                                            <i class="fa fa-spinner process"></i> Process</a>
+                                            <i class="fa fa-spinner process"></i> Process
+                                        </a>
+                                        <a class="btn btn-danger btn-sm" href="import/delete/{{ $file['filename'] }}"><i class="fa fa-trash icon-white"></i></a>
                                     </td>
                                 </tr>
                                 @endforeach


### PR DESCRIPTION
This ones a bit big, but fairly straightforward.

It allows for updating of items on import.  If the field matches and has a different value, and the "update" flag is set, we now replace the value instead of ignoring it.  This has been implemented for assets, accessories, and consumables.

Furthermore, the web interface has been extended with the following features:
1) Clicking the "Process" button pops up a modal dialog.  This dialog allows for selection of whether to update items, and also allows choosing what type of items the csv contains.
2) There is now a button next to each file to allow for deleting the file.  Please check AssetsController::getDeleteImportFile for any security issues, I don't think there should be any because we scope it to the directory, but I might be missing something.

Now that the web interface allows importing items beyond assets, I wonder if we need to move it somewhere else in the menu... but I'm not sure where to put it.