### PR TITLE
Fixes for Red Hat Enterprise Linux 7 and CentOS 6

### DIFF
--- a/snipeit.sh
+++ b/snipeit.sh
@@ -151,7 +151,7 @@ case $distro in
                 echo "  The installer has detected Debian version $version as the OS."
                 distro=debian
                 ;;
-        *centos*|*redhat*|*ol*)
+        *centos*|*redhat*|*ol*|*rhel*)
                 echo "  The installer has detected $distro version $version as the OS."
                 distro=centos
                 ;;
@@ -409,7 +409,7 @@ case $distro in
 
 	       service httpd restart
 
-	elif [ "$version" == "7" ]; then
+	elif [[ "$version" =~ ^7 ]]; then
 		#####################################  Install for Centos/Redhat 7  ##############################################
 
 		webdir=/var/www/html

--- a/snipeit.sh
+++ b/snipeit.sh
@@ -292,7 +292,7 @@ case $distro in
 		service apache2 restart
 		;;
 	centos )
-	if [ "$version" == "6" ]; then
+	if [[ "$version" =~ ^6 ]]; then
 		#####################################  Install for Centos/Redhat 6  ##############################################
 
 		webdir=/var/www/html


### PR DESCRIPTION
RHEL uses "rhel" in the ID field in /etc/os-release. We'll leave
"redhat" in the script just in case.

Also, RHEL uses a two digit version number in the VERSION_ID field. So
instead of looking for just "7", look for anything that starts with "7".
This should fix RHEL installations as well as not break anything
with CentOS.

"lsb_release -s -r" returns a two digit version number (at least on recent CentOS releases) while the script is looking for a single digit version. We'll change the script so that it only looks for the version starting with 6. This fixes recent releases of CentOS, while also not breaking previous versions that may have used a single digit.