### PR TITLE
Make cipher configurable through env

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -94,7 +94,7 @@ return [
 
     'key' => env('APP_KEY'),
 
-    'cipher' => 'rijndael-256',
+    'cipher' => env('APP_CIPHER', 'rijndael-256'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
We're trying to deploy snipe-it in an environment where `rijndael-256` is not available.