### PR TITLE
Adds basic GET api support for CustomFieldsets

### DIFF
--- a/app/Http/Controllers/Api/CustomFieldsetsController.php
+++ b/app/Http/Controllers/Api/CustomFieldsetsController.php
@@ -1,0 +1,53 @@
+<?php
+namespace App\Http\Controllers\Api;
+
+use View;
+use App\Models\CustomFieldset;
+use App\Models\CustomField;
+use Input;
+use Validator;
+use Redirect;
+use App\Models\AssetModel;
+use Lang;
+use Auth;
+use Illuminate\Http\Request;
+use Log;
+use App\Http\Controllers\Controller;
+use App\Helpers\Helper;
+use App\Http\Transformers\CustomFieldsTransformer;
+use App\Http\Transformers\CustomFieldsetsTransformer;
+
+/**
+ * This controller handles all actions related to Custom Asset Fieldsets for
+ * the Snipe-IT Asset Management application.
+ *
+ * @todo Improve documentation here.
+ * @todo Check for raw DB queries and try to convert them to query builder statements
+ * @version    v2.0
+ * @author [Brady Wetherington] [<uberbrady@gmail.com>]
+ * @author [Josh Gibson]
+ */
+
+class CustomFieldsetsController extends Controller
+{
+
+    /**
+    * Shows the given fieldset and its fields
+    * @author [A. Gianotto] [<snipe@snipe.net>]
+    * @author [Josh Gibson]
+    * @param int $id
+    * @since [v1.8]
+    * @return View
+    */
+    public function show($id)
+    {
+        if ($fieldset = CustomFieldset::find($id)) {
+            $this->authorize('view', $fieldset);
+            return (new CustomFieldsetsTransformer)->transformCustomFieldset($fieldset);
+        }
+
+        return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/custom_fields/message.fieldset.does_not_exist')), 200);
+
+    }
+
+}

--- a/app/Http/Transformers/CustomFieldsTransformer.php
+++ b/app/Http/Transformers/CustomFieldsTransformer.php
@@ -1,0 +1,30 @@
+<?php
+namespace App\Http\Transformers;
+
+use App\Models\CustomField;
+use Illuminate\Database\Eloquent\Collection;
+use App\Helpers\Helper;
+use Gate;
+
+class CustomFieldsTransformer
+{
+
+    public function transformCustomFields (Collection $fields, $total)
+    {
+        $array = array();
+        foreach ($fields as $field) {
+            $array[] = self::transformCustomField($field);
+        }
+        return (new DatatablesTransformer)->transformDatatables($array, $total);
+    }
+
+    public function transformCustomField (CustomField $field)
+    {
+        $array = [
+            'name' => $field->name,
+            'db_column_name' => $field->db_column_name(),
+            'format'   =>  $field->format
+        ];
+        return $array;
+    }
+}

--- a/app/Http/Transformers/CustomFieldsetsTransformer.php
+++ b/app/Http/Transformers/CustomFieldsetsTransformer.php
@@ -1,0 +1,35 @@
+<?php
+namespace App\Http\Transformers;
+
+use App\Models\CustomFieldset;
+use App\Models\CustomField;
+use App\Models\AssetModel;
+use Illuminate\Database\Eloquent\Collection;
+use App\Helpers\Helper;
+use Gate;
+
+class CustomFieldsetsTransformer
+{
+
+    public function transformCustomFieldsets (Collection $fieldsets, $total)
+    {
+        $array = array();
+        foreach ($fields as $field) {
+            $array[] = self::transformCustomFieldset($field);
+        }
+        return (new DatatablesTransformer)->transformDatatables($array, $total);
+    }
+
+    public function transformCustomFieldset (CustomFieldset $fieldset)
+    {
+        $fields = $fieldset->fields;
+        $models = $fieldset->models;
+        $totalFields = $fields->count();
+        $totalModels = $models->count();
+        $array = [
+            'fields' => (new CustomFieldsTransformer)->transformCustomFields($fields, $totalFields),
+            'models' => (new AssetModelsTransformer)->transformAssetModels($models, $totalModels)
+        ];
+        return $array;
+    }
+}

--- a/resources/lang/en/admin/custom_fields/message.php
+++ b/resources/lang/en/admin/custom_fields/message.php
@@ -28,7 +28,7 @@ return array(
 
     'fieldset' => array(
 
-
+        'does_not_exist' => 'Fieldset does not exist',
 
         'create' => array(
             'error'   => 'Fieldset was not created, please try again.',

--- a/routes/api.php
+++ b/routes/api.php
@@ -172,6 +172,17 @@ Route::group(['prefix' => 'v1','namespace' => 'Api'], function () {
         );
     }); // Fields group
 
+    /*--- Fieldsets API ---*/
+
+    Route::group(['prefix' => 'fieldsets'], function () {
+
+        Route::get('{id}',
+        [
+            'as' => 'api.customfields.show',
+            'uses' => 'CustomFieldsetsController@show'
+        ]);
+    }); // Fieldsets group
+
 
     /*--- Groups API ---*/
 


### PR DESCRIPTION
Currently there is not support for getting what fields a given fieldset contains
from the API.  This commit creates a new API Controller for CustomFieldsets as
well as Transformers for CustomFields CustomFieldsets.  Additionally, the api
route has been updated so that a show method can be access from
http:\//myapp/api/v1/fieldsets/{id}