### PR TITLE
Fix improper namespacing of License in action logs.

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -10,6 +10,7 @@ use App\Models\Asset;
 use App\Models\Group;
 use App\Models\Company;
 use App\Models\Location;
+use App\Models\License;
 use App\Models\Setting;
 use App\Models\Statuslabel;
 use App\Http\Requests\SaveUserRequest;


### PR DESCRIPTION
Add a use declaration to Userscontroller to prevent assigning the wrong item_type.  Should fix/prevent #3160