### PR TITLE
Fixing a regression for RHEL 6 with snipe/snipe-it#2993

### DIFF
--- a/snipeit.sh
+++ b/snipeit.sh
@@ -111,10 +111,8 @@ function isinstalled {
 }
 
 if [ -f /etc/lsb-release ]; then
-	. /etc/lsb-release
-	distro="${DISTRIB_ID,,}"
-	version="$DISTRIB_RELEASE"
-	codename="$DISTRIB_CODENAME"
+	distro="$(lsb_release -s -i )"
+	version="$(lsb_release -s -r)"
 elif [ -f /etc/os-release ]; then
 	distro="$(. /etc/os-release && echo $ID)"
 	version="$(. /etc/os-release && echo $VERSION_ID)"


### PR DESCRIPTION
The contents of the `/etc/lsb-release` file on Red Hat Enterprise Linux Server release 6.9 (Santiago) does not contain `DISTRIB_ID`, `DISTRIB_RELEASE`, or `DISTRIB_CODENAME`.

Reverting to using `lsb_release` binary with appropriate flags.