### PR TITLE
Company to logs

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -204,7 +204,7 @@ class Helper
     public static function usersList()
     {
         $users_list =   array( '' => trans('general.select_user')) +
-                        User::where('deleted_at', '=', null)
+                        Company::scopeCompanyables(User::where('deleted_at', '=', null))
                         ->where('show_in_list','=',1)
                         ->orderBy('last_name', 'asc')
                         ->orderBy('first_name', 'asc')->get()

--- a/app/Http/Controllers/AssetsController.php
+++ b/app/Http/Controllers/AssetsController.php
@@ -1156,7 +1156,7 @@ class AssetsController extends Controller
                                 'target_id' => $item[$asset_tag][$batch_counter]['user_id'],
                                 'target_type' => User::class,
                                 'created_at' =>  $item[$asset_tag][$batch_counter]['checkout_date'],
-                                'action_type'   => 'checkout'
+                                'action_type'   => 'checkout',
                             )
                         );
 

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -30,12 +30,6 @@ class DashboardController extends Controller
         // Show the page
         if (Auth::user()->hasAccess('admin')) {
 
-            $recent_activity = Actionlog::latest()
-                ->with('item')
-                ->take(20)
-                ->get();
-
-
             $asset_stats['total'] = Asset::Hardware()->count();
 
             $asset_stats['rtd']['total'] = Asset::Hardware()->RTD()->count();
@@ -82,7 +76,7 @@ class DashboardController extends Controller
             }
 
 
-            return View::make('dashboard')->with('asset_stats', $asset_stats)->with('recent_activity', $recent_activity);
+            return View::make('dashboard')->with('asset_stats', $asset_stats);
         } else {
         // Redirect to the profile page
             return redirect()->route('view-assets');

--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -333,10 +333,10 @@ class ReportsController extends Controller
 
 
         $activityCount = $activitylogs->count();
-        $activitylogs = $activitylogs->skip($offset)->take($limit)->get();
+        // dd("Offset:" . $offset . " Limit " . $limit);
+        $activitylogs = $activitylogs->offset($offset)->limit($limit)->get();
 
         $rows = array();
-
         foreach ($activitylogs as $activity) {
 
             if ($activity->itemType() == "asset") {
@@ -354,24 +354,27 @@ class ReportsController extends Controller
             }
 
             if (($activity->item) && ($activity->itemType()=="asset")) {
-              $actvity_item = '<a href="'.route('view/hardware', $activity->item_id).'">'.e($activity->item->asset_tag).' - '. e($activity->item->showAssetName()).'</a>';
+              $activity_item = '<a href="'.route('view/hardware', $activity->item_id).'">'.e($activity->item->asset_tag).' - '. e($activity->item->showAssetName()).'</a>';
                 $item_type = 'asset';
-            } elseif ($activity->item) {
-                $actvity_item = '<a href="'.route('view/'. $activity->itemType(), $activity->item_id).'">'.e($activity->item->name).'</a>';
+            } elseif ($activity->item()) {
+                $activity_item = '<a href="'.route('view/'. $activity->itemType(), $activity->item_id).'">'.e($activity->item->name).'</a>';
                 $item_type = $activity->itemType();
+            } else {
+                $activity_item = "unkonwn";
+                $item_type = "null";
             }
             
 
-            if (($activity->userasassetlog) && ($activity->action_type=="uploaded") && ($activity->itemType()=="user")) {
+            if (($activity->user) && ($activity->action_type=="uploaded") && ($activity->itemType()=="user")) {
                 $activity_target = '<a href="'.route('view/user', $activity->target_id).'">'.$activity->user->fullName().'</a>';
-            } elseif (($activity->item) && ($activity->target instanceof \App\Models\Asset)) {
+            } elseif (($activity->item) && ($activity->target_type === "App\Models\Asset")) {
                 $activity_target = '<a href="'.route('view/hardware', $activity->target_id).'">'.$activity->target->showAssetName().'</a>';
-            } elseif (($activity->item) && ($activity->target instanceof \App\Models\User)) {
+            } elseif ( $activity->target_type === "App\Models\User") {
                 $activity_target = '<a href="'.route('view/user', $activity->target_id).'">'.$activity->target->fullName().'</a>';
             } elseif ($activity->action_type=='requested') {
                 $activity_target =  '<a href="'.route('view/user', $activity->user_id).'">'.$activity->user->fullName().'</a>';
             } else {
-                $activity_target = $activity->target;
+                $activity_target = $activity->target->id;
             }
 
             
@@ -381,7 +384,7 @@ class ReportsController extends Controller
                 'action_type'              => strtolower(trans('general.'.str_replace(' ','_',$activity->action_type))),
                 'admin'         =>  $activity->user ? (string) link_to('/admin/users/'.$activity->user_id.'/view', $activity->user->fullName()) : 'Deleted Admin',
                 'target'          => $activity_target,
-                'item'          => $actvity_item,
+                'item'          => $activity_item,
                 'item_type'     => $item_type,
                 'note'     => e($activity->note),
 

--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -382,7 +382,7 @@ class ReportsController extends Controller
                 'icon'          => $activity_icons,
                 'created_at'    => date("M d, Y g:iA", strtotime($activity->created_at)),
                 'action_type'              => strtolower(trans('general.'.str_replace(' ','_',$activity->action_type))),
-                'admin'         =>  $activity->user ? (string) link_to('/admin/users/'.$activity->user_id.'/view', $activity->user->fullName()) : 'Deleted Admin',
+                'admin'         =>  $activity->user ? (string) link_to('/admin/users/'.$activity->user_id.'/view', $activity->user->fullName()) : '',
                 'target'          => $activity_target,
                 'item'          => $activity_item,
                 'item_type'     => $item_type,

--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -308,7 +308,7 @@ class ReportsController extends Controller
      */
     public function getActivityReportDataTable()
     {
-        $activitylogs = Actionlog::orderBy('created_at', 'DESC');
+        $activitylogs = Company::scopeCompanyables(Actionlog::with('item', 'user', 'target'))->orderBy('created_at', 'DESC');
 
         if (Input::has('search')) {
             $activity = $activity->TextSearch(e(Input::get('search')));
@@ -363,7 +363,7 @@ class ReportsController extends Controller
             
 
             if (($activity->userasassetlog) && ($activity->action_type=="uploaded") && ($activity->itemType()=="user")) {
-                $activity_target = '<a href="'.route('view/user', $activity->target_id).'">'.$activity->userasassetlog->fullName().'</a>';
+                $activity_target = '<a href="'.route('view/user', $activity->target_id).'">'.$activity->user->fullName().'</a>';
             } elseif (($activity->item) && ($activity->target instanceof \App\Models\Asset)) {
                 $activity_target = '<a href="'.route('view/hardware', $activity->target_id).'">'.$activity->target->showAssetName().'</a>';
             } elseif (($activity->item) && ($activity->target instanceof \App\Models\User)) {

--- a/app/Http/Controllers/ViewAssetsController.php
+++ b/app/Http/Controllers/ViewAssetsController.php
@@ -39,9 +39,18 @@ class ViewAssetsController extends Controller
     public function getIndex()
     {
 
-        $user = User::with('assets', 'assets.model', 'consumables', 'accessories', 'licenses', 'userloc')->withTrashed()->find(Auth::user()->id);
+        $user = User::with(
+            'assets',
+            'assets.model',
+            'consumables',
+            'accessories',
+            'licenses',
+            'userloc',
+            'userlog'
+        )->withTrashed()->find(Auth::user()->id);
 
-        $userlog = Company::scopeCompanyables($user->userlog)->load('item', 'user', 'target');
+
+        $userlog = $user->userlog->load('item', 'user', 'target');
 
         if (isset($user->id)) {
             return View::make('account/view-assets', compact('user', 'userlog'));
@@ -76,7 +85,7 @@ class ViewAssetsController extends Controller
     {
         $item = null;
         $fullItemType = 'App\\Models\\' . studly_case($itemType);
-        if($itemType == "asset_model") {
+        if ($itemType == "asset_model") {
             $itemType = "model";
         }
         $item = call_user_func(array($fullItemType, 'find'), $itemId);

--- a/app/Http/Controllers/ViewAssetsController.php
+++ b/app/Http/Controllers/ViewAssetsController.php
@@ -41,7 +41,7 @@ class ViewAssetsController extends Controller
 
         $user = User::with('assets', 'assets.model', 'consumables', 'accessories', 'licenses', 'userloc')->withTrashed()->find(Auth::user()->id);
 
-        $userlog = $user->userlog->load('item', 'user', 'target');
+        $userlog = Company::scopeCompanyables($user->userlog)->load('item', 'user', 'target');
 
         if (isset($user->id)) {
             return View::make('account/view-assets', compact('user', 'userlog'));

--- a/app/Models/Actionlog.php
+++ b/app/Models/Actionlog.php
@@ -28,8 +28,11 @@ class Actionlog extends Model
     {
         parent::boot();
         static::creating( function (Actionlog $actionlog) {
-            if (Auth::user() && Auth::user()->company) {
-                $actionlog->company_id = Auth::user()->company->id;
+            // If the admin is a superadmin, let's see if the target instead has a company.
+            if (Auth::user() && Auth::user()->isSuperUser()) {
+                $actionlog->company_id = $actionlog->target->company_id;
+            } else if (Auth::user() && Auth::user()->company) {
+                $actionlog->company_id = Auth::user()->company_id;
             }
         });
     }

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -198,6 +198,6 @@ final class Company extends Model
     }
 
     public function components() {
-        return $this->hasMany(Components::class);
+        return $this->hasMany(Component::class);
     }
 }

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -136,7 +136,8 @@ final class Company extends Model
 
     public static function scopeCompanyables($query, $column = 'company_id')
     {
-        if (!static::isFullMultipleCompanySupportEnabled() || (Auth::check() && Auth::user()->isSuperUser())) {
+        // If not logged in and hitting this, assume we are on the command line and don't scope?'
+        if (!static::isFullMultipleCompanySupportEnabled() || (Auth::check() && Auth::user()->isSuperUser()) || (!Auth::check())) {
             return $query;
         } else {
             return static::scopeCompanyablesDirectly($query, $column);
@@ -175,5 +176,28 @@ final class Company extends Model
         } else {
             return e($company->name);
         }
+    }
+
+    public function users() {
+        return $this->hasMany(User::class);
+    }
+
+    public function assets() {
+        return $this->hasMany(Asset::class);
+    }
+
+    public function licenses() {
+        return $this->hasMany(License::class);
+    }
+    public function accessories() {
+        return $this->hasMany(Accessory::class);
+    }
+
+    public function consumables() {
+        return $this->hasMany(Consumable::class);
+    }
+
+    public function components() {
+        return $this->hasMany(Components::class);
     }
 }

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -25,6 +25,7 @@ $factory->defineAs(App\Models\Asset::class, 'asset', function (Faker\Generator $
     'order_number' => $faker->numberBetween(1000000,50000000),
     'supplier_id' => $faker->numberBetween(1,5),
     'requestable' => $faker->numberBetween(0,1),
+    'company_id' => \App\Models\Company::inRandomOrder()->first()->id
   ];
 });
 
@@ -96,6 +97,7 @@ $factory->defineAs(App\Models\Component::class, 'component', function (Faker\Gen
     'category_id' => $faker->numberBetween(21,25),
     'total_qty' => $faker->numberBetween(3, 10),
     'min_amt' => $faker->numberBetween($min = 1, $max = 2),
+    'company_id' => \App\Models\Company::inRandomOrder()->first()->id
   ];
 });
 
@@ -113,6 +115,7 @@ $factory->defineAs(App\Models\Accessory::class, 'accessory', function (Faker\Gen
     'qty' => $faker->numberBetween(5, 10),
     'location_id' => $faker->numberBetween(1,5),
     'min_amt' => $faker->numberBetween($min = 1, $max = 2),
+    'company_id' => \App\Models\Company::inRandomOrder()->first()->id
   ];
 });
 
@@ -138,6 +141,7 @@ $factory->defineAs(App\Models\Consumable::class, 'consumable', function (Faker\G
     'company_id' => $faker->numberBetween(1, 10),
     'qty' => $faker->numberBetween(5, 10),
     'min_amt' => $faker->numberBetween($min = 1, $max = 2),
+    'company_id' => \App\Models\Company::inRandomOrder()->first()->id
 
   ];
 });
@@ -265,19 +269,76 @@ $factory->defineAs(App\Models\LicenseSeat::class, 'license-seat', function (Fake
 });
 
 $factory->defineAs(App\Models\Actionlog::class, 'asset-checkout', function (Faker\Generator $faker) {
+  $company = \App\Models\Company::has('users', 'assets')->inRandomOrder()->first();
+  return $company;
   return [
-    'user_id'      	=> 1,
+    'user_id'      	=> $company->users()->inRandomOrder()->first()->id,
     'action_type' 		=> 'checkout',
-    'item_id' 		=> $faker->numberBetween(1, 10),
-    'target_id' => 1,
+    'item_id' 		=> $company->assets()->inRandomOrder()->first()->id,
+    'target_id' => $company->users()->inRandomOrder()->first()->id,
     'target_type' => 'App\\Models\\User',
     'created_at'  => $faker->dateTime(),
     'item_type'  => 'App\\Models\\Asset',
     'note' 			=> $faker->sentence,
-    'user_id' 			=> '1',
+    'company_id' => $company->id
   ];
 });
 
+$factory->defineAs(App\Models\Actionlog::class, 'license-checkout-asset', function (Faker\Generator $faker) {
+  return [
+    'user_id'      	=> $company->users()->inRandomOrder()->first()->id,
+    'action_type' 		=> 'checkout',
+    'item_id' 		=> $company->licenses()->whereNotNull('company_id')->inRandomOrder()->first()->id,
+    'target_id' => $company->assets()->inRandomOrder()->first()->id,
+    'target_type' => 'App\\Models\\Asset',
+    'created_at'  => $faker->dateTime(),
+    'item_type'  => 'App\\Models\\License',
+    'note' 			=> $faker->sentence,
+    'company_id' => $company->id
+  ];
+});
+
+$factory->defineAs(App\Models\Actionlog::class, 'accessory-checkout', function (Faker\Generator $faker) {
+  return [
+    'user_id'      	=> $company->users()->inRandomOrder()->first()->id,
+    'action_type' 		=> 'checkout',
+    'item_id' 		=> $company->accessories()->whereNotNull('company_id')->inRandomOrder()->first()->id,
+    'target_id' => $company->users()->inRandomOrder()->first()->id,
+    'target_type' => 'App\\Models\\User',
+    'created_at'  => $faker->dateTime(),
+    'item_type'  => 'App\\Models\\Accessory',
+    'note' 			=> $faker->sentence,
+    'company_id' => $company->id
+  ];
+});
+
+$factory->defineAs(App\Models\Actionlog::class, 'consumable-checkout', function (Faker\Generator $faker) {
+  return [
+    'user_id'      	=> $company->users()->inRandomOrder()->first()->id,
+    'action_type' 		=> 'checkout',
+    'item_id' 		=> $company->consumables()->whereNotNull('company_id')->inRandomOrder()->first()->id,
+    'target_id' => $company->users()->inRandomOrder()->first()->id,
+    'target_type' => 'App\\Models\\User',
+    'created_at'  => $faker->dateTime(),
+    'item_type'  => 'App\\Models\\Consumable',
+    'note' 			=> $faker->sentence,
+    'company_id' => $company->id
+  ];
+});
+
+$factory->defineAs(App\Models\Actionlog::class, 'component-checkout', function (Faker\Generator $faker) {
+  return [
+    'user_id'      	=> $company->users()->inRandomOrder()->first()->id,
+    'action_type' 		=> 'checkout',
+    'item_id' 		=> $company->components()->whereNotNull('company_id')->inRandomOrder()->first()->id,
+    'target_id' => $company->users()->inRandomOrder()->first()->id,
+    'target_type' => 'App\\Models\\User',
+    'created_at'  => $faker->dateTime(),
+    'item_type'  => 'App\\Models\\Component',
+    'note' 			=> $faker->sentence,
+    'company_id' => $company->id
+  ];
+});
 
 $factory->defineAs(App\Models\CustomField::class, 'customfield-ip', function (Faker\Generator $faker) {
   return [
@@ -295,5 +356,6 @@ $factory->defineAs(App\Models\User::class, 'valid-user', function (Faker\Generat
     'email' => $faker->safeEmail,
     'password' => $faker->password,
     'username' => $faker->username,
+    'company_id' => \App\Models\Company::inRandomOrder()->first()->id
   ];
 });

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -255,6 +255,7 @@ $factory->defineAs(App\Models\License::class, 'license', function (Faker\Generat
     'purchase_date' 		=> $faker->dateTime(),
     'purchase_cost' 		=> $faker->randomFloat(2),
     'notes'   => $faker->sentence,
+    'company_id' => \App\Models\Company::inRandomOrder()->first()->id
   ];
 });
 
@@ -269,8 +270,7 @@ $factory->defineAs(App\Models\LicenseSeat::class, 'license-seat', function (Fake
 });
 
 $factory->defineAs(App\Models\Actionlog::class, 'asset-checkout', function (Faker\Generator $faker) {
-  $company = \App\Models\Company::has('users', 'assets')->inRandomOrder()->first();
-  return $company;
+  $company = \App\Models\Company::has('users')->has('assets')->inRandomOrder()->first();
   return [
     'user_id'      	=> $company->users()->inRandomOrder()->first()->id,
     'action_type' 		=> 'checkout',
@@ -285,6 +285,8 @@ $factory->defineAs(App\Models\Actionlog::class, 'asset-checkout', function (Fake
 });
 
 $factory->defineAs(App\Models\Actionlog::class, 'license-checkout-asset', function (Faker\Generator $faker) {
+  $company = \App\Models\Company::has('users')->has('licenses')->inRandomOrder()->first();
+
   return [
     'user_id'      	=> $company->users()->inRandomOrder()->first()->id,
     'action_type' 		=> 'checkout',
@@ -299,6 +301,7 @@ $factory->defineAs(App\Models\Actionlog::class, 'license-checkout-asset', functi
 });
 
 $factory->defineAs(App\Models\Actionlog::class, 'accessory-checkout', function (Faker\Generator $faker) {
+    $company = \App\Models\Company::has('users')->has('accessories')->inRandomOrder()->first();    
   return [
     'user_id'      	=> $company->users()->inRandomOrder()->first()->id,
     'action_type' 		=> 'checkout',
@@ -313,6 +316,8 @@ $factory->defineAs(App\Models\Actionlog::class, 'accessory-checkout', function (
 });
 
 $factory->defineAs(App\Models\Actionlog::class, 'consumable-checkout', function (Faker\Generator $faker) {
+    $company = \App\Models\Company::has('users')->has('consumables')->inRandomOrder()->first();    
+
   return [
     'user_id'      	=> $company->users()->inRandomOrder()->first()->id,
     'action_type' 		=> 'checkout',
@@ -327,6 +332,8 @@ $factory->defineAs(App\Models\Actionlog::class, 'consumable-checkout', function 
 });
 
 $factory->defineAs(App\Models\Actionlog::class, 'component-checkout', function (Faker\Generator $faker) {
+   $company = \App\Models\Company::has('users')->has('components')->inRandomOrder()->first();    
+
   return [
     'user_id'      	=> $company->users()->inRandomOrder()->first()->id,
     'action_type' 		=> 'checkout',

--- a/database/migrations/2016_09_28_231359_add_company_to_logs.php
+++ b/database/migrations/2016_09_28_231359_add_company_to_logs.php
@@ -20,11 +20,12 @@ class AddCompanyToLogs extends Migration
 
         $logs = Actionlog::with('item')->get();
         foreach ($logs as $log) {
-            if(!$log->item) {
-                break;
+            if($log->item) {
+                $log->company_id = $log->item->company_id;
+                $log->save();
+            } else {
+                var_dump($log);
             }
-            $log->company_id = $log->item->company_id;
-            $log->save();
         }
     }
 

--- a/database/migrations/2016_09_28_231359_add_company_to_logs.php
+++ b/database/migrations/2016_09_28_231359_add_company_to_logs.php
@@ -1,0 +1,43 @@
+<?php
+
+use App\Models\Actionlog;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class AddCompanyToLogs extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('action_logs', function (Blueprint $table) {
+            //
+            $table->integer('company_id')->nullable()->default(null);
+        });
+
+        $logs = Actionlog::with('item')->get();
+        foreach ($logs as $log) {
+            if(!$log->item) {
+                break;
+            }
+            $log->company_id = $log->item->company_id;
+            $log->save();
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('action_logs', function (Blueprint $table) {
+            //
+            $table->dropColumn('company_id');
+        });
+    }
+}

--- a/database/seeds/ActionlogSeeder.php
+++ b/database/seeds/ActionlogSeeder.php
@@ -7,6 +7,10 @@ class ActionlogSeeder extends Seeder
   public function run()
   {
     Actionlog::truncate();
-    factory(Actionlog::class, 'asset-checkout',5)->create();
+    factory(Actionlog::class, 'asset-checkout',25)->create();
+    factory(Actionlog::class, 'accessory-checkout',15)->create();
+    factory(Actionlog::class, 'consumable-checkout', 15)->create();
+    factory(Actionlog::class, 'component-checkout', 15)->create();
+    factory(Actionlog::class, 'license-checkout-asset', 15)->create();
   }
 }

--- a/database/seeds/CompanySeeder.php
+++ b/database/seeds/CompanySeeder.php
@@ -1,0 +1,19 @@
+<?php
+
+use App\Models\Company;
+use Illuminate\Database\Seeder;
+
+class CompanySeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        //
+        Company::truncate();
+        factory(Company::class, 'company', 4)->create();
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -14,9 +14,12 @@ class DatabaseSeeder extends Seeder
     {
         Model::unguard();
 
+        $this->call(CompanySeeder::class);
+        $this->call(UserSeeder::class);
         $this->call(AssetModelSeeder::class);
         $this->call(AccessorySeeder::class);
         $this->call(AssetSeeder::class);
+        $this->call(ComponentSeeder::class);
         $this->call(ConsumableSeeder::class);
         $this->call(StatuslabelSeeder::class);
         $this->call(SupplierSeeder::class);
@@ -27,7 +30,6 @@ class DatabaseSeeder extends Seeder
         $this->call(ManufacturerSeeder::class);
         $this->call(LocationSeeder::class);
         $this->call(CustomFieldSeeder::class);
-        $this->call(ComponentSeeder::class);
 
         Model::reguard();
     }

--- a/database/seeds/UserSeeder.php
+++ b/database/seeds/UserSeeder.php
@@ -1,0 +1,18 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+class UserSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        // Don't truncate the user column, that might suck.
+        factory(User::class, 'valid-user', 10)->create();
+    }
+}


### PR DESCRIPTION
Okay.  Finally.

This commit series adds a "company_id" field to the logs and populates it.  This prevents trying to determine the company by loading the related target of the log, and fixes an issue with the way Laravel handles polymorphism.

Actionlog no longer uses the CompanyableChild trait, instead we scope on demand (TODO: Should we instead use the Companyable Trait?)

Actionlogs inject the company_id in the Model::create event, so it does not need to be set manually everywhere.  We assume the company to be the company of the user generating the log unless they are a superadmin, in which case we go for the company of the target of the log.

This also beefs up the database seeder to allow for much more testing.  It's entirely possible I missed something, but this should be much better than the current state.

Sorry for the delay in solving all of this.