### PR TITLE
Fix missing 'filename' field in asset_log to action_log migration

### DIFF
--- a/database/migrations/2016_09_04_182149_migrate_asset_log_to_action_log.php
+++ b/database/migrations/2016_09_04_182149_migrate_asset_log_to_action_log.php
@@ -59,6 +59,7 @@ class MigrateAssetLogToActionLog extends Migration
             $a->expected_checkin    = $log->expected_checkin;
             $a->thread_id           = $log->thread_id;
             $a->accepted_id         = $log->accepted_id;
+            $a->filename            = $log->filename;
 
             $a->save();
 


### PR DESCRIPTION
I believe this fixes the issue where the "filename" field wasn't being migrated over from the asset_log to the action_log, which caused an asset's "files" page to be empty after an upgrade.