### PR TITLE
Importer fixes v2

### DIFF
--- a/app/Console/Commands/PaveIt.php
+++ b/app/Console/Commands/PaveIt.php
@@ -72,6 +72,7 @@ class PaveIt extends Command
                 Statuslabel::getQuery()->delete();
                 Supplier::getQuery()->delete();
                 Group::getQuery()->delete();
+                Import::getQuery()->delete();
 
                 DB::statement('delete from accessories_users');
                 DB::statement('delete from asset_logs');
@@ -131,6 +132,7 @@ class PaveIt extends Command
                 \DB::statement('drop table IF EXISTS throttle');
                 \DB::statement('drop table IF EXISTS users_groups');
                 \DB::statement('drop table IF EXISTS users');
+                \DB::statement('drop table IF EXISTS imports');
             }
         }
     }

--- a/app/Http/Controllers/Api/ImportController.php
+++ b/app/Http/Controllers/Api/ImportController.php
@@ -45,7 +45,6 @@ class ImportController extends Controller
             $results = [];
             $import = new Import;
             foreach ($files as $file) {
-
                 if (!in_array($file->getMimeType(), array(
                     'application/vnd.ms-excel',
                     'text/csv',
@@ -53,7 +52,7 @@ class ImportController extends Controller
                     'text/comma-separated-values',
                     'text/tsv'))) {
                     $results['error']='File type must be CSV';
-                    return $results;
+                    return response()->json(Helper::formatStandardApiResponse('error', null, $results['error']), 500);
                 }
 
                 $date = date('Y-m-d-his');
@@ -132,7 +131,7 @@ class ImportController extends Controller
         try {
             unlink(config('app.private_uploads').'/imports/'.$import->file_path);
             $import->delete();
-            return response()->json(Helper::formatStandardApiResponse('success', null, trans('message.import.file_delete_success')));
+            return response()->json(Helper::formatStandardApiResponse('success', null, trans('admin/hardware/message.import.file_delete_success')));
         } catch (\Exception $e) {
             return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/hardware/message.import.file_delete_error')), 500);
         }

--- a/app/Importer/AssetImporter.php
+++ b/app/Importer/AssetImporter.php
@@ -24,8 +24,10 @@ class AssetImporter extends ItemImporter
         parent::handle($row);
 
         foreach ($this->customFields as $customField) {
-            if ($this->item['custom_fields'][$customField->db_column_name()] = $this->array_smart_custom_field_fetch($row, $customField)) {
-                $this->log('Custom Field '. $customField->name.': '.$this->array_smart_custom_field_fetch($row, $customField));
+            $customFieldValue = $this->array_smart_custom_field_fetch($row, $customField);
+            if ($customFieldValue) {
+                $this->item['custom_fields'][$customField->db_column_name()] = $customFieldValue;
+                $this->log('Custom Field '. $customField->name.': '.$customFieldValue);
             }
         }
 
@@ -87,7 +89,6 @@ class AssetImporter extends ItemImporter
                 $asset->{$custom_field} = $val;
             }
         }
-
         if (!$this->testRun) {
             if ($asset->save()) {
                 $asset->logCreate('Imported using csv importer');

--- a/app/Importer/Importer.php
+++ b/app/Importer/Importer.php
@@ -133,7 +133,7 @@ abstract class Importer
     public function array_smart_custom_field_fetch(array $array, $key)
     {
         $index_name = strtolower($key->name);
-        return array_key_exists($index_name, $array) ? e(trim($array[$index_name])) : '';
+        return array_key_exists($index_name, $array) ? e(trim($array[$index_name])) : false;
     }
 
     protected function log($string)

--- a/app/Models/CustomField.php
+++ b/app/Models/CustomField.php
@@ -101,7 +101,8 @@ class CustomField extends Model
 
     public function db_column_name()
     {
-        return self::convertUnicodeDbSlug();
+        return $this->db_column;
+        // return self::convertUnicodeDbSlug();
     }
 
     //mutators for 'format' attribute


### PR DESCRIPTION
A few fixes/improvements.  The major issue was that CustomField::convertUnicodeDbSlug() appears to replace the id with xx if it's already been run once.. And because the db_column is stored on the custom field model, we can just fetch it rather than recreating the slug when looking for the name.

Other small issues fixed include formating the error string properly if the wrong mimetype is uploaded, and paving the imports table in snipeit:pave.

I need to look at filtering MIME types on the client side again, and I'd like to try and add a small "default status to import as" to the dialog box.