### PR TITLE
Barcode Reader Support

### DIFF
--- a/config/barcode.php
+++ b/config/barcode.php
@@ -1,0 +1,24 @@
+<?php
+
+return [
+	/*
+    |--------------------------------------------------------------------------
+    | Barcode reader configuration
+    |--------------------------------------------------------------------------
+    |
+    | This configuration allows you to read barcode from Label
+	| and redirect you to specific Asset
+    | Barcode reader need configuration for PREFIX (Default: ~) and SUFFIX (Default: \r -> Enter)
+    |
+    */
+	"reader_active" => true,
+
+	"prefix" => ord( "~" ),
+
+	"suffix" => ord( "\r" ),
+
+	/**
+	 * Limit is a failsafe in case PREFIX char comes from keyboard and not from Barcode Reader
+	 */
+	"limit" => 30,
+];

--- a/resources/lang/ar/admin/settings/general.php
+++ b/resources/lang/ar/admin/settings/general.php
@@ -30,6 +30,7 @@ return array(
 	'display_alt_barcode'		=> 'Display 1D barcode',
 	'barcode_type'				=> '2D Barcode Type',
 	'alt_barcode_type'			=> '1D barcode type',
+    'alt_barcode_reader_tooltip'=> 'Barcode on the label can be read by Barcode Reader.<br/>Barcode reader need to be set with Prefix(Default: ~) and Suffix(Default: Enter).<br/>If you want change barcode prefix or suffix you can do it in config/barcode.php',
     'eula_settings'				=> 'EULA Settings',
     'eula_markdown'				=> 'This EULA allows <a href="https://help.github.com/articles/github-flavored-markdown/">Github flavored markdown</a>.',
     'general_settings'			=> 'General Settings',

--- a/resources/lang/bg/admin/settings/general.php
+++ b/resources/lang/bg/admin/settings/general.php
@@ -30,6 +30,7 @@ return array(
 	'display_alt_barcode'		=> 'Показване на 1D баркод',
 	'barcode_type'				=> '2D тип на баркод',
 	'alt_barcode_type'			=> '1D тип на баркод',
+    'alt_barcode_reader_tooltip'=> 'Barcode on the label can be read by Barcode Reader.<br/>Barcode reader need to be set with Prefix(Default: ~) and Suffix(Default: Enter).<br/>If you want change barcode prefix or suffix you can do it in config/barcode.php',
     'eula_settings'				=> 'Настройки на EULA',
     'eula_markdown'				=> 'Съдържанието на EULA може да бъде форматирано с <a href="https://help.github.com/articles/github-flavored-markdown/">Github flavored markdown</a>.',
     'general_settings'			=> 'Общи настройки',

--- a/resources/lang/cs/admin/settings/general.php
+++ b/resources/lang/cs/admin/settings/general.php
@@ -30,6 +30,7 @@ return array(
 	'display_alt_barcode'		=> 'Zobrazit 1D čárový kód',
 	'barcode_type'				=> 'Typ 2D čárového kódu',
 	'alt_barcode_type'			=> 'Typ 1D čárového kódu',
+	'alt_barcode_reader_tooltip'=> 'Čiarový kód na Label-och sa dá prečítať čítačkou čiarových kódov.<br/>Čítačka musí mať nastavený Prefix(Default: ~) a Suffix(Default: Enter).<br/>Ak chete zmeniť základný prefix alebo subbix môžete tak urobiť v config/barcode.php',
     'eula_settings'				=> 'Nastavení EULA',
     'eula_markdown'				=> 'Tato EULA umožňuje <a href="https://help.github.com/articles/github-flavored-markdown/">Github markdown</a>.',
     'general_settings'			=> 'Obecné nastavení',

--- a/resources/lang/da/admin/settings/general.php
+++ b/resources/lang/da/admin/settings/general.php
@@ -30,6 +30,7 @@ return array(
 	'display_alt_barcode'		=> 'Display 1D barcode',
 	'barcode_type'				=> '2D Barcode Type',
 	'alt_barcode_type'			=> '1D barcode type',
+    'alt_barcode_reader_tooltip'=> 'Barcode on the label can be read by Barcode Reader.<br/>Barcode reader need to be set with Prefix(Default: ~) and Suffix(Default: Enter).<br/>If you want change barcode prefix or suffix you can do it in config/barcode.php',
     'eula_settings'				=> 'EULA Settings',
     'eula_markdown'				=> 'This EULA allows <a href="https://help.github.com/articles/github-flavored-markdown/">Github flavored markdown</a>.',
     'general_settings'			=> 'General Settings',

--- a/resources/lang/de/admin/settings/general.php
+++ b/resources/lang/de/admin/settings/general.php
@@ -30,6 +30,7 @@ return array(
 	'display_alt_barcode'		=> 'Zeige 1D Barcode an',
 	'barcode_type'				=> '2D Barcode Typ',
 	'alt_barcode_type'			=> '1D Barcode Typ',
+    'alt_barcode_reader_tooltip'=> 'Barcode on the label can be read by Barcode Reader.<br/>Barcode reader need to be set with Prefix(Default: ~) and Suffix(Default: Enter).<br/>If you want change barcode prefix or suffix you can do it in config/barcode.php',
     'eula_settings'				=> 'EULA Einstellungen',
     'eula_markdown'				=> 'Diese EULA <a href="https://help.github.com/articles/github-flavored-markdown/"> erlaubt Github Flavored Markdown</a>.',
     'general_settings'			=> 'Allgemeine Einstellungen',

--- a/resources/lang/el/admin/settings/general.php
+++ b/resources/lang/el/admin/settings/general.php
@@ -30,6 +30,7 @@ return array(
 	'display_alt_barcode'		=> 'Display 1D barcode',
 	'barcode_type'				=> '2D Barcode Type',
 	'alt_barcode_type'			=> '1D barcode type',
+    'alt_barcode_reader_tooltip'=> 'Barcode on the label can be read by Barcode Reader.<br/>Barcode reader need to be set with Prefix(Default: ~) and Suffix(Default: Enter).<br/>If you want change barcode prefix or suffix you can do it in config/barcode.php',
     'eula_settings'				=> 'EULA Settings',
     'eula_markdown'				=> 'This EULA allows <a href="https://help.github.com/articles/github-flavored-markdown/">Github flavored markdown</a>.',
     'general_settings'			=> 'Γενικές ρυθμίσεις',

--- a/resources/lang/en-GB/admin/settings/general.php
+++ b/resources/lang/en-GB/admin/settings/general.php
@@ -30,6 +30,7 @@ return array(
 	'display_alt_barcode'		=> 'Display 1D barcode',
 	'barcode_type'				=> '2D Barcode Type',
 	'alt_barcode_type'			=> '1D barcode type',
+    'alt_barcode_reader_tooltip'=> 'Barcode on the label can be read by Barcode Reader.<br/>Barcode reader need to be set with Prefix(Default: ~) and Suffix(Default: Enter).<br/>If you want change barcode prefix or suffix you can do it in config/barcode.php',
     'eula_settings'				=> 'EULA Settings',
     'eula_markdown'				=> 'This EULA allows <a href="https://help.github.com/articles/github-flavored-markdown/">Github flavored markdown</a>.',
     'general_settings'			=> 'General Settings',

--- a/resources/lang/en-ID/admin/settings/general.php
+++ b/resources/lang/en-ID/admin/settings/general.php
@@ -30,6 +30,7 @@ return array(
 	'display_alt_barcode'		=> 'Display 1D barcode',
 	'barcode_type'				=> '2D Barcode Type',
 	'alt_barcode_type'			=> '1D barcode type',
+    'alt_barcode_reader_tooltip'=> 'Barcode on the label can be read by Barcode Reader.<br/>Barcode reader need to be set with Prefix(Default: ~) and Suffix(Default: Enter).<br/>If you want change barcode prefix or suffix you can do it in config/barcode.php',
     'eula_settings'				=> 'EULA Settings',
     'eula_markdown'				=> 'This EULA allows <a href="https://help.github.com/articles/github-flavored-markdown/">Github flavored markdown</a>.',
     'general_settings'			=> 'General Settings',

--- a/resources/lang/en/admin/settings/general.php
+++ b/resources/lang/en/admin/settings/general.php
@@ -30,6 +30,7 @@ return array(
 	'display_alt_barcode'		=> 'Display 1D barcode',
 	'barcode_type'				=> '2D Barcode Type',
 	'alt_barcode_type'			=> '1D barcode type',
+	'alt_barcode_reader_tooltip'=> 'Barcode on the label can be read by Barcode Reader.<br/>Barcode reader need to be set with Prefix(Default: ~) and Suffix(Default: Enter).<br/>If you want change barcode prefix or suffix you can do it in config/barcode.php',
     'eula_settings'				=> 'EULA Settings',
     'eula_markdown'				=> 'This EULA allows <a href="https://help.github.com/articles/github-flavored-markdown/">Github flavored markdown</a>.',
     'general_settings'			=> 'General Settings',

--- a/resources/lang/es-CO/admin/settings/general.php
+++ b/resources/lang/es-CO/admin/settings/general.php
@@ -30,6 +30,7 @@ return array(
 	'display_alt_barcode'		=> 'Mostrar códigos de barras en 1D',
 	'barcode_type'				=> 'Tipo de códigos de barras 2D',
 	'alt_barcode_type'			=> 'Tipo de códigos de barras 1D',
+    'alt_barcode_reader_tooltip'=> 'Barcode on the label can be read by Barcode Reader.<br/>Barcode reader need to be set with Prefix(Default: ~) and Suffix(Default: Enter).<br/>If you want change barcode prefix or suffix you can do it in config/barcode.php',
     'eula_settings'				=> 'Configuración EULA',
     'eula_markdown'				=> 'Este EULS permite <a href="https://help.github.com/articles/github-flavored-markdown/">makrdown estilo Github</a>.',
     'general_settings'			=> 'Configuración General',

--- a/resources/lang/es-ES/admin/settings/general.php
+++ b/resources/lang/es-ES/admin/settings/general.php
@@ -30,6 +30,7 @@ return array(
 	'display_alt_barcode'		=> 'Mostrar códigos de barras en 1D',
 	'barcode_type'				=> 'Tipo de códigos de barras 2D',
 	'alt_barcode_type'			=> 'Tipo de códigos de barras 1D',
+    'alt_barcode_reader_tooltip'=> 'Barcode on the label can be read by Barcode Reader.<br/>Barcode reader need to be set with Prefix(Default: ~) and Suffix(Default: Enter).<br/>If you want change barcode prefix or suffix you can do it in config/barcode.php',
     'eula_settings'				=> 'Configuración EULA',
     'eula_markdown'				=> 'Este EULS permite <a href="https://help.github.com/articles/github-flavored-markdown/">makrdown estilo Github</a>.',
     'general_settings'			=> 'Configuración General',

--- a/resources/lang/fa/admin/settings/general.php
+++ b/resources/lang/fa/admin/settings/general.php
@@ -30,6 +30,7 @@ return array(
 	'display_alt_barcode'		=> 'Display 1D barcode',
 	'barcode_type'				=> '2D Barcode Type',
 	'alt_barcode_type'			=> '1D barcode type',
+    'alt_barcode_reader_tooltip'=> 'Barcode on the label can be read by Barcode Reader.<br/>Barcode reader need to be set with Prefix(Default: ~) and Suffix(Default: Enter).<br/>If you want change barcode prefix or suffix you can do it in config/barcode.php',
     'eula_settings'				=> 'EULA تنظیمات',
     'eula_markdown'				=> 'این EULA اجازه می دهد تا <a href="https://help.github.com/articles/github-flavored-markdown/">Github با طعم markdown</a>.',
     'general_settings'			=> 'تنظیمات عمومی',

--- a/resources/lang/fi/admin/settings/general.php
+++ b/resources/lang/fi/admin/settings/general.php
@@ -30,6 +30,7 @@ return array(
 	'display_alt_barcode'		=> 'Display 1D barcode',
 	'barcode_type'				=> '2D Barcode Type',
 	'alt_barcode_type'			=> '1D barcode type',
+    'alt_barcode_reader_tooltip'=> 'Barcode on the label can be read by Barcode Reader.<br/>Barcode reader need to be set with Prefix(Default: ~) and Suffix(Default: Enter).<br/>If you want change barcode prefix or suffix you can do it in config/barcode.php',
     'eula_settings'				=> 'EULA Settings',
     'eula_markdown'				=> 'This EULA allows <a href="https://help.github.com/articles/github-flavored-markdown/">Github flavored markdown</a>.',
     'general_settings'			=> 'Yleiset asetukset',

--- a/resources/lang/fr/admin/settings/general.php
+++ b/resources/lang/fr/admin/settings/general.php
@@ -30,6 +30,7 @@ return array(
 	'display_alt_barcode'		=> 'Affiche le code-barres 1D',
 	'barcode_type'				=> 'Type du code-barres 2D',
 	'alt_barcode_type'			=> 'Type du code-barres 1D',
+    'alt_barcode_reader_tooltip'=> 'Barcode on the label can be read by Barcode Reader.<br/>Barcode reader need to be set with Prefix(Default: ~) and Suffix(Default: Enter).<br/>If you want change barcode prefix or suffix you can do it in config/barcode.php',
     'eula_settings'				=> 'Configuration pour les licences d\'utilisation',
     'eula_markdown'				=> 'Cette licence d\'utilisation permet l\'utilisation des <a href="https://help.github.com/articles/github-flavored-markdown/">"Github flavored markdown"</a>.',
     'general_settings'			=> 'Configuration générale',

--- a/resources/lang/he/admin/settings/general.php
+++ b/resources/lang/he/admin/settings/general.php
@@ -30,6 +30,7 @@ return array(
 	'display_alt_barcode'		=> 'Display 1D barcode',
 	'barcode_type'				=> '2D Barcode Type',
 	'alt_barcode_type'			=> '1D barcode type',
+    'alt_barcode_reader_tooltip'=> 'Barcode on the label can be read by Barcode Reader.<br/>Barcode reader need to be set with Prefix(Default: ~) and Suffix(Default: Enter).<br/>If you want change barcode prefix or suffix you can do it in config/barcode.php',
     'eula_settings'				=> 'EULA Settings',
     'eula_markdown'				=> 'This EULA allows <a href="https://help.github.com/articles/github-flavored-markdown/">Github flavored markdown</a>.',
     'general_settings'			=> 'General Settings',

--- a/resources/lang/hr/admin/settings/general.php
+++ b/resources/lang/hr/admin/settings/general.php
@@ -30,6 +30,7 @@ return array(
 	'display_alt_barcode'		=> 'Display 1D barcode',
 	'barcode_type'				=> '2D Barcode Type',
 	'alt_barcode_type'			=> '1D barcode type',
+    'alt_barcode_reader_tooltip'=> 'Barcode on the label can be read by Barcode Reader.<br/>Barcode reader need to be set with Prefix(Default: ~) and Suffix(Default: Enter).<br/>If you want change barcode prefix or suffix you can do it in config/barcode.php',
     'eula_settings'				=> 'EULA Settings',
     'eula_markdown'				=> 'This EULA allows <a href="https://help.github.com/articles/github-flavored-markdown/">Github flavored markdown</a>.',
     'general_settings'			=> 'General Settings',

--- a/resources/lang/hu/admin/settings/general.php
+++ b/resources/lang/hu/admin/settings/general.php
@@ -30,6 +30,7 @@ return array(
 	'display_alt_barcode'		=> '1D vonalkód megjelenítése',
 	'barcode_type'				=> '2D vonalkód típusa',
 	'alt_barcode_type'			=> '1D vonalkód típusa',
+    'alt_barcode_reader_tooltip'=> 'Barcode on the label can be read by Barcode Reader.<br/>Barcode reader need to be set with Prefix(Default: ~) and Suffix(Default: Enter).<br/>If you want change barcode prefix or suffix you can do it in config/barcode.php',
     'eula_settings'				=> 'EULA beállítások',
     'eula_markdown'				=> 'This EULA allows <a href="https://help.github.com/articles/github-flavored-markdown/">Github flavored markdown</a>.',
     'general_settings'			=> 'Általános beállítások',

--- a/resources/lang/id/admin/settings/general.php
+++ b/resources/lang/id/admin/settings/general.php
@@ -30,6 +30,7 @@ return array(
 	'display_alt_barcode'		=> 'Tampilan barcode 1D',
 	'barcode_type'				=> 'Tipe Barcode 2D',
 	'alt_barcode_type'			=> 'Tipe Barcode 1D',
+    'alt_barcode_reader_tooltip'=> 'Barcode on the label can be read by Barcode Reader.<br/>Barcode reader need to be set with Prefix(Default: ~) and Suffix(Default: Enter).<br/>If you want change barcode prefix or suffix you can do it in config/barcode.php',
     'eula_settings'				=> 'Konfigurasi EULA',
     'eula_markdown'				=> 'EULA mengijinkan <a href="https://help.github.com/articles/github-flavored-markdown/">Github flavored markdown</a>.',
     'general_settings'			=> 'Konfigurasi umum',

--- a/resources/lang/it/admin/settings/general.php
+++ b/resources/lang/it/admin/settings/general.php
@@ -30,6 +30,7 @@ return array(
 	'display_alt_barcode'		=> 'Visualizza codici a barre',
 	'barcode_type'				=> 'Tipo di codice a barre 2D',
 	'alt_barcode_type'			=> 'Tipo di codice a barre 1D',
+    'alt_barcode_reader_tooltip'=> 'Barcode on the label can be read by Barcode Reader.<br/>Barcode reader need to be set with Prefix(Default: ~) and Suffix(Default: Enter).<br/>If you want change barcode prefix or suffix you can do it in config/barcode.php',
     'eula_settings'				=> 'Impostazioni EULA',
     'eula_markdown'				=> 'Questa EULA consente <a href="https://help.github.com/articles/github aromatizzato-markdown/">Github flavored markdown</a>.',
     'general_settings'			=> 'Impostazioni Generali',

--- a/resources/lang/ja/admin/settings/general.php
+++ b/resources/lang/ja/admin/settings/general.php
@@ -30,6 +30,7 @@ return array(
 	'display_alt_barcode'		=> 'バーコードを表示',
 	'barcode_type'				=> '2次元バーコードタイプ',
 	'alt_barcode_type'			=> 'バーコードタイプ',
+    'alt_barcode_reader_tooltip'=> 'Barcode on the label can be read by Barcode Reader.<br/>Barcode reader need to be set with Prefix(Default: ~) and Suffix(Default: Enter).<br/>If you want change barcode prefix or suffix you can do it in config/barcode.php',
     'eula_settings'				=> 'EULA設定',
     'eula_markdown'				=> 'この EULA は、<a href="https://help.github.com/articles/github-flavored-markdown/">Github flavored markdown</a>で、利用可能です。',
     'general_settings'			=> '全般設定',

--- a/resources/lang/ko/admin/settings/general.php
+++ b/resources/lang/ko/admin/settings/general.php
@@ -30,6 +30,7 @@ return array(
 	'display_alt_barcode'		=> '1 D 바코드 표시',
 	'barcode_type'				=> '2D 바코드 형식',
 	'alt_barcode_type'			=> '1D 바코드 형식',
+    'alt_barcode_reader_tooltip'=> 'Barcode on the label can be read by Barcode Reader.<br/>Barcode reader need to be set with Prefix(Default: ~) and Suffix(Default: Enter).<br/>If you want change barcode prefix or suffix you can do it in config/barcode.php',
     'eula_settings'				=> '최종 사용 계약 설정',
     'eula_markdown'				=> '이 최종 사용 계약은 <a href="https://help.github.com/articles/github-flavored-markdown/">GFM을 따른다</a>.',
     'general_settings'			=> '일반 설정',

--- a/resources/lang/lt/admin/settings/general.php
+++ b/resources/lang/lt/admin/settings/general.php
@@ -30,6 +30,7 @@ return array(
 	'display_alt_barcode'		=> 'Rodyti 1D barkodus',
 	'barcode_type'				=> '2D barkodo tipas',
 	'alt_barcode_type'			=> '1D barkodo tipas',
+    'alt_barcode_reader_tooltip'=> 'Barcode on the label can be read by Barcode Reader.<br/>Barcode reader need to be set with Prefix(Default: ~) and Suffix(Default: Enter).<br/>If you want change barcode prefix or suffix you can do it in config/barcode.php',
     'eula_settings'				=> 'EULA nustatymai',
     'eula_markdown'				=> 'Šis EULA leidžia <a href="https://help.github.com/articles/github-flavored-markdown/">Github flavored markdown</a>.',
     'general_settings'			=> 'Bendrieji nustatymai',

--- a/resources/lang/ms/admin/settings/general.php
+++ b/resources/lang/ms/admin/settings/general.php
@@ -30,6 +30,7 @@ return array(
 	'display_alt_barcode'		=> 'Display 1D barcode',
 	'barcode_type'				=> '2D Barcode Type',
 	'alt_barcode_type'			=> '1D barcode type',
+    'alt_barcode_reader_tooltip'=> 'Barcode on the label can be read by Barcode Reader.<br/>Barcode reader need to be set with Prefix(Default: ~) and Suffix(Default: Enter).<br/>If you want change barcode prefix or suffix you can do it in config/barcode.php',
     'eula_settings'				=> 'EULA Settings',
     'eula_markdown'				=> 'This EULA allows <a href="https://help.github.com/articles/github-flavored-markdown/">Github flavored markdown</a>.',
     'general_settings'			=> 'General Settings',

--- a/resources/lang/nl/admin/settings/general.php
+++ b/resources/lang/nl/admin/settings/general.php
@@ -30,6 +30,7 @@ return array(
 	'display_alt_barcode'		=> 'Streepjescode weergeven',
 	'barcode_type'				=> 'QR-code soort',
 	'alt_barcode_type'			=> 'Streepjescode soort',
+    'alt_barcode_reader_tooltip'=> 'Barcode on the label can be read by Barcode Reader.<br/>Barcode reader need to be set with Prefix(Default: ~) and Suffix(Default: Enter).<br/>If you want change barcode prefix or suffix you can do it in config/barcode.php',
     'eula_settings'				=> 'Gebruikersovereenkomsten instellingen',
     'eula_markdown'				=> 'Deze gebruikersovereenkomst staat <a href="https://help.github.com/articles/github-flavored-markdown/">Github flavored markdown</a> toe.',
     'general_settings'			=> 'Algemene Instellingen',

--- a/resources/lang/no/admin/settings/general.php
+++ b/resources/lang/no/admin/settings/general.php
@@ -30,6 +30,7 @@ return array(
 	'display_alt_barcode'		=> 'Vis 1D strekkode',
 	'barcode_type'				=> '2D strekkodetype',
 	'alt_barcode_type'			=> '1D strekkodetype',
+    'alt_barcode_reader_tooltip'=> 'Barcode on the label can be read by Barcode Reader.<br/>Barcode reader need to be set with Prefix(Default: ~) and Suffix(Default: Enter).<br/>If you want change barcode prefix or suffix you can do it in config/barcode.php',
     'eula_settings'				=> 'EULA-innstillinger',
     'eula_markdown'				=> 'Denne EULAen tillater <a href="https://help.github.com/articles/github-flavored-markdown/">Github Flavored markdown</a>.',
     'general_settings'			=> 'Generelle innstillinger',

--- a/resources/lang/pl/admin/settings/general.php
+++ b/resources/lang/pl/admin/settings/general.php
@@ -30,6 +30,7 @@ return array(
 	'display_alt_barcode'		=> 'Wyświetlaj kod kreskowy w 1D',
 	'barcode_type'				=> 'Kod kreskowy typu 2D',
 	'alt_barcode_type'			=> 'Kod kreskowy typu 1D',
+    'alt_barcode_reader_tooltip'=> 'Barcode on the label can be read by Barcode Reader.<br/>Barcode reader need to be set with Prefix(Default: ~) and Suffix(Default: Enter).<br/>If you want change barcode prefix or suffix you can do it in config/barcode.php',
     'eula_settings'				=> 'Ustawienia Licencji',
     'eula_markdown'				=> 'Ta licencja zezwala na <a href="https://help.github.com/articles/github-flavored-markdown/">Github flavored markdown</a>.',
     'general_settings'			=> 'Ustawienia ogólne',

--- a/resources/lang/pt-BR/admin/settings/general.php
+++ b/resources/lang/pt-BR/admin/settings/general.php
@@ -30,6 +30,7 @@ return array(
 	'display_alt_barcode'		=> 'Exibir códigos de barra em 1D',
 	'barcode_type'				=> 'Código de barras do tipo 2D',
 	'alt_barcode_type'			=> 'Código de barras do tipo 1D',
+    'alt_barcode_reader_tooltip'=> 'Barcode on the label can be read by Barcode Reader.<br/>Barcode reader need to be set with Prefix(Default: ~) and Suffix(Default: Enter).<br/>If you want change barcode prefix or suffix you can do it in config/barcode.php',
     'eula_settings'				=> 'Configuração do termo de uso',
     'eula_markdown'				=> 'Este EULA permite <a href="https://help.github.com/articles/github-flavored-markdown/">Github flavored markdown</a>.',
     'general_settings'			=> 'Configuracoes Gerais',

--- a/resources/lang/pt-PT/admin/settings/general.php
+++ b/resources/lang/pt-PT/admin/settings/general.php
@@ -30,6 +30,7 @@ return array(
 	'display_alt_barcode'		=> 'Mostrar codigos de barra 1D',
 	'barcode_type'				=> 'Tipo de código de barras 2D',
 	'alt_barcode_type'			=> 'Tipo de código de barras 1D',
+    'alt_barcode_reader_tooltip'=> 'Barcode on the label can be read by Barcode Reader.<br/>Barcode reader need to be set with Prefix(Default: ~) and Suffix(Default: Enter).<br/>If you want change barcode prefix or suffix you can do it in config/barcode.php',
     'eula_settings'				=> 'Definições de EULA',
     'eula_markdown'				=> 'Este EULA permite <a href="https://help.github.com/articles/github-flavored-markdown/">Github flavored markdown</a>.',
     'general_settings'			=> 'Configurações Gerais',

--- a/resources/lang/ro/admin/settings/general.php
+++ b/resources/lang/ro/admin/settings/general.php
@@ -30,6 +30,7 @@ return array(
 	'display_alt_barcode'		=> 'Display 1D barcode',
 	'barcode_type'				=> '2D Barcode Type',
 	'alt_barcode_type'			=> '1D barcode type',
+    'alt_barcode_reader_tooltip'=> 'Barcode on the label can be read by Barcode Reader.<br/>Barcode reader need to be set with Prefix(Default: ~) and Suffix(Default: Enter).<br/>If you want change barcode prefix or suffix you can do it in config/barcode.php',
     'eula_settings'				=> 'EULA Settings',
     'eula_markdown'				=> 'This EULA allows <a href="https://help.github.com/articles/github-flavored-markdown/">Github flavored markdown</a>.',
     'general_settings'			=> 'General Settings',

--- a/resources/lang/ru/admin/settings/general.php
+++ b/resources/lang/ru/admin/settings/general.php
@@ -30,6 +30,7 @@ return array(
 	'display_alt_barcode'		=> 'Показывать штрих-коды',
 	'barcode_type'				=> 'Тип 2D штрихкода',
 	'alt_barcode_type'			=> 'Тип линейного штрихкода',
+    'alt_barcode_reader_tooltip'=> 'Barcode on the label can be read by Barcode Reader.<br/>Barcode reader need to be set with Prefix(Default: ~) and Suffix(Default: Enter).<br/>If you want change barcode prefix or suffix you can do it in config/barcode.php',
     'eula_settings'				=> 'Настройки лицензионного соглашения',
     'eula_markdown'				=> 'Это EULA поддерживает <a href="https://help.github.com/articles/github-flavored-markdown/">форматирование Github flavored markdown</a>.',
     'general_settings'			=> 'Общие настройки',

--- a/resources/lang/sv-SE/admin/settings/general.php
+++ b/resources/lang/sv-SE/admin/settings/general.php
@@ -30,6 +30,7 @@ return array(
 	'display_alt_barcode'		=> 'Display 1D barcode',
 	'barcode_type'				=> '2D Barcode Type',
 	'alt_barcode_type'			=> '1D barcode type',
+    'alt_barcode_reader_tooltip'=> 'Barcode on the label can be read by Barcode Reader.<br/>Barcode reader need to be set with Prefix(Default: ~) and Suffix(Default: Enter).<br/>If you want change barcode prefix or suffix you can do it in config/barcode.php',
     'eula_settings'				=> 'EULA Settings',
     'eula_markdown'				=> 'This EULA allows <a href="https://help.github.com/articles/github-flavored-markdown/">Github flavored markdown</a>.',
     'general_settings'			=> 'Allmänna inställningar',

--- a/resources/lang/th/admin/settings/general.php
+++ b/resources/lang/th/admin/settings/general.php
@@ -30,6 +30,7 @@ return array(
 	'display_alt_barcode'		=> 'Display 1D barcode',
 	'barcode_type'				=> '2D Barcode Type',
 	'alt_barcode_type'			=> '1D barcode type',
+    'alt_barcode_reader_tooltip'=> 'Barcode on the label can be read by Barcode Reader.<br/>Barcode reader need to be set with Prefix(Default: ~) and Suffix(Default: Enter).<br/>If you want change barcode prefix or suffix you can do it in config/barcode.php',
     'eula_settings'				=> 'ตั้งค่าข้อตกลงการใช้งาน',
     'eula_markdown'				=> 'อนุญาต EULA นี้ <a href="https://help.github.com/articles/github-flavored-markdown/">Github flavored markdown</a>.',
     'general_settings'			=> 'การตั้งค่าทั่วไป',

--- a/resources/lang/tr/admin/settings/general.php
+++ b/resources/lang/tr/admin/settings/general.php
@@ -30,6 +30,7 @@ return array(
 	'display_alt_barcode'		=> 'Display 1D barcode',
 	'barcode_type'				=> '2D Barcode Type',
 	'alt_barcode_type'			=> '1D barcode type',
+    'alt_barcode_reader_tooltip'=> 'Barcode on the label can be read by Barcode Reader.<br/>Barcode reader need to be set with Prefix(Default: ~) and Suffix(Default: Enter).<br/>If you want change barcode prefix or suffix you can do it in config/barcode.php',
     'eula_settings'				=> 'Son Kullanıcı Lisans Sözleşmesi Ayarları',
     'eula_markdown'				=> 'This EULA allows <a href="https://help.github.com/articles/github-flavored-markdown/">Github flavored markdown</a>.',
     'general_settings'			=> 'Genel Ayarlar',

--- a/resources/lang/vi/admin/settings/general.php
+++ b/resources/lang/vi/admin/settings/general.php
@@ -30,6 +30,7 @@ return array(
 	'display_alt_barcode'		=> 'Display 1D barcode',
 	'barcode_type'				=> '2D Barcode Type',
 	'alt_barcode_type'			=> '1D barcode type',
+    'alt_barcode_reader_tooltip'=> 'Barcode on the label can be read by Barcode Reader.<br/>Barcode reader need to be set with Prefix(Default: ~) and Suffix(Default: Enter).<br/>If you want change barcode prefix or suffix you can do it in config/barcode.php',
     'eula_settings'				=> 'Cài đặt EULA',
     'eula_markdown'				=> 'Đây là EULA cho phép <a href="https://help.github.com/articles/github-flavored-markdown/">Github flavored markdown</a>.',
     'general_settings'			=> 'Cài đặt thường',

--- a/resources/lang/zh-CN/admin/settings/general.php
+++ b/resources/lang/zh-CN/admin/settings/general.php
@@ -30,6 +30,7 @@ return array(
 	'display_alt_barcode'		=> '显示条码',
 	'barcode_type'				=> '二维码类型',
 	'alt_barcode_type'			=> '条码类型',
+    'alt_barcode_reader_tooltip'=> 'Barcode on the label can be read by Barcode Reader.<br/>Barcode reader need to be set with Prefix(Default: ~) and Suffix(Default: Enter).<br/>If you want change barcode prefix or suffix you can do it in config/barcode.php',
     'eula_settings'				=> '最终用户许可协议(EULA)设置',
     'eula_markdown'				=> 'EULA中可以使用<a href="https://help.github.com/articles/github-flavored-markdown/">Github flavored markdown</a>.',
     'general_settings'			=> '一般设置',

--- a/resources/lang/zh-TW/admin/settings/general.php
+++ b/resources/lang/zh-TW/admin/settings/general.php
@@ -30,6 +30,7 @@ return array(
 	'display_alt_barcode'		=> '顯示條碼',
 	'barcode_type'				=> '二維條碼類型',
 	'alt_barcode_type'			=> '條碼類型',
+    'alt_barcode_reader_tooltip'=> 'Barcode on the label can be read by Barcode Reader.<br/>Barcode reader need to be set with Prefix(Default: ~) and Suffix(Default: Enter).<br/>If you want change barcode prefix or suffix you can do it in config/barcode.php',
     'eula_settings'				=> 'EULA 設定',
     'eula_markdown'				=> 'EULA中可使用<a href="https://help.github.com/articles/github-flavored-markdown/">Github flavored markdown</a>.',
     'general_settings'			=> '一般設定',

--- a/resources/views/layouts/barcode_reader.blade.php
+++ b/resources/views/layouts/barcode_reader.blade.php
@@ -1,0 +1,55 @@
+<script>
+    var _barcode_variables = {
+        'word' : '',
+        'state' : 0,
+        'prefix' : {{ config( 'barcode.prefix' ) }},
+        'suffix' : {{ config( 'barcode.suffix' ) }},
+        'limit' : {{ config( 'barcode.limit' ) }}
+    };
+
+    $(document).keypress(function(e) {
+
+        if ( e.keyCode == _barcode_variables.prefix ) // Waiting for barcode Preffix
+        {
+            $("#tagSearch").blur();
+            _barcode_variables.state=1;
+        }
+        else if ( e.keyCode == _barcode_variables.suffix ) // Wait for barcode Suffix
+        {
+            if (_barcode_variables.state == 1)
+            {
+                _barcode_variables.state = 2;
+            }
+            else
+            {
+                _barcode_variables.word='';
+                _barcode_variables.state = 0;
+            }
+        }
+        else if ( _barcode_variables.word.length > _barcode_variables.limit ) // insurance in case of not read by barcode reader
+        {
+            _barcode_variables.word='';
+            _barcode_variables.state=0;
+        }
+
+        if (_barcode_variables.state==1 )
+        {
+            // if not Barcode Preffix
+            if ( e.keyCode != _barcode_variables.prefix )
+            {
+                // put char at the end of string
+                _barcode_variables.word = _barcode_variables.word + String.fromCharCode(e.keyCode);
+            }
+        }
+        else if (_barcode_variables.state==2)
+        {
+            // insert scanned data into search field
+            $("#tagSearch").val( _barcode_variables.word );
+            $("form[role=search]").submit();
+
+            _barcode_variables.word='';
+            _barcode_variables.state=0;
+        }
+
+    });
+</script>

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -643,7 +643,7 @@
 
 
 
-    <script src="{{ mix('js/dist/all.js') }}"></script>
+    <script src="{{ url( mix('js/dist/all.js') ) }}"></script>
     <script>
         $(function () {
             var datepicker = $.fn.datepicker.noConflict(); // return $.fn.datepicker to previously assigned value
@@ -669,6 +669,10 @@
     <script>
          $("#tagSearch").focus();
     </script>
+    @endif
+
+    @if( config( 'barcode.reader_active', false ) )
+        @include( 'layouts.barcode_reader' )
     @endif
 
   </body>

--- a/resources/views/settings/barcodes.blade.php
+++ b/resources/views/settings/barcodes.blade.php
@@ -84,6 +84,10 @@
                                     {!! $errors->first('barcode_type', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
                                 </div>
                             </div>
+
+                            <span class="help-block col-md-offset-3 col-md-12">
+                                {!! trans('admin/settings/general.alt_barcode_reader_tooltip') !!}
+                            </span>
                         @else
                             <span class="help-block col-md-offset-3 col-md-12">
                     {{ trans('admin/settings/general.php_gd_warning') }}


### PR DESCRIPTION
Allows to scan barcode on the Label, put it into Search field  and redirect to specific Asset.
Barcode reader needs to be set with specific  Prefix(Default: ~) and Suffix(Default: Enter), settings can be changed in config/barcode.php