### PR TITLE
Changes to how we handle company scoping in the logs.

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -2,12 +2,15 @@
 namespace App\Http\Controllers;
 
 use App\Http\Controllers\AdminController;
+use App\Models\Accessory;
 use App\Models\Actionlog;
-use View;
-use Auth;
-use Redirect;
 use App\Models\Asset;
 use App\Models\Company;
+use App\Models\Consumable;
+use App\Models\License;
+use Auth;
+use Redirect;
+use View;
 
 /**
  * This controller handles all actions related to the Admin Dashboard
@@ -29,12 +32,6 @@ class DashboardController extends Controller
     {
         // Show the page
         if (Auth::user()->hasAccess('admin')) {
-
-            $recent_activity = Actionlog::latest()
-                ->with('item')
-                ->take(20)
-                ->get();
-
 
             $asset_stats['total'] = Asset::Hardware()->count();
 
@@ -82,7 +79,7 @@ class DashboardController extends Controller
             }
 
 
-            return View::make('dashboard')->with('asset_stats', $asset_stats)->with('recent_activity', $recent_activity);
+            return View::make('dashboard')->with('asset_stats', $asset_stats);
         } else {
         // Redirect to the profile page
             return redirect()->route('view-assets');

--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -8,6 +8,7 @@ use App\Models\Asset;
 use App\Models\AssetMaintenance;
 use App\Models\AssetModel;
 use App\Models\Company;
+use App\Models\Consumable;
 use App\Models\CustomField;
 use App\Models\License;
 use App\Models\Location;
@@ -310,11 +311,7 @@ class ReportsController extends Controller
      */
     public function getActivityReportDataTable()
     {
-        $activitylogs = Actionlog::orderBy('created_at', 'DESC');
-
-        if (Input::has('search')) {
-            $activity = $activity->TextSearch(e(Input::get('search')));
-        }
+        $settings = Setting::getSettings();
 
         if (Input::has('offset')) {
             $offset = e(Input::get('offset'));
@@ -328,6 +325,52 @@ class ReportsController extends Controller
             $limit = 50;
         }
 
+        if (!$settings || $settings->full_multiple_companies_support == 0 || (\Auth::check() && \Auth::user()->isSuperUser())) {
+            $activitylogs = Actionlog::orderBy('created_at', 'DESC');
+            $activitylogs = $activitylogs->skip($offset)->take($limit)->get();
+        } else {
+            $assets = Company::scopeCompanyables(Asset::with('model', 'log', 'log.item', 'log.user'))->get();
+            // dd($assets);
+            $logs = array();
+            foreach($assets as $asset) {
+                if(!$asset->log) {
+                    continue;
+                }
+                $logs[] = $asset->log;
+            }
+
+            $accessories  = Company::scopeCompanyables(Accessory::with('log', 'log.item', 'log.user'))->get();
+            foreach($accessories as $accessory) {
+                if(!$accessory->log) {
+                    continue;
+                }
+                $logs[] = $accessory->log;
+            }
+
+            $consumables  = Company::scopeCompanyables(Consumable::with('log', 'log.item', 'log.user'))->get();
+            foreach($consumables as $consumable) {
+                if(!$consumable->log) {
+                    continue;
+                }
+                $logs[] = $consumable->log;
+            }
+
+            $licenses  = Company::scopeCompanyables(License::with('log', 'log.item', 'log.user'))->get();
+            foreach($licenses as $license) {
+                if(!$license->log) {
+                    continue;
+                }
+                $logs[] = $license->log();
+            }
+
+            $activitylogs = collect(array_flatten($logs))->sortByDesc('updated_at');
+            $activitylogs = $activitylogs->slice($offset)->take($limit);
+        }
+
+        if (Input::has('search')) {
+            $activity = $activity->TextSearch(e(Input::get('search')));
+        }
+
 
         $allowed_columns = ['created_at'];
         $order = Input::get('order') === 'asc' ? 'asc' : 'desc';
@@ -335,7 +378,6 @@ class ReportsController extends Controller
 
 
         $activityCount = $activitylogs->count();
-        $activitylogs = $activitylogs->skip($offset)->take($limit)->get();
 
         $rows = array();
 
@@ -376,7 +418,7 @@ class ReportsController extends Controller
                 $activity_target = $activity->target;
             }
 
-            
+
             $rows[] = array(
                 'icon'          => $activity_icons,
                 'created_at'    => date("M d, Y g:iA", strtotime($activity->created_at)),

--- a/app/Http/Controllers/ViewAssetsController.php
+++ b/app/Http/Controllers/ViewAssetsController.php
@@ -38,21 +38,11 @@ class ViewAssetsController extends Controller
      */
     public function getIndex()
     {
-
-        $user = User::with('assets', 'assets.model', 'consumables', 'accessories', 'licenses', 'userloc')->withTrashed()->find(Auth::user()->id);
-
-        $userlog = $user->userlog->load('item', 'user', 'target');
-
-        if (isset($user->id)) {
-            return View::make('account/view-assets', compact('user', 'userlog'));
-        } else {
-            // Prepare the error message
-            $error = trans('admin/users/message.user_not_found', compact('id'));
-
-            // Redirect to the user management page
-            return redirect()->route('users')->with('error', $error);
-        }
-
+        $user = Auth::user();
+        $user->load('assets', 'assets.model', 'consumables', 'accessories', 'licenses', 'userloc')->withTrashed();
+        $userlog = $user->userlog;
+        $userlog->load('item', 'user');
+        return View::make('account/view-assets', compact('user', 'userlog'));
     }
 
 
@@ -62,7 +52,7 @@ class ViewAssetsController extends Controller
         $assets = Asset::with('model', 'defaultLoc', 'assetloc', 'assigneduser')->Hardware()->RequestableAssets()->get();
         $models = AssetModel::with('category')->RequestableModels()->get();
 
-        return View::make('account/requestable-assets', compact('user', 'assets', 'models'));
+        return View::make('account/requestable-assets', compact('assets', 'models'));
     }
 
     public function getRequestedIndex()
@@ -76,7 +66,7 @@ class ViewAssetsController extends Controller
     {
         $item = null;
         $fullItemType = 'App\\Models\\' . studly_case($itemType);
-        if($itemType == "asset_model") {
+        if ($itemType == "asset_model") {
             $itemType = "model";
         }
         $item = call_user_func(array($fullItemType, 'find'), $itemId);

--- a/app/Models/Actionlog.php
+++ b/app/Models/Actionlog.php
@@ -15,7 +15,6 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 class Actionlog extends Model implements ICompanyableChild
 {
     use SoftDeletes;
-    use CompanyableChildTrait;
 
     protected $dates = [ 'deleted_at' ];
 
@@ -25,7 +24,8 @@ class Actionlog extends Model implements ICompanyableChild
 
     public function getCompanyableParents()
     {
-        return [ 'accessorylog', 'assetlog', 'licenselog', 'consumablelog' ];
+        return ['item'];
+        // return [''];
     }
 
     // Eloquent Relationships below
@@ -66,19 +66,9 @@ class Actionlog extends Model implements ICompanyableChild
         return $this->morphTo('target');
     }
 
-    public function childlogs()
-    {
-        return $this->hasMany('\App\Models\ActionLog', 'thread_id');
-    }
-
-    public function parentlog()
-    {
-        return $this->belongsTo('\App\Models\ActionLog', 'thread_id');
-    }
-
     /**
-       * Check if the file exists, and if it does, force a download
-       **/
+      * Check if the file exists, and if it does, force a download
+      **/
     public function get_src($type = 'assets')
     {
 
@@ -102,6 +92,7 @@ class Actionlog extends Model implements ICompanyableChild
             return false;
         }
     }
+
 
     /**
        * getListingOfActionLogsChronologicalOrder

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -690,7 +690,6 @@ public function checkin_email()
 
     public function scopeRequestableAssets($query)
     {
-
         return Company::scopeCompanyables($query->where('requestable', '=', 1))
         ->whereHas('assetstatus', function ($query) {
 

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -58,7 +58,6 @@ final class Company extends Model
         } else {
             $company_id = null;
         }
-
         return $query->where($column, '=', $company_id);
     }
 
@@ -157,7 +156,6 @@ final class Company extends Model
 
             $q = $query->where(function ($q) use ($companyable_names, $f) {
                 $q2 = $q->whereHas($companyable_names[0], $f);
-
                 for ($i = 1; $i < count($companyable_names); $i++) {
                     $q2 = $q2->orWhereHas($companyable_names[$i], $f);
                 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -201,7 +201,7 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
      */
     public function userlog()
     {
-        return $this->hasMany('\App\Models\Actionlog', 'target_id')->orderBy('created_at', 'DESC')->withTrashed();
+        return $this->morphMany(Actionlog::class, 'target')->orderBy('created_at', 'DESC')->withTrashed();
     }
 
     /**
@@ -244,18 +244,12 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
         }
     }
 
-    public function assetlog()
-    {
-        return $this->hasMany('\App\Models\Asset', 'id')->withTrashed();
-    }
-
     /**
      * Get uploads for this asset
      */
     public function uploads()
     {
-        return $this->hasMany('\App\Models\Actionlog', 'item_id')
-            ->where('item_type', User::class)
+        return $this->morphMany('\App\Models\Actionlog', 'target')
             ->where('action_type', '=', 'uploaded')
             ->whereNotNull('filename')
             ->orderBy('created_at', 'desc');


### PR DESCRIPTION
Laravel is really unhappy with polymorphic scopes and complex where
clauses. This was causing infinite recursion and all sorts of fun when
trying to determine if a log's item belonged to a company.  This
rewrites all of that related code to start all logging from the item,
and fetch the log from there.  The major impact to this is
ReportsController::getActivityReportDataTable(), which now fetches
collections of all items, and then builds up a collection of related
logs (Eww from a memory standpoint...)

Might be able to do some DB::queries to get this more efficient,
Eloquent doesn't seem to like Asset::where('log') or similar.

More work.  Migrate towards items being the keeper of logs.

Fix dashboardcontroller.  Generate activity logs based on items available. Probably still needs testing on various data sources

Sort logs in the collection by updated date in reverse order.

Fix formatting