### PR TITLE
Allows a null location value for importing LDAP users 

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -89,12 +89,10 @@ class LdapSync extends Command
             $location = Location::where('id', '=', $this->option('location_id'))->first();
             LOG::debug('Location ID '.$this->option('location_id').' passed');
             LOG::debug('Importing to '.$location->name.' ('.$location->id.')');
-        } else {
-            $location = new Location;
         }
 
         if (!isset($location)) {
-            LOG::debug('That location is invalid, so no location will be assigned by default.');
+            LOG::debug('That location is invalid or a location was not provided, so no location will be assigned by default.');
         }
 
         // Grab subsets based on location-specific DNs, and overwrite location for these users.

--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -89,7 +89,9 @@ class LdapSync extends Command
             $location = Location::where('id', '=', $this->option('location_id'))->first();
             LOG::debug('Location ID '.$this->option('location_id').' passed');
             LOG::debug('Importing to '.$location->name.' ('.$location->id.')');
-        }
+        } else {
+	    $location = NULL;
+	}
 
         if (!isset($location)) {
             LOG::debug('That location is invalid or a location was not provided, so no location will be assigned by default.');


### PR DESCRIPTION
When migrating non-LDAP users to LDAP users their Location gets reset if none is specified during the import process via the CLI.

This allows for a null Location value to be passed onto the migrated LDAP user so it does **not** override the value placed on the user when the account was created originally as non-LDAP account. 