### PR TITLE
DB_DUMP_PATH not set when using install.sh

### DIFF
--- a/snipeit.sh
+++ b/snipeit.sh
@@ -200,6 +200,7 @@ case $distro in
 		DB_PASSWORD=$mysqluserpw
 		APP_URL=http://$fqdn
 		APP_KEY=$random32
+		DB_DUMP_PATH='/usr/bin'
 		EOF
 
 		echo "##  Setting up hosts file."
@@ -315,6 +316,7 @@ case $distro in
 		DB_PASSWORD=$mysqluserpw
 		APP_URL=http://$fqdn
 		APP_KEY=$random32
+		DB_DUMP_PATH='/usr/bin'
 		EOF
 
 		##  TODO make sure mysql is set to start on boot and go ahead and start it
@@ -447,6 +449,7 @@ case $distro in
 		DB_PASSWORD=$mysqluserpw
 		APP_URL=http://$fqdn
 		APP_KEY=$random32
+		DB_DUMP_PATH='/usr/bin'
 		EOF
 
 
@@ -561,7 +564,7 @@ case $distro in
 		DB_PASSWORD=$mysqluserpw
 		APP_URL=http://$fqdn
 		APP_KEY=$random32
-
+		DB_DUMP_PATH='/usr/bin'
 		EOF
 
 		# Change permissions on directories


### PR DESCRIPTION
Backup errors out when DB_DUMP_PATH is not set. 

```
Starting backup...
Dumping database snipeit...
Backup failed because The dump process failed with exitcode 127 : Command not found : sh: 1: /usr/local/bin/mysqldump: not found
.
Backup completed!
```


According to https://snipe-it.readme.io/docs/configuration#required-database-settings this is usually '/usr/bin'

Tested on CentOS 7 and Ubuntu 16.04.1 LTS.