### PR TITLE
Use correct array when deleting users with location

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -109,7 +109,7 @@ class LdapSync extends Command
 
             // Delete located users from the general group.
             foreach ($results as $key => $generic_entry) {
-                if (in_array($generic_entry[$ldap_result_username][0], $location_users)) {
+                if (in_array($generic_entry[$ldap_result_username][0], $usernames)) {
                     unset($results[$key]);
                 }
             }


### PR DESCRIPTION
Hey,
I backported the location-aware LDAP import, we've seen a strange issue. Users which are in an OU which is assigned to a specific location won't have the correct location set. As it turned out, they weren't properly removed from the "general result array" because of a wrong array used in the array_merge-function.

With the provided fix, users will have their correct location set.

With best regards,
Jan Felix