### PR TITLE
Present assetlogs

### DIFF
--- a/app/Http/Controllers/AssetsController.php
+++ b/app/Http/Controllers/AssetsController.php
@@ -526,7 +526,7 @@ class AssetsController extends Controller
         $this->authorize('checkin', $asset);
 
         $admin = Auth::user();
-
+        $user = $asset->assignedUser;
         if (is_null($target = $asset->assignedTo)) {
             return redirect()->route('hardware.index')->with('error', trans('admin/hardware/message.checkin.already_checked_in'));
         }

--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -288,12 +288,8 @@ class ReportsController extends Controller
     */
     public function getActivityReport()
     {
-        $log_actions = Actionlog::orderBy('created_at', 'DESC')
-                                ->with('item')
-                                ->orderBy('created_at', 'DESC')
-                                ->get();
 
-        return View::make('reports/activity', compact('log_actions'));
+        return View::make('reports/activity');
     }
 
     /**
@@ -334,61 +330,7 @@ class ReportsController extends Controller
 
         $rows = array();
         foreach ($activitylogs as $activity) {
-
-            if (($activity->item) && ($activity->itemType()=="asset")) {
-                $activity_item = '<a href="'.route('hardware.show', $activity->item_id).'">'.e($activity->item->asset_tag).' - '. e($activity->item->present()->name()).'</a>';
-                $item_type = 'asset';
-            } elseif ($activity->item) {
-                $activity_item = '<a href="' . route($activity->parseItemRoute().'.show', $activity->item_id) . '">' . e($activity->item->name) . '</a>';
-                $item_type = $activity->itemType();
-            } else {
-                $activity_item = "unkonwn";
-                $item_type = "null";
-            }
-
-
-            if (($activity->user) && ($activity->action_type=="uploaded") && ($activity->itemType()=="user")) {
-                $activity_target = '<a href="'.route('users.show', $activity->target_id).'">'.$activity->user->present()->fullName().'</a>';
-            } elseif ($activity->target_type === "App\Models\Asset") {
-                if ($activity->target) {
-                    $activity_target = '<a href="'.route('hardware.show', $activity->target_id).'">'.$activity->target->present()->name().'</a>';
-                } else {
-                    $activity_target = "";
-                }
-            } elseif ($activity->target_type === "App\Models\User") {
-                if ($activity->target) {
-                    $activity_target = '<a href="'.route('users.show', $activity->target_id).'">'.$activity->target->present()->fullName().'</a>';
-                } else {
-                    $activity_target = '';
-                }
-            } elseif (($activity->action_type=='accepted') || ($activity->action_type=='declined')) {
-                $activity_target = $activity->item->assignedTo->nameUrl();
-            } elseif ($activity->action_type=='requested') {
-                if ($activity->user) {
-                    $activity_target =  '<a href="'.route('users.show', $activity->user_id).'">'.$activity->user->present()->fullName().'</a>';
-                } else {
-                    $activity_target = '';
-                }
-            } else {
-                if ($activity->target) {
-                    $activity_target = $activity->target->id;
-                } else {
-                    $activity_target = "";
-                }
-            }
-
-
-            $rows[] = array(
-                'icon'          => '<i class="'.$activity->parseItemIcon().'"></i>',
-                'created_at'    => date("M d, Y g:iA", strtotime($activity->created_at)),
-                'action_type'              => strtolower(trans('general.'.str_replace(' ', '_', $activity->action_type))),
-                'admin'         =>  $activity->user ? (string) link_to_route('users.show', $activity->user->present()->fullName(), [$activity->user_id]) : '',
-                'target'          => $activity_target,
-                'item'          => $activity_item,
-                'item_type'     => $item_type,
-                'note'     => e($activity->note),
-
-            );
+            $rows[] = $activity->present()->forDataTable();
         }
 
         $data = array('total'=>$activityCount, 'rows'=>$rows);

--- a/app/Http/Requests/AssetRequest.php
+++ b/app/Http/Requests/AssetRequest.php
@@ -38,9 +38,9 @@ class AssetRequest extends Request
             'status'          => 'integer|nullable',
             'asset_tag'       => 'required',
             'purchase_cost'   => 'numeric|nullable',
-            "assigned_user"   => 'required_without_all:assigned_asset,assigned_location',
-            "assigned_asset"   => 'required_without_all:assigned_user,assigned_location',
-            "assigned_location"   => 'required_without_all:assigned_user,assigned_asset',
+            "assigned_user"   => 'sometimes:required_without_all:assigned_asset,assigned_location',
+            "assigned_asset"   => 'sometimes:required_without_all:assigned_user,assigned_location',
+            "assigned_location"   => 'sometimes:required_without_all:assigned_user,assigned_asset',
         ];
 
         $model = AssetModel::find($this->request->get('model_id'));

--- a/app/Models/Actionlog.php
+++ b/app/Models/Actionlog.php
@@ -1,6 +1,6 @@
 <?php
 namespace App\Models;
-
+use App\Presenters\Presentable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Auth;
@@ -12,10 +12,11 @@ use Response;
  *
  * @version    v1.0
  */
-class Actionlog extends Model
+class Actionlog extends SnipeModel
 {
+    protected $presenter = "App\Presenters\ActionlogPresenter";
     use SoftDeletes;
-
+    use Presentable;
     protected $dates = [ 'deleted_at' ];
 
     protected $table      = 'action_logs';

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -237,9 +237,9 @@ class Asset extends Depreciable
             } elseif ($this->assignedType() == self::LOCATION) {
                 return $this->assignedTo();
             }
-            // Default to User
-//            var_dump($this);
-            return $this->assignedTo->userLoc();
+            if($this->assignedTo) {
+              return $this->assignedTo->userLoc();
+            }
         }
         return $this->defaultLoc();
     }

--- a/app/Presenters/ActionlogPresenter.php
+++ b/app/Presenters/ActionlogPresenter.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Presenters;
+
+/**
+ * Class CompanyPresenter
+ * @package App\Presenters
+ */
+class ActionlogPresenter extends Presenter
+{
+    /**
+     * Link to this companies name
+     * @return string
+     */
+    public function forDataTable()
+    {
+
+        return [
+            'icon'          => '<i class="'.$this->parseItemIcon().'"></i>',
+            'created_at'    => date("M d, Y g:iA", strtotime($this->created_at)),
+            'action_type'   => strtolower(trans('general.'.str_replace(' ', '_', $this->action_type))),
+            'admin'         =>  $this->model->user ? $this->model->user->present()->nameUrl() : '',
+            'target'        => $this->target(),
+            'item'          => $this->item(),
+            'item_type'     => $this->itemType(),
+            'note'          => e($this->note),
+
+        ];
+    }
+
+    public function admin()
+    {
+    }
+
+    public function item()
+    {//
+        // oute('show/userfile', [$user->id, $file->id])
+        if($this->action_type=='uploaded') {
+            return (string) link_to_route('show/userfile', $this->model->filename, [$this->model->item->id, $this->model->id]);
+        }
+        if ($this->model->item) {
+            return $this->model->item->present()->nameUrl();
+        }
+        return '';
+    }
+
+    public function target()
+    {
+        // Target is messy.
+        // On an upload, the target is the item we are uploading to, stored as the "item" in the log.
+        if ($this->action_type=='uploaded') {
+            return $this->model->item->present()->nameUrl();
+        }
+        // If we are logging an accept/reject, the target is not stored directly, 
+        // so we access it through who the item is assigned to.
+        // FIXME: On a reject it's not assigned to anyone.
+        if (($this->action_type=='accepted') || ($this->action_type=='declined')) {
+            return $this->model->item->assignedTo->nameUrl();
+        } elseif ($this->action_type=='requested') {
+            if ($this->model->user) {
+                return $this->model->user->present()->nameUrl();
+            }
+        }
+        // Otherwise, we'll just take the target of the log.
+        if ($this->model->target) {
+            return $this->model->target->present()->nameUrl();
+        }
+        return '';
+    }
+}

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -159,6 +159,7 @@
     'supplier'              => 'Supplier',
     'suppliers'  			=> 'Suppliers',
     'submit'				=> 'Submit',
+    'target'                => 'Target',
     'total_assets'			=> 'total assets',
     'total_licenses'		=> 'total licenses',
     'total_accessories'		=> 'total accessories',

--- a/resources/views/account/view-assets.blade.php
+++ b/resources/views/account/view-assets.blade.php
@@ -236,47 +236,22 @@ View Assets for  {{ $user->present()->fullName() }}
             </thead>
             <tbody>
               @foreach ($userlog as $log)
+              @php $result = $log->present()->forDataTable();
+              @endphp
               <tr>
                 <td class="text-center">
-                  @if ($log->itemType()=="asset")
-                      <i class="fa fa-barcode"></i>
-                  @elseif ($log->itemType()=="accessory")
-                      <i class="fa fa-keyboard-o"></i>
-                  @elseif ($log->itemType()=="consumable")
-                      <i class="fa fa-tint"></i>
-                  @elseif ($log->itemType()=="license")
-                      <i class="fa fa-floppy-o"></i>
-                  @else
-                      <i class="fa fa-times"></i>
-                  @endif
+                  {!! $result['icon'] !!}
                 </td>
                 <td>
-                  {{ strtolower(trans('general.'.str_replace(' ','_',$log->action_type))) }}
+                  {{ $result['action_type'] }}
                 </td>
                 <td>
-                  @if (($log->item) && ($log->itemType()=="asset"))
-                    @if ($log->item->deleted_at=='')
-                      {{ $log->item->present()->name() }}
-                    @else
-                      <del>{{ $log->item->present()->name() }}</del> (deleted)
-                    @endif
-
-                  @elseif ($log->item)
-                    @if ($log->item->deleted_at=='')
-                      {{ $log->item->name }}
-                    @else
-                      <del>{{ $log->item->name }}</del> (deleted)
-                    @endif
-                  @else
-                    {{ trans('general.bad_data') }}
-                  @endif
+                  {!! $result['item'] !!}
                 </td>
                 <td>
-                  @if ($log->user)
-                  {{ $log->user->present()->fullName() }}
-                  @endif
+                  {!! $result['admin'] !!}
                 </td>
-                <td>{{ $log->created_at }}</td>
+                <td>{{ $result['created_at'] }}</td>
               </tr>
               @endforeach
             </tbody>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -104,7 +104,7 @@
                     <th class="col-sm-2" data-field="admin">{{ trans('general.admin') }}</th>
                     <th class="col-sm-2" data-field="action_type">{{ trans('general.action') }}</th>
                     <th class="col-sm-4" data-field="item">{{ trans('general.item') }}</th>
-                    <th class="col-sm-2" data-field="target">To</th>
+                    <th class="col-sm-2" data-field="target">{{ trans('general.target') }}</th>
                   </tr>
                 </thead>
               </table>

--- a/resources/views/hardware/qr-view.blade.php
+++ b/resources/views/hardware/qr-view.blade.php
@@ -271,31 +271,30 @@
                         </tr>
                     </thead>
                     <tbody>
+                                'icon'          => '<i class="'.$this->parseItemIcon().'"></i>',
+            'created_at'    => date("M d, Y g:iA", strtotime($this->created_at)),
+            'action_type'   => strtolower(trans('general.'.str_replace(' ', '_', $this->action_type))),
+            'admin'         =>  $this->model->user ? $this->model->user->present()->nameUrl() : '',
+            'target'        => $this->target(),
+            'item'          => $this->item(),
+            'item_type'     => $this->itemType(),
+            'note'          => e($this->note),
+
                         @if (count($asset->assetlog) > 0)
                         @foreach ($asset->assetlog as $log)
+                        @php $result = $log->present()->forDataTable();
+                        @endphp
                         <tr>
-                            <td>{{ $log->created_at }}</td>
+                            <td>{{ $result['created_at'] }}</td>
                             <td>
-                                @if (isset($log->user_id))
-                                {{ $log->user->present()->fullName() }}
-                                @endif
+                                {!! $result['admin'] !!}
                             </td>
-                            <td>{{ $log->action_type }}</td>
+                            <td>{{ $result['action_type'] }}</td>
                             <td>
-                            @if ((isset($log->target_id)) && ($log->target_id!=0) && ($log->target_id!=''))
-                                @if ($log->target->deleted_at=='')
-                                    <a href="{{ route('users.show', $log->target_id) }}">
-                                    {{ $log->user->present()->fullName() }}
-                                     </a>
-                                @else
-                                    <del>{{ $log->user->present()->fullName() }}</del>
-                                @endif
-                            @endif
+                            {!! $result['target'] !!}
                             </td>
                             <td>
-                                @if ($log->note)
-                                {{ $log->note }}
-                                @endif
+                                {{ $result['note'] }}
                             </td>
                         </tr>
                         @endforeach

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -552,53 +552,15 @@
                 <tbody>
                   @if (count($asset->assetlog) > 0)
                     @foreach ($asset->assetlog as $log)
+                    @php $result = $log->present()->forDataTable();
+                    @endphp
                       <tr>
-                        <td>{{ $log->created_at }}</td>
+                        <td>{{ $result['created_at'] }}</td>
+                        <td> {!! $result['admin'] !!} </td>
+                        <td>{{ $result['action_type'] }}</td>
+                        <td>{!! $result['target'] !!} </td>
                         <td>
-                        @if ($log->action_type != 'requested')
-                          @if (isset($log->user))
-                            {{ $log->user->present()->fullName() }}
-                          @endif
-                        @endif
-                        </td>
-                        <td>{{ $log->action_type }}</td>
-                        <td>
-                          @if ($log->action_type=='uploaded')
-                            {{ $log->filename }}
-                          @elseif ((isset($log->target_id)) && ($log->target_id!=0) && ($log->target_id!=''))
-
-                            @if ($log->target instanceof \App\Models\User)
-                              @if ($log->target->deleted_at=='')
-                                <a href="{{ route('users.show', $log->target_id) }}">
-                                {{ $log->target->present()->fullName() }}
-                                </a>
-                              @else
-                                <del>{{ $log->target->present()->fullName() }}</del>
-                              @endif
-                            @elseif($log->target instanceof \App\Models\Asset)
-                              @if ($log->target->deleted_at=='')
-                                <a href="{{ route('hardware.show', $log->target_id) }}">
-                                {{ $log->target->present()->name() }}
-                                </a>
-                              @else
-                                <del>{{ $log->target->present()->name() }}</del>
-                              @endif
-                            @elseif (($log->action_type=='accepted') || ($log->action_type=='declined'))
-                                {{-- On a declined log, the asset isn't assigned to anyone when we look this up. --}}
-                                @if ($log->item->assignedTo)
-                                    {{ $log->item->assignedTo->present()->name() }}
-                                @else
-                                    Unknown
-                                @endif
-                            @else
-                              Deleted User
-                            @endif
-                          @endif
-                        </td>
-                        <td>
-                          @if ($log->note)
-                          {{ $log->note }}
-                          @endif
+                          {{ $result['note'] }}
                         </td>
                         @if ($snipeSettings->require_accept_signature=='1')
                         <td>

--- a/resources/views/licenses/view.blade.php
+++ b/resources/views/licenses/view.blade.php
@@ -317,46 +317,34 @@
             <div class="col-md-12">
               <table class="table table-hover table-fixed break-word">
                 <thead>
+
+
                   <tr>
                     <th class="col-md-2">{{ trans('general.date') }}</th>
                     <th class="col-md-2"><span class="line"></span>{{ trans('general.admin') }}</th>
                     <th class="col-md-2"><span class="line"></span>{{ trans('button.actions') }}</th>
-                    <th class="col-md-2"><span class="line"></span>{{ trans('admin/licenses/general.user') }}</th>
+                    <th class="col-md-2"><span class="line"></span>{{ trans('general.target') }}</th>
                     <th class="col-md-4"><span class="line"></span>{{ trans('general.notes') }}</th>
                   </tr>
                 </thead>
                 <tbody>
                   @if (count($license->assetlog) > 0)
                     @foreach ($license->assetlog as $log)
+                    @php $result = $log->present()->forDataTable()
+                    @endphp
                     <tr>
-                      <td>{{ $log->created_at }}</td>
+                      <td>{{ $result['created_at'] }}</td>
                       <td>
-                      @if (isset($log->user_id))
-                        <a href="{{ route('users.show', $log->user_id)}}">{{ $log->user->present()->fullName() }}</a>
-                      @endif
+                      {!! $result['admin'] !!}
                       </td>
-                      <td>{{ $log->action_type }}</td>
+                      <td>{{ $result['action_type'] }}</td>
 
                       <td>
-                      @if (($log->target) && ($log->target->id!='0'))
-                        @if ($log->target_type == 'App\Models\User')
-                          <a href="{{ route('users.show', $log->target_id) }}">
-                            {{ $log->userlog->present()->fullName() }}
-                          </a>
-                        @elseif ($log->target_type == 'App\Models\Asset')
-                          <a href="{{ route('hardware.show', $log->target_id) }}">
-                            {{ $log->userlog->present()->name() }}
-                          </a>
-                        @endif
-                      @elseif ($log->action_type=='uploaded')
-                        {{ $log->filename }}
-                      @endif
+                      {!! $result['target'] !!}
                       </td>
 
                       <td>
-                      @if ($log->note)
-                        {{ $log->note }}
-                      @endif
+                      {{ $result['note'] }}
                       </td>
                     </tr>
                     @endforeach

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -342,7 +342,7 @@
                 <i class="fa fa-plus icon-white"></i>
                 <span>Select File...</span>
                 <!-- The file input field used as target for the file upload widget -->
-                <input id="fileupload" type="file" name="file[]" data-url="{{ url('/') }}/api/users/{{ $user->id }}/upload">
+                <input id="fileupload" type="file" name="file[]" data-url="{{ route('upload/user', $user->id) }}">
               </span>
               @endcan
             </div>
@@ -396,7 +396,7 @@
                       </td>
                       <td>
                         @can('update', $user)
-                        <a class="btn delete-asset btn-danger btn-sm" href="{{ route('users.destroyfile', [$user->id, $file->id]) }}" data-content="Are you sure you wish to delete this file?" data-title="Delete {{ $file->filename }}?"><i class="fa fa-trash icon-white"></i></a>
+                        <a class="btn delete-asset btn-danger btn-sm" href="{{ route('delete/userfile', [$user->id, $file->id]) }}" data-content="Are you sure you wish to delete this file?" data-title="Delete {{ $file->filename }}?"><i class="fa fa-trash icon-white"></i></a>
                         @endcan
                       </td>
                     </tr>

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -422,31 +422,19 @@
               </thead>
               <tbody>
                 @foreach ($userlog as $log)
+                @php $result = $log->present()->forDataTable;
+                @endphp
                 <tr>
                   <td class="text-center">
-                    <i class="{{ ($log->parseItemIcon()) }}"></i>
+                    {!!$result['icon']!!}
                   </td>
-                  <td>{{ $log->created_at }}</td>
-                  <td>{{ $log->action_type }}</td>
+                  <td>{{ $result['created_at'] }}</td>
+                  <td>{{ $result['action_type'] }}</td>
                   <td>
-                    @if (($log->item) && ($log->itemType()=="asset"))
-                      {!! $log->item->present()->nameUrl() !!}
-                    @elseif ($log->item)
-                      <a href="{{ route($log->parseItemRoute().'.show', $log->item_id) }}">
-                            {{ $log->item->name }}
-                      </a>
-                    @else
-                      {{ trans('general.bad_data') }}
-                    @endif
+                    {!! $result['item'] !!}
                   </td>
                   <td>
-                    @if ($log->action_type != 'requested')
-                      @if (isset($log->user))
-                        {!! $log->user->present()->nameUrl() !!}
-                      @else
-                          Deleted Admin
-                      @endif
-                    @endif
+                    {!! $result['admin'] !!}
                 </tr>
                 @endforeach
               </tbody>

--- a/tests/functional/AssetsCest.php
+++ b/tests/functional/AssetsCest.php
@@ -58,7 +58,7 @@ class AssetsCest
             'model_id'          => $asset->model_id,
             'status_id'         => $asset->status_id,
             'assigned_to'       => $I->getUserId(),
-            'assigned_type'     => 'App\Models\User',
+            'assigned_type'     => 'App\\Models\\User',
             'serial'            => $asset->serial,
             'name'              => $asset->name,
             'purchase_date'     => '2016-01-01',


### PR DESCRIPTION
This does a few things

1) Fixes an issue in the new checkout asset logic where validation would fail if the item was not being checked out to anyone on the edit page.

2) Moves Actionlog datatable bits to a presenter.  This fixes some bugs in the activity report json and will really help cleanup code around the application as I dig into the places that are displaying histories currently.