### PR TITLE
Actionlog: Use DB:: instead of filtering the collection

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -2,12 +2,15 @@
 namespace App\Http\Controllers;
 
 use App\Http\Controllers\AdminController;
+use App\Models\Accessory;
 use App\Models\Actionlog;
-use View;
-use Auth;
-use Redirect;
 use App\Models\Asset;
 use App\Models\Company;
+use App\Models\Consumable;
+use App\Models\License;
+use Auth;
+use Redirect;
+use View;
 
 /**
  * This controller handles all actions related to the Admin Dashboard
@@ -29,12 +32,6 @@ class DashboardController extends Controller
     {
         // Show the page
         if (Auth::user()->hasAccess('admin')) {
-
-            $recent_activity = Actionlog::latest()
-                ->with('item')
-                ->take(20)
-                ->get();
-
 
             $asset_stats['total'] = Asset::Hardware()->count();
 
@@ -82,7 +79,7 @@ class DashboardController extends Controller
             }
 
 
-            return View::make('dashboard')->with('asset_stats', $asset_stats)->with('recent_activity', $recent_activity);
+            return View::make('dashboard')->with('asset_stats', $asset_stats);
         } else {
         // Redirect to the profile page
             return redirect()->route('view-assets');

--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -8,6 +8,7 @@ use App\Models\Asset;
 use App\Models\AssetMaintenance;
 use App\Models\AssetModel;
 use App\Models\Company;
+use App\Models\Consumable;
 use App\Models\CustomField;
 use App\Models\License;
 use App\Models\Location;
@@ -310,11 +311,7 @@ class ReportsController extends Controller
      */
     public function getActivityReportDataTable()
     {
-        $activitylogs = Actionlog::orderBy('created_at', 'DESC');
-
-        if (Input::has('search')) {
-            $activity = $activity->TextSearch(e(Input::get('search')));
-        }
+        $settings = Setting::getSettings();
 
         if (Input::has('offset')) {
             $offset = e(Input::get('offset'));
@@ -328,6 +325,52 @@ class ReportsController extends Controller
             $limit = 50;
         }
 
+        if (!$settings || $settings->full_multiple_companies_support == 0 || (\Auth::check() && \Auth::user()->isSuperUser())) {
+            $activitylogs = Actionlog::orderBy('created_at', 'DESC');
+            $activitylogs = $activitylogs->skip($offset)->take($limit)->get();
+        } else {
+            $assets = Company::scopeCompanyables(Asset::with('model', 'log', 'log.item', 'log.user'))->get();
+            // dd($assets);
+            $logs = array();
+            foreach($assets as $asset) {
+                if(!$asset->log) {
+                    continue;
+                }
+                $logs[] = $asset->log;
+            }
+
+            $accessories  = Company::scopeCompanyables(Accessory::with('log', 'log.item', 'log.user'))->get();
+            foreach($accessories as $accessory) {
+                if(!$accessory->log) {
+                    continue;
+                }
+                $logs[] = $accessory->log;
+            }
+
+            $consumables  = Company::scopeCompanyables(Consumable::with('log', 'log.item', 'log.user'))->get();
+            foreach($consumables as $consumable) {
+                if(!$consumable->log) {
+                    continue;
+                }
+                $logs[] = $consumable->log;
+            }
+
+            $licenses  = Company::scopeCompanyables(License::with('log', 'log.item', 'log.user'))->get();
+            foreach($licenses as $license) {
+                if(!$license->log) {
+                    continue;
+                }
+                $logs[] = $license->log();
+            }
+
+            $activitylogs = collect(array_flatten($logs))->sortByDesc('updated_at');
+            $activitylogs = $activitylogs->slice($offset)->take($limit);
+        }
+
+        if (Input::has('search')) {
+            $activity = $activity->TextSearch(e(Input::get('search')));
+        }
+
 
         $allowed_columns = ['created_at'];
         $order = Input::get('order') === 'asc' ? 'asc' : 'desc';
@@ -335,7 +378,6 @@ class ReportsController extends Controller
 
 
         $activityCount = $activitylogs->count();
-        $activitylogs = $activitylogs->skip($offset)->take($limit)->get();
 
         $rows = array();
 
@@ -376,7 +418,7 @@ class ReportsController extends Controller
                 $activity_target = $activity->target;
             }
 
-            
+
             $rows[] = array(
                 'icon'          => $activity_icons,
                 'created_at'    => date("M d, Y g:iA", strtotime($activity->created_at)),

--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -16,7 +16,7 @@ use App\Models\Setting;
 use App\Models\User;
 use Auth;
 use Carbon\Carbon;
-use Db;
+use DB;
 use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Response;
@@ -327,7 +327,7 @@ class ReportsController extends Controller
             $limit = 50;
         }
         $scopeCompanies = ($settings && $settings->full_multiple_companies_support == 1) && (\Auth::check() && !\Auth::user()->isSuperUser());
-
+        $activityCount = 0;
         $commonSelects = [
             'action_logs.item_type',
             'action_logs.updated_at as al_updated_at',
@@ -340,89 +340,148 @@ class ReportsController extends Controller
             'users.first_name',
             'users.last_name',
         ];
-        $assets = \DB::table('assets')
+
+        // Assets
+        $assetsCount = DB::table('assets')
             ->join('action_logs', 'assets.id', '=', 'action_logs.item_id')
-            ->leftJoin('users', 'action_logs.user_id', '=', 'users.id')
-            ->select('assets.*')
-            ->addSelect($commonSelects)
-            ->where('action_logs.item_type', 'App\Models\Asset')
-            ->orderBy('al_updated_at', 'DESC')
-            ->skip($offset)
-            ->take($limit);
+            ->where('action_logs.item_type', 'App\Models\Asset');
+
         if($scopeCompanies) {
-            $assets->where('assets.company_id', Auth::user()->company_id);
+            $assetsCount->where('assets.company_id', Auth::user()->company_id);
         }
 
+        $assetsCount = $assetsCount->count();
+        $assets = array();
+        if ($assetsCount > 0 ) {
+            $assets = DB::table('assets')
+                ->join('action_logs', 'assets.id', '=', 'action_logs.item_id')
+                ->leftJoin('users', 'action_logs.user_id', '=', 'users.id')
+                ->select('assets.*')
+                ->addSelect($commonSelects)
+                ->where('action_logs.item_type', 'App\Models\Asset')
+                ->orderBy('al_updated_at', 'DESC');
 
-        $accessories = \DB::table('accessories')
+            if($scopeCompanies) {
+                $assets->where('assets.company_id', Auth::user()->company_id);
+            }
+            $assets = $assets->get();
+        }
+
+        //Accessories
+        $accessoriesCount = DB::table('accessories')
             ->join('action_logs', 'accessories.id', '=', 'action_logs.item_id')
-            ->leftJoin('users', 'action_logs.user_id', '=', 'users.id')
-            ->select('accessories.*')
-            ->addSelect($commonSelects)
-            ->orderBy('al_updated_at', 'DESC')
-            ->where('action_logs.item_type', 'App\Models\Accessory')
-            ->skip($offset)
-            ->take($limit);
+            ->where('action_logs.item_type', 'App\Models\Accessory');
 
         if($scopeCompanies) {
-            $accessories->where('accessories.company_id', Auth::user()->company_id);
+            $accessoriesCount->where('accessories.company_id', Auth::user()->company_id);
         }
 
+        $accessoriesCount = $accessoriesCount->count();
+        $accessories = array();
+        if ($accessoriesCount > 0 ) {
+            $accessories = DB::table('accessories')
+                ->join('action_logs', 'accessories.id', '=', 'action_logs.item_id')
+                ->leftJoin('users', 'action_logs.user_id', '=', 'users.id')
+                ->select('accessories.*')
+                ->addSelect($commonSelects)
+                ->orderBy('al_updated_at', 'DESC')
+                ->where('action_logs.item_type', 'App\Models\Accessory');
 
-        $consumables = \DB::table('consumables')
+            if($scopeCompanies) {
+                $accessories->where('accessories.company_id', Auth::user()->company_id);
+            }
+            $accessories = $accessories->get();
+        }
+        // Consumables
+        $consumablesCount = DB::table('consumables')
             ->join('action_logs', 'consumables.id', '=', 'action_logs.item_id')
-            ->leftJoin('users', 'action_logs.user_id', '=', 'users.id')
-            ->select('consumables.*')
-            ->addSelect($commonSelects)
-            ->orderBy('al_updated_at', 'DESC')
-            ->where('action_logs.item_type', 'App\Models\Consumable')
-            ->skip($offset)
-            ->take($limit);
+            ->where('action_logs.item_type', 'App\Models\Consumable');
 
         if($scopeCompanies) {
-            $consumables->where('consumables.company_id', Auth::user()->company_id);
+            $consumablesCount->where('consumables.company_id', Auth::user()->company_id);
         }
 
-        $licenses  = \DB::table('licenses')
+        $consumablesCount = $consumablesCount->count();
+        $consumables = array();
+        if ($consumablesCount > 0 ) {
+            $consumables = DB::table('consumables')
+                ->join('action_logs', 'consumables.id', '=', 'action_logs.item_id')
+                ->leftJoin('users', 'action_logs.user_id', '=', 'users.id')
+                ->select('consumables.*')
+                ->addSelect($commonSelects)
+                ->orderBy('al_updated_at', 'DESC')
+                ->where('action_logs.item_type', 'App\Models\Consumable');
+
+            if($scopeCompanies) {
+                $consumables->where('consumables.company_id', Auth::user()->company_id);
+            }
+
+            $consumables = $consumables->get();
+        }
+
+        // Licenses
+        $licensesCount = DB::table('licenses')
             ->join('action_logs', 'licenses.id', '=', 'action_logs.item_id')
-            ->leftJoin('users', 'action_logs.user_id', '=', 'users.id')
-            ->select('licenses.*')
-            ->addSelect($commonSelects)
-            ->orderBy('al_updated_at', 'DESC')
-            ->where('action_logs.item_type', 'App\Models\License')
-            ->skip($offset)
-            ->take($limit);
+            ->where('action_logs.item_type', 'App\Models\License');
 
         if($scopeCompanies) {
-            $licenses->where('licenses.company_id', Auth::user()->company_id);
+            $licensesCount->where('licenses.company_id', Auth::user()->company_id);
+        }
+        $licensesCount = $licensesCount->count();
+
+        $licenses = array();
+        if ($licensesCount > 0 ) {
+            $licenses  = DB::table('licenses')
+                ->join('action_logs', 'licenses.id', '=', 'action_logs.item_id')
+                ->leftJoin('users', 'action_logs.user_id', '=', 'users.id')
+                ->addSelect($commonSelects)
+                ->orderBy('al_updated_at', 'DESC')
+                ->where('action_logs.item_type', 'App\Models\License');
+
+            if($scopeCompanies) {
+                $licenses->where('licenses.company_id', Auth::user()->company_id);
+            }
+
+            $licenses = $licenses->get();
         }
 
-        $components  = \DB::table('components')
+        // Components
+        $componentsCount = DB::table('components')
             ->join('action_logs', 'components.id', '=', 'action_logs.item_id')
-            ->leftJoin('users', 'action_logs.user_id', '=', 'users.id')
-            ->select('components.*')
-            ->addSelect($commonSelects)
-            ->orderBy('al_updated_at', 'DESC')
-            ->where('action_logs.item_type', 'App\Models\Component')
-            ->skip($offset)
-            ->take($limit);
+            ->where('action_logs.item_type', 'App\Models\Component');
 
         if($scopeCompanies) {
-            $components->where('components.company_id', Auth::user()->company_id);
+            $componentsCount->where('components.company_id', Auth::user()->company_id);
+        }
+        $componentsCount = $componentsCount->count();
+        
+        $components = array();
+        if ($componentsCount > 0) {
+            $components  = \DB::table('components')
+                ->join('action_logs', 'components.id', '=', 'action_logs.item_id')
+                ->leftJoin('users', 'action_logs.user_id', '=', 'users.id')
+                ->select('components.*')
+                ->addSelect($commonSelects)
+                ->orderBy('al_updated_at', 'DESC')
+                ->where('action_logs.item_type', 'App\Models\Component');
+
+            if($scopeCompanies) {
+                $components->where('components.company_id', Auth::user()->company_id);
+            }
+            $components = $components->get();
         }
 
-        $activitylogs = collect([$assets->get(), $accessories->get(), $consumables->get(), $licenses->get(), $components->get()]);
+        $activitylogs = collect([$assets, $accessories, $consumables, $licenses, $components]);
+
+        $activityCount = $assetsCount + $accessoriesCount + $consumablesCount + $licensesCount + $componentsCount;
+
         $allowed_columns = ['created_at'];
         $order = Input::get('order') === 'asc' ? 'asc' : 'desc';
         $sort = 'al_updated_at';
         $order === 'asc' ? $activitylogs->sortBy($sort) : $activitylogs->sortByDesc($sort);
-       return $activitylogs;
         $activitylogs = collect(array_flatten($activitylogs));
-        $activitylogs = $activitylogs->slice($offset)->take($limit);
- $activityCount = $activitylogs->count();
-        
-
-
+        $activitylogs = $activitylogs->slice($offset,$limit);
+       
         $rows = array();
         foreach ($activitylogs as $activity) {
             if ($activity->item_type == "App\Models\Asset") {
@@ -445,7 +504,7 @@ class ReportsController extends Controller
                 $item_type = 'asset';
             } else {
                 $item_type = $activity->item_type == AssetModel::class ? 'model' : camel_case(class_basename($activity->item_type));
-                $actvity_item = '<a href="'.route('view/'. $item_type, $activity->item_id).'">'.e($activity->name).'</a>';
+                $actvity_item = '<a href="'.route("view/{$item_type}", $activity->item_id).'">'.e($activity->name).'</a>';
             }
             
             if (($activity->action_type=="uploaded") && ($activity->item_type =="App\Models\User")) {
@@ -473,8 +532,8 @@ class ReportsController extends Controller
                 'item'          => $actvity_item,
                 'item_type'     => $item_type,
                 'note'     => e($activity->note),
-
             );
+
         }
 
         $data = array('total'=>$activityCount, 'rows'=>$rows);

--- a/app/Http/Controllers/ViewAssetsController.php
+++ b/app/Http/Controllers/ViewAssetsController.php
@@ -38,21 +38,11 @@ class ViewAssetsController extends Controller
      */
     public function getIndex()
     {
-
-        $user = User::with('assets', 'assets.model', 'consumables', 'accessories', 'licenses', 'userloc')->withTrashed()->find(Auth::user()->id);
-
-        $userlog = $user->userlog->load('item', 'user', 'target');
-
-        if (isset($user->id)) {
-            return View::make('account/view-assets', compact('user', 'userlog'));
-        } else {
-            // Prepare the error message
-            $error = trans('admin/users/message.user_not_found', compact('id'));
-
-            // Redirect to the user management page
-            return redirect()->route('users')->with('error', $error);
-        }
-
+        $user = Auth::user();
+        $user->load('assets', 'assets.model', 'consumables', 'accessories', 'licenses', 'userloc')->withTrashed();
+        $userlog = $user->userlog;
+        $userlog->load('item', 'user');
+        return View::make('account/view-assets', compact('user', 'userlog'));
     }
 
 
@@ -62,7 +52,7 @@ class ViewAssetsController extends Controller
         $assets = Asset::with('model', 'defaultLoc', 'assetloc', 'assigneduser')->Hardware()->RequestableAssets()->get();
         $models = AssetModel::with('category')->RequestableModels()->get();
 
-        return View::make('account/requestable-assets', compact('user', 'assets', 'models'));
+        return View::make('account/requestable-assets', compact('assets', 'models'));
     }
 
     public function getRequestedIndex()
@@ -76,7 +66,7 @@ class ViewAssetsController extends Controller
     {
         $item = null;
         $fullItemType = 'App\\Models\\' . studly_case($itemType);
-        if($itemType == "asset_model") {
+        if ($itemType == "asset_model") {
             $itemType = "model";
         }
         $item = call_user_func(array($fullItemType, 'find'), $itemId);

--- a/app/Models/Actionlog.php
+++ b/app/Models/Actionlog.php
@@ -15,7 +15,6 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 class Actionlog extends Model implements ICompanyableChild
 {
     use SoftDeletes;
-    use CompanyableChildTrait;
 
     protected $dates = [ 'deleted_at' ];
 
@@ -25,7 +24,8 @@ class Actionlog extends Model implements ICompanyableChild
 
     public function getCompanyableParents()
     {
-        return [ 'accessorylog', 'assetlog', 'licenselog', 'consumablelog' ];
+        return ['item'];
+        // return [''];
     }
 
     // Eloquent Relationships below
@@ -66,19 +66,9 @@ class Actionlog extends Model implements ICompanyableChild
         return $this->morphTo('target');
     }
 
-    public function childlogs()
-    {
-        return $this->hasMany('\App\Models\ActionLog', 'thread_id');
-    }
-
-    public function parentlog()
-    {
-        return $this->belongsTo('\App\Models\ActionLog', 'thread_id');
-    }
-
     /**
-       * Check if the file exists, and if it does, force a download
-       **/
+      * Check if the file exists, and if it does, force a download
+      **/
     public function get_src($type = 'assets')
     {
 
@@ -102,6 +92,7 @@ class Actionlog extends Model implements ICompanyableChild
             return false;
         }
     }
+
 
     /**
        * getListingOfActionLogsChronologicalOrder

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -690,7 +690,6 @@ public function checkin_email()
 
     public function scopeRequestableAssets($query)
     {
-
         return Company::scopeCompanyables($query->where('requestable', '=', 1))
         ->whereHas('assetstatus', function ($query) {
 

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -58,7 +58,6 @@ final class Company extends Model
         } else {
             $company_id = null;
         }
-
         return $query->where($column, '=', $company_id);
     }
 
@@ -157,7 +156,6 @@ final class Company extends Model
 
             $q = $query->where(function ($q) use ($companyable_names, $f) {
                 $q2 = $q->whereHas($companyable_names[0], $f);
-
                 for ($i = 1; $i < count($companyable_names); $i++) {
                     $q2 = $q2->orWhereHas($companyable_names[$i], $f);
                 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -201,7 +201,7 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
      */
     public function userlog()
     {
-        return $this->hasMany('\App\Models\Actionlog', 'target_id')->orderBy('created_at', 'DESC')->withTrashed();
+        return $this->morphMany(Actionlog::class, 'target')->orderBy('created_at', 'DESC')->withTrashed();
     }
 
     /**
@@ -244,18 +244,12 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
         }
     }
 
-    public function assetlog()
-    {
-        return $this->hasMany('\App\Models\Asset', 'id')->withTrashed();
-    }
-
     /**
      * Get uploads for this asset
      */
     public function uploads()
     {
-        return $this->hasMany('\App\Models\Actionlog', 'item_id')
-            ->where('item_type', User::class)
+        return $this->morphMany('\App\Models\Actionlog', 'target')
             ->where('action_type', '=', 'uploaded')
             ->whereNotNull('filename')
             ->orderBy('created_at', 'desc');

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -303,6 +303,32 @@ $factory->defineAs(App\Models\Actionlog::class, 'accessory-checkout', function (
   ];
 });
 
+$factory->defineAs(App\Models\Actionlog::class, 'consumable-checkout', function (Faker\Generator $faker) {
+  return [
+    'user_id'      	=> \App\Models\User::inRandomOrder()->first()->id,
+    'action_type' 		=> 'checkout',
+    'item_id' 		=> \App\Models\Consumable::inRandomOrder()->first()->id,
+    'target_id' => \App\Models\User::inRandomOrder()->first()->id,
+    'target_type' => 'App\\Models\\User',
+    'created_at'  => $faker->dateTime(),
+    'item_type'  => 'App\\Models\\Consumable',
+    'note' 			=> $faker->sentence,
+  ];
+});
+
+$factory->defineAs(App\Models\Actionlog::class, 'component-checkout', function (Faker\Generator $faker) {
+  return [
+    'user_id'      	=> \App\Models\User::inRandomOrder()->first()->id,
+    'action_type' 		=> 'checkout',
+    'item_id' 		=> \App\Models\Component::inRandomOrder()->first()->id,
+    'target_id' => \App\Models\User::inRandomOrder()->first()->id,
+    'target_type' => 'App\\Models\\User',
+    'created_at'  => $faker->dateTime(),
+    'item_type'  => 'App\\Models\\Component',
+    'note' 			=> $faker->sentence,
+  ];
+});
+
 $factory->defineAs(App\Models\CustomField::class, 'customfield-ip', function (Faker\Generator $faker) {
   return [
     'name' => $faker->catchPhrase,

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -266,18 +266,42 @@ $factory->defineAs(App\Models\LicenseSeat::class, 'license-seat', function (Fake
 
 $factory->defineAs(App\Models\Actionlog::class, 'asset-checkout', function (Faker\Generator $faker) {
   return [
-    'user_id'      	=> 1,
+    'user_id'      	=> \App\Models\User::inRandomOrder()->first()->id,
     'action_type' 		=> 'checkout',
-    'item_id' 		=> $faker->numberBetween(1, 10),
-    'target_id' => 1,
+    'item_id' 		=> \App\Models\Asset::inRandomOrder()->first()->id,
+    'target_id' => \App\Models\User::inRandomOrder()->first()->id,
     'target_type' => 'App\\Models\\User',
     'created_at'  => $faker->dateTime(),
     'item_type'  => 'App\\Models\\Asset',
     'note' 			=> $faker->sentence,
-    'user_id' 			=> '1',
   ];
 });
 
+$factory->defineAs(App\Models\Actionlog::class, 'license-checkout-asset', function (Faker\Generator $faker) {
+  return [
+    'user_id'      	=> \App\Models\User::inRandomOrder()->first()->id,
+    'action_type' 		=> 'checkout',
+    'item_id' 		=> \App\Models\License::inRandomOrder()->first()->id,
+    'target_id' => \App\Models\Asset::inRandomOrder()->first()->id,
+    'target_type' => 'App\\Models\\Asset',
+    'created_at'  => $faker->dateTime(),
+    'item_type'  => 'App\\Models\\License',
+    'note' 			=> $faker->sentence,
+  ];
+});
+
+$factory->defineAs(App\Models\Actionlog::class, 'accessory-checkout', function (Faker\Generator $faker) {
+  return [
+    'user_id'      	=> \App\Models\User::inRandomOrder()->first()->id,
+    'action_type' 		=> 'checkout',
+    'item_id' 		=> \App\Models\Accessory::inRandomOrder()->first()->id,
+    'target_id' => \App\Models\User::inRandomOrder()->first()->id,
+    'target_type' => 'App\\Models\\User',
+    'created_at'  => $faker->dateTime(),
+    'item_type'  => 'App\\Models\\Accessory',
+    'note' 			=> $faker->sentence,
+  ];
+});
 
 $factory->defineAs(App\Models\CustomField::class, 'customfield-ip', function (Faker\Generator $faker) {
   return [


### PR DESCRIPTION
This is an option using DB:: to fetch everything instead of loading full collections and then filtering them.

This code can probably be simplified, but my joinery sucks :(  There are currently a few places for n+1 queries here, we can't really eager load targets simply I don't think, but it seems fairly efficient.

Let me know your thoughts!  This is a superset of #2675, I'd only merge one or the other.