### PR TITLE
Set a user_id of -1 if there isn't a logged in user. 

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -371,25 +371,25 @@ class ReportsController extends Controller
                 if($activity->target) {
                     $activity_target = '<a href="'.route('view/hardware', $activity->target_id).'">'.$activity->target->showAssetName().'</a>';
                 } else {
-                    $activity_target = "Unknown Item";
+                    $activity_target = "";
                 }
             } elseif ( $activity->target_type === "App\Models\User") {
                 if($activity->target()) {
                    $activity_target = '<a href="'.route('view/user', $activity->target_id).'">'.$activity->target->fullName().'</a>';
                 } else {
-                    $activity_target = 'Unknown User';
+                    $activity_target = '';
                 }
             } elseif ($activity->action_type=='requested') {
                 if ($activity->user) {
                     $activity_target =  '<a href="'.route('view/user', $activity->user_id).'">'.$activity->user->fullName().'</a>';
                 } else {
-                    $activity_target = 'Unknown User';
+                    $activity_target = '';
                 }
             } else {
                 if($activity->target) {
                     $activity_target = $activity->target->id;
                 } else {
-                    $activity_target = "Unknown";
+                    $activity_target = "";
                 }
             }
 

--- a/app/Models/Loggable.php
+++ b/app/Models/Loggable.php
@@ -83,11 +83,15 @@ trait Loggable
 
     /**
      * @author  Daniel Meltzer <parallelgrapefruit@gmail.com
-     * @since [v3.4]
+     * @since [v3.5]
      * @return \App\Models\Actionlog
      */
     public function logCreate($note = null)
     {
+        $user_id = -1;
+        if (Auth::user()) {
+            $user_id = Auth::user()->id;
+        }
         $log = new Actionlog;
         if (static::class == LicenseSeat::class) {
             $log->item_type = License::class;
@@ -98,9 +102,9 @@ trait Loggable
         }
         $log->location_id = null;
         $log->note = $note;
-        $log->user_id = Auth::user()->id;
+        $log->user_id = $user_id;
         $log->logaction('created');
-
+        $log->save();
         return $log;
     }
 


### PR DESCRIPTION
 This fixes the CLI importer, and opens the door in the future for some sort of virtual importer user... which may fix other issues the importer currently has--currently the id for all imported items is just assumed to be 1, which is less than ideal.