### PR TITLE
docker: use ubuntu:xenial with php7.0

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-cd /var/www/html
 
 # fix key if needed
 if [ -z "$APP_KEY" ]


### PR DESCRIPTION
Using Ubuntu, which comes with PHP 7.0 ootb, we can speed up things a bit (opcache, generally faster).

I've also added tini as "init" daemon which takes care of some basic pid handling (reaping zombies,...).