### PR TITLE
Add in location parent and child information into API requests

### DIFF
--- a/app/Http/Controllers/Api/LocationsController.php
+++ b/app/Http/Controllers/Api/LocationsController.php
@@ -21,7 +21,7 @@ class LocationsController extends Controller
     {
         $this->authorize('view', Location::class);
         $allowed_columns = ['id','name','address','address2','city','state','country','zip','created_at',
-        'updated_at'];
+        'updated_at','parent_id'];
 
         $locations = Location::select([
             'locations.id',

--- a/app/Http/Transformers/LocationsTransformer.php
+++ b/app/Http/Transformers/LocationsTransformer.php
@@ -26,6 +26,11 @@ class LocationsTransformer
             foreach($location->assets() as $asset) {
                 $assets_arr = ['id' => $asset->id];
             }
+            
+            $children_arr = [];
+            foreach($location->childLocations() as $child) {
+                $children_arr = ['id' => $child->id];
+            }
 
             $array = [
                 'id' => e($location->id),
@@ -39,6 +44,8 @@ class LocationsTransformer
                 'assets' => $assets_arr,
                 'created_at' => Helper::getFormattedDateObject($location->created_at, 'datetime'),
                 'updated_at' => Helper::getFormattedDateObject($location->updated_at, 'datetime'),
+                'parent_id' => e($location->parent_id),
+                'children' => $children_arr,
             ];
 
             $permissions_array['available_actions'] = [


### PR DESCRIPTION
Currently the API does not always return information about a Location's parent and child. This information is vital to a number of use cases I'm working on and would like to bring that change back into the 4.0 release