### PR TITLE
Fixes ComponentsController postCheckout() logging

### DIFF
--- a/app/Http/Controllers/ComponentsController.php
+++ b/app/Http/Controllers/ComponentsController.php
@@ -283,7 +283,7 @@ class ComponentsController extends Controller
             'asset_id' => $asset_id
         ]);
 
-        $component->logCheckout(e(Input::get('note')), $asset_id);
+        $component->logCheckout(e(Input::get('note')));
         return redirect()->route('components.index')->with('success', trans('admin/components/message.checkout.success'));
     }
 


### PR DESCRIPTION
In ComponentsController postCheckout(), when the function tries to log the transaction, it gives `$asset_id` as a parameter. The second parameter for this logging function (logCheckout()) is expected to be an object.  All of the other controllers do not log the object that the asset is being checked out to so this PR removes that part of the logging and instead only logs notes.