### PR TITLE
Rework permissions view

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -233,6 +233,17 @@ class UsersController extends Controller
     * @param int $id
     * @return View
     */
+
+    private function filterDisplayable($permissions) {
+        $output = null;
+        foreach($permissions as $key=>$permission) {
+                $output[$key] = array_filter($permission, function($p) {
+                    return $p['display'] === true;
+                });
+            }
+        return $output;
+    }
+
     public function getEdit($id = null)
     {
         try {
@@ -249,7 +260,7 @@ class UsersController extends Controller
             $userGroups = $user->groups()->pluck('name', 'id');
             $user->permissions = $user->decodePermissions();
             $userPermissions = Helper::selectedPermissionsArray($permissions, $user->permissions);
-
+            $permissions = $this->filterDisplayable($permissions);
             $location_list = Helper::locationsList();
             $company_list = Helper::companyList();
             $manager_list = Helper::managerList();
@@ -282,7 +293,6 @@ class UsersController extends Controller
         // permissions here before we update the user.
         $permissions = $request->input('permissions', array());
         app('request')->request->set('permissions', $permissions);
-
         // Only update the email address if locking is set to false
         if (config('app.lock_passwords')) {
             return redirect()->route('users')->with('error', 'Denied! You cannot update user information on the demo.');
@@ -332,7 +342,6 @@ class UsersController extends Controller
         $user->manager_id = e($request->input('manager_id'));
         $user->notes = e($request->input('notes'));
         $user->permissions = json_encode($request->input('permission'));
-
 
         if ($user->manager_id == "") {
             $user->manager_id = null;

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -81,6 +81,7 @@ class UsersController extends Controller
 
         $permissions = config('permissions');
         $userPermissions = Helper::selectedPermissionsArray($permissions, Input::old('permissions', array()));
+        $permissions = $this->filterDisplayable($permissions);
 
         $location_list = Helper::locationsList();
         $manager_list = Helper::managerList();

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -126,41 +126,41 @@
           <!-- Navbar Right Menu -->
             <div class="navbar-custom-menu">
               <ul class="nav navbar-nav">
-                          @can('assets.view')
-                              <li {!! (Request::is('hardware*') ? ' class="active"' : '') !!}>
-                                  <a href="{{ URL::to('hardware') }}">
-                                      <i class="fa fa-barcode"></i>
-                                  </a>
-                              </li>
-                          @endcan
-                          @can('licenses.view')
-                          <li {!! (Request::is('admin/licenses*') ? ' class="active"' : '') !!}>
-                              <a href="{{ URL::to('admin/licenses') }}">
-                                  <i class="fa fa-floppy-o"></i>
-                              </a>
-                          </li>
-                          @endcan
-                          @can('accessories.view')
-                          <li {!! (Request::is('admin/accessories*') ? ' class="active"' : '') !!}>
-                              <a href="{{ URL::to('admin/accessories') }}">
-                                  <i class="fa fa-keyboard-o"></i>
-                              </a>
-                          </li>
-                          @endcan
-                          @can('consumables.view')
-                          <li {!! (Request::is('admin/consumables*') ? ' class="active"' : '') !!}>
-                              <a href="{{ URL::to('admin/consumables') }}">
-                                  <i class="fa fa-tint"></i>
-                              </a>
-                          </li>
-                          @endcan
-                          @can('components.view')
-                          <li {!! (Request::is('admin/components*') ? ' class="active"' : '') !!}>
-                              <a href="{{ URL::to('admin/components') }}">
-                                  <i class="fa fa-hdd-o"></i>
-                              </a>
-                          </li>
-                          @endcan
+                  @can('assets.view')
+                  <li {!! (Request::is('hardware*') ? ' class="active"' : '') !!}>
+                      <a href="{{ URL::to('hardware') }}">
+                          <i class="fa fa-barcode"></i>
+                      </a>
+                  </li>
+                  @endcan
+                  @can('licenses.view')
+                  <li {!! (Request::is('admin/licenses*') ? ' class="active"' : '') !!}>
+                      <a href="{{ URL::to('admin/licenses') }}">
+                          <i class="fa fa-floppy-o"></i>
+                      </a>
+                  </li>
+                  @endcan
+                  @can('accessories.view')
+                  <li {!! (Request::is('admin/accessories*') ? ' class="active"' : '') !!}>
+                      <a href="{{ URL::to('admin/accessories') }}">
+                          <i class="fa fa-keyboard-o"></i>
+                      </a>
+                  </li>
+                  @endcan
+                  @can('consumables.view')
+                  <li {!! (Request::is('admin/consumables*') ? ' class="active"' : '') !!}>
+                      <a href="{{ URL::to('admin/consumables') }}">
+                          <i class="fa fa-tint"></i>
+                      </a>
+                  </li>
+                  @endcan
+                  @can('components.view')
+                  <li {!! (Request::is('admin/components*') ? ' class="active"' : '') !!}>
+                      <a href="{{ URL::to('admin/components') }}">
+                          <i class="fa fa-hdd-o"></i>
+                      </a>
+                  </li>
+                  @endcan
 
                   @can('assets.view')
                   <form class="navbar-form navbar-left form-horizontal" role="search" action="{{ route('findbytag/hardware') }}" method="get">
@@ -227,7 +227,7 @@
                        </li>
                        @endcan
                    </ul>
-               </li>
+                </li>
                @endcan
 
                @can('admin')
@@ -288,7 +288,6 @@
                  </a>
                  <ul class="dropdown-menu">
                    <!-- User image -->
-                   <li>
                      <li {!! (Request::is('account/profile') ? ' class="active"' : '') !!}>
                        <a href="{{ route('view-assets') }}">
                              <i class="fa fa-check fa-fw"></i> @lang('general.viewassets')
@@ -304,7 +303,6 @@
                              @lang('general.logout')
                          </a>
                      </li>
-                   </li>
                  </ul>
                </li>
 
@@ -434,7 +432,7 @@
                   <li{!! (Request::query('status') == 'Pending' ? ' class="active"' : '') !!}><a href="{{ URL::to('hardware?status=Pending') }}">@lang('general.pending')</a></li>
                   <li{!! (Request::query('status') == 'Undeployable' ? ' class="active"' : '') !!} ><a href="{{ URL::to('hardware?status=Undeployable') }}">@lang('general.undeployable')</a></li>
                   <li{!! (Request::query('status') == 'Archived' ? ' class="active"' : '') !!}><a href="{{ URL::to('hardware?status=Archived') }}">@lang('admin/hardware/general.archived')</a></li>
-                    <li{!! (Request::query('status') == 'Requestable' ? ' class="active"' : '') !!}><a href="{{ URL::to('hardware?status=Requestable') }}"><a href="{{ URL::to('hardware?status=Requestable') }}" >@lang('admin/hardware/general.requestable')</a></li>
+                    <li{!! (Request::query('status') == 'Requestable' ? ' class="active"' : '') !!}><a href="{{ URL::to('hardware?status=Requestable') }}">@lang('admin/hardware/general.requestable')</a></li>
 
                   <li class="divider">&nbsp;</li>
                     <li{!! (Request::is('hardware/bulkcheckout') ? ' class="active>"' : '') !!}>

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -21,25 +21,22 @@
 @section('content')
 
 <style>
-.form-horizontal .control-label {
-  padding-top: 0px;
-}
+    .form-horizontal .control-label {
+      padding-top: 0px;
+    }
 
-input[type='text'][disabled], input[disabled], textarea[disabled], input[readonly], textarea[readonly], .form-control[disabled], .form-control[readonly], fieldset[disabled] .form-control {
-  background-color: white;
-  color: #555555;
-  cursor:text;
-}
-.radio-padding {
-    padding-left: 50px;
-}
+    input[type='text'][disabled], input[disabled], textarea[disabled], input[readonly], textarea[readonly], .form-control[disabled], .form-control[readonly], fieldset[disabled] .form-control {
+      background-color: white;
+      color: #555555;
+      cursor:text;
+    }
 </style>
 
 <div class="row">
 <div class="col-md-8 col-md-offset-2">
 
 
-<form class="form-horizontal" method="post" action="" autocomplete="off" id="userForm">
+<form class="form-horizontal" method="post" autocomplete="off" id="userForm">
 <!-- CSRF Token -->
 <input type="hidden" name="_token" value="{{ csrf_token() }}">
 
@@ -49,341 +46,368 @@ input[type='text'][disabled], input[disabled], textarea[disabled], input[readonl
     <li class="active"><a href="#tab_1" data-toggle="tab">Information</a></li>
     <li><a href="#tab_2" data-toggle="tab">Permissions</a></li>
   </ul>
+
   <div class="tab-content">
     <div class="tab-pane active" id="tab_1">
       <div class="row">
         <div class="col-md-12">
 
-      <!-- First Name -->
-      <div class="form-group {{ $errors->has('first_name') ? 'has-error' : '' }}">
-          <label class="col-md-3 control-label" for="first_name">{{ trans('general.first_name') }}</label>
-          <div class="col-md-8{{  (\App\Helpers\Helper::checkIfRequired($user, 'first_name')) ? ' required' : '' }}">
-              <input class="form-control" type="text" name="first_name" id="first_name" value="{{ Input::old('first_name', $user->first_name) }}" />
-              {!! $errors->first('first_name', '<span class="alert-msg">:message</span>') !!}
+          <!-- First Name -->
+          <div class="form-group {{ $errors->has('first_name') ? 'has-error' : '' }}">
+              <label class="col-md-3 control-label" for="first_name">{{ trans('general.first_name') }}</label>
+              <div class="col-md-8{{  (\App\Helpers\Helper::checkIfRequired($user, 'first_name')) ? ' required' : '' }}">
+                <input class="form-control" type="text" name="first_name" id="first_name" value="{{ Input::old('first_name', $user->first_name) }}" />
+                {!! $errors->first('first_name', '<span class="alert-msg">:message</span>') !!}
+              </div>
           </div>
-      </div>
 
-      <!-- Last Name -->
-      <div class="form-group {{ $errors->has('last_name') ? 'has-error' : '' }}">
-          <label class="col-md-3 control-label" for="last_name">{{ trans('general.last_name') }} </label>
-          <div class="col-md-8{{  (\App\Helpers\Helper::checkIfRequired($user, 'last_name')) ? ' required' : '' }}">
+          <!-- Last Name -->
+          <div class="form-group {{ $errors->has('last_name') ? 'has-error' : '' }}">
+            <label class="col-md-3 control-label" for="last_name">{{ trans('general.last_name') }} </label>
+            <div class="col-md-8{{  (\App\Helpers\Helper::checkIfRequired($user, 'last_name')) ? ' required' : '' }}">
               <input class="form-control" type="text" name="last_name" id="last_name" value="{{ Input::old('last_name', $user->last_name) }}" />
               {!! $errors->first('last_name', '<span class="alert-msg">:message</span>') !!}
+            </div>
           </div>
-      </div>
 
-
-<!-- Username -->
-  <div class="form-group {{ $errors->has('username') ? 'has-error' : '' }}">
-      <label class="col-md-3 control-label" for="username">{{ trans('admin/users/table.username') }}</label>
-      <div class="col-md-8{{  (\App\Helpers\Helper::checkIfRequired($user, 'username')) ? ' required' : '' }}">
-        @if ($user->ldap_import!='1')
-            <input class="form-control" type="text" name="username" id="username" value="{{ Input::old('username', $user->username) }}"  {{ ((config('app.lock_passwords') && ($user->id)) ? ' disabled' : '') }} autocomplete="false" readonly onfocus="this.removeAttribute('readonly');">
-            @if (config('app.lock_passwords') && ($user->id))
+          <!-- Username -->
+          <div class="form-group {{ $errors->has('username') ? 'has-error' : '' }}">
+            <label class="col-md-3 control-label" for="username">{{ trans('admin/users/table.username') }}</label>
+            <div class="col-md-8{{  (\App\Helpers\Helper::checkIfRequired($user, 'username')) ? ' required' : '' }}">
+              @if ($user->ldap_import!='1')
+                <input 
+                  class="form-control" 
+                  type="text" 
+                  name="username" 
+                  id="username" 
+                  value="{{ Input::old('username', $user->username) }}"
+                  autocomplete="false" 
+                  readonly 
+                  onfocus="this.removeAttribute('readonly');"
+                  {{ ((config('app.lock_passwords') && ($user->id)) ? ' disabled' : '') }} 
+                >
+                @if (config('app.lock_passwords') && ($user->id))
                   <p class="help-block">{{ trans('admin/users/table.lock_passwords') }}</p>
-            @endif
-        @else
-            (Managed via LDAP)
-        @endif
-
-        {!! $errors->first('username', '<span class="alert-msg">:message</span>') !!}
-      </div>
-  </div>
-
-
-  <!-- Password -->
-  <div class="form-group {{ $errors->has('password') ? 'has-error' : '' }}">
-    <label class="col-md-3 control-label" for="password">{{ trans('admin/users/table.password') }}
-    </label>
-    <div class="col-md-5{{  (\App\Helpers\Helper::checkIfRequired($user, 'password')) ? ' required' : '' }}">
-      @if ($user->ldap_import!='1')
-          <input type="password" name="password" class="form-control" id="password" value="" {{ ((config('app.lock_passwords') && ($user->id)) ? ' disabled' : '') }} autocomplete="false" readonly onfocus="this.removeAttribute('readonly');">
-      @else
-          (Managed via LDAP)
-      @endif
-      <span id="generated-password"></span>
-        {!! $errors->first('password', '<span class="alert-msg">:message</span>') !!}
-    </div>
-    <div class="col-md-4">
-      @if ($user->ldap_import!='1')
-       <a href="#" class="left" id="genPassword">Generate</a>
-       @endif
-    </div>
-  </div>
-
-  @if ($user->ldap_import!='1')
-  <!-- Password Confirm -->
-  <div class="form-group {{ $errors->has('password_confirm') ? 'has-error' : '' }}">
-    <label class="col-md-3 control-label" for="password_confirm">{{ trans('admin/users/table.password_confirm') }}
-    </label>
-    <div class="col-md-5{{  ((\App\Helpers\Helper::checkIfRequired($user, 'first_name')) && (!$user->id)) ? ' required' : '' }}">
-    <input type="password" name="password_confirm" id="password_confirm"  class="form-control" value="" {{ ((config('app.lock_passwords') && ($user->id)) ? ' disabled' : '') }} autocomplete="off">
-    @if (config('app.lock_passwords') && ($user->id))
-      <p class="help-block">{{ trans('admin/users/table.lock_passwords') }}</p>
-    @endif
-      {!! $errors->first('password_confirm', '<span class="alert-msg">:message</span>') !!}
-    </div>
-  </div>
-  @endif
-
-
-    <!-- Email -->
-      <div class="form-group {{ $errors->has('email') ? 'has-error' : '' }}">
-          <label class="col-md-3 control-label" for="email">{{ trans('admin/users/table.email') }} </label>
-          <div class="col-md-8{{  (\App\Helpers\Helper::checkIfRequired($user, 'email')) ? ' required' : '' }}">
-              <input class="form-control" type="text" name="email" id="email" value="{{ Input::old('email', $user->email) }}"  {{ ((config('app.lock_passwords') && ($user->id)) ? ' disabled' : '') }} autocomplete="off"  readonly onfocus="this.removeAttribute('readonly');">
-               @if (config('app.lock_passwords') && ($user->id))
-                <p class="help-block">{{ trans('admin/users/table.lock_passwords') }}</p>
-               @endif
-
-              {!! $errors->first('email', '<span class="alert-msg">:message</span>') !!}
-          </div>
-      </div>
-
-    <!-- Company -->
-    @if (\App\Models\Company::canManageUsersCompanies())
-        <!-- Company -->
-        <div class="form-group {{ $errors->has('company_id') ? 'has-error' : '' }}">
-            <div class="col-md-3 control-label">
-                {{ Form::label('company_id', trans('general.company')) }}
-            </div>
-            <div class="col-md-8">
-                {{ Form::select('company_id', $company_list , Input::old('company_id', $user->company_id), array('class'=>'select2', 'style'=>'width:350px')) }}
-                {!! $errors->first('company_id', '<span class="alert-msg">:message</span>') !!}
-            </div>
-        </div>
-      @endif
-
-
-
-
-       <!-- language -->
-         <div class="form-group {{ $errors->has('locale') ? 'has-error' : '' }}">
-             <label class="col-md-3 control-label" for="locale">{{ trans('general.language') }}</label>
-             <div class="col-md-8">
-                 {!! Form::locales('locale', Input::old('locale', $user->locale), 'select2') !!}
-                 {!! $errors->first('locale', '<span class="alert-msg">:message</span>') !!}
-             </div>
-         </div>
-
-
-    <!-- Employee Number -->
-      <div class="form-group {{ $errors->has('employee_num') ? 'has-error' : '' }}">
-          <label class="col-md-3 control-label" for="employee_num">{{ trans('admin/users/table.employee_num') }}</label>
-          <div class="col-md-8">
-              <input class="form-control" type="text" name="employee_num" id="employee_num" value="{{ Input::old('employee_num', $user->employee_num) }}" />
-              {!! $errors->first('employee_num', '<span class="alert-msg">:message</span>') !!}
-          </div>
-      </div>
-
-
-      <!-- Jobtitle -->
-      <div class="form-group {{ $errors->has('jobtitle') ? 'has-error' : '' }}">
-          <label class="col-md-3 control-label" for="jobtitle">{{ trans('admin/users/table.title') }}</label>
-          <div class="col-md-8">
-              <input class="form-control" type="text" name="jobtitle" id="jobtitle" value="{{ Input::old('jobtitle', $user->jobtitle) }}" />
-              {!! $errors->first('jobtitle', '<span class="alert-msg">:message</span>') !!}
-          </div>
-      </div>
-
-
-<!-- Manager -->
-      <div class="form-group {{ $errors->has('manager_id') ? 'has-error' : '' }}">
-          <label class="col-md-3 control-label" for="manager_id">{{ trans('admin/users/table.manager') }}</label>
-          <div class="col-md-8">
-              {{ Form::select('manager_id', $manager_list , Input::old('manager_id', $user->manager_id), array('class'=>'select2', 'style'=>'width:350px')) }}
-              {!! $errors->first('manager_id', '<span class="alert-msg">:message</span>') !!}
-          </div>
-      </div>
-
-<!-- Location -->
-      <div class="form-group {{ $errors->has('location_id') ? 'has-error' : '' }}">
-          <label class="col-md-3 control-label" for="location_id">{{ trans('admin/users/table.location') }}
-              </label>
-          <div class="col-md-8">
-              {{ Form::select('location_id', $location_list , Input::old('location_id', $user->location_id), array('class'=>'select2', 'style'=>'width:350px')) }}
-              {!! $errors->first('location_id', '<span class="alert-msg">:message</span>') !!}
-          </div>
-      </div>
-
-<!-- Phone -->
-      <div class="form-group {{ $errors->has('phone') ? 'has-error' : '' }}">
-          <label class="col-md-3 control-label" for="phone">{{ trans('admin/users/table.phone') }}</label>
-          <div class="col-md-4">
-              <input class="form-control" type="text" name="phone" id="phone" value="{{ Input::old('phone', $user->phone) }}" />
-              {!! $errors->first('phone', '<span class="alert-msg">:message</span>') !!}
-          </div>
-      </div>
-
-<!-- Activation Status -->
-      <div class="form-group {{ $errors->has('activated') ? 'has-error' : '' }}">
-          <label class="col-md-3 control-label" for="activated">{{ trans('admin/users/table.activated') }}</label>
-          <div class="col-md-8">
-             <div class="controls">
-              <select{{ ($user->id === Auth::user()->id ? ' disabled="disabled"' : '') }} name="activated" id="activated" {{ ((config('app.lock_passwords') && ($user->id)) ? ' disabled' : '') }}>
-              @if ($user->id)
-                <option value="1"{{ ($user->isActivated() ? ' selected="selected"' : '') }}>{{ trans('general.yes') }}</option>
-                  <option value="0"{{ ( ! $user->isActivated() ? ' selected="selected"' : '') }}>{{ trans('general.no') }}</option>
+                @endif
               @else
-                <option value="1"{{ (Input::old('activated') == 1 ? ' selected="selected"' : '') }}>{{ trans('general.yes') }}</option>
-                  <option value="0">{{ trans('general.no') }}</option>
+                (Managed via LDAP)
               @endif
 
-              </select>
-
-              {!! $errors->first('activated', '<span class="alert-msg">:message</span>') !!}
+              {!! $errors->first('username', '<span class="alert-msg">:message</span>') !!}
+            </div>
           </div>
-          </div>
-      </div>
 
-       <!-- Notes -->
-      <div class="form-group{!! $errors->has('notes') ? ' has-error' : '' !!}">
-          <label for="notes" class="col-md-3 control-label">{{ trans('admin/users/table.notes') }}</label>
-          <div class="col-md-8">
+          <!-- Password -->
+          <div class="form-group {{ $errors->has('password') ? 'has-error' : '' }}">
+            <label class="col-md-3 control-label" for="password">
+              {{ trans('admin/users/table.password') }}
+            </label>
+            <div class="col-md-5{{  (\App\Helpers\Helper::checkIfRequired($user, 'password')) ? ' required' : '' }}">
+              @if ($user->ldap_import!='1')
+                <input 
+                  type="password" 
+                  name="password"
+                  class="form-control"
+                  id="password"
+                  value=""
+                  autocomplete="false"
+                  readonly
+                  onfocus="this.removeAttribute('readonly');"
+                  {{ ((config('app.lock_passwords') && ($user->id)) ? ' disabled' : '') }}
+                >
+              @else
+                (Managed via LDAP)
+              @endif
+              <span id="generated-password"></span>
+              {!! $errors->first('password', '<span class="alert-msg">:message</span>') !!}
+            </div>
+            <div class="col-md-4">
+              @if ($user->ldap_import!='1')
+                <a href="#" class="left" id="genPassword">Generate</a>
+              @endif
+            </div>
+          </div>
+
+          @if ($user->ldap_import!='1')
+          <!-- Password Confirm -->
+          <div class="form-group {{ $errors->has('password_confirm') ? 'has-error' : '' }}">
+            <label class="col-md-3 control-label" for="password_confirm">
+              {{ trans('admin/users/table.password_confirm') }}
+            </label>
+            <div class="col-md-5 {{  ((\App\Helpers\Helper::checkIfRequired($user, 'first_name')) && (!$user->id)) ? ' required' : '' }}">
+              <input
+              type="password"
+              name="password_confirm"
+              id="password_confirm"
+              class="form-control"
+              value=""
+              autocomplete="off"
+              {{ ((config('app.lock_passwords') && ($user->id)) ? ' disabled' : '') }} 
+              >
+              @if (config('app.lock_passwords') && ($user->id))
+              <p class="help-block">{{ trans('admin/users/table.lock_passwords') }}</p>
+              @endif
+              {!! $errors->first('password_confirm', '<span class="alert-msg">:message</span>') !!}
+            </div>
+          </div>
+          @endif
+
+          <!-- Email -->
+          <div class="form-group {{ $errors->has('email') ? 'has-error' : '' }}">
+            <label class="col-md-3 control-label" for="email">{{ trans('admin/users/table.email') }} </label>
+            <div class="col-md-8{{  (\App\Helpers\Helper::checkIfRequired($user, 'email')) ? ' required' : '' }}">
+              <input
+                class="form-control"
+                type="text"
+                name="email"
+                id="email"
+                value="{{ Input::old('email', $user->email) }}"
+                {{ ((config('app.lock_passwords') && ($user->id)) ? ' disabled' : '') }}
+                autocomplete="off"
+                readonly
+                onfocus="this.removeAttribute('readonly');"
+              >
+              @if (config('app.lock_passwords') && ($user->id))
+              <p class="help-block">{{ trans('admin/users/table.lock_passwords') }}</p>
+              @endif
+              {!! $errors->first('email', '<span class="alert-msg">:message</span>') !!}
+            </div>
+          </div>
+
+          <!-- Company -->
+          @if (\App\Models\Company::canManageUsersCompanies())
+          <!-- Company -->
+          <div class="form-group {{ $errors->has('company_id') ? 'has-error' : '' }}">
+            <div class="col-md-3 control-label">
+              {{ Form::label('company_id', trans('general.company')) }}
+            </div>
+            <div class="col-md-8">
+              {{ Form::select('company_id', $company_list , Input::old('company_id', $user->company_id), array('class'=>'select2', 'style'=>'width:350px')) }}
+              {!! $errors->first('company_id', '<span class="alert-msg">:message</span>') !!}
+            </div>
+          </div>
+          @endif
+
+          <!-- language -->
+          <div class="form-group {{ $errors->has('locale') ? 'has-error' : '' }}">
+            <label class="col-md-3 control-label" for="locale">{{ trans('general.language') }}</label>
+            <div class="col-md-8">
+              {!! Form::locales('locale', Input::old('locale', $user->locale), 'select2') !!}
+              {!! $errors->first('locale', '<span class="alert-msg">:message</span>') !!}
+            </div>
+          </div>
+
+          <!-- Employee Number -->
+          <div class="form-group {{ $errors->has('employee_num') ? 'has-error' : '' }}">
+            <label class="col-md-3 control-label" for="employee_num">{{ trans('admin/users/table.employee_num') }}</label>
+            <div class="col-md-8">
+              <input
+                class="form-control"
+                type="text"
+                name="employee_num"
+                id="employee_num"
+                value="{{ Input::old('employee_num', $user->employee_num) }}" 
+              />
+              {!! $errors->first('employee_num', '<span class="alert-msg">:message</span>') !!}
+            </div>
+          </div>
+
+
+          <!-- Jobtitle -->
+          <div class="form-group {{ $errors->has('jobtitle') ? 'has-error' : '' }}">
+            <label class="col-md-3 control-label" for="jobtitle">{{ trans('admin/users/table.title') }}</label>
+            <div class="col-md-8">
+              <input
+                class="form-control"
+                type="text"
+                name="jobtitle"
+                id="jobtitle"
+                value="{{ Input::old('jobtitle', $user->jobtitle) }}"
+              />
+              {!! $errors->first('jobtitle', '<span class="alert-msg">:message</span>') !!}
+            </div>
+          </div>
+
+
+          <!-- Manager -->
+          <div class="form-group {{ $errors->has('manager_id') ? 'has-error' : '' }}">
+            <label class="col-md-3 control-label" for="manager_id">{{ trans('admin/users/table.manager') }}</label>
+            <div class="col-md-8">
+              {{ Form::select('manager_id', $manager_list , Input::old('manager_id', $user->manager_id), array('class'=>'select2', 'style'=>'width:350px')) }}
+              {!! $errors->first('manager_id', '<span class="alert-msg">:message</span>') !!}
+            </div>
+          </div>
+
+          <!-- Location -->
+          <div class="form-group {{ $errors->has('location_id') ? 'has-error' : '' }}">
+            <label class="col-md-3 control-label" for="location_id">{{ trans('admin/users/table.location') }}
+            </label>
+            <div class="col-md-8">
+              {{ Form::select('location_id', $location_list , Input::old('location_id', $user->location_id), array('class'=>'select2', 'style'=>'width:350px')) }}
+              {!! $errors->first('location_id', '<span class="alert-msg">:message</span>') !!}
+            </div>
+          </div>
+
+          <!-- Phone -->
+          <div class="form-group {{ $errors->has('phone') ? 'has-error' : '' }}">
+            <label class="col-md-3 control-label" for="phone">{{ trans('admin/users/table.phone') }}</label>
+            <div class="col-md-4">
+              <input class="form-control" type="text" name="phone" id="phone" value="{{ Input::old('phone', $user->phone) }}" />
+              {!! $errors->first('phone', '<span class="alert-msg">:message</span>') !!}
+            </div>
+          </div>
+
+          <!-- Activation Status -->
+          <div class="form-group {{ $errors->has('activated') ? 'has-error' : '' }}">
+            <label class="col-md-3 control-label" for="activated">{{ trans('admin/users/table.activated') }}</label>
+            <div class="col-md-8">
+              <div class="controls">
+                <select
+                  {{ ($user->id === Auth::user()->id ? ' disabled="disabled"' : '') }}
+                  name="activated"
+                  id="activated"
+                  {{ ((config('app.lock_passwords') && ($user->id)) ? ' disabled' : '') }}
+                >
+                @if ($user->id)
+                <option value="1"{{ ($user->isActivated() ? ' selected="selected"' : '') }}>{{ trans('general.yes') }}</option>
+                <option value="0"{{ ( ! $user->isActivated() ? ' selected="selected"' : '') }}>{{ trans('general.no') }}</option>
+                @else
+                <option value="1"{{ (Input::old('activated') == 1 ? ' selected="selected"' : '') }}>{{ trans('general.yes') }}</option>
+                <option value="0">{{ trans('general.no') }}</option>
+                @endif
+
+                </select>
+                {!! $errors->first('activated', '<span class="alert-msg">:message</span>') !!}
+              </div>
+            </div>
+          </div>
+
+          <!-- Notes -->
+          <div class="form-group{!! $errors->has('notes') ? ' has-error' : '' !!}">
+            <label for="notes" class="col-md-3 control-label">{{ trans('admin/users/table.notes') }}</label>
+            <div class="col-md-8">
               <textarea class="form-control" id="notes" name="notes">{{ Input::old('notes', $user->notes) }}</textarea>
               {!! $errors->first('notes', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
-          </div>
-      </div>
-
-      <!-- Groups -->
-            <div class="form-group{{ $errors->has('groups') ? ' has-error' : '' }}">
-                <label class="col-md-3 control-label" for="groups"> {{ trans('general.groups') }}</label>
-                <div class="col-md-5">
-                   <div class="controls">
-
-                    <select name="groups[]" id="groups[]" multiple="multiple" class="form-control" {{ ((Config::get('app.lock_passwords') || ($user->id==Auth::user()->id) || (!Auth::user()->isSuperUser())) ? ' disabled' : '') }}>
-
-                        @foreach ($groups as $id => $group)
-                        <option value="{{ $id }}"
-                        {{ ($userGroups->keys()->contains($id) ? ' selected="selected"' : '') }}>
-                        {{ $group }}
-                        </option>
-                        @endforeach
-                    </select>
-
-                    <span class="help-block">
-                    	{{ trans('admin/users/table.groupnotes') }}
-
-                    </span>
-                </div>
-                </div>
             </div>
-      <!-- Email user -->
-      @if (!$user->id)
-
-      <div class="form-group">
-        <div class="col-sm-3">
-        </div>
-        <div class="col-sm-9">
-          <div class="checkbox">
-            <label for="email_user">
-              {{ Form::checkbox('email_user', '1', Input::old('email_user'), array('id'=>'email_user','disabled'=>'disabled')) }}
-
-              Email this user their credentials? <span class="help-text" id="email_user_warn">(Cannot send email. No user email address specified.)</span>
-            </label>
           </div>
+
+          <!-- Groups -->
+          <div class="form-group{{ $errors->has('groups') ? ' has-error' : '' }}">
+            <label class="col-md-3 control-label" for="groups"> {{ trans('general.groups') }}</label>
+            <div class="col-md-5">
+              <div class="controls">
+                <select
+                  name="groups[]"
+                  id="groups[]"
+                  multiple="multiple"
+                  class="form-control"
+                  {{ ((Config::get('app.lock_passwords') || ($user->id==Auth::user()->id) || (!Auth::user()->isSuperUser())) ? ' disabled' : '') }}
+                >
+
+                @foreach ($groups as $id => $group)
+                  <option value="{{ $id }}"
+                    {{ ($userGroups->keys()->contains($id) ? ' selected="selected"' : '') }}>
+                    {{ $group }}
+                  </option>
+                @endforeach
+                </select>
+
+                <span class="help-block">
+                  {{ trans('admin/users/table.groupnotes') }}
+                </span>
+              </div>
+            </div>
+          </div>
+          <!-- Email user -->
+          @if (!$user->id)
+
+          <div class="form-group">
+            <div class="col-sm-3">
+            </div>
+            <div class="col-sm-9">
+              <div class="checkbox">
+                <label for="email_user">
+                  {{ Form::checkbox('email_user', '1', Input::old('email_user'), array('id'=>'email_user','disabled'=>'disabled')) }}
+
+                  Email this user their credentials? <span class="help-text" id="email_user_warn">(Cannot send email. No user email address specified.)</span>
+                </label>
+              </div>
+            </div>
+          </div>
+          @endif
         </div>
-      </div>
-      @endif
-      </div>
       </div>
     </div><!-- /.tab-pane -->
+
     <div class="tab-pane" id="tab_2">
         <div class="col-md-10 col-md-offset-2">
-
-
             @if (!Auth::user()->isSuperUser())
                 <p class="alert alert-warning">Only superadmins may grant a user superadmin access.</p>
             @endif
-
+        </div>
         <table class="table table-striped">
-            <thead>
-                <tr>
-                    <th class="col-md-2"><span class="line"></span>Permission</th>
-                    <th class="col-md-1"><span class="line"></span>Grant</th>
-                    <th class="col-md-1"><span class="line"></span>Deny</th>
-                    <th class="col-md-1"><span class="line"></span>Inherit</th>
-                </tr>
-            </thead>
-            <tbody>
-                <?php $counter = 1; ?>
-        @foreach ($permissions as $area => $permission)
-
-            
-            @for ($i = 0; $i < count($permission); $i++)
+          <thead>
             <tr>
-                <?php
-                $permission_name = $permission[$i]['permission'];
-
-                ?>
-
-                @if ($counter == 2)
-                    <div id="nonadmin">
-                 @endif
-
-
-                @if ($permission[$i]['display'])
-                    <td class="col-md-2" 
-                        data-toggle="tooltip"
-                        data-placement="right"
-                        title="{{ $permission[$i]['note'] }}">
-                        {{ $area }}: {{ $permission[$i]['label'] }}
-                    </td>
-
-                    <!-- radio -->
-                    <div class="form-group" style="padding-left: 15px;">
-<td class="col-md-1">
-                            @if (($permission_name == 'superuser') && (!Auth::user()->isSuperUser()))
-                                {{ Form::radio('', '1', $userPermissions[$permission_name] == '1', ['disabled'=>'disabled']) }}
-                            @else
-                                {{ Form::radio('', '1', $userPermissions[$permission_name] == '1', ['class' => "$permission_name"]) }}
-                            @endif
-</td>
-<td class="col-md-1">
-                            @if (($permission_name == 'superuser') && (!Auth::user()->isSuperUser()))
-                                {{ Form::radio('', '-1', $userPermissions[$permission_name] == '-1', ['disabled'=>'disabled']) }}
-
-                            @else
-                                {{ Form::radio('', $userPermissions[$permission_name] == '-1', ['class' => "$permission_name"]) }}
-
-
-                            @endif
-</td>
-<td class="col-md-1">
-                            @if (($permission_name == 'superuser') && (!Auth::user()->isSuperUser()))
-                                {{ Form::radio('', '0', $userPermissions[$permission_name] =='0', ['disabled'=>'disabled']) }}
-                            @else
-                                {{ Form::radio('', $userPermissions[$permission_name] =='0', ['class' => "$permission_name"]) }}
-                            @endif
-</td>
-
-                    </div>
-                    <hr>
-                @endif
-
-                    </tr>
-            @endfor
-                        @if ($counter == count($permissions))
-                            
-                    </div>
+              <th class="col-md-2"><span class="line"></span>Permission</th>
+              <th class="col-md-1"><span class="line"></span>Grant</th>
+              <th class="col-md-1"><span class="line"></span>Deny</th>
+              <th class="col-md-1"><span class="line"></span>Inherit</th>
+            </tr>
+          </thead>
+            {{-- @foreach ($permissions as $area => $permission) --}}
+            @foreach ($permissions as $area => $permissionsArray)
+            {{-- <tr><td class="col-md-5"><h3>{{ $area }}</h3></td></tr> --}}
+              {{-- @for ($i = 0; $i < count($permission); $i++) --}}
+              <tbody>
+              @foreach ($permissionsArray as $index => $permission)
+              <tr>
+                @if ($permission['display'])
+                  <td
+                    class="col-md-2 tooltip-base" 
+                    data-toggle="tooltip"
+                    data-placement="right"
+                    title="{{ $permission['note'] }}">
+                    {{ $area }}: {{ $permission['label'] }}
+                  </td>
+                  <td class="col-md-1">
+                    @if (($permission['permission'] == 'superuser') && (!Auth::user()->isSuperUser()))
+                    {{ Form::radio('permission['.$permission['permission'].']', '1', $userPermissions[$permission['permission'] ] == '1', ['disabled'=>'disabled']) }}
+                    @else
+                    {{ Form::radio('permission['.$permission['permission'].']', '1', $userPermissions[ $permission['permission'] ] == '1', ['class' => $permission["permission"] ]) }}
                     @endif
-        <?php $counter++; ?>
-        @endforeach
-        </tbody>
+                  </td>
+                  <td class="col-md-1">
+                    @if (($permission['permission'] == 'superuser') && (!Auth::user()->isSuperUser()))
+                    {{ Form::radio('permission['.$permission['permission'].']', '-1', $userPermissions[$permission['permission'] ] == '-1', ['disabled'=>'disabled']) }}
+
+                    @else
+                    {{ Form::radio('permission['.$permission['permission'].']', '-1', $userPermissions[$permission['permission'] ] == '-1', ['class' => $permission["permission"] ]) }}
+                    @endif
+                  </td>
+                  <td class="col-md-1">
+                    @if (($permission['permission'] == 'superuser') && (!Auth::user()->isSuperUser()))
+                    {{ Form::radio('permission['.$permission['permission'].']', '0', $userPermissions[$permission['permission']] =='0', ['disabled'=>'disabled']) }}
+                    @else
+                    {{ Form::radio('permission['.$permission['permission'].']', '0', $userPermissions[$permission['permission']] =='0', ['class' => $permission["permission"]]) }}
+                    @endif
+                  </td>
+                  
+                @endif
+              </tr>
+              @endforeach
+              </tbody>
+            @endforeach
         </table>
-            </div>
-
-
     </div><!-- /.tab-pane -->
   </div><!-- /.tab-content -->
   <div class="box-footer text-right">
     <button type="submit" class="btn btn-success"><i class="fa fa-check icon-white"></i> {{ trans('general.save') }}</button>
   </div>
 </div><!-- nav-tabs-custom -->
-
-
 </form>
-
+</div>
+</div>
+@stop
 @section('moar_scripts')
 <script>
 $(document).ready(function() {
@@ -409,6 +433,7 @@ $(document).ready(function() {
 
 $(document).ready(function(){
 
+    $('.tooltip-base').tooltip({container: 'body'})
     $(".superuser").change(function() {
         var perms = $(this).val();
         if (perms =='1') {
@@ -433,6 +458,4 @@ $(document).ready(function(){
     });
 });
 </script>
-@stop
-
 @stop

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -39,7 +39,11 @@
       flex-direction:column;
     }
 
-    .permissions.table > thead, .permissions.table > tbody, .permissions.table > tbody+tbody {
+    .permissions.table > thead, .permissions.table > tbody {
+      margin: 15px;
+      margin-top: 0px;
+    }
+    .permissions.table > tbody+tbody {
       margin: 15px;
     }
     .header-row {
@@ -60,6 +64,10 @@
     }
     table, tbody {
       border: 1px solid #ccc;
+    }
+    
+    .header-name {
+      cursor: pointer;
     }
 
 </style>
@@ -389,7 +397,7 @@
             @foreach ($permissions as $area => $permissionsArray)
               <tbody class="permissions-group">
               <tr class="header-row permissions-row">
-                <td class="col-md-2">
+                <td class="col-md-2 header-name">
                   <h3>{{ $area }}</h3>
                 </td>
                 <td class="col-md-1 permissions-item">
@@ -476,6 +484,10 @@ $('tr.header-row input:radio').click(function() {
     $(this).find('td input:radio[value='+value+']').prop("checked", true);
   })
 });
+
+$('.header-name').click(function() {
+  $(this).parent().nextUntil('tr.header-row').slideToggle(500);
+})
 </script>
 
 <script src="{{ asset('assets/js/pGenerator.jquery.js') }}"></script>

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -30,6 +30,38 @@
       color: #555555;
       cursor:text;
     }
+    table.permissions {
+      display:flex;
+      flex-direction: column;
+    }
+    tbody.permissions-group {
+      display:flex;
+      flex-direction:column;
+    }
+
+    .permissions.table > thead, .permissions.table > tbody, .permissions.table > tbody+tbody {
+      margin: 15px;
+    }
+    .header-row {
+      border-bottom: 1px solid #ccc;
+    }
+
+    .header-row h3 {
+      margin:0px;
+    }
+    .permissions-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+    }
+    .table > tbody > tr > td.permissions-item {
+      padding: 1px;
+      padding-left: 8px;
+    }
+    table, tbody {
+      border: 1px solid #ccc;
+    }
+
 </style>
 
 <div class="row">
@@ -75,16 +107,16 @@
             <label class="col-md-3 control-label" for="username">{{ trans('admin/users/table.username') }}</label>
             <div class="col-md-8{{  (\App\Helpers\Helper::checkIfRequired($user, 'username')) ? ' required' : '' }}">
               @if ($user->ldap_import!='1')
-                <input 
-                  class="form-control" 
-                  type="text" 
-                  name="username" 
-                  id="username" 
+                <input
+                  class="form-control"
+                  type="text"
+                  name="username"
+                  id="username"
                   value="{{ Input::old('username', $user->username) }}"
-                  autocomplete="false" 
-                  readonly 
+                  autocomplete="false"
+                  readonly
                   onfocus="this.removeAttribute('readonly');"
-                  {{ ((config('app.lock_passwords') && ($user->id)) ? ' disabled' : '') }} 
+                  {{ ((config('app.lock_passwords') && ($user->id)) ? ' disabled' : '') }}
                 >
                 @if (config('app.lock_passwords') && ($user->id))
                   <p class="help-block">{{ trans('admin/users/table.lock_passwords') }}</p>
@@ -104,8 +136,8 @@
             </label>
             <div class="col-md-5{{  (\App\Helpers\Helper::checkIfRequired($user, 'password')) ? ' required' : '' }}">
               @if ($user->ldap_import!='1')
-                <input 
-                  type="password" 
+                <input
+                  type="password"
                   name="password"
                   class="form-control"
                   id="password"
@@ -142,7 +174,7 @@
               class="form-control"
               value=""
               autocomplete="off"
-              {{ ((config('app.lock_passwords') && ($user->id)) ? ' disabled' : '') }} 
+              {{ ((config('app.lock_passwords') && ($user->id)) ? ' disabled' : '') }}
               >
               @if (config('app.lock_passwords') && ($user->id))
               <p class="help-block">{{ trans('admin/users/table.lock_passwords') }}</p>
@@ -206,7 +238,7 @@
                 type="text"
                 name="employee_num"
                 id="employee_num"
-                value="{{ Input::old('employee_num', $user->employee_num) }}" 
+                value="{{ Input::old('employee_num', $user->employee_num) }}"
               />
               {!! $errors->first('employee_num', '<span class="alert-msg">:message</span>') !!}
             </div>
@@ -345,53 +377,64 @@
                 <p class="alert alert-warning">Only superadmins may grant a user superadmin access.</p>
             @endif
         </div>
-        <table class="table table-striped">
+        <table class="table table-striped permissions">
           <thead>
-            <tr>
+            <tr class="permissions-row">
               <th class="col-md-2"><span class="line"></span>Permission</th>
               <th class="col-md-1"><span class="line"></span>Grant</th>
               <th class="col-md-1"><span class="line"></span>Deny</th>
               <th class="col-md-1"><span class="line"></span>Inherit</th>
             </tr>
           </thead>
-            {{-- @foreach ($permissions as $area => $permission) --}}
             @foreach ($permissions as $area => $permissionsArray)
-            {{-- <tr><td class="col-md-5"><h3>{{ $area }}</h3></td></tr> --}}
-              {{-- @for ($i = 0; $i < count($permission); $i++) --}}
-              <tbody>
+              <tbody class="permissions-group">
+              <tr class="header-row permissions-row">
+                <td class="col-md-2">
+                  <h3>{{ $area }}</h3>
+                </td>
+                <td class="col-md-1 permissions-item">
+                    {{ Form::radio("$area", '1',false,['value'=>"grant"]) }}
+                  </td>
+                  <td class="col-md-1 permissions-item">
+                    {{ Form::radio("$area", '-1',false,['value'=>"deny"]) }}
+                  </td>
+                  <td class="col-md-1 permissions-item">
+                    {{ Form::radio("$area", '0',false,['value'=>"inherit"] ) }}
+                  </td>
               @foreach ($permissionsArray as $index => $permission)
-              <tr>
+              <tr class="permissions-row">
                 @if ($permission['display'])
                   <td
-                    class="col-md-2 tooltip-base" 
+                    class="col-md-2 tooltip-base permissions-item"
                     data-toggle="tooltip"
                     data-placement="right"
-                    title="{{ $permission['note'] }}">
-                    {{ $area }}: {{ $permission['label'] }}
+                    title="{{ $permission['note'] }}"
+                  >
+                    {{ $permission['label'] }}
                   </td>
-                  <td class="col-md-1">
+                  <td class="col-md-1 permissions-item">
                     @if (($permission['permission'] == 'superuser') && (!Auth::user()->isSuperUser()))
-                    {{ Form::radio('permission['.$permission['permission'].']', '1', $userPermissions[$permission['permission'] ] == '1', ['disabled'=>'disabled']) }}
+                    {{ Form::radio('permission['.$permission['permission'].']', '1', $userPermissions[$permission['permission'] ] == '1', ["value"=>"grant", 'disabled'=>'disabled']) }}
                     @else
-                    {{ Form::radio('permission['.$permission['permission'].']', '1', $userPermissions[ $permission['permission'] ] == '1', ['class' => $permission["permission"] ]) }}
+                    {{ Form::radio('permission['.$permission['permission'].']', '1', $userPermissions[ $permission['permission'] ] == '1', ["value"=>"grant"]) }}
                     @endif
                   </td>
-                  <td class="col-md-1">
+                  <td class="col-md-1 permissions-item">
                     @if (($permission['permission'] == 'superuser') && (!Auth::user()->isSuperUser()))
-                    {{ Form::radio('permission['.$permission['permission'].']', '-1', $userPermissions[$permission['permission'] ] == '-1', ['disabled'=>'disabled']) }}
+                    {{ Form::radio('permission['.$permission['permission'].']', '-1', $userPermissions[$permission['permission'] ] == '-1', ["value"=>"deny", 'disabled'=>'disabled']) }}
 
                     @else
-                    {{ Form::radio('permission['.$permission['permission'].']', '-1', $userPermissions[$permission['permission'] ] == '-1', ['class' => $permission["permission"] ]) }}
+                    {{ Form::radio('permission['.$permission['permission'].']', '-1', $userPermissions[$permission['permission'] ] == '-1', ["value"=>"deny"]) }}
                     @endif
                   </td>
-                  <td class="col-md-1">
+                  <td class="col-md-1 permissions-item">
                     @if (($permission['permission'] == 'superuser') && (!Auth::user()->isSuperUser()))
-                    {{ Form::radio('permission['.$permission['permission'].']', '0', $userPermissions[$permission['permission']] =='0', ['disabled'=>'disabled']) }}
+                    {{ Form::radio('permission['.$permission['permission'].']', '0', $userPermissions[$permission['permission']] =='0', ["value"=>"inherit", 'disabled'=>'disabled']) }}
                     @else
-                    {{ Form::radio('permission['.$permission['permission'].']', '0', $userPermissions[$permission['permission']] =='0', ['class' => $permission["permission"]]) }}
+                    {{ Form::radio('permission['.$permission['permission'].']', '0', $userPermissions[$permission['permission']] =='0', ["value"=>"inherit"]) }}
                     @endif
                   </td>
-                  
+
                 @endif
               </tr>
               @endforeach
@@ -423,6 +466,15 @@ $(document).ready(function() {
 	    }
 
 	});
+});
+</script>
+
+<script>
+$('tr.header-row input:radio').click(function() {
+  value = $(this).attr('value');
+  $(this).parent().parent().siblings().each(function() {
+    $(this).find('td input:radio[value='+value+']').prop("checked", true);
+  })
 });
 </script>
 

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -296,12 +296,22 @@ input[type='text'][disabled], input[disabled], textarea[disabled], input[readonl
                 <p class="alert alert-warning">Only superadmins may grant a user superadmin access.</p>
             @endif
 
-
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th class="col-md-2"><span class="line"></span>Permission</th>
+                    <th class="col-md-1"><span class="line"></span>Grant</th>
+                    <th class="col-md-1"><span class="line"></span>Deny</th>
+                    <th class="col-md-1"><span class="line"></span>Inherit</th>
+                </tr>
+            </thead>
+            <tbody>
                 <?php $counter = 1; ?>
         @foreach ($permissions as $area => $permission)
 
-
+            
             @for ($i = 0; $i < count($permission); $i++)
+            <tr>
                 <?php
                 $permission_name = $permission[$i]['permission'];
 
@@ -313,45 +323,45 @@ input[type='text'][disabled], input[disabled], textarea[disabled], input[readonl
 
 
                 @if ($permission[$i]['display'])
-                    <h3>{{ $area }}: {{ $permission[$i]['label'] }}</h3>
-                    <p>{{ $permission[$i]['note'] }}</p>
+                    <td class="col-md-2" 
+                        data-toggle="tooltip"
+                        data-placement="right"
+                        title="{{ $permission[$i]['note'] }}">
+                        {{ $area }}: {{ $permission[$i]['label'] }}
+                    </td>
 
                     <!-- radio -->
                     <div class="form-group" style="padding-left: 15px;">
-
-                        <label class="radio-padding">
-
+<td class="col-md-1">
                             @if (($permission_name == 'superuser') && (!Auth::user()->isSuperUser()))
-                                {{ Form::radio('permission['.$permission_name.']', '1', $userPermissions[$permission_name] == '1', ['disabled'=>'disabled']) }}
+                                {{ Form::radio('', '1', $userPermissions[$permission_name] == '1', ['disabled'=>'disabled']) }}
                             @else
-                                {{ Form::radio('permission['.$permission_name.']', '1', $userPermissions[$permission_name] == '1', ['class' => "$permission_name"]) }}
+                                {{ Form::radio('', '1', $userPermissions[$permission_name] == '1', ['class' => "$permission_name"]) }}
                             @endif
-
-                            Grant</label>
-
-                        <label class="radio-padding">
-
+</td>
+<td class="col-md-1">
                             @if (($permission_name == 'superuser') && (!Auth::user()->isSuperUser()))
-                                {{ Form::radio('permission['.$permission_name.']', '-1', $userPermissions[$permission_name] == '-1', ['disabled'=>'disabled']) }}
+                                {{ Form::radio('', '-1', $userPermissions[$permission_name] == '-1', ['disabled'=>'disabled']) }}
 
                             @else
-                                {{ Form::radio('permission['.$permission_name.']', '-1', $userPermissions[$permission_name] == '-1', ['class' => "$permission_name"]) }}
+                                {{ Form::radio('', $userPermissions[$permission_name] == '-1', ['class' => "$permission_name"]) }}
+
 
                             @endif
-                            Deny</label>
-
-                        <label class="radio-padding">
+</td>
+<td class="col-md-1">
                             @if (($permission_name == 'superuser') && (!Auth::user()->isSuperUser()))
-                                {{ Form::radio('permission['.$permission_name.']', '0', $userPermissions[$permission_name] =='0', ['disabled'=>'disabled']) }}
+                                {{ Form::radio('', '0', $userPermissions[$permission_name] =='0', ['disabled'=>'disabled']) }}
                             @else
-                                {{ Form::radio('permission['.$permission_name.']', '0', $userPermissions[$permission_name] =='0', ['class' => "$permission_name"]) }}
+                                {{ Form::radio('', $userPermissions[$permission_name] =='0', ['class' => "$permission_name"]) }}
                             @endif
+</td>
 
-                              Inherit</label>
                     </div>
                     <hr>
                 @endif
 
+                    </tr>
             @endfor
                         @if ($counter == count($permissions))
                             
@@ -359,6 +369,8 @@ input[type='text'][disabled], input[disabled], textarea[disabled], input[readonl
                     @endif
         <?php $counter++; ?>
         @endforeach
+        </tbody>
+        </table>
             </div>
 
 

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -34,10 +34,6 @@
       display:flex;
       flex-direction: column;
     }
-    tbody.permissions-group {
-      display:flex;
-      flex-direction:column;
-    }
 
     .permissions.table > thead, .permissions.table > tbody {
       margin: 15px;
@@ -382,7 +378,7 @@
     <div class="tab-pane" id="tab_2">
         <div class="col-md-10 col-md-offset-2">
             @if (!Auth::user()->isSuperUser())
-                <p class="alert alert-warning">Only superadmins may grant a user superadmin access.</p>
+              <p class="alert alert-warning">Only superadmins may grant a user superadmin access.</p>
             @endif
         </div>
         <table class="table table-striped permissions">
@@ -395,6 +391,31 @@
             </tr>
           </thead>
             @foreach ($permissions as $area => $permissionsArray)
+            @if (count($permissionsArray) == 1)
+              <tbody class="permissions-group">
+              <?php $localPermission = $permissionsArray[0] ?>
+                <tr class="header-row permissions-row">
+                  <td class="col-md-2 tooltip-base permissions-item"
+                    data-toggle="tooltip"
+                    data-placement="right"
+                    title="{{ $localPermission['note'] }}"
+                  >
+                    <h4>{{ $area . ': ' . $localPermission['label'] }}</h4>
+                  </td>
+                  <td class="col-md-1 permissions-item">
+
+                      {{ Form::radio('permission['.$localPermission['permission'].']', '1',$userPermissions[$localPermission['permission'] ] == '1',['value'=>"grant"]) }}
+
+                    </td>
+                    <td class="col-md-1 permissions-item">
+                      {{ Form::radio('permission['.$localPermission['permission'].']', '-1',$userPermissions[$localPermission['permission'] ] == '-1',['value'=>"deny"]) }}
+                    </td>
+                    <td class="col-md-1 permissions-item">
+                      {{ Form::radio('permission['.$localPermission['permission'].']','0',$userPermissions[$localPermission['permission'] ] == '0',['value'=>"inherit"] ) }}
+                    </td>
+                  </tr>
+                </tbody>
+            @else
               <tbody class="permissions-group">
               <tr class="header-row permissions-row">
                 <td class="col-md-2 header-name">
@@ -409,6 +430,7 @@
                   <td class="col-md-1 permissions-item">
                     {{ Form::radio("$area", '0',false,['value'=>"inherit"] ) }}
                   </td>
+                </tr>
               @foreach ($permissionsArray as $index => $permission)
               <tr class="permissions-row">
                 @if ($permission['display'])
@@ -447,6 +469,7 @@
               </tr>
               @endforeach
               </tbody>
+              @endif
             @endforeach
         </table>
     </div><!-- /.tab-pane -->


### PR DESCRIPTION
This cleans up the "permissions" tab of the user edit/create page.  Everything is grouped into tables, with collapsable "tbodys" for each section of permissions.  The descriptive text for an item has been moved to a bootstrap tooltip (this may need some style love..)

We also support enabling/disabling an entire section of permissions at once through the magic of javascript.  This doesn't change anything in the permissions backend, just makes the front-end interface a little more friendly.

If this looks like the right direction, I'll refactor it out into a partial and use it in the "groups" permission page as well.