### PR TITLE
SELinux and iptables update for installer

### DIFF
--- a/snipeit.sh
+++ b/snipeit.sh
@@ -492,11 +492,18 @@ case $distro in
 		sudo chmod -R 755 $webdir/$name/public/uploads
 		sudo chown -R apache:apache $webdir/$name
 
-#TODO detect if SELinux and firewall are enabled to decide what to do
-		#Add SELinux and firewall exception/rules. Youll have to allow 443 if you want ssl connectivity.
+#TODO detect if SELinux is enabled to decide what to do.
 		# chcon -R -h -t httpd_sys_script_rw_t $webdir/$name/
-		# firewall-cmd --zone=public --add-port=80/tcp --permanent
-		# firewall-cmd --reload
+
+    #Check if iptables is running
+    /sbin/service iptables status >/dev/null 2>&1
+    if [ $? = 0 ]; then
+      #Open http/https port
+      iptables -I INPUT 1 -p tcp -m tcp --dport 80 -j ACCEPT
+      iptables -I INPUT 1 -p tcp -m tcp --dport 443 -j ACCEPT
+      #Save iptables
+      service iptables save
+    fi
 
 		service httpd restart
 

--- a/snipeit.sh
+++ b/snipeit.sh
@@ -285,7 +285,7 @@ case $distro in
 
 		#We already established MySQL root & user PWs, so we dont need to be prompted. Let's go ahead and install Apache, PHP and MySQL.
 		echo "##  Setting up LAMP."
-		sudo DEBIAN_FRONTEND=noninteractive apt-get install -y lamp-server^ >> /var/log/snipeit-install.log & pid=$! 2>&1 
+		sudo DEBIAN_FRONTEND=noninteractive apt-get install -y lamp-server^ >> /var/log/snipeit-install.log & pid=$! 2>&1
 		echo ""
 		progress
 		if [ "$version" == "16.04" ]; then
@@ -499,7 +499,7 @@ case $distro in
 		# firewall-cmd --reload
 
 		service httpd restart
-		
+
 	elif [ "$version" == "7" ]; then
 		#####################################  Install for Centos/Redhat 7  ##############################################
 
@@ -608,10 +608,17 @@ case $distro in
 		sudo chmod -R 755 $webdir/$name/storage/private_uploads
 		sudo chmod -R 755 $webdir/$name/public/uploads
 		sudo chown -R apache:apache $webdir/$name
-		# Make SeLinux happy
-		sudo chcon -R -h -t httpd_sys_script_rw_t $webdir/$name/
-#TODO detect if SELinux and firewall are enabled to decide what to do
-		#Add SELinux and firewall exception/rules. Youll have to allow 443 if you want ssl connectivity.
+
+    #Check if SELinux is enforcing
+    if [ $(getenforce) == "Enforcing" ]; then
+      #Required for ldap integration
+      setsebool -P httpd_can_connect_ldap on
+      #Sets SELinux context type so that scripts running in the web server process are allowed read/write access
+      sudo chcon -R -h -t httpd_sys_script_rw_t $webdir/$name/
+    fi
+
+#TODO detect if firewall is enabled to decide what to do
+		#Add firewall exception/rules. Youll have to allow 443 if you want ssl connectivity.
 		# chcon -R -h -t httpd_sys_script_rw_t $webdir/$name/
 		# firewall-cmd --zone=public --add-port=80/tcp --permanent
 		# firewall-cmd --reload


### PR DESCRIPTION
CentOS 7
Set httpd_can_connect_ldap on for ldap integration if SELinux is enforcing.

CentOS 6
Add http/https ports if iptables is running.