### PR TITLE
Allow uploading rtf files

### DIFF
--- a/app/Http/Controllers/LicensesController.php
+++ b/app/Http/Controllers/LicensesController.php
@@ -843,7 +843,7 @@ class LicensesController extends Controller
                 foreach (Input::file('licensefile') as $file) {
 
                     $rules = array(
-                    'licensefile' => 'required|mimes:png,gif,jpg,jpeg,doc,docx,pdf,txt,zip,rar|max:2000'
+                    'licensefile' => 'required|mimes:png,gif,jpg,jpeg,doc,docx,pdf,txt,zip,rar,rtf|max:2000'
                     );
                     $validator = Validator::make(array('licensefile'=> $file), $rules);
 


### PR DESCRIPTION
Microsoft Open License Order Confirmation's are sent in RTF format. 

This change allows us to upload the RTF files under View License -> File Uploads.