### PR TITLE
Fix travis with new observer code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,9 @@ before_script:
   - php artisan migrate --env=testing-ci --database=mysql --force
   - ./vendor/bin/codecept build
   - php artisan --env=testing-ci key:generate 
+  - php artisan --env=testing-ci snipeit:travisci-install
   - php artisan --env=testing-ci db:seed --database=mysql --force
   - php artisan --env=testing-ci snipeit:create-admin --first_name=Alison --last_name=Foobar --email=me@example.com --username=snipe --password=password
-  - php artisan --env=testing-ci snipeit:travisci-install
   - php artisan --env=testing-ci passport:install
   - php artisan serve --env=testing-ci --port=8000 --host=localhost &
   - sleep 5

--- a/app/Observers/AccessoryObserver.php
+++ b/app/Observers/AccessoryObserver.php
@@ -22,7 +22,7 @@ class AccessoryObserver
         $logAction->item_type = Accessory::class;
         $logAction->item_id = $accessory->id;
         $logAction->created_at =  date("Y-m-d H:i:s");
-        $logAction->user_id = Auth::user()->id;
+        $logAction->user_id = Auth::id();
         $logAction->logaction('update');
 
 
@@ -47,7 +47,7 @@ class AccessoryObserver
         $logAction->item_type = Accessory::class;
         $logAction->item_id = $accessory->id;
         $logAction->created_at =  date("Y-m-d H:i:s");
-        $logAction->user_id = Auth::user()->id;
+        $logAction->user_id = Auth::id();
         $logAction->logaction('create');
 
     }
@@ -64,7 +64,7 @@ class AccessoryObserver
         $logAction->item_type = Accessory::class;
         $logAction->item_id = $accessory->id;
         $logAction->created_at =  date("Y-m-d H:i:s");
-        $logAction->user_id = Auth::user()->id;
+        $logAction->user_id = Auth::id();
         $logAction->logaction('delete');
     }
 }

--- a/app/Observers/AssetObserver.php
+++ b/app/Observers/AssetObserver.php
@@ -22,7 +22,7 @@ class AssetObserver
         $logAction->item_type = Asset::class;
         $logAction->item_id = $asset->id;
         $logAction->created_at =  date("Y-m-d H:i:s");
-        $logAction->user_id = Auth::user()->id;
+        $logAction->user_id = Auth::id();
         $logAction->logaction('update');
 
 
@@ -47,7 +47,7 @@ class AssetObserver
         $logAction->item_type = Asset::class;
         $logAction->item_id = $asset->id;
         $logAction->created_at =  date("Y-m-d H:i:s");
-        $logAction->user_id = Auth::user()->id;
+        $logAction->user_id = Auth::id();
         $logAction->logaction('create');
 
     }
@@ -64,7 +64,7 @@ class AssetObserver
         $logAction->item_type = Asset::class;
         $logAction->item_id = $asset->id;
         $logAction->created_at =  date("Y-m-d H:i:s");
-        $logAction->user_id = Auth::user()->id;
+        $logAction->user_id = Auth::id();
         $logAction->logaction('delete');
     }
 }

--- a/app/Observers/ComponentObserver.php
+++ b/app/Observers/ComponentObserver.php
@@ -22,7 +22,7 @@ class ComponentObserver
         $logAction->item_type = Component::class;
         $logAction->item_id = $component->id;
         $logAction->created_at =  date("Y-m-d H:i:s");
-        $logAction->user_id = Auth::user()->id;
+        $logAction->user_id = Auth::id();
         $logAction->logaction('update');
 
 
@@ -47,7 +47,7 @@ class ComponentObserver
         $logAction->item_type = Component::class;
         $logAction->item_id = $component->id;
         $logAction->created_at =  date("Y-m-d H:i:s");
-        $logAction->user_id = Auth::user()->id;
+        $logAction->user_id = Auth::id();
         $logAction->logaction('create');
 
     }
@@ -64,7 +64,7 @@ class ComponentObserver
         $logAction->item_type = Component::class;
         $logAction->item_id = $component->id;
         $logAction->created_at =  date("Y-m-d H:i:s");
-        $logAction->user_id = Auth::user()->id;
+        $logAction->user_id = Auth::id();
         $logAction->logaction('delete');
     }
 }

--- a/app/Observers/ConsumableObserver.php
+++ b/app/Observers/ConsumableObserver.php
@@ -22,7 +22,7 @@ class ConsumableObserver
         $logAction->item_type = Consumable::class;
         $logAction->item_id = $consumable->id;
         $logAction->created_at =  date("Y-m-d H:i:s");
-        $logAction->user_id = Auth::user()->id;
+        $logAction->user_id = Auth::id();
         $logAction->logaction('update');
 
 
@@ -47,7 +47,7 @@ class ConsumableObserver
         $logAction->item_type = Consumable::class;
         $logAction->item_id = $consumable->id;
         $logAction->created_at =  date("Y-m-d H:i:s");
-        $logAction->user_id = Auth::user()->id;
+        $logAction->user_id = Auth::id();
         $logAction->logaction('create');
 
     }
@@ -64,7 +64,7 @@ class ConsumableObserver
         $logAction->item_type = Consumable::class;
         $logAction->item_id = $consumable->id;
         $logAction->created_at =  date("Y-m-d H:i:s");
-        $logAction->user_id = Auth::user()->id;
+        $logAction->user_id = Auth::id();
         $logAction->logaction('delete');
     }
 }

--- a/app/Observers/LicenseObserver.php
+++ b/app/Observers/LicenseObserver.php
@@ -22,7 +22,7 @@ class LicenseObserver
         $logAction->item_type = License::class;
         $logAction->item_id = $license->id;
         $logAction->created_at =  date("Y-m-d H:i:s");
-        $logAction->user_id = Auth::user()->id;
+        $logAction->user_id = Auth::id();
         $logAction->logaction('update');
 
 
@@ -47,7 +47,7 @@ class LicenseObserver
         $logAction->item_type = License::class;
         $logAction->item_id = $license->id;
         $logAction->created_at =  date("Y-m-d H:i:s");
-        $logAction->user_id = Auth::user()->id;
+        $logAction->user_id = Auth::id();
         $logAction->logaction('create');
 
     }
@@ -64,7 +64,7 @@ class LicenseObserver
         $logAction->item_type = License::class;
         $logAction->item_id = $license->id;
         $logAction->created_at =  date("Y-m-d H:i:s");
-        $logAction->user_id = Auth::user()->id;
+        $logAction->user_id = Auth::id();
         $logAction->logaction('delete');
     }
 }


### PR DESCRIPTION
We don't have an authenticated user when seeding, so the observers got angry trying to deference the user to get the id, and we need to create the settings table prior to seeding on travis.

This creates logs with no admin associated, but I don't think there's a better way of handling it without some major reworking.