### PR TITLE
 fix upload hour so it's 24hr instead of always AM

### DIFF
--- a/app/Models/Loggable.php
+++ b/app/Models/Loggable.php
@@ -157,7 +157,7 @@ trait Loggable
         $log->user_id = Auth::user()->id;
         $log->note = $note;
         $log->target_id =  null;
-        $log->created_at =  date("Y-m-d h:i:s");
+        $log->created_at =  date("Y-m-d H:i:s");
         $log->filename =  $filename;
         $log->logaction('uploaded');
 


### PR DESCRIPTION
fix a bug where logUpload() was trying to save 12-hr time to a 24-hr field.  E.g. 15:00 (3pm) was becoming 3:00 (3am)