### PR TITLE
Use debian base container and clean up apt-get

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:jessie-slim
 MAINTAINER Brady Wetherington <uberbrady@gmail.com>
 
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:trusty
+FROM debian:jessie
 MAINTAINER Brady Wetherington <uberbrady@gmail.com>
 
 RUN apt-get update && apt-get install -y \
@@ -13,7 +13,9 @@ patch \
 curl \
 vim \
 git \
-mysql-client
+mysql-client \
+&& apt-get clean \
+&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN php5enmod mcrypt
 RUN php5enmod gd


### PR DESCRIPTION
Hey! I'm proposing two minor(ish) changes to the Dockerfile:

* Swapping out `ubuntu:trusty` for `debian:jessie`
* Cleaning up after apt-get

The cleanup and switch to the Debian base image trims about 9% off the final snipe-it image. It's less dramatic than I had hoped, but enough to merit the effort I think. Since Jessie is a bit more modern than the Trusty family, we get nice new php 5.6 packages as an added bonus.

Testing I did:

1. Checked out 2ef4b58 (v3.6.0)
2. Built the image via `docker build -t byronwolfman/snipe-it:v3.6.0 .`
3. Launched a new `mysql:5.6 container` and the `byronwolfman/snipe-it:v3.6.0` container
4. Went through the pre-flight and setup steps and loaded the dashboard

It works! I'm not sure if this is considered adequate or if something more thorough is required. Let me know.

Back on the subject of size: it probably can't get much smaller without being crammed into an alpine container, but I'm not savvy enough to php to sanely make sure all the dependencies are installed.