### PR TITLE
Assocate a locations asset with User, not log.

### DIFF
--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -50,7 +50,7 @@ class Location extends SnipeModel
 
     public function assets()
     {
-        return $this->hasManyThrough('\App\Models\Asset', '\App\Models\Actionlog', 'location_id', 'id');
+        return $this->hasManyThrough('\App\Models\Asset', '\App\Models\User', 'location_id', 'assigned_to', 'id');
     }
 
     public function assignedassets()


### PR DESCRIPTION
This fixes an issue where locations could not be deleted if at any point
they had an associated log entry.  Fixes #2916