### PR TITLE
Issue #2048 - Update Product Key Field to higher character limit

### DIFF
--- a/database/2016_02_13_071006_create_snipeit_laravel_database.php
+++ b/database/2016_02_13_071006_create_snipeit_laravel_database.php
@@ -321,7 +321,7 @@ Schema::create('license_seats', function($table) {
 Schema::create('licenses', function($table) {
  $table->increments('id')->unsigned();
  $table->string('name', 255);
- $table->text('serial')->nullable();
+ $table->strin('serial', 2048)->nullable();
  $table->date('purchase_date')->nullable();
  $table->decimal('purchase_cost', 13,4)->nullable();
  $table->string('order_number', 50)->nullable();

--- a/database/2016_02_13_071006_create_snipeit_laravel_database.php
+++ b/database/2016_02_13_071006_create_snipeit_laravel_database.php
@@ -321,7 +321,7 @@ Schema::create('license_seats', function($table) {
 Schema::create('licenses', function($table) {
  $table->increments('id')->unsigned();
  $table->string('name', 255);
- $table->strin('serial', 2048)->nullable();
+ $table->string('serial', 2048)->nullable();
  $table->date('purchase_date')->nullable();
  $table->decimal('purchase_cost', 13,4)->nullable();
  $table->string('order_number', 50)->nullable();


### PR DESCRIPTION
Updates the product key field from ~255< to a varchar entry in the database with 2048 character entry.

This should appropriately fix the limited entry for serial numbers.

Might want to double check my laravel. Still trying to glass over the code, but, if I understood it right, this is the location of where it needs to be changed?