### PR TITLE
Fix pre-flight port number check.

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -52,29 +52,18 @@ class SettingsController extends Controller
 
         $protocol = array_key_exists('HTTPS', $_SERVER) && ( $_SERVER['HTTPS'] == "on") ? 'https://' : 'http://';
 
-
-        $pageURL = $protocol;
-        if ($_SERVER["SERVER_PORT"] != "80") {
-            $main_page = $_SERVER["SERVER_NAME"].":".$_SERVER["SERVER_PORT"];
-            $pageURL .= $main_page.$_SERVER["REQUEST_URI"];
-        } else {
-            $main_page = $_SERVER["SERVER_NAME"].$_SERVER["REQUEST_URI"];
-            $pageURL .= $main_page;
+        $host = $_SERVER['SERVER_NAME'];
+        if (($protocol === 'http://' && $_SERVER['SERVER_PORT'] != '80') || ($protocol === 'https://' && $_SERVER['SERVER_PORT'] != '443')) {
+          $host .= ':' . $_SERVER['SERVER_PORT'];
         }
+        $pageURL = $protocol . $host . $_SERVER['REQUEST_URI'];
 
-        $start_settings['env_location'] = $pageURL.'../.env';
+        $start_settings['url_valid'] = (config('app.url').'/setup' === $pageURL);
 
+        $start_settings['url_config'] = config('app.url');
+        $start_settings['real_url'] = $pageURL;
 
-        if (config('app.url').'/setup'!=$pageURL) {
-            $start_settings['url_valid']= false;
-        } else {
-            $start_settings['url_valid']= true;
-        }
-
-        $start_settings['url_config']= config('app.url');
-        $start_settings['real_url']= $pageURL;
-
-        $exposed_env = @file_get_contents($main_page.'/.env');
+        $exposed_env = @file_get_contents($protocol . $host.'/.env');
 
         if ($exposed_env) {
             $start_settings['env_exposed'] = true;


### PR DESCRIPTION
Incorrect check on port when using https:
```Uh oh! Snipe-IT thinks your URL is https://snipeit.my.domain.com, but your real URL is https://snipeit.my.domain.com:443/setup Please update your APP_URL settings in your .env file ```

