### PR TITLE
Syntax correction on VOLUME instruction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,7 @@ RUN cd /var/www/html;composer install
 
 ############### DATA VOLUME #################
 
-VOLUME [/var/lib/snipeit]
+VOLUME ["/var/lib/snipeit"]
 
 ##### START SERVER
 


### PR DESCRIPTION
Added quotes to volume path.
Fixes error message: "Invalid volume destination path: [/var/lib/snipeit] mount path must be absolute"