### PR TITLE
Clear audit input field

### DIFF
--- a/resources/views/hardware/quickscan.blade.php
+++ b/resources/views/hardware/quickscan.blade.php
@@ -152,7 +152,7 @@
                     } else {
                         handleAuditFail(data);
                     }
-
+                    $('input#asset_tag').val('');
                 },
                 error: function (data) {
                     handleAuditFail(data);


### PR DESCRIPTION
Workflow for the audit page could be increased if the Asset Tag field is cleared on each call.
Could extend it to be a checkbox option. As this is supposed to be a bulk method with scanner, manually clearing the input field after each tag is bothersome. 

Zapping equipment with my wireless bar-code reader, checking on the status panel from across the room would be bliss.