### PR TITLE
Add presenters for models.

### DIFF
--- a/app/Console/Commands/Purge.php
+++ b/app/Console/Commands/Purge.php
@@ -65,7 +65,7 @@ class Purge extends Command
             $asset_maintenances = 0;
 
             foreach ($assets as $asset) {
-                $this->info('- Asset "'.$asset->showAssetName().'" deleted.');
+                $this->info('- Asset "'.$asset->present()->name().'" deleted.');
                 $asset_assoc += $asset->assetlog()->count();
                 $asset->assetlog()->forceDelete();
                 $asset_maintenances += $asset->assetmaintenances()->count();

--- a/app/Console/Commands/SendExpirationAlerts.php
+++ b/app/Console/Commands/SendExpirationAlerts.php
@@ -55,7 +55,7 @@ class SendExpirationAlerts extends Command
 
         foreach ($expiring_assets as $asset) {
 
-            $expires = $asset->warrantee_expires();
+            $expires = $asset->present()->warrantee_expires();
             $difference =  round(abs(strtotime($expires) - strtotime($now))/86400);
 
             if ($difference > 30) {
@@ -64,11 +64,11 @@ class SendExpirationAlerts extends Command
                 $asset_data['email_content'] .= '<tr style="background-color:#d9534f;">';
             }
             $asset_data['email_content'] .= '<td><a href="'.config('app.url').'/hardware/'.e($asset->id).'/view">';
-            $asset_data['email_content'] .= $asset->showAssetName().'</a></td><td>'.e($asset->asset_tag).'</td>';
-            $asset_data['email_content'] .= '<td>'.e($asset->warrantee_expires()).'</td>';
+            $asset_data['email_content'] .= $asset->present()->name().'</a></td><td>'.e($asset->asset_tag).'</td>';
+            $asset_data['email_content'] .= '<td>'.e($asset->present()->warrantee_expires()).'</td>';
             $asset_data['email_content'] .= '<td>'.$difference.' '.trans('mail.days').'</td>';
             $asset_data['email_content'] .= '<td>'.($asset->supplier ? e($asset->supplier->name) : '').'</td>';
-            $asset_data['email_content'] .= '<td>'.($asset->assigneduser ? e($asset->assigneduser->fullName()) : '').'</td>';
+            $asset_data['email_content'] .= '<td>'.($asset->assigneduser ? e($asset->assigneduser->present()->fullName()) : '').'</td>';
             $asset_data['email_content'] .= '</tr>';
         }
 

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -139,7 +139,7 @@ class Helper
         $models = AssetModel::with('manufacturer')->get();
         $model_array[''] = trans('general.select_model');
         foreach ($models as $model) {
-            $model_array[$model->id] = $model->displayModelName();
+            $model_array[$model->id] = $model->present()->modelName();
         }
         return $model_array;
     }

--- a/app/Http/Controllers/AccessoriesController.php
+++ b/app/Http/Controllers/AccessoriesController.php
@@ -317,7 +317,7 @@ class AccessoriesController extends Controller
                 'fields' => [
                   [
                   'title' => 'Checked Out:',
-                  'value' => 'Accessory <'.route('accessories.show', $accessory->id).'|'.$accessory->name.'> checked out to <'.route('users.show', $user->id).'|'.$user->fullName().'> by <'.route('users.show', $admin_user->id).'|'.$admin_user->fullName().'>.'
+                  'value' => 'Accessory <'.route('accessories.show', $accessory->id).'|'.$accessory->name.'> checked out to <'.route('users.show', $user->id).'|'.$user->present()->fullName().'> by <'.route('users.show', $admin_user->id).'|'.$admin_user->present()->fullName().'>.'
                   ],
                   [
                       'title' => 'Note:',
@@ -431,7 +431,7 @@ class AccessoriesController extends Controller
                         'fields' => [
                             [
                                 'title' => 'Checked In:',
-                                'value' => class_basename(strtoupper($logaction->item_type)).' <'.route('accessories.show', $accessory->id).'|'.e($accessory->name).'> checked in by <'.route('users.show', $admin_user->id).'|'.e($admin_user->fullName()).'>.'
+                                'value' => class_basename(strtoupper($logaction->item_type)).' <'.route('accessories.show', $accessory->id).'|'.e($accessory->name).'> checked in by <'.route('users.show', $admin_user->id).'|'.e($admin_user->present()->fullName()).'>.'
                             ],
                             [
                                 'title' => 'Note:',
@@ -540,46 +540,7 @@ class AccessoriesController extends Controller
         $rows = array();
 
         foreach ($accessories as $accessory) {
-
-            $actions = '<nobr>';
-            if (Gate::allows('checkout', $accessory)) {
-                $actions .= Helper::generateDatatableButton(
-                    'checkout',
-                    route('checkout/accessory', $accessory->id),
-                    $accessory->numRemaining() > 0
-                );
-            }
-            if (Gate::allows('update', $accessory)) {
-                $actions .= Helper::generateDatatableButton('edit', route('accessories.update', $accessory->id));
-            }
-            if (Gate::allows('delete', $accessory)) {
-                $actions .= Helper::generateDatatableButton(
-                    'delete',
-                    route('accessories.destroy', $accessory->id),
-                    $enabled = true,
-                    trans('admin/accessories/message.delete.confirm'),
-                    $accessory->name
-                );
-            }
-            $actions .= '</nobr>';
-            $company = $accessory->company;
-
-            $rows[] = array(
-            'name'          => '<a href="'.route('accessories.show',$accessory->id).'">'. $accessory->name.'</a>',
-            'category'      => ($accessory->category) ? (string)link_to('admin/settings/categories/'.$accessory->category->id.'/view', $accessory->category->name) : '',
-            'model_number'      =>  e($accessory->model_number),
-            'qty'           => e($accessory->qty),
-            'order_number'  => e($accessory->order_number),
-            'min_amt'  => e($accessory->min_amt),
-            'location'      => ($accessory->location) ? e($accessory->location->name): '',
-            'purchase_date' => e($accessory->purchase_date),
-            'purchase_cost' => Helper::formatCurrencyOutput($accessory->purchase_cost),
-            'numRemaining'  => $accessory->numRemaining(),
-            'actions'       => $actions,
-            'companyName'   => is_null($company) ? '' : e($company->name),
-            'manufacturer'      => $accessory->manufacturer ? (string) link_to(route('manufacturers.show', $accessory->manufacturer_id), $accessory->manufacturer->name) : ''
-
-            );
+            $rows[] = $accessory->present()->forDataTable();
         }
 
         $data = array('total'=>$accessCount, 'rows'=>$rows);
@@ -633,9 +594,9 @@ class AccessoriesController extends Controller
             }
 
             if (Gate::allows('view', $user)) {
-                $name = (string) link_to_route('users.show', e($user->fullName()), [$user->id]);
+                $name = (string) link_to_route('users.show', e($user->present()->fullName()), [$user->id]);
             } else {
-                $name = e($user->fullName());
+                $name = e($user->present()->fullName());
             }
 
             $rows[] = array(

--- a/app/Http/Controllers/AssetMaintenancesController.php
+++ b/app/Http/Controllers/AssetMaintenancesController.php
@@ -125,7 +125,7 @@ class AssetMaintenancesController extends Controller
 
             $rows[] = array(
                 'id'            => $maintenance->id,
-                'asset_name'    =>  ($maintenance->asset) ? (string)link_to_route('maintenances.show', $maintenance->asset->showAssetName(), ['maintenance' => $maintenance->asset->id]) : 'Deleted Asset' ,
+                'asset_name'    =>  ($maintenance->asset) ? (string)link_to_route('maintenances.show', $maintenance->asset->present()->Name(), ['maintenance' => $maintenance->asset->id]) : 'Deleted Asset' ,
                 'title'         => $maintenance->title,
                 'notes'         => $maintenance->notes,
                 'supplier'      => ($maintenance->supplier) ? (string)link_to_route('suppliers.show', $maintenance->supplier->name, ['maintenance'=>$maintenance->supplier->id]) : 'Deleted Supplier',
@@ -134,7 +134,7 @@ class AssetMaintenancesController extends Controller
                 'start_date'         => $maintenance->start_date,
                 'asset_maintenance_time'          => $maintenance->asset_maintenance_time,
                 'completion_date'     => $maintenance->completion_date,
-                'user_id'       => ($maintenance->admin) ? (string)link_to_route('users.show', $maintenance->admin->fullName(), ['user'=>$maintenance->admin->id]) : '',
+                'user_id'       => ($maintenance->admin) ? (string)link_to_route('users.show', $maintenance->admin->present()->fullName(), ['user'=>$maintenance->admin->id]) : '',
                 'actions'       => $actions,
                 'companyName'   => ($maintenance->asset->company) ? $maintenance->asset->company->name : ''
             );

--- a/app/Http/Controllers/ConsumablesController.php
+++ b/app/Http/Controllers/ConsumablesController.php
@@ -401,44 +401,7 @@ class ConsumablesController extends Controller
         $rows = array();
 
         foreach ($consumables as $consumable) {
-            $actions = '<nobr>';
-            if (Gate::allows('checkout', $consumable)) {
-                $actions .= Helper::generateDatatableButton('checkout', route('checkout/consumable', $consumable->id), $consumable->numRemaining() > 0);
-            }
-
-            if (Gate::allows('update', $consumable)) {
-                $actions .= Helper::generateDatatableButton('edit', route('consumables.edit', $consumable->id));
-            }
-            if (Gate::allows('delete', $consumable)) {
-                $actions .= Helper::generateDatatableButton(
-                    'delete',
-                    route('consumables.destroy', $consumable->id),
-                    true, /* enabled */
-                    trans('admin/consumables/message.delete.confirm'),
-                    $consumable->name
-                );
-            }
-            $actions .='</nobr>';
-
-            $company = $consumable->company;
-
-            $rows[] = array(
-                'id'            => $consumable->id,
-                'name'          => (string)link_to_route('consumables.show', e($consumable->name), ['consumable' => $consumable->id]),
-                'location'   => ($consumable->location) ? e($consumable->location->name) : '',
-                'min_amt'           => e($consumable->min_amt),
-                'qty'           => e($consumable->qty),
-                'manufacturer'  => ($consumable->manufacturer) ? (string) link_to_route('manufacturers.show', $consumable->manufacturer->name, ['manufacturer' => $consumable->manufacturer_id]): '',
-                'model_number'      => e($consumable->model_number),
-                'item_no'       => e($consumable->item_no),
-                'category'      => ($consumable->category) ? (string) link_to_route('categories.show', $consumable->category->name, ['category' => $consumable->category_id]) : 'Missing category',
-                'order_number'  => e($consumable->order_number),
-                'purchase_date'  => e($consumable->purchase_date),
-                'purchase_cost'  => Helper::formatCurrencyOutput($consumable->purchase_cost),
-                'numRemaining'  => $consumable->numRemaining(),
-                'actions'       => $actions,
-                'companyName'   => is_null($company) ? '' : e($company->name),
-            );
+            $rows[] = $consumable->present()->forDataTable();
         }
 
         $data = array('total' => $consumCount, 'rows' => $rows);
@@ -478,11 +441,11 @@ class ConsumablesController extends Controller
         $rows = array();
 
         foreach ($consumable->consumableAssigments as $consumable_assignment) {
-            $rows[] = array(
-            'name' => (string)link_to_route('users.show', e($consumable_assignment->user->fullName()), ['user' => $consumable_assignment->user->id]),
-            'created_at' => ($consumable_assignment->created_at->format('Y-m-d H:i:s')=='-0001-11-30 00:00:00') ? '' : $consumable_assignment->created_at->format('Y-m-d H:i:s'),
-            'admin' => ($consumable_assignment->admin) ? e($consumable_assignment->admin->fullName()) : '',
-            );
+            $rows[] = [
+                'name' => $consumable_assignment->user->present()->nameUrl(),
+                'created_at' => ($consumable_assignment->created_at->format('Y-m-d H:i:s')=='-0001-11-30 00:00:00') ? '' : $consumable_assignment->created_at->format('Y-m-d H:i:s'),
+                'admin' => ($consumable_assignment->admin) ? $consumable_assignment->admin->present()->nameUrl() : '',
+            ];
         }
 
         $consumableCount = $consumable->users->count();

--- a/app/Http/Controllers/DepreciationsController.php
+++ b/app/Http/Controllers/DepreciationsController.php
@@ -189,21 +189,7 @@ class DepreciationsController extends Controller
         $rows = array();
 
         foreach ($depreciations as $depreciation) {
-            $actions = Helper::generateDatatableButton('edit', route('depreciations.edit', $depreciation->id));
-            $actions .= Helper::generateDatatableButton(
-                'delete',
-                route('depreciations.destroy', $depreciation->id),
-                true, /*enabled*/
-                trans('admin/depreciations/message.delete.confirm'),
-                $depreciation->name
-            );
-
-            $rows[] = array(
-                'id'            => $depreciation->id,
-                'name'          => e($depreciation->name),
-                'months'        => e($depreciation->months),
-                'actions'       => $actions
-            );
+            $rows[] = $depreciation->present()->forDataTable();
         }
 
         $data = array('total' => $depreciationsCount, 'rows' => $rows);

--- a/app/Http/Controllers/LocationsController.php
+++ b/app/Http/Controllers/LocationsController.php
@@ -310,32 +310,7 @@ class LocationsController extends Controller
         $rows = array();
 
         foreach ($locations as $location) {
-            $actions = '<nobr>';
-            $actions .= Helper::generateDatatableButton('edit', route('locations.edit', $location->id));
-            $actions .= Helper::generateDatatableButton(
-                'delete',
-                route('locations.destroy', $location->id),
-                true, /*enabled*/
-                trans('admin/locations/message.delete.confirm'),
-                $location->name
-            );
-            $actions .= '</nobr>';
-
-            $rows[] = array(
-                'id'            => $location->id,
-                'name'          => (string)link_to_route('locations.show', e($location->name), ['location' => $location->id]),
-                'parent'        => ($location->parent) ? e($location->parent->name) : '',
-              //  'assets'        => ($location->assets->count() + $location->assignedassets->count()),
-                'assets_default' => $location->assignedassets->count(),
-                'assets_checkedout' => $location->assets->count(),
-                'address'       => ($location->address) ? e($location->address): '',
-                'city'          => e($location->city),
-                'state'         => e($location->state),
-                'zip'           => e($location->zip),
-                'country'       => e($location->country),
-                'currency'      => e($location->currency),
-                'actions'       => $actions
-            );
+            $rows[] = $location->present()->forDataTable();
         }
         $data = array('total' => $locationsCount, 'rows' => $rows);
 
@@ -369,7 +344,7 @@ class LocationsController extends Controller
 
         foreach ($users as $user) {
             $rows[] = array(
-              'name' => (string)link_to_route('users.show', e($user->fullName()), ['user'=>$user->id])
+              'name' => (string)link_to_route('users.show', e($user->present()->fullName()), ['user'=>$user->id])
               );
         }
 
@@ -406,7 +381,7 @@ class LocationsController extends Controller
 
         foreach ($assets as $asset) {
             $rows[] = [
-                'name' => (string)link_to_route('hardware.show', e($asset->showAssetName()), ['hardware' => $asset->id]),
+                'name' => (string)link_to_route('hardware.show', e($asset->present()->name()), ['hardware' => $asset->id]),
                 'asset_tag' => e($asset->asset_tag),
                 'serial' => e($asset->serial),
                 'model' => e($asset->model->name),

--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -160,7 +160,7 @@ class ReportsController extends Controller
                         ($asset->purchase_cost > 0) ? Helper::formatCurrencyOutput($asset->purchase_cost) : '',
                         ($asset->order_number) ? e($asset->order_number) : '',
                         ($asset->supplier) ? e($asset->supplier->name) : '',
-                        ($asset->assigneduser) ? e($asset->assigneduser->fullName()) : '',
+                        ($asset->assigneduser) ? e($asset->assigneduser->present()->fullName()) : '',
                         ($asset->last_checkout!='') ? e($asset->last_checkout) : '',
                         ($asset->assigneduser && $asset->assigneduser->userloc!='') ?
                             e($asset->assigneduser->userloc->name) : ( ($asset->defaultLoc!='') ? e($asset->defaultLoc->name) : ''),
@@ -246,7 +246,7 @@ class ReportsController extends Controller
 
             if ($asset->assigned_to > 0) {
                 $user  = User::find($asset->assigned_to);
-                $row[] = e($user->fullName());
+                $row[] = e($user->present()->fullName());
             } else {
                 $row[] = ''; // Empty string if unassigned
             }
@@ -339,7 +339,7 @@ class ReportsController extends Controller
         foreach ($activitylogs as $activity) {
 
             if (($activity->item) && ($activity->itemType()=="asset")) {
-              $activity_item = '<a href="'.route('hardware.show', $activity->item_id).'">'.e($activity->item->asset_tag).' - '. e($activity->item->showAssetName()).'</a>';
+              $activity_item = '<a href="'.route('hardware.show', $activity->item_id).'">'.e($activity->item->asset_tag).' - '. e($activity->item->present()->name()).'</a>';
                 $item_type = 'asset';
             } elseif ($activity->item) {
                 $activity_item = '<a href="' . route($activity->parseItemRoute().'.show', $activity->item_id) . '">' . e($activity->item->name) . '</a>';
@@ -351,25 +351,25 @@ class ReportsController extends Controller
 
 
             if (($activity->user) && ($activity->action_type=="uploaded") && ($activity->itemType()=="user")) {
-                $activity_target = '<a href="'.route('users.show', $activity->target_id).'">'.$activity->user->fullName().'</a>';
+                $activity_target = '<a href="'.route('users.show', $activity->target_id).'">'.$activity->user->present()->fullName().'</a>';
             } elseif ($activity->target_type === "App\Models\Asset") {
                 if($activity->target) {
-                    $activity_target = '<a href="'.route('hardware.show', $activity->target_id).'">'.$activity->target->showAssetName().'</a>';
+                    $activity_target = '<a href="'.route('hardware.show', $activity->target_id).'">'.$activity->target->present()->name().'</a>';
                 } else {
                     $activity_target = "";
                 }
             } elseif ( $activity->target_type === "App\Models\User") {
                 if($activity->target) {
-                   $activity_target = '<a href="'.route('users.show', $activity->target_id).'">'.$activity->target->fullName().'</a>';
+                   $activity_target = '<a href="'.route('users.show', $activity->target_id).'">'.$activity->target->present()->fullName().'</a>';
                 } else {
                     $activity_target = '';
                 }
             } elseif (($activity->action_type=='accepted') || ($activity->action_type=='declined')) {
-                $activity_target = '<a href="' . route('users.show', $activity->item->assigneduser->id) . '">' . e($activity->item->assigneduser->fullName()) . '</a>';
+                $activity_target = '<a href="' . route('users.show', $activity->item->assigneduser->id) . '">' . e($activity->item->assigneduser->present()->fullName()) . '</a>';
 
             } elseif ($activity->action_type=='requested') {
                 if ($activity->user) {
-                    $activity_target =  '<a href="'.route('users.show', $activity->user_id).'">'.$activity->user->fullName().'</a>';
+                    $activity_target =  '<a href="'.route('users.show', $activity->user_id).'">'.$activity->user->present()->fullName().'</a>';
                 } else {
                     $activity_target = '';
                 }
@@ -386,7 +386,7 @@ class ReportsController extends Controller
                 'icon'          => '<i class="'.$activity->parseItemIcon().'"></i>',
                 'created_at'    => date("M d, Y g:iA", strtotime($activity->created_at)),
                 'action_type'              => strtolower(trans('general.'.str_replace(' ','_',$activity->action_type))),
-                'admin'         =>  $activity->user ? (string) link_to_route('users.show', $activity->user->fullName(), [$activity->user_id]) : '',
+                'admin'         =>  $activity->user ? (string) link_to_route('users.show', $activity->user->present()->fullName(), [$activity->user_id]) : '',
                 'target'          => $activity_target,
                 'item'          => $activity_item,
                 'item_type'     => $item_type,
@@ -613,7 +613,7 @@ class ReportsController extends Controller
                 $row[] = '"' . Helper::formatCurrencyOutput($asset->purchase_cost) . '"';
             }
             if (e(Input::get('eol')) == '1') {
-                $row[] = '"' .($asset->eol_date()) ? $asset->eol_date() : ''. '"';
+                $row[] = '"' .($asset->present()->eol_date()) ? $asset->present()->eol_date() : ''. '"';
             }
             if (e(Input::get('order')) == '1') {
                 if ($asset->order_number) {
@@ -652,7 +652,7 @@ class ReportsController extends Controller
 
             if (e(Input::get('assigned_to')) == '1') {
                 if ($asset->assigneduser) {
-                    $row[] = '"' .e($asset->assigneduser->fullName()). '"';
+                    $row[] = '"' .e($asset->assigneduser->present()->fullName()). '"';
                 } else {
                     $row[] = ''; // Empty string if unassigned
                 }
@@ -688,7 +688,7 @@ class ReportsController extends Controller
             if (e(Input::get('warranty')) == '1') {
                 if ($asset->warranty_months) {
                     $row[] = $asset->warranty_months;
-                    $row[] = $asset->warrantee_expires();
+                    $row[] = $asset->present()->warrantee_expires();
                 } else {
                     $row[] = '';
                     $row[] = '';
@@ -857,9 +857,9 @@ class ReportsController extends Controller
             $row    = [ ];
             $row[]  = str_replace(',', '', e($assetItem->assetlog->model->category->name));
             $row[]  = str_replace(',', '', e($assetItem->assetlog->model->name));
-            $row[]  = str_replace(',', '', e($assetItem->assetlog->showAssetName()));
+            $row[]  = str_replace(',', '', e($assetItem->assetlog->present()->name()));
             $row[]  = str_replace(',', '', e($assetItem->assetlog->asset_tag));
-            $row[]  = str_replace(',', '', e($assetItem->assetlog->assigneduser->fullName()));
+            $row[]  = str_replace(',', '', e($assetItem->assetlog->assigneduser->present()->fullName()));
             $rows[] = implode($row, ',');
         }
 

--- a/app/Http/Controllers/StatuslabelsController.php
+++ b/app/Http/Controllers/StatuslabelsController.php
@@ -281,7 +281,7 @@ class StatuslabelsController extends Controller
             $actions .= Helper::generateDatatableButton('edit', route('statuslabels.edit', $statuslabel->id));
             $actions .= Helper::generateDatatableButton(
                 'delete',
-                route('statuslabels.destroy'),
+                route('statuslabels.destroy', $statuslabel->id),
                 true, /*enabled*/
                 trans('admin/statuslabels/message.delete.confirm'),
                 $statuslabel->name

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -333,7 +333,7 @@ class UsersController extends Controller
        // Update the user
         $user->first_name = $request->input('first_name');
         $user->last_name = $request->input('last_name');
-        $user->two_factor_optin = $request->input('two_factor_optin');
+        $user->two_factor_optin = $request->input('two_factor_optin') ?: 0;
         $user->locale = $request->input('locale');
         $user->employee_num = $request->input('employee_num');
         $user->activated = $request->input('activated', $user->activated);

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -884,7 +884,7 @@ class UsersController extends Controller
         $rows = array();
 
         foreach ($users as $user) {
-            $row[] = $user->present()->forDataTable();
+            $rows[] = $user->present()->forDataTable();
         }
 
         $data = array('total'=>$userCount, 'rows'=>$rows);

--- a/app/Http/Controllers/ViewAssetsController.php
+++ b/app/Http/Controllers/ViewAssetsController.php
@@ -103,16 +103,16 @@ class ViewAssetsController extends Controller
         $logaction->target_id = $data['user_id'] = Auth::user()->id;
         $logaction->target_type = User::class;
 
-        $data['requested_by'] = $user->fullName();
+        $data['requested_by'] = $user->present()->fullName();
         $data['item_name'] = $item->name;
         $data['item_type'] = $itemType;
 
         if ($fullItemType == Asset::class) {
             $data['item_url'] = route('hardware.show', $item->id);
-            $slackMessage = ' Asset <'.url('/').'/hardware/'.$item->id.'/view'.'|'.$item->showAssetName().'> requested by <'.url('/').'/users/'.$item->user_id.'/view'.'|'.$user->fullName().'>.';
+            $slackMessage = ' Asset <'.url('/').'/hardware/'.$item->id.'/view'.'|'.$item->present()->name().'> requested by <'.url('/').'/users/'.$item->user_id.'/view'.'|'.$user->present()->fullName().'>.';
         } else {
             $data['item_url'] = route("view/${itemType}", $item->id);
-            $slackMessage = $quantity. ' ' . class_basename(strtoupper($logaction->item_type)).' <'.$data['item_url'].'|'.$item->name.'> requested by <'.url('/').'/user/'.$item->id.'/view'.'|'.$user->fullName().'>.';
+            $slackMessage = $quantity. ' ' . class_basename(strtoupper($logaction->item_type)).' <'.$data['item_url'].'|'.$item->name.'> requested by <'.url('/').'/user/'.$item->id.'/view'.'|'.$user->present()->fullName().'>.';
         }
 
         $settings = Setting::getSettings();
@@ -226,8 +226,8 @@ class ViewAssetsController extends Controller
             $logaction->target_type = User::class;
             $log = $logaction->logaction('requested');
 
-            $data['requested_by'] = $user->fullName();
-            $data['asset_name'] = $asset->showAssetName();
+            $data['requested_by'] = $user->present()->fullName();
+            $data['asset_name'] = $asset->present()->name();
 
             $settings = Setting::getSettings();
 
@@ -259,7 +259,7 @@ class ViewAssetsController extends Controller
                             'fields' => [
                                 [
                                     'title' => 'REQUESTED:',
-                                    'value' => class_basename(strtoupper($logaction->item_type)).' asset <'.url('/').'/hardware/'.$asset->id.'/view'.'|'.$asset->showAssetName().'> requested by <'.url('/').'/hardware/'.$asset->id.'/view'.'|'.Auth::user()->fullName().'>.'
+                                    'value' => class_basename(strtoupper($logaction->item_type)).' asset <'.url('/').'/hardware/'.$asset->id.'/view'.'|'.$asset->present()->name().'> requested by <'.url('/').'/hardware/'.$asset->id.'/view'.'|'.Auth::user()->present()->fullName().'>.'
                                 ]
 
                             ]

--- a/app/Models/Accessory.php
+++ b/app/Models/Accessory.php
@@ -1,9 +1,7 @@
 <?php
 namespace App\Models;
 
-use App\Models\Loggable;
-use App\Models\SnipeModel;
-use Illuminate\Database\Eloquent\Model;
+use App\Presenters\Presentable;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Watson\Validating\ValidatingTrait;
 
@@ -14,8 +12,9 @@ use Watson\Validating\ValidatingTrait;
  */
 class Accessory extends SnipeModel
 {
+    protected $presenter = 'App\Presenters\AccessoryPresenter';
     use CompanyableTrait;
-    use Loggable;
+    use Loggable, Presentable;
     use SoftDeletes;
 
     protected $dates = ['deleted_at'];
@@ -109,10 +108,8 @@ class Accessory extends SnipeModel
             return $Parsedown->text(e($this->category->eula_text));
         } elseif ((Setting::getSettings()->default_eula_text) && ($this->category->use_default_eula=='1')) {
             return $Parsedown->text(e(Setting::getSettings()->default_eula_text));
-        } else {
-            return null;
         }
-
+            return null;
     }
 
     public function numRemaining()

--- a/app/Models/AssetModel.php
+++ b/app/Models/AssetModel.php
@@ -3,6 +3,7 @@ namespace App\Models;
 
 use App\Models\Requestable;
 use App\Models\SnipeModel;
+use App\Presenters\Presentable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Watson\Validating\ValidatingTrait;
@@ -16,7 +17,8 @@ use Watson\Validating\ValidatingTrait;
 class AssetModel extends SnipeModel
 {
     use SoftDeletes;
-    use Requestable;
+    protected $presenter = 'App\Presenters\AssetModelPresenter';
+    use Requestable, Presentable;
     protected $dates = ['deleted_at'];
     protected $table = 'models';
 
@@ -46,8 +48,6 @@ class AssetModel extends SnipeModel
      */
     protected $fillable = ['name','manufacturer_id','category_id','eol'];
 
-
-
     public function assets()
     {
         return $this->hasMany('\App\Models\Asset', 'model_id');
@@ -76,26 +76,6 @@ class AssetModel extends SnipeModel
     public function fieldset()
     {
         return $this->belongsTo('\App\Models\CustomFieldset', 'fieldset_id');
-    }
-
-    public function getNote()
-    {
-
-        $Parsedown = new \Parsedown();
-
-        if ($this->note) {
-            return $Parsedown->text(e($this->note));
-        }
-
-    }
-
-    public function displayModelName()
-    {
-        $name = $this->manufacturer->name.' '.$this->name;
-        if ($this->model_number) {
-            $name .=" / ".$this->model_number;
-        }
-        return $name;
     }
 
     /**

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -3,6 +3,7 @@ namespace App\Models;
 
 use App\Http\Traits\UniqueUndeletedTrait;
 use App\Models\SnipeModel;
+use App\Presenters\Presentable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Watson\Validating\ValidatingTrait;
@@ -17,7 +18,8 @@ use Watson\Validating\ValidatingTrait;
  */
 class Category extends SnipeModel
 {
-
+    protected $presenter = 'App\Presenters\CategoryPresenter';
+    use Presentable;
     use SoftDeletes;
     protected $dates = ['deleted_at'];
     protected $table = 'categories';
@@ -75,13 +77,13 @@ class Category extends SnipeModel
     {
         switch ($this->category_type) {
             case 'asset':
-                return $this->assets->count();
+                return $this->assets()->count();
             case 'accessory':
-                return $this->accessories->count();
+                return $this->accessories()->count();
             case 'component':
-                return $this->components->count();
+                return $this->components()->count();
             case 'consumable':
-                return $this->consumables->count();
+                return $this->consumables()->count();
         }
         return '0';
     }

--- a/app/Models/CheckoutRequest.php
+++ b/app/Models/CheckoutRequest.php
@@ -51,7 +51,7 @@ class CheckoutRequest extends Model
     public function name()
     {
         if ($this->itemType() == "asset") {
-            return $this->itemRequested()->showAssetName();
+            return $this->itemRequested()->present()->name();
         }
         return $this->itemRequested()->name;
 

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -2,6 +2,7 @@
 namespace App\Models;
 
 use App\Models\SnipeModel;
+use App\Presenters\Presentable;
 use Auth;
 use DB;
 use Illuminate\Database\Eloquent\Model;
@@ -21,6 +22,8 @@ final class Company extends SnipeModel
         'name' => 'required|min:1|max:255|unique:companies,name'
     ];
 
+    protected $presenter = 'App\Presenters\CompanyPresenter';
+    use Presentable;
 
     /**
     * Whether the model should inject it's identifier to the unique
@@ -61,12 +64,6 @@ final class Company extends SnipeModel
         }
 
         return $query->where($column, '=', $company_id);
-    }
-
-    public static function getSelectList()
-    {
-        $select_company = trans('general.select_company');
-        return ['0' => $select_company] + DB::table('companies')->orderBy('name', 'ASC')->lists('name', 'id');
     }
 
     public static function getIdFromInput($unescaped_input)
@@ -116,7 +113,6 @@ final class Company extends SnipeModel
 
     public static function isCurrentUserAuthorized()
     {
-
         return ((!static::isFullMultipleCompanySupportEnabled()) || (Auth::user()->isSuperUser()));
     }
 
@@ -165,17 +161,6 @@ final class Company extends SnipeModel
                 }
             });
             return $q;
-        }
-    }
-
-    public static function getName($companyable)
-    {
-        $company = $companyable->company;
-
-        if (is_null($company)) {
-            return '';
-        } else {
-            return e($company->name);
         }
     }
 

--- a/app/Models/Component.php
+++ b/app/Models/Component.php
@@ -1,15 +1,7 @@
 <?php
 namespace App\Models;
 
-use App\Models\ActionLog;
-use App\Models\Category;
-use App\Models\Company;
-use App\Models\ConsumableAssignment;
-use App\Models\Location;
-use App\Models\Loggable;
-use App\Models\SnipeModel;
-use App\Models\User;
-use Illuminate\Database\Eloquent\Model;
+use App\Presenters\Presentable;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Watson\Validating\ValidatingTrait;
 
@@ -20,8 +12,9 @@ use Watson\Validating\ValidatingTrait;
  */
 class Component extends SnipeModel
 {
+    protected $presenter = 'App\Presenters\ComponentPresenter';
     use CompanyableTrait;
-    use Loggable;
+    use Loggable, Presentable;
     use SoftDeletes;
 
     protected $dates = ['deleted_at'];

--- a/app/Models/Consumable.php
+++ b/app/Models/Consumable.php
@@ -1,22 +1,15 @@
 <?php
 namespace App\Models;
 
-use App\Models\ActionLog;
-use App\Models\Category;
-use App\Models\Company;
-use App\Models\ConsumableAssignment;
-use App\Models\Location;
-use App\Models\Loggable;
-use App\Models\SnipeModel;
-use App\Models\User;
-use Illuminate\Database\Eloquent\Model;
+use App\Presenters\Presentable;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Watson\Validating\ValidatingTrait;
 
 class Consumable extends SnipeModel
 {
+    protected $presenter = 'App\Presenters\ConsumablePresenter';
     use CompanyableTrait;
-    use Loggable;
+    use Loggable, Presentable;
     use SoftDeletes;
 
     protected $dates = ['deleted_at'];

--- a/app/Models/Depreciation.php
+++ b/app/Models/Depreciation.php
@@ -1,12 +1,13 @@
 <?php
 namespace App\Models;
 
-use App\Models\SnipeModel;
-use Illuminate\Database\Eloquent\Model;
+use App\Presenters\Presentable;
 use Watson\Validating\ValidatingTrait;
 
 class Depreciation extends SnipeModel
 {
+    protected $presenter = 'App\Presenters\DepreciationPresenter';
+    use Presentable;
     // Declare the rules for the form validation
     protected $rules = array(
         'name' => 'required|min:3|max:255|unique:depreciations,name',

--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -3,15 +3,17 @@ namespace App\Models;
 
 use App\Models\Company;
 use App\Models\Loggable;
+use App\Presenters\Presentable;
 use DB;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Watson\Validating\ValidatingTrait;
 
 class License extends Depreciable
 {
+    protected $presenter = 'App\Presenters\LicensePresenter';
     use SoftDeletes;
     use CompanyableTrait;
-    use Loggable;
+    use Loggable, Presentable;
     protected $injectUniqueIdentifier = true;
     use ValidatingTrait;
 

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -5,12 +5,15 @@ use App\Http\Traits\UniqueUndeletedTrait;
 use App\Models\Asset;
 use App\Models\SnipeModel;
 use App\Models\User;
+use App\Presenters\Presentable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Watson\Validating\ValidatingTrait;
 
 class Location extends SnipeModel
 {
+    protected $presenter = 'App\Presenters\LocationPresenter';
+    use Presentable;
     use SoftDeletes;
     protected $dates = ['deleted_at'];
     protected $table = 'locations';

--- a/app/Models/Manufacturer.php
+++ b/app/Models/Manufacturer.php
@@ -1,13 +1,14 @@
 <?php
 namespace App\Models;
 
-use App\Models\SnipeModel;
-use Illuminate\Database\Eloquent\Model;
+use App\Presenters\Presentable;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Watson\Validating\ValidatingTrait;
 
 class Manufacturer extends SnipeModel
 {
+    protected $presenter = 'App\Presenters\ManufacturerPresenter';
+    use Presentable;
     use SoftDeletes;
     protected $dates = ['deleted_at'];
     protected $table = 'manufacturers';

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1,6 +1,7 @@
 <?php
 namespace App\Models;
 
+use App\Presenters\Presentable;
 use Illuminate\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Auth\Passwords\CanResetPassword;
@@ -9,21 +10,17 @@ use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
 use Watson\Validating\ValidatingTrait;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use App\Http\Traits\UniqueUndeletedTrait;
-use App\Models\Setting;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Passport\HasApiTokens;
 
-class User extends Model implements AuthenticatableContract, CanResetPasswordContract
+class User extends SnipeModel implements AuthenticatableContract, CanResetPasswordContract
 {
-
-    use SoftDeletes;
-    use ValidatingTrait;
-    use Authenticatable;
-    use CanResetPassword;
+    protected $presenter = 'App\Presenters\UserPresenter';
+    use SoftDeletes, ValidatingTrait;
+    use Authenticatable, CanResetPassword, HasApiTokens;
     use UniqueUndeletedTrait;
     use Notifiable;
-    use HasApiTokens;
-
+    use Presentable;
     protected $dates = ['deleted_at'];
     protected $table = 'users';
     protected $injectUniqueIdentifier = true;
@@ -112,23 +109,7 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
 
     public function isActivated()
     {
-        if ($this->activated == 1) {
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-
-    /**
-     * Returns the user full name, it simply concatenates
-     * the user first and last name.
-     *
-     * @return string
-     */
-    public function fullName()
-    {
-        return "{$this->first_name} {$this->last_name}";
+        return $this->activated ==1;
     }
 
     public function getFullNameAttribute()
@@ -141,26 +122,7 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
         return $this->last_name . ", " . $this->first_name . " (" . $this->username . ")";
     }
 
-    /**
-     * Returns the user Gravatar image url.
-     *
-     * @return string
-     */
-    public function gravatar()
-    {
 
-        if ($this->avatar) {
-            return config('app.url').'/uploads/avatars/'.$this->avatar;
-        }
-
-        if ((Setting::getSettings()->load_remote=='1') && ($this->email!='')) {
-            $gravatar = md5(strtolower(trim($this->email)));
-            return "//gravatar.com/avatar/".$gravatar;
-        }
-
-        return false;
-
-    }
 
     /**
      * Get assets assigned to this user

--- a/app/Presenters/AccessoryPresenter.php
+++ b/app/Presenters/AccessoryPresenter.php
@@ -123,7 +123,7 @@ class AccessoryPresenter extends Presenter
             $actions .= Helper::generateDatatableButton(
                 'delete',
                 route('accessories.destroy', $this->id),
-                $enabled = true,
+                true, /*enabled*/
                 trans('admin/accessories/message.delete.confirm'),
                 $this->name
             );

--- a/app/Presenters/AccessoryPresenter.php
+++ b/app/Presenters/AccessoryPresenter.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: parallelgrapefruit
+ * Date: 12/23/16
+ * Time: 11:51 AM
+ */
+
+namespace App\Presenters;
+
+
+use App\Helpers\Helper;
+use Illuminate\Support\Facades\Gate;
+
+/**
+ * Class AccessoryPresenter
+ * @package App\Presenters
+ */
+class AccessoryPresenter extends Presenter
+{
+    /**
+     * Json Column Layout for bootstrap table
+     * @return string
+     */
+    public static function dataTableLayout()
+    {
+        $layout = [
+            [
+                "field" => "companyName",
+                "searchable" => true,
+                "sortable" => true,
+                "switchable" => true,
+                "title" => trans('admin/companies/table.title'),
+                "visible" => false,
+            ], [
+                "field" => "name",
+                "searchable" => true,
+                "sortable" => true,
+                "title" => trans('admin/accessories/table.title'),
+            ], [
+                "field" => "category",
+                "searchable" => true,
+                "sortable" => true,
+                "title" => trans('admin/accessories/general.accessory_category'),
+            ], [
+                "field" => "model_number",
+                "searchable" => true,
+                "sortable" => true,
+                "title" => trans('admin/models/table.modelnumber'),
+            ], [
+                "field" => "manufacturer",
+                "searchable" => true,
+                "sortable" => true,
+                "title" => trans('general.manufacturer'),
+            ], [
+                "field" => "location",
+                "searchable" => true,
+                "sortable" => true,
+                "title" => trans('general.location'),
+            ], [
+                "field" => "qty",
+                "searchable" => false,
+                "sortable" => false,
+                "title" => trans('admin/accessories/general.total'),
+            ], [
+                "field" => "purchase_date",
+                "searchable" => true,
+                "sortable" => true,
+                "visible" => false,
+                "title" => trans('general.purchase_date'),
+            ], [
+                "field" => "purchase_cost",
+                "searchable" => true,
+                "sortable" => true,
+                "title" => trans('general.purchase_cost'),
+            ], [
+                "field" => "order_number",
+                "searchable" => true,
+                "sortable" => true,
+                "visible" => false,
+                "title" => trans('general.order_number'),
+            ], [
+                "field" => "min_amt",
+                "searchable" => false,
+                "sortable" => true,
+                "title" => trans('general.min_amt'),
+            ], [
+                "field" => "numRemaining",
+                "searchable" => false,
+                "sortable" => false,
+                "title" => trans('admin/accessories/general.remaining'),
+            ], [
+                "field" => "actions",
+                "searchable" => false,
+                "sortable" => false,
+                "switchable" => false,
+                "title" => trans('table.actions'),
+            ]
+        ];
+
+        return json_encode($layout);
+    }
+
+    /**
+     * JSON representation of Accessory for datatable.
+     * @return array
+     */
+    public function forDataTable()
+    {
+
+        $actions = '<nobr>';
+        if (Gate::allows('checkout', $this->model)) {
+            $actions .= Helper::generateDatatableButton(
+                'checkout',
+                route('checkout/accessory', $this->id),
+                $this->numRemaining() > 0
+            );
+        }
+        if (Gate::allows('update', $this->model)) {
+            $actions .= Helper::generateDatatableButton('edit', route('accessories.update', $this->id));
+        }
+        if (Gate::allows('delete', $this->model)) {
+            $actions .= Helper::generateDatatableButton(
+                'delete',
+                route('accessories.destroy', $this->id),
+                $enabled = true,
+                trans('admin/accessories/message.delete.confirm'),
+                $this->name
+            );
+        }
+        $actions .= '</nobr>';
+
+        $results = [];
+        $results['name'] = $this->nameUrl();
+        $results['category'] = '';
+        if($this->model->category) {
+            $results['category'] = $this->model->category->present()->nameUrl();
+        }
+        $results['model_number'] = $this->model_number;
+        $results['qty'] = $this->qty;
+        $results['order_number'] = $this->order_number;
+        $results['min_amt'] = $this->min_amt;
+        $results['location'] = $this->model->location ? $this->model->location->present()->nameUrl() : '';
+        $results['purchase_date'] = $this->purchase_date;
+        $results['purchase_cost'] = Helper::formatCurrencyOutput($this->purchase_cost);
+        $results['numRemaining'] = $this->numRemaining();
+        $results['companyName'] = $this->model->company ? $this->model->company->present()->nameUrl() : '';
+        $results['manufacturer'] = $this->model->manufacturer ? $this->model->manufacturer->present()->nameUrl() : '';
+        $results['actions']       = $actions;
+
+        return $results;
+    }
+
+    /**
+     * Pregenerated link to this accessories view page.
+     * @return string
+     */
+    public function nameUrl()
+    {
+        return (string) link_to_route('accessories.show', $this->name, $this->id);
+    }
+}

--- a/app/Presenters/AssetModelPresenter.php
+++ b/app/Presenters/AssetModelPresenter.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: parallelgrapefruit
+ * Date: 12/23/16
+ * Time: 12:15 PM
+ */
+
+namespace App\Presenters;
+
+
+use App\Helpers\Helper;
+
+/**
+ * Class AssetModelPresenter
+ * @package App\Presenters
+ */
+class AssetModelPresenter extends Presenter
+{
+    /**
+    * JSON representation of Accessory for datatable.
+     * @return array
+     */
+    public function forDataTable()
+    {
+
+        $actions = '<div style="white-space: nowrap;">';
+        if ($this->deleted_at == '') {
+            $actions .= Helper::generateDatatableButton('clone', route('clone/model', $this->id));
+            $actions .= Helper::generateDatatableButton('edit', route('models.edit', $this->id));
+            $actions .= Helper::generateDatatableButton(
+                'delete',
+                route('models.destroy', $this->id),
+                trans('admin/models/message.delete.confirm'),
+                $this->name
+            );
+        } else {
+            $actions .= Helper::generateDatatableButton('restore', route('restore/model', $this->id));
+        }
+        $actions .="</div>";
+
+        $results = [];
+
+        $results['id'] = $this->id;
+        $results['manufacturer'] = $this->model->manufacturer->present()->nameUrl();
+        $results['name'] = $this->nameUrl();
+        $results['image'] = $this->imageUrl();
+        $results['model_number'] = $this->model_number;
+        $results['numassets'] = $this->assets()->count();
+        $results['depreciation'] = trans('general.no_depreciation');
+        if(($depreciation = $this->model->depreciation) and $depreciation->id > 0) {
+            $results['depreciation'] = $depreciation->name.' ('.$depreciation->months.')';
+        }
+        $results['category'] = $this->model->category ? $this->model->category->present()->nameUrl() : '';
+        $results['eol'] = $this->eol ? $this->eol.' '.trans('general.months') : '';
+        $results['note'] = $this->note();
+        $results['fieldset'] = $this->model->fieldset ? link_to_route('custom_fields/model', $this->model->fieldset->name, $this->model->fieldset->id) : '';
+        $results['actions']           = $actions;
+
+        return $results;
+    }
+
+    /**
+     * Formatted note for this model
+     * @return string
+     */
+    public function note()
+    {
+        $Parsedown = new \Parsedown();
+
+        if ($this->model->note) {
+            return $Parsedown->text($this->model->note);
+        }
+
+    }
+
+    /**
+     * Pretty name for this model
+     * @return string
+     */
+    public function modelName()
+    {
+        $name = $this->manufacturer->name.' '.$this->name;
+        if ($this->model_number) {
+            $name .=" / ".$this->model_number;
+        }
+        return $name;
+    }
+
+    /**
+     * Standard url for use to view page.
+     * @return string
+     */
+    public function nameUrl()
+    {
+        return  (string) link_to_route('models.show',$this->name, $this->id);
+    }
+
+    /**
+     * Generate img tag to this models image.
+     * @return string
+     */
+    public function imageUrl()
+    {
+        if(!empty($this->image)) {
+            return '<img src="' . url('/') . '/uploads/models/' . $this->image . '" height=50 width=50>';
+        }
+        return '';
+    }
+}

--- a/app/Presenters/AssetModelPresenter.php
+++ b/app/Presenters/AssetModelPresenter.php
@@ -80,7 +80,7 @@ class AssetModelPresenter extends Presenter
      */
     public function modelName()
     {
-        $name = $this->manufacturer->name.' '.$this->name;
+        $name = $this->model->manufacturer->name.' '.$this->name;
         if ($this->model_number) {
             $name .=" / ".$this->model_number;
         }

--- a/app/Presenters/AssetPresenter.php
+++ b/app/Presenters/AssetPresenter.php
@@ -37,7 +37,7 @@ class AssetPresenter extends Presenter
                 $actions .= Helper::generateDatatableButton(
                     'delete',
                     route('hardware.destroy', $this->model->id),
-                    $enabled = true,
+                    true, /*enabled*/
                     trans('admin/hardware/message.delete.confirm'),
                     $this->model->asset_tag
                 );
@@ -61,8 +61,7 @@ class AssetPresenter extends Presenter
                         $this->model->id) . '" class="btn btn-primary btn-sm" title="Checkin this asset" data-toggle="tooltip">' . trans('general.checkin') . '</a>';
             }
         }
-        
-        $url = config('app.url');
+
         $results = [];
         $results['checkbox'] = '<div class="text-center"><input type="checkbox" name="edit_asset['.$this->id.']" class="one_required"></div>';
         $results['id']        = $this->id;
@@ -185,7 +184,7 @@ class AssetPresenter extends Presenter
         } else if ($this->model && !empty($this->model->image)) {
             $imagePath = $this->model->image;
         }
-
+        $url = config('app.url');
         if(!empty($imagePath)) {
             $imagePath = "<img src='{$url}/uploads/assets/{$imagePath}' height=50 width=50>";
         }

--- a/app/Presenters/AssetPresenter.php
+++ b/app/Presenters/AssetPresenter.php
@@ -1,0 +1,257 @@
+<?php
+namespace App\Presenters;
+use App\Helpers\Helper;
+use App\Models\SnipeModel;
+use DateTime;
+use Illuminate\Support\Facades\Gate;
+
+/**
+ * Class AssetPresenter
+ * @package App\Presenters
+ */
+class AssetPresenter extends Presenter
+
+{
+
+    /**
+     * Bootstrap Table Bits
+     * @param array $all_custom_fields Preloaded cache of custom fields
+     * @return mixed
+     */
+    public function forDataTable($all_custom_fields)
+    {
+        
+        // Actions
+
+        $inout = '';
+        $actions = '<div style="white-space: nowrap;">';
+        if ($this->model->deleted_at=='') {
+            if (Gate::allows('create', $this->model)) {
+                $actions .= Helper::generateDatatableButton('clone', route('clone/hardware', $this->model->id));
+            }
+            if (Gate::allows('update', $this->model)) {
+                $actions .= Helper::generateDatatableButton('edit', route('hardware.edit', $this->model->id));
+            }
+
+            if (Gate::allows('delete', $this->model)) {
+                $actions .= Helper::generateDatatableButton(
+                    'delete',
+                    route('hardware.destroy', $this->model->id),
+                    $enabled = true,
+                    trans('admin/hardware/message.delete.confirm'),
+                    $this->model->asset_tag
+                );
+            }
+        } elseif ($this->model->model->deleted_at=='') {
+            $actions .= Helper::generateDatatableButton('restore', route('restore/hardware', $this->model->id));
+        }
+
+        $actions .= '</div>';
+
+        if (($this->model->availableForCheckout()))
+        {
+            if (Gate::allows('checkout', $this->model)) {
+                $inout = '<a href="' . route('checkout/hardware',
+                        $this->model->id) . '" class="btn btn-info btn-sm" title="Checkout this asset to a user" data-toggle="tooltip">' . trans('general.checkout') . '</a>';
+            }
+
+        } else {
+            if (Gate::allows('checkin', $this->model)) {
+                $inout = '<a href="' . route('checkin/hardware',
+                        $this->model->id) . '" class="btn btn-primary btn-sm" title="Checkin this asset" data-toggle="tooltip">' . trans('general.checkin') . '</a>';
+            }
+        }
+        
+        $url = config('app.url');
+        $results = [];
+        $results['checkbox'] = '<div class="text-center"><input type="checkbox" name="edit_asset['.$this->id.']" class="one_required"></div>';
+        $results['id']        = $this->id;
+
+        $results['name'] = $this->nameUrl();
+        $results['asset_tag'] = $this->assetTagUrl();
+        $results['serial'] = $this->serial;
+        $results['image'] = $this->imageUrl();
+        // Presets for when conditionals fail.
+        $results['model'] = 'No Model';
+        $results['model_number'] = '';
+        $results['category'] = '';
+        $results['manufacturer'] = '';
+        if($model = $this->model->model) {
+            $results['model'] = $model->present()->nameUrl();
+
+            if(!empty($model->model_number)) {
+                $results['model_number'] = $model->model_number;
+            }
+            if ($model->category) {
+                $results['category'] = $model->category->present()->nameUrl();
+            }
+
+            if($model->manufacturer) {
+                $results['manufacturer'] = $model->manufacturer->present()->nameUrl();
+            }
+        }
+
+        $results['status_label'] = '';
+        $results['assigned_to'] = '';
+        if($assigned = $this->model->assigneduser) {
+            $results['status_label'] = 'Deployed';
+            $results['assigned_to'] = (string) link_to_route('users.show', $assigned->present()->fullName(), $this->assigned_to );
+        } else if($this->model->assetstatus) {
+            $results['status_label'] = $this->model->assetstatus->name;
+        }
+        $results['location'] = '';
+        if (isset($assigned) and !empty($assignedLoc = $assigned->userloc)) {
+            $results['location'] = $assignedLoc->present()->nameUrl();
+        } else if (!empty($this->model->defaultLoc)) {
+            $results['location'] = $this->model->defaultLoc->present()->nameUrl();
+        }
+
+        $results['eol'] = $this->eol_date() ?: '';
+        $results['purchase_cost'] = Helper::formatCurrencyOutput($this->purchase_cost);
+        $results['purchase_date'] = $this->purchase_date ?: '';
+        $results['notes'] = e($this->notes);
+        $results['order_number'] = '';
+        if(!empty($this->order_number)) {
+            $results['order_number'] = link_to_route('hardware.index', $this->order_number, ['order_number' => $this->order_number]);
+        }
+
+        $results['last_checkout'] = $this->last_checkout ?: '';
+        $results['expected_checkin'] = $this->expected_checkin ?: '';
+        $results['created_at'] = '';
+        if(!empty($this->created_at)) {
+            $results['created_at'] = $this->created_at->format('F j, Y h:iA');
+        }
+        $results['companyName'] = $this->model->company ? $this->model->company->name : '';
+        $results['actions'] = $actions ?: '';
+        $results['change'] = $inout ?: '';
+
+
+        // Custom Field bits
+        foreach ($all_custom_fields as $field) {
+            $column_name = $field->db_column_name();
+
+            if ($field->isFieldDecryptable($this->model->{$column_name})) {
+
+                if (Gate::allows('admin')) {
+                    if (($field->format=='URL') && ($this->model->{$column_name}!='')) {
+                        $row[$column_name] = '<a href="'.Helper::gracefulDecrypt($field, $this->model->{$column_name}).'" target="_blank">'.Helper::gracefulDecrypt($field, $this->model->{$column_name}).'</a>';
+                    } else {
+                        $row[$column_name] = Helper::gracefulDecrypt($field, $this->model->{$column_name});
+                    }
+
+                } else {
+                    $row[$field->db_column_name()] = strtoupper(trans('admin/custom_fields/general.encrypted'));
+                }
+            } else {
+                if (($field->format=='URL') && ($this->model->{$field->db_column_name()}!='')) {
+                    $row[$field->db_column_name()] = '<a href="'.$this->model->{$field->db_column_name()}.'" target="_blank">'.$this->model->{$field->db_column_name()}.'</a>';
+                } else {
+                    $row[$field->db_column_name()] = e($this->model->{$field->db_column_name()});
+                }
+            }
+
+        }
+
+        return $results;
+    }
+
+    /**
+     * Generate html link to this items asset tag
+     * @return string
+     */
+    public function assetTagUrl()
+    {
+        return (string) link_to_route('hardware.show', e($this->asset_tag), $this->id);
+    }
+
+    /**
+     * Generate html link to this items name.
+     * @return string
+     */
+    public function nameUrl()
+    {
+        return (string) link_to_route('hardware.show', e($this->name), $this->id);
+    }
+
+    /**
+     * Generate img tag to this items image.
+     * @return mixed|string
+     */
+    public function imageUrl()
+    {
+        $imagePath = '';
+        if($this->image && !empty($this->image)) {
+            $imagePath = $this->image;
+        } else if ($this->model && !empty($this->model->image)) {
+            $imagePath = $this->model->image;
+        }
+
+        if(!empty($imagePath)) {
+            $imagePath = "<img src='{$url}/uploads/assets/{$imagePath}' height=50 width=50>";
+        }
+        return $imagePath;
+    }
+
+    /**
+     * Get Displayable Name
+     * @return string
+     **/
+    public function name()
+    {
+
+        if (empty($this->name)) {
+            if (isset($this->model)) {
+                return $this->model->name.' ('.$this->asset_tag.')';
+            }
+            return $this->asset_tag;
+        } else {
+            return $this->name;
+        }
+    }
+
+    /**
+     * Returns the date this item hits EOL.
+     * @return false|string
+     */
+    public function eol_date()
+    {
+
+        if (( $this->purchase_date ) && ( $this->model )) {
+            $date = date_create($this->purchase_date);
+            date_add($date, date_interval_create_from_date_string($this->model->model->eol . ' months'));
+            return date_format($date, 'Y-m-d');
+        }
+
+    }
+
+    /**
+     * How many months until this asset hits EOL.
+     * @return null
+     */
+    public function months_until_eol()
+    {
+
+        $today = date("Y-m-d");
+        $d1    = new DateTime($today);
+        $d2    = new DateTime($this->eol_date());
+
+        if ($this->eol_date() > $today) {
+            $interval = $d2->diff($d1);
+        } else {
+            $interval = null;
+        }
+
+        return $interval;
+    }
+
+    /**
+     * Date the warantee expires.
+     * @return false|string
+     */
+    public function warrantee_expires()
+    {
+        $date = date_create($this->purchase_date);
+        date_add($date, date_interval_create_from_date_string($this->warranty_months . ' months'));
+        return date_format($date, 'Y-m-d');
+    }
+}

--- a/app/Presenters/CategoryPresenter.php
+++ b/app/Presenters/CategoryPresenter.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Presenters;
+
+
+use App\Helpers\Helper;
+
+/**
+ * Class CategoryPresenter
+ * @package App\Presenters
+ */
+class CategoryPresenter extends Presenter
+{
+    /**
+     * JSON representation of category for datatable.
+     * @return array
+     */
+    public function forDataTable()
+    {
+        $actions = Helper::generateDatatableButton('edit', route('categories.edit', $this->id));
+        $actions .= Helper::generateDatatableButton(
+            'delete',
+            route('categories.destroy', $this->id),
+            $this->itemCount() == 0, /* enabled */
+            trans('admin/categories/message.delete.confirm'),
+            $this->name
+        );
+        $results = [];
+        $results['id'] = $this->id;
+        $results['name'] = $this->nameUrl();
+        $results['category_type'] = ucwords($this->category_type);
+        $results['count'] = $this->itemCount();
+        $results['acceptance'] = ($this->require_acceptance == '1') ? '<i class="fa fa-check"></i>' : '';
+        $results['eula'] = $this->getEula() ? '<i class="fa fa-check"></i>' : '';
+        $results['actions'] = $actions;
+
+        return $results;
+    }
+
+    /**
+     * Link to this categories name
+     * @return string
+     */
+    public function nameUrl()
+    {
+        return (string) link_to_route('categories.show', $this->name, $this->id);
+    }
+}

--- a/app/Presenters/CompanyPresenter.php
+++ b/app/Presenters/CompanyPresenter.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Presenters;
+
+
+/**
+ * Class CompanyPresenter
+ * @package App\Presenters
+ */
+class CompanyPresenter extends Presenter
+{
+    /**
+     * Link to this companies name
+     * @return string
+     */
+    public function nameUrl()
+    {
+        return (string) link_to_route('companies.show', $this->name, $this->id);
+    }
+}

--- a/app/Presenters/ComponentPresenter.php
+++ b/app/Presenters/ComponentPresenter.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Presenters;
+
+
+use App\Helpers\Helper;
+use Illuminate\Support\Facades\Gate;
+
+/**
+ * Class ComponentPresenter
+ * @package App\Presenters
+ */
+class ComponentPresenter extends Presenter
+{
+
+    /**
+     * Formatted JSON string for data table.
+     * @return array
+     */
+    public function forDataTable()
+    {
+        $actions = '<nobr>';
+        if (Gate::allows('checkout', $this->model)) {
+            $actions .= Helper::generateDatatableButton('checkout', route('checkout/component', $this->id), $this->numRemaining() > 0);
+        }
+
+        if (Gate::allows('update', $this->model)) {
+            $actions .= Helper::generateDatatableButton('edit', route('components.edit', $this->id));
+        }
+
+        if (Gate::allows('delete', $this->model)) {
+            $actions .= Helper::generateDatatableButton(
+                'delete',
+                route('components.destroy', $this->id),
+                true, /* enabled */
+                trans('admin/components/message.delete.confirm'),
+                $this->name
+            );
+        }
+
+        $actions .='</nobr>';
+
+        $results = [
+            'checkbox'      =>'<div class="text-center"><input type="checkbox" name="component['.$this->id.']" class="one_required"></div>',
+            'id'            => $this->id,
+            'name'          => $this->nameUrl(),
+            'serial_number'          => $this->serial,
+            'location'      => ($this->model->location) ? $this->model->location->present()->nameUrl() : '',
+            'qty'           => number_format($this->qty),
+            'min_amt'           => e($this->min_amt),
+            'category'           => ($this->model->category) ? $this->model->category->present()->nameUrl() : 'Missing category',
+            'order_number'  => $this->order_number,
+            'purchase_date'  => $this->purchase_date,
+            'purchase_cost'  => Helper::formatCurrencyOutput($this->purchase_cost),
+            'numRemaining'  => $this->numRemaining(),
+            'actions'       => $actions,
+            'companyName'   => $this->model->company ? $this->model->company->present()->nameUrl() : '',
+        ];
+
+        return $results;
+    }
+
+    /**
+     * Link to this components name
+     * @return string
+     */
+    public function nameUrl()
+    {
+        return (string) link_to_route('components.show', $this->name, $this->id);
+    }
+}

--- a/app/Presenters/ConsumablePresenter.php
+++ b/app/Presenters/ConsumablePresenter.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Presenters;
+
+
+use App\Helpers\Helper;
+use Illuminate\Support\Facades\Gate;
+
+/**
+ * Class ConsumablePresenter
+ * @package App\Presenters
+ */
+class ConsumablePresenter extends Presenter
+{
+
+    /**
+     * Formatted JSON for data table.
+     * @return array
+     */
+    public function forDataTable()
+    {
+        $actions = '<nobr>';
+        if (Gate::allows('checkout', $this->model)) {
+            $actions .= Helper::generateDatatableButton('checkout', route('checkout/consumable', $this->id), $this->numRemaining() > 0);
+        }
+
+        if (Gate::allows('update', $this->model)) {
+            $actions .= Helper::generateDatatableButton('edit', route('consumables.edit', $this->id));
+        }
+        if (Gate::allows('delete', $this->model)) {
+            $actions .= Helper::generateDatatableButton(
+                'delete',
+                route('consumables.destroy', $this->id),
+                true, /* enabled */
+                trans('admin/consumables/message.delete.confirm'),
+                $this->name
+            );
+        }
+        $actions .='</nobr>';
+
+        $results = [
+            'id'            => $this->id,
+            'name'          => $this->nameUrl(),
+            'location'      => ($this->model->location) ? $this->model->location->present()->nameUrl() : '',
+            'min_amt'           => $this->min_amt,
+            'qty'           => $this->qty,
+            'manufacturer'  => ($this->model->manufacturer) ? $this->model->manufacturer->present()->nameUrl() : '',
+            'model_number'      => $this->model_number,
+            'item_no'       => $this->item_no,
+            'category'      => ($this->model->category) ? $this->model->category->present()->nameUrl() : 'Missing category',
+            'order_number'  => $this->order_number,
+            'purchase_date'  => $this->purchase_date,
+            'purchase_cost'  => Helper::formatCurrencyOutput($this->purchase_cost),
+            'numRemaining'  => $this->numRemaining(),
+            'actions'       => $actions,
+            'companyName'   => $this->model->company ? $this->model->company->present()->nameUrl() : '',
+        ];
+        return $results;
+    }
+
+    /**
+     * Link to this consumables name
+     * @return string
+     */
+    private function nameUrl()
+    {
+        return (string)link_to_route('consumables.show', $this->name, $this->id);
+    }
+}

--- a/app/Presenters/DepreciationPresenter.php
+++ b/app/Presenters/DepreciationPresenter.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Presenters;
+
+
+use App\Helpers\Helper;
+
+/**
+ * Class DepreciationPresenter
+ * @package App\Presenters
+ */
+class DepreciationPresenter extends Presenter
+{
+    /**
+     * Formatted JSON representation of this Depreciation
+     * @return array
+     */
+    public function forDataTable()
+    {
+        $actions = Helper::generateDatatableButton('edit', route('depreciations.edit', $this->id));
+        $actions .= Helper::generateDatatableButton(
+            'delete',
+            route('depreciations.destroy', $this->id),
+            true, /*enabled*/
+            trans('admin/depreciations/message.delete.confirm'),
+            $this->name
+        );
+
+        $results = [
+            'id'            => $this->id,
+            'name'          => $this->name,
+            'months'        => $this->months,
+            'actions'       => $actions
+        ];
+
+        return $results;
+    }
+}

--- a/app/Presenters/LicensePresenter.php
+++ b/app/Presenters/LicensePresenter.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Presenters;
+
+
+use App\Helpers\Helper;
+use Illuminate\Support\Facades\Gate;
+
+/**
+ * Class LicensePresenter
+ * @package App\Presenters
+ */
+class LicensePresenter extends Presenter
+{
+    /**
+     * JSON representation of this license for data table.
+     * @return array
+     */
+    public function forDataTable()
+    {
+        $actions = '<span style="white-space: nowrap;">';
+
+        if (Gate::allows('checkout', License::class)) {
+            $actions .= Helper::generateDatatableButton(
+                'checkout',
+                route('licenses.freecheckout', $this->id),
+                $this->remaincount() > 0
+            );
+        }
+
+        if (Gate::allows('create', $this->model)) {
+            $actions .= Helper::generateDatatableButton('clone', route('clone/license', $this->id));
+        }
+        if (Gate::allows('update', $this->model)) {
+            $actions .= Helper::generateDatatableButton('edit', route('licenses.edit', $this->id));
+        }
+        if (Gate::allows('delete', $this->model)) {
+            $actions .= Helper::generateDatatableButton(
+                'delete',
+                route('licenses.destroy', $this->id),
+                true, /*enabled*/
+                trans('admin/licenses/message.delete.confirm'),
+                $this->name
+            );
+        }
+        $actions .='</span>';
+
+        $results = [
+            'id'                => $this->id,
+            'name'              => $this->nameUrl(),
+            'serial'            => $this->serialUrl(),
+            'totalSeats'        => $this->model->licenseSeatsCount,
+            'remaining'         => $this->remaincount(),
+            'license_name'      => $this->license_name,
+            'license_email'     => $this->license_email,
+            'purchase_date'     => ($this->purchase_date) ?: '',
+            'expiration_date'   => ($this->expiration_date) ?: '',
+            'purchase_cost'     => Helper::formatCurrencyOutput($this->purchase_cost),
+            'purchase_order'    => ($this->purchase_order) ?: '',
+            'order_number'      => ($this->order_number) ?: '',
+            'notes'             => ($this->notes) ?: '',
+            'actions'           => $actions,
+            'company'           => $this->model->company ? e($this->model->company->present()->nameUrl()) : '',
+            'manufacturer'      => $this->model->manufacturer ? $this->model->manufacturer->present()->nameUrl() : ''
+        ];
+
+        return $results;
+    }
+
+    /**
+     * Link to this licenses Name
+     * @return string
+     */
+    public function nameUrl()
+    {
+        return (string)link_to_route('licenses.show', $this->name, $this->id);
+    }
+
+    /**
+     * Link to this licenses serial
+     * @return string
+     */
+    public function serialUrl()
+    {
+        return (string) link_to('/licenses/'.$this->id, mb_strimwidth($this->serial, 0, 50, "..."));
+    }
+}

--- a/app/Presenters/LocationPresenter.php
+++ b/app/Presenters/LocationPresenter.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Presenters;
+
+
+use App\Helpers\Helper;
+
+/**
+ * Class LocationPresenter
+ * @package App\Presenters
+ */
+class LocationPresenter extends Presenter
+{
+    /**
+     * JSON representation of this location for data table.
+     * @return array
+     */
+    public function forDataTable()
+    {
+        $actions = '<nobr>';
+        $actions .= Helper::generateDatatableButton('edit', route('locations.edit', $this->id));
+        $actions .= Helper::generateDatatableButton(
+            'delete',
+            route('locations.destroy', $this->id),
+            true, /*enabled*/
+            trans('admin/locations/message.delete.confirm'),
+            $this->name
+        );
+        $actions .= '</nobr>';
+
+        $results = [
+            'id'            => $this->id,
+            'name'          => $this->nameUrl(),
+            'parent'        => ($this->model->parent) ? $this->model->parent->present()->nameUrl() : '',
+            //  'assets'        => ($this->assets->count() + $this->assignedassets->count()),
+            'assets_default' => $this->model->assignedassets()->count(),
+            'assets_checkedout' => $this->model->assets()->count(),
+            'address'       => $this->address,
+            'city'          => $this->city,
+            'state'         => $this->state,
+            'zip'           => $this->zip,
+            'country'       => $this->country,
+            'currency'      => $this->currency,
+            'actions'       => $actions
+        ];
+
+        return $results;
+    }
+
+    /**
+     * Link to this locations name
+     * @return string
+     */
+    public function nameUrl()
+    {
+        return (string)link_to_route('locations.show', $this->name, $this->id);
+    }
+}

--- a/app/Presenters/ManufacturerPresenter.php
+++ b/app/Presenters/ManufacturerPresenter.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Presenters;
+
+
+use App\Helpers\Helper;
+
+/**
+ * Class ManufacturerPresenter
+ * @package App\Presenters
+ */
+class ManufacturerPresenter extends Presenter
+{
+
+    /**
+     * JSON representation of this manufacturer for data table.
+     * @return array
+     */
+    public function forDataTable()
+    {
+        $actions = '<nobr>';
+        $actions .= Helper::generateDatatableButton('edit', route('manufacturers.edit', $this->id));
+        $actions .= Helper::generateDatatableButton(
+            'delete',
+            route('manufacturers.destroy', $this->id),
+            true, /*enabled*/
+            trans('admin/manufacturers/message.delete.confirm'),
+            $this->name
+        );
+        $actions .= '</nobr>';
+
+        $results = [
+            'id'            => $this->id,
+            'name'          => $this->nameUrl(),
+            'assets'        => $this->assets()->count(),
+            'licenses'      => $this->licenses()->count(),
+            'accessories'   => $this->accessories()->count(),
+            'consumables'   => $this->consumables()->count(),
+            'actions'       => $actions
+        ];
+
+        return $results;
+    }
+
+    /**
+     * Link to this manufacturers name
+     * @return string
+     */
+    public function nameUrl()
+    {
+       return (string) link_to_route('manufacturers.show', $this->name, $this->id);
+    }
+}

--- a/app/Presenters/Presentable.php
+++ b/app/Presenters/Presentable.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Presenters;
+
+trait Presentable
+{
+
+    protected $presenterInterface;
+
+    public function present()
+    {
+
+        if (!$this->presenter || !class_exists($this->presenter)) {
+            throw new \Exception('Presenter class does not exist');
+        }
+
+        if (!isset($this->presenterInterface)) {
+            $this->presenterInterface = new $this->presenter($this);
+        }
+
+        return $this->presenterInterface;
+
+    }
+}

--- a/app/Presenters/Presenter.php
+++ b/app/Presenters/Presenter.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Presenters;
+
+
+use App\Models\SnipeModel;
+
+abstract class Presenter
+{
+    /**
+     * @var SnipeModel
+     */
+    protected $model;
+
+    /**
+     * Presenter constructor.
+     * @param SnipeModel $model
+     */
+    public function __construct(SnipeModel $model)
+    {
+        $this->model = $model;
+    }
+
+    public function __get($property)
+    {
+        if( method_exists($this, $property)) {
+            return $this->{$property}();
+        }
+
+        return e($this->model->{$property});
+    }
+
+    public function __call($method, $args)
+    {
+        return $this->model->$method($args);
+    }
+}

--- a/app/Presenters/UserPresenter.php
+++ b/app/Presenters/UserPresenter.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace App\Presenters;
+
+
+use App\Helpers\Helper;
+use App\Models\Setting;
+use Illuminate\Support\Facades\Gate;
+
+/**
+ * Class UserPresenter
+ * @package App\Presenters
+ */
+class UserPresenter extends Presenter
+{
+
+    /**
+     * Generates json for bootstrap table.
+     * @param string $status Status of User to filter on
+     * @return array
+     */
+    public function forDataTable($status)
+    {
+        $group_names = '';
+        $actions = '<nobr>';
+
+        foreach ($this->groups as $group) {
+            $group_names .= link_to_route('update/group', $group->name, $group->id, ['class' => 'label label-default']);
+        }
+        if (!is_null($this->deleted_at)) {
+            if (Gate::allows('delete', $this)) {
+                $actions .= Helper::generateDatatableButton('restore', route('restore/user', $this->id));
+            }
+        } else {
+            if (Gate::allows('delete', $this)) {
+                if ($this->accountStatus() == 'suspended') {
+                    $actions .= link_to_route(
+                        'unsuspend/user',
+                        '<span class="fa fa-clock-o"></span>"',
+                            $this->id,
+                            ['class' => 'btn btn-default btn-sm']
+                    );
+                }
+            }
+            if (Gate::allows('update', $this)) {
+                $actions .= Helper::generateDatatableButton('edit', route('users.edit', $this->id));
+                $actions .= Helper::generateDatatableButton('clone', route('clone/user', $this->id));
+            }
+            if (Gate::allows('delete', $this)) {
+                if ((Auth::user()->id !== $this->id) && (!config('app.lock_passwords'))) {
+                    $actions .= Helper::generateDatatableButton(
+                        'delete',
+                        route('users.destroy', $this->id),
+                        true, /*enabled*/
+                        "Are you sure you wish to delete this user?",
+                        $this->first_name
+                    );
+                } else {
+                    $actions .= ' <span class="btn delete-asset btn-danger btn-sm disabled"><i class="fa fa-trash icon-white"></i></span>';
+                }
+            }
+        }
+        $actions .= '</nobr>';
+        $result = [
+            'id'            => $this->id,
+            'checkbox'      => ($status!='deleted') ? '<div class="text-center hidden-xs hidden-sm"><input type="checkbox" name="edit_user['.e($this->id).']" class="one_required"></div>' : '',
+            'name'          => $this->present()->fullName(),
+            'jobtitle'      => $this->jobtitle,
+            'email'         => ($this->email!='') ?
+                '<a href="mailto:'.$this->email.'" class="hidden-md hidden-lg">'.$this->email.'</a>'
+                .'<a href="mailto:'.$this->email.'" class="hidden-xs hidden-sm"><i class="fa fa-envelope"></i></a>'
+                .'</span>' : '',
+            'username'      => $this->username,
+            'location'      => ($this->model->userloc) ? $this->model->userloc->present()->nameUrl() : '',
+            'manager'       => ($this->model->manager) ? $this->manager->present()->nameUrl() : '',
+            'employee_num'  => $this->employee_num,
+            'assets'        => $this->model->assets()->count(),
+            'licenses'      => $this->model->licenses()->count(),
+            'accessories'   => $this->model->accessories()->count(),
+            'consumables'   => $this->model->consumables()->count(),
+            'groups'        => $group_names,
+            'notes'         => $this->notes,
+            'two_factor_enrolled'        => ($this->two_factor_enrolled=='1') ? '<i class="fa fa-check text-success"></i>' : '<i class="fa fa-times  text-danger"></i>',
+            'two_factor_optin'        => (($this->two_factor_optin=='1') || (Setting::getSettings()->two_factor_enabled=='2') ) ? '<i class="fa fa-check text-success"></i>' : '<i class="fa fa-times  text-danger"></i>',
+            'created_at'    => ($this->created_at!='')  ? e($this->created_at->format('F j, Y h:iA')) : '',
+            'activated'     => ($this->activated=='1') ? '<i class="fa fa-check text-success"></i>' : '<i class="fa fa-times  text-danger"></i>',
+            'actions'       => $actions ?: '',
+            'companyName'   => $this->company ? $this->company->name : ''
+
+        ];
+
+        return $result;
+    }
+    /**
+     * Returns the user full name, it simply concatenates
+     * the user first and last name.
+     *
+     * @return string
+     */
+    public function fullName()
+    {
+        return "{$this->first_name} {$this->last_name}";
+    }
+
+    /**
+     * Returns the user Gravatar image url.
+     *
+     * @return string
+     */
+    public function gravatar()
+    {
+
+        if ($this->avatar) {
+            return config('app.url').'/uploads/avatars/'.$this->avatar;
+        }
+
+        if ((Setting::getSettings()->load_remote=='1') && ($this->email!='')) {
+            $gravatar = md5(strtolower(trim($this->email)));
+            return "//gravatar.com/avatar/".$gravatar;
+        }
+
+        return false;
+
+    }
+
+    /**
+     * Formatted url for use in tables.
+     * @return string
+     */
+    public function nameUrl()
+    {
+        return (string) link_to_route('users.show', $this->fullName(), $this->id);
+    }
+}

--- a/app/Presenters/UserPresenter.php
+++ b/app/Presenters/UserPresenter.php
@@ -5,6 +5,7 @@ namespace App\Presenters;
 
 use App\Helpers\Helper;
 use App\Models\Setting;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 
 /**
@@ -19,15 +20,15 @@ class UserPresenter extends Presenter
      * @param string $status Status of User to filter on
      * @return array
      */
-    public function forDataTable($status)
+    public function forDataTable($status = null)
     {
         $group_names = '';
         $actions = '<nobr>';
 
-        foreach ($this->groups as $group) {
+        foreach ($this->model->groups as $group) {
             $group_names .= link_to_route('update/group', $group->name, $group->id, ['class' => 'label label-default']);
         }
-        if (!is_null($this->deleted_at)) {
+        if (!is_null($this->model->deleted_at)) {
             if (Gate::allows('delete', $this)) {
                 $actions .= Helper::generateDatatableButton('restore', route('restore/user', $this->id));
             }
@@ -82,7 +83,7 @@ class UserPresenter extends Presenter
             'notes'         => $this->notes,
             'two_factor_enrolled'        => ($this->two_factor_enrolled=='1') ? '<i class="fa fa-check text-success"></i>' : '<i class="fa fa-times  text-danger"></i>',
             'two_factor_optin'        => (($this->two_factor_optin=='1') || (Setting::getSettings()->two_factor_enabled=='2') ) ? '<i class="fa fa-check text-success"></i>' : '<i class="fa fa-times  text-danger"></i>',
-            'created_at'    => ($this->created_at!='')  ? e($this->created_at->format('F j, Y h:iA')) : '',
+            'created_at'    => ($this->model->created_at!='')  ? e($this->model->created_at->format('F j, Y h:iA')) : '',
             'activated'     => ($this->activated=='1') ? '<i class="fa fa-check text-success"></i>' : '<i class="fa fa-times  text-danger"></i>',
             'actions'       => $actions ?: '',
             'companyName'   => $this->company ? $this->company->name : ''

--- a/resources/views/accessories/index.blade.php
+++ b/resources/views/accessories/index.blade.php
@@ -30,23 +30,6 @@
           data-cookie="true"
           data-click-to-select="true"
           data-cookie-id-table="accessoriesTable-{{ config('version.hash_version') }}">
-            <thead>
-                <tr>
-                  <th data-switchable="true" data-searchable="true" data-sortable="true" data-field="companyName" data-visible="false">{{ trans('admin/companies/table.title') }}</th>
-                  <th data-sortable="true" data-searchable="true"  data-field="name">{{ trans('admin/accessories/table.title') }}</th>
-                  <th data-searchable="true" data-sortable="true" data-field="category">{{ trans('admin/accessories/general.accessory_category') }}</th>
-                  <th data-searchable="true" data-sortable="true" data-field="model_number">{{ trans('admin/models/table.modelnumber') }}</th>
-                  <th data-field="manufacturer" data-searchable="true" data-sortable="true">{{ trans('general.manufacturer') }}</th>
-                  <th data-searchable="true" data-sortable="true" data-field="location">{{ trans('general.location') }}</th>
-                  <th data-searchable="false" data-sortable="false" data-field="qty">{{ trans('admin/accessories/general.total') }}</th>
-                  <th data-searchable="true" data-sortable="true" data-field="purchase_date" data-visible="false">{{ trans('general.purchase_date') }}</th>
-                  <th data-searchable="true" data-sortable="true" data-field="purchase_cost">{{ trans('general.purchase_cost') }}</th>
-                  <th data-searchable="true" data-sortable="true" data-field="order_number" data-visible="false">{{ trans('general.order_number') }}</th>
-                  <th data-searchable="false" data-sortable="true" data-field="min_amt">{{ trans('general.min_amt') }}</th>
-                  <th data-searchable="false" data-sortable="false" data-field="numRemaining">{{ trans('admin/accessories/general.remaining') }}</th>
-                  <th data-switchable="false" data-searchable="false" data-sortable="false" data-field="actions">{{ trans('table.actions') }}</th>
-                </tr>
-            </thead>
           </table>
         </div>
       </div>
@@ -55,7 +38,11 @@
 
 
 @section('moar_scripts')
-@include ('partials.bootstrap-table', ['exportFile' => 'accessories-export', 'search' => true])
+@include ('partials.bootstrap-table', [
+    'exportFile' => 'accessories-export',
+    'search' => true,
+    'columns' => \App\Presenters\AccessoryPresenter::dataTableLayout()
+    ])
 @stop
 
 

--- a/resources/views/account/accept-asset.blade.php
+++ b/resources/views/account/accept-asset.blade.php
@@ -2,7 +2,7 @@
 
 {{-- Page title --}}
 @section('title')
-    Accept {{ $item->showAssetName() }}
+    Accept {{ $item->present()->name() }}
     @parent
 @stop
 

--- a/resources/views/account/view-assets.blade.php
+++ b/resources/views/account/view-assets.blade.php
@@ -2,7 +2,7 @@
 
 {{-- Page title --}}
 @section('title')
-View Assets for  {{ $user->fullName() }}
+View Assets for  {{ $user->present()->fullName() }}
 @parent
 @stop
 
@@ -266,9 +266,9 @@ View Assets for  {{ $user->fullName() }}
                     <td>
                         @if (($log->item) && ($log->itemType()=="asset"))
                             @if ($log->item->deleted_at=='')
-                                {{ $log->item->showAssetName() }}
+                                {{ $log->item->present()->name() }}
                             @else
-                                <del>{{ $log->item->showAssetName() }}</del> (deleted)
+                                <del>{{ $log->item->present()->name() }}</del> (deleted)
                             @endif
 
                         @elseif ($log->item)
@@ -284,7 +284,7 @@ View Assets for  {{ $user->fullName() }}
                     </td>
                     <td>
                         @if ($log->user)
-                        {{ $log->user->fullName() }}
+                        {{ $log->user->present()->fullName() }}
                         @endif
                     </td>
                     <td>{{ $log->created_at }}</td>

--- a/resources/views/admin/requested-assets.blade.php
+++ b/resources/views/admin/requested-assets.blade.php
@@ -53,7 +53,7 @@
                                 "N/A"
                             @endif
                             </td>
-                            <td>{{ $request->requestingUser()->fullName() }}</td>
+                            <td>{{ $request->requestingUser()->present()->fullName() }}</td>
                             <td>{{$request->created_at}}</td>
                             <td>
                             </td>

--- a/resources/views/hardware/bulk-delete.blade.php
+++ b/resources/views/hardware/bulk-delete.blade.php
@@ -49,7 +49,7 @@
                             <tr>
                                 <td><input type="checkbox" name="bulk_edit[]" value="{{ $asset->id }}" checked="checked"></td>
                                 <td>{{ $asset->id }}</td>
-                                <td>{{ $asset->showAssetName() }}</td>
+                                <td>{{ $asset->present()->name() }}</td>
                                 <td>
                                     @if ($asset->assetloc)
                                         {{ $asset->assetloc->name }}
@@ -57,7 +57,7 @@
                                 </td>
                                 <td>
                                     @if ($asset->assigneduser)
-                                        {{ $asset->assigneduser->fullName() }} ({{ $asset->assigneduser->username }})
+                                        {{ $asset->assigneduser->present()->fullName() }} ({{ $asset->assigneduser->username }})
                                     @endif
                                 </td>
                             </tr>

--- a/resources/views/hardware/qr-view.blade.php
+++ b/resources/views/hardware/qr-view.blade.php
@@ -111,8 +111,8 @@
             {{ $asset->warranty_months }}
             {{ trans('admin/hardware/form.months') }}
             </div>
-            <div class="col-md-12 {{ $asset->warrantee_expires() < date("Y-m-d H:i:s") ? 'ui-state-highlight' : '' }}"  style="padding-bottom: 5px;"><strong>{{ trans('admin/hardware/form.expires') }}:</strong>
-            {{ $asset->warrantee_expires() }}</div>
+            <div class="col-md-12 {{ $asset->present()->warrantee_expires() < date("Y-m-d H:i:s") ? 'ui-state-highlight' : '' }}"  style="padding-bottom: 5px;"><strong>{{ trans('admin/hardware/form.expires') }}:</strong>
+            {{ $asset->present()->warrantee_expires() }}</div>
         @endif
 
         @if ($asset->depreciation)
@@ -140,14 +140,14 @@
             {{ trans('admin/hardware/form.months') }} </div>
             <div class="col-md-12" style="padding-bottom: 5px;">
             <strong>{{ trans('admin/hardware/form.eol_date') }}: </strong>
-            {{ $asset->eol_date() }}
-            @if ($asset->months_until_eol())
+            {{ $asset->present()->eol_date() }}
+            @if ($asset->present()->months_until_eol())
                  (
-                 @if ($asset->months_until_eol()->y > 0) {{ $asset->months_until_eol()->y }}
+                 @if ($asset->present()->months_until_eol()->y > 0) {{ $asset->present()->months_until_eol()->y }}
                   {{ trans('general.years') }},
                  @endif
 
-                {{ $asset->months_until_eol()->m }}
+                {{ $asset->present()->months_until_eol()->m }}
                 {{ trans('general.months') }}
                 )
             @endif
@@ -273,7 +273,7 @@
                     <td>{{ $log->created_at }}</td>
                     <td>
                         @if (isset($log->user_id))
-                        {{ $log->user->fullName() }}
+                        {{ $log->user->present()->fullName() }}
                         @endif
                     </td>
                     <td>{{ $log->action_type }}</td>
@@ -282,10 +282,10 @@
 
 	                        @if ($log->target->deleted_at=='')
 		                        <a href="{{ route('users.show', $log->target_id) }}">
-		                        {{ $log->user->fullName() }}
+		                        {{ $log->user->present()->fullName() }}
 		                         </a>
 		                    @else
-		 						<del>{{ $log->user->fullName() }}</del>
+		 						<del>{{ $log->user->present()->fullName() }}</del>
 	                        @endif
 
                         @endif
@@ -301,7 +301,7 @@
                 <tr>
                     <td>{{ $asset->created_at }}</td>
                     <td>
-                    @if (isset($asset->adminuser->id)) {{ $asset->adminuser->fullName() }}
+                    @if (isset($asset->adminuser->id)) {{ $asset->adminuser->present()->fullName() }}
                     @else
                     {{ trans('general.unknown_admin') }}
                     @endif
@@ -345,8 +345,8 @@
                 <h6><br>{{ trans('admin/hardware/form.checkedout_to') }}</h6>
                 <ul>
 
-                    <li><img src="{{ $asset->assigneduser->gravatar() }}" class="img-circle" style="width: 100px; margin-right: 20px;" /><br /><br /></li>
-                    <li><a href="{{ route('users.show', $asset->assigned_to) }}">{{ $asset->assigneduser->fullName() }}</a></li>
+                    <li><img src="{{ $asset->assigneduser->present()->gravatar() }}" class="img-circle" style="width: 100px; margin-right: 20px;" /><br /><br /></li>
+                    <li><a href="{{ route('users.show', $asset->assigned_to) }}">{{ $asset->assigneduser->present()->fullName() }}</a></li>
 
 
                     @if (isset($asset->assetloc->address))

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -228,14 +228,14 @@
                     @endif
 
                     @if ($asset->warranty_months)
-                      <tr {!! $asset->warrantee_expires() < date("Y-m-d") ? ' class="warning"' : '' !!}>
+                      <tr {!! $asset->present()->warrantee_expires() < date("Y-m-d") ? ' class="warning"' : '' !!}>
                         <td>{{ trans('admin/hardware/form.warranty') }}</td>
                         <td>
                           {{ $asset->warranty_months }}
                           {{ trans('admin/hardware/form.months') }}
 
                           ({{ trans('admin/hardware/form.expires') }}
-                          {{ $asset->warrantee_expires() }})
+                          {{ $asset->present()->warrantee_expires() }})
                         </td>
                       </tr>
                     @endif
@@ -276,14 +276,14 @@
 
                           (
                           {{ trans('admin/hardware/form.eol_date') }}:
-                          {{ $asset->eol_date() }}
-                          @if ($asset->months_until_eol())
+                          {{ $asset->present()->eol_date() }}
+                          @if ($asset->present()->months_until_eol())
                             (
-                            @if ($asset->months_until_eol()->y > 0) {{ $asset->months_until_eol()->y }}
+                            @if ($asset->present()->months_until_eol()->y > 0) {{ $asset->present()->months_until_eol()->y }}
                             {{ trans('general.years') }},
                             @endif
 
-                            {{ $asset->months_until_eol()->m }}
+                            {{ $asset->present()->months_until_eol()->m }}
                             {{ trans('general.months') }}
                             )
                           @endif
@@ -367,8 +367,8 @@
               @if (($asset->assigneduser) && ($asset->assigned_to > 0) && ($asset->deleted_at==''))
                 <h4>{{ trans('admin/hardware/form.checkedout_to') }}</h4>
                 <p>
-                  <img src="{{ $asset->assigneduser->gravatar() }}" class="user-image-inline" alt="{{ $asset->assigneduser->fullName() }}">
-                  <a href="{{ route('users.show', $asset->assigned_to) }}">{{ $asset->assigneduser->fullName() }}</a>
+                  <img src="{{ $asset->assigneduser->present()->gravatar() }}" class="user-image-inline" alt="{{ $asset->assigneduser->present()->fullName() }}">
+                  <a href="{{ route('users.show', $asset->assigned_to) }}">{{ $asset->assigneduser->present()->fullName() }}</a>
                 </p>
 
                 <ul class="list-unstyled">
@@ -537,7 +537,7 @@
                             <td class="text-right"><nobr>{{ $use_currency.$assetMaintenance->cost }}</nobr></td>
                             <td>
                               @if ($assetMaintenance->admin)
-                                <a href="{{ route('users.show', $assetMaintenance->admin->id) }}">{{ $assetMaintenance->admin->fullName() }}</a>
+                                <a href="{{ route('users.show', $assetMaintenance->admin->id) }}">{{ $assetMaintenance->admin->present()->fullName() }}</a>
                               @endif
                             </td>
                             <?php $totalCost += $assetMaintenance->cost; ?>
@@ -591,7 +591,7 @@
                         <td>
                             @if ($log->action_type != 'requested')
                                 @if (isset($log->user))
-                                    {{ $log->user->fullName() }}
+                                    {{ $log->user->present()->fullName() }}
                                 @endif
                             @endif
                         </td>
@@ -607,23 +607,23 @@
 
                               @if ($log->target->deleted_at=='')
                                 <a href="{{ route('users.show', $log->target_id) }}">
-                                {{ $log->target->fullName() }}
+                                {{ $log->target->present()->fullName() }}
                                 </a>
                               @else
-                                <del>{{ $log->target->fullName() }}</del>
+                                <del>{{ $log->target->present()->fullName() }}</del>
                               @endif
                             @elseif($log->target instanceof \App\Models\Asset)
                               @if ($log->target->deleted_at=='')
                                 <a href="{{ route('hardware.show', $log->target_id) }}">
-                                {{ $log->target->showAssetName() }}
+                                {{ $log->target->present()->name() }}
                                 </a>
                               @else
-                                <del>{{ $log->target->showAssetName() }}</del>
+                                <del>{{ $log->target->present()->name() }}</del>
                               @endif
                             @elseif (($log->action_type=='accepted') || ($log->action_type=='declined'))
                                 {{-- On a declined log, the asset isn't assigned to anyone when we look this up. --}}
                                 @if ($log->item->assigneduser)
-                                    {{ $log->item->assigneduser->fullName() }}
+                                    {{ $log->item->assigneduser->present()->fullName() }}
                                 @else
                                     Unknown
                                 @endif
@@ -653,7 +653,7 @@
                     <td>{{ $asset->created_at }}</td>
                     <td>
                         @if ($asset->adminuser)
-                            {{ $asset->adminuser->fullName() }}
+                            {{ $asset->adminuser->present()->fullName() }}
                         @else
                             {{ trans('general.unknown_admin') }}
                         @endif

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -280,8 +280,8 @@
                <!-- User Account: style can be found in dropdown.less -->
                <li class="dropdown user user-menu">
                  <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                   @if (Auth::user()->gravatar())
-                       <img src="{{ Auth::user()->gravatar() }}" class="user-image" alt="User Image">
+                   @if (Auth::user()->present()->gravatar())
+                       <img src="{{ Auth::user()->present()->gravatar() }}" class="user-image" alt="User Image">
                    @else
                       <i class="fa fa-user fa-fws"></i>
                    @endif

--- a/resources/views/licenses/view.blade.php
+++ b/resources/views/licenses/view.blade.php
@@ -65,22 +65,22 @@
                                 @if (($licensedto->user) && ($licensedto->deleted_at == NULL))
                                     @can('users.view')
                                         <a href="{{ route('users.show', $licensedto->assigned_to) }}">
-                                            {{ $licensedto->user->fullName() }}
+                                            {{ $licensedto->user->present()->fullName() }}
                                         </a>
                                      @else
-                                        {{ $licensedto->user->fullName() }}
+                                        {{ $licensedto->user->present()->fullName() }}
                                      @endcan
 
                                 @elseif (($licensedto->user) && ($licensedto->deleted_at != NULL))
-                                    <del>{{ $licensedto->user->fullName() }}</del>
+                                    <del>{{ $licensedto->user->present()->fullName() }}</del>
                                 @elseif ($licensedto->asset)
                                     @if ($licensedto->asset->assigned_to != 0)
                                         @can('users.view')
                                             <a href="{{ route('users.show', $licensedto->asset->assigned_to) }}">
-                                                {{ $licensedto->asset->assigneduser->fullName() }}
+                                                {{ $licensedto->asset->assigneduser->present()->fullName() }}
                                             </a>
                                         @else
-                                            {{ $licensedto->asset->assigneduser->fullName() }}
+                                            {{ $licensedto->asset->assigneduser->present()->fullName() }}
                                         @endcan
 
                                     @endif
@@ -371,7 +371,7 @@
                           <td>{{ $log->created_at }}</td>
                           <td>
                               @if (isset($log->user_id))
-                              <a href="{{ route('users.show', $log->user_id)}}">{{ $log->user->fullName() }}</a>
+                              <a href="{{ route('users.show', $log->user_id)}}">{{ $log->user->present()->fullName() }}</a>
                               @endif
                           </td>
                           <td>{{ $log->action_type }}</td>
@@ -381,11 +381,11 @@
 
                                   @if ($log->target_type == 'App\Models\User')
                                       <a href="{{ route('users.show', $log->target_id) }}">
-                                          {{ $log->userlog->fullName() }}
+                                          {{ $log->userlog->present()->fullName() }}
                                       </a>
                                   @elseif ($log->target_type == 'App\Models\Asset')
                                       <a href="{{ route('hardware.show', $log->target_id) }}">
-                                          {{ $log->userlog->showAssetName() }}
+                                          {{ $log->userlog->present()->name() }}
                                       </a>
                                   @endif
 
@@ -407,7 +407,7 @@
                       <tr>
                           <td>{{ $license->created_at }}</td>
                           <td>
-                          @if ($license->adminuser) {{ $license->adminuser->fullName() }}
+                          @if ($license->adminuser) {{ $license->adminuser->present()->fullName() }}
                           @else
                           {{ trans('general.unknown_admin') }}
                           @endif

--- a/resources/views/models/view.blade.php
+++ b/resources/views/models/view.blade.php
@@ -115,8 +115,8 @@
     </ul>
 
     @if ($model->note)
-    Notesd:
-    <p>{!! $model->getNote() !!}
+    Notes:
+    <p>{!! $model->present()->note() !!}
     </p>
     @endif
 

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -21,6 +21,9 @@ $('.snipe-table').bootstrapTable({
         sortable: true,
         cookie: true,
         cookieExpire: '2y',
+        @if (isset($columns))
+        columns: {!! $columns !!},
+        @endif
         mobileResponsive: true,
         @if (isset($multiSort))
         showMultiSort: true,

--- a/resources/views/reports/depreciation.blade.php
+++ b/resources/views/reports/depreciation.blade.php
@@ -81,10 +81,10 @@
             <td>
             @if ($asset->assigneduser)
             	 @if ($asset->assigneduser->deleted_at!='')
-            	 	<del>{{ $asset->assigneduser->fullName() }}</del>
+            	 	<del>{{ $asset->assigneduser->present()->fullName() }}</del>
             	 @else
             	 	<a href="{{ route('users.show', $asset->assigned_to) }}">
-					{{ $asset->assigneduser->fullName() }}
+					{{ $asset->assigneduser->present()->fullName() }}
 					</a>
             	 @endif
 
@@ -100,7 +100,7 @@
             <td>{{ $asset->purchase_date }}</td>
 
             <td>
-            @if ($asset->model->eol) {{ $asset->eol_date() }}
+            @if ($asset->model->eol) {{ $asset->present()->eol_date() }}
             @endif
             </td>
 

--- a/resources/views/reports/index.blade.php
+++ b/resources/views/reports/index.blade.php
@@ -54,7 +54,7 @@
             <td>
             @if ($asset->assigned_to != '')
                 <a href="{{ route('users.show', $asset->assigned_to) }}">
-                {{ $asset->assigneduser->fullName() }}
+                {{ $asset->assigneduser->present()->fullName() }}
                 </a>
             @endif
             </td>
@@ -67,7 +67,7 @@
             <td>{{ $asset->purchase_date }}</td>
 
             <td>
-            @if ($asset->model->eol) {{ $asset->eol_date() }}
+            @if ($asset->model->eol) {{ $asset->present()->eol_date() }}
             @endif
             </td>
 

--- a/resources/views/reports/unaccepted_assets.blade.php
+++ b/resources/views/reports/unaccepted_assets.blade.php
@@ -41,9 +41,9 @@
                        <td>{{ is_null($assetItem->company) ? '' : $assetItem->company->name }}</td>
                        <td>{{ $assetItem->model->category->name }}</td>
                        <td>{{ $assetItem->model->name }}</td>
-                       <td>{{ link_to_route('hardware.show',$assetItem->showAssetName(), [$assetItem->id]) }}</td>
+                       <td>{{ link_to_route('hardware.show',$assetItem->present()->name(), [$assetItem->id]) }}</td>
                        <td>{{ $assetItem->asset_tag }}</td>
-                       <td>{{ link_to_route('users.show', $assetItem->assigneduser->fullName(), [$assetItem->assigned_to])}}</td>
+                       <td>{{ link_to_route('users.show', $assetItem->assigneduser->present()->fullName(), [$assetItem->assigned_to])}}</td>
                    </tr>
                @endforeach
            @endif

--- a/resources/views/suppliers/view.blade.php
+++ b/resources/views/suppliers/view.blade.php
@@ -49,11 +49,11 @@
                         <tr>
 
                             <td><a href="{{ route('hardware.show', $supplierassets->id) }}">{{ $supplierassets->asset_tag }}</a></td>
-                            <td><a href="{{ route('hardware.show', $supplierassets->id) }}">{{ $supplierassets->showAssetName() }}</a></td>
+                            <td><a href="{{ route('hardware.show', $supplierassets->id) }}">{{ $supplierassets->present()->name() }}</a></td>
                             <td>
                             @if ($supplierassets->assigneduser)
                             <a href="{{ route('users.show', $supplierassets->assigned_to) }}">
-                            {{ $supplierassets->assigneduser->fullName() }}
+                            {{ $supplierassets->assigneduser->present()->fullName() }}
                             </a>
                             @endif
                             </td>

--- a/resources/views/users/confirm-bulk-delete.blade.php
+++ b/resources/views/users/confirm-bulk-delete.blade.php
@@ -75,7 +75,7 @@ Bulk Checkin &amp; Delete
                                       </td>
 
                                       <td>
-                                          <span{{ (Auth::user()->id==$user->id ? ' style="text-decoration: line-through"' : '') }}>{{ $user->fullName() }} ({{ $user->username }})</span>
+                                          <span{{ (Auth::user()->id==$user->id ? ' style="text-decoration: line-through"' : '') }}>{{ $user->present()->fullName() }} ({{ $user->username }})</span>
 
                                           {{ (Auth::user()->id==$user->id ? ' (cannot delete yourself)' : '') }}
 

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -4,7 +4,7 @@
 @section('title')
 	@if ($user->id)
 		{{ trans('admin/users/table.updateuser') }}
-		{{ $user->fullName() }}
+		{{ $user->present()->fullName() }}
 	@else
 		{{ trans('admin/users/table.createuser') }}
 	@endif

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -2,7 +2,7 @@
 
 {{-- Page title --}}
 @section('title')
-{{ trans('admin/users/general.view_user', array('name' => $user->fullName())) }}
+{{ trans('admin/users/general.view_user', array('name' => $user->present()->fullName())) }}
 @parent
 @stop
 
@@ -58,7 +58,7 @@
               @if ($user->avatar)
                 <img src="/uploads/avatars/{{ $user->avatar }}" class="avatar img-thumbnail hidden-print">
               @else
-                <img src="{{ $user->gravatar() }}" class="avatar img-circle hidden-print">
+                <img src="{{ $user->present()->gravatar() }}" class="avatar img-circle hidden-print">
               @endif
             </div>
             <div class="col-md-8">
@@ -74,7 +74,7 @@
 
                     <tr>
                         <td>Name</td>
-                        <td>{{ $user->fullName() }}</td>
+                        <td>{{ $user->present()->fullName() }}</td>
                     </tr>
                     @if ($user->jobtitle)
                     <tr>
@@ -93,7 +93,7 @@
                     @if ($user->manager)
                     <tr>
                         <td>Manager</td>
-                        <td><a href="{{ route('users.show', $user->manager->id) }}">{{ $user->manager->fullName() }}</a></td>
+                        <td><a href="{{ route('users.show', $user->manager->id) }}">{{ $user->manager->present()->fullName() }}</a></td>
                     </tr>
                     @endif
 
@@ -392,7 +392,7 @@
                       <td>
 
                         @if (($log->item) && ($log->itemType()=="asset"))
-                            <a href="{{ route('hardware.show', $log->item_id) }}">{{ $log->item->asset_tag }} - {{ $log->item->showAssetName() }}</a>
+                            <a href="{{ route('hardware.show', $log->item_id) }}">{{ $log->item->asset_tag }} - {{ $log->item->present()->name() }}</a>
                         @elseif ($log->item)
                             <a href="{{ route($log->parseItemRoute().'.show', $log->item_id) }}">
                                 {{ $log->item->name }}
@@ -405,7 +405,7 @@
                         <td>
                            @if ($log->action_type != 'requested')
                                 @if (isset($log->user))
-                                    <a href="{{route('users.show', $log->user_id)}}">{{ $log->user->fullName() }}</a>
+                                    <a href="{{route('users.show', $log->user_id)}}">{{ $log->user->present()->fullName() }}</a>
                                 @else
                                     Deleted Admin
                                 @endif

--- a/tests/_envs/testing-ci.yml
+++ b/tests/_envs/testing-ci.yml
@@ -12,8 +12,8 @@ modules:
   config:
     WebDriver:
       url: 'http://localhost:8000'
-      browser: 'firefox'
+      browser: 'phantomjs'
     Laravel5:
       part: ORM
-      env_file: .env
+      environment_file: .env
 

--- a/tests/_envs/testing-ci.yml
+++ b/tests/_envs/testing-ci.yml
@@ -11,8 +11,5 @@ class_name: AcceptanceTester
 modules:
     config:
         WebDriver:
-            url: http://localhost:8000
-            browser: phantomjs
-        Laravel5:
-            part: ORM
-            environment_file: .env
+            url: 'http://localhost:8000'
+            browser: 'phantomjs'

--- a/tests/_envs/testing-ci.yml
+++ b/tests/_envs/testing-ci.yml
@@ -9,7 +9,11 @@
 # RUN `build` COMMAND AFTER ADDING/REMOVING MODULES.
 class_name: AcceptanceTester
 modules:
-    config:
-        WebDriver:
-            url: 'http://localhost:8000'
-            browser: 'phantomjs'
+  config:
+    WebDriver:
+      url: 'http://localhost:8000'
+      browser: 'firefox'
+    Laravel5:
+      part: ORM
+      env_file: .env
+


### PR DESCRIPTION
  Move bootstrap table JSON generation to these presenters, which cleans up controllers a lot.  Move view specific modifications from the models to the presenters as well.

This is some playing I did today.  It allows us to have one true source of dataTable() information for all the places we reuse it.  With a little bit of work, I think we can make this work for future API usages as well. 

One thing I started into on this (In AccessoriesPresenter+ accessories/index.blade.php--but wasn't very happy with where it was going, so paused on-- was moving the "columns" definition of the bootstrap tables from the view file to the presenter, to keep it in sync with the values easier.  It turned quickly into a lot of JSON though, and I don't like the way the file started to look.  I think it can be cleaned up though, wanted to leave it in for a second set of eyes/opinions.

There are some bug fixes in here for issues found along the way from the 5.3 port, but I can extract them if we decide this isn't a route we want to go down.  