### PR TITLE
Fix various installer issues.

### DIFF
--- a/snipeit.sh
+++ b/snipeit.sh
@@ -40,11 +40,11 @@ mkdir $tmp
 
 # Debian/Ubuntu friendly f(x)s
 progress () {
-	while kill -0 "$pid" > /dev/null 2>&1
+    while kill -0 "$pid" > /dev/null 2>&1
         do
-        	for i in "${spin[@]}"
+            for i in "${spin[@]}"
                 do
-                	if [ -e /proc/"$pid" ]; then
+                    if [ -e /proc/"$pid" ]; then
                         echo -ne "\b$i"
                         sleep .1
                         else
@@ -54,60 +54,61 @@ progress () {
         done
 }
 
+#Used for Debian and Ubuntu
 vhenvfile () {
-		find /etc/apache2/mods-enabled -maxdepth 1 -name 'rewrite.load' >/dev/null 2>&1
-		apachefile=/etc/apache2/sites-available/$name.conf
-		echo "* Create Virtual host for apache."
-		{
-			echo "<VirtualHost *:80>"
-			echo "ServerAdmin webmaster@localhost"
-			echo "<Directory $webdir/$name/public>"
-			echo "        Require all granted"
-			echo "        AllowOverride All"
-			echo "   </Directory>"
-			echo "    DocumentRoot $webdir/$name/public"
-			echo "    ServerName $fqdn"
-			echo "        ErrorLog /var/log/apache2/snipeIT.error.log"
-			echo "        CustomLog /var/log/apache2/access.log combined"
-			echo "</VirtualHost>"
-		} >> $apachefile
-		echo >> $hosts "127.0.0.1 $hostname $fqdn"
-		log "a2ensite $name.conf"
+    find /etc/apache2/mods-enabled -maxdepth 1 -name 'rewrite.load' >/dev/null 2>&1
+    apachefile=/etc/apache2/sites-available/$name.conf
+    echo "* Create Virtual host for apache."
+    {
+        echo "<VirtualHost *:80>"
+        echo "ServerAdmin webmaster@localhost"
+        echo "<Directory $webdir/$name/public>"
+        echo "        Require all granted"
+        echo "        AllowOverride All"
+        echo "   </Directory>"
+        echo "    DocumentRoot $webdir/$name/public"
+        echo "    ServerName $fqdn"
+        echo "        ErrorLog /var/log/apache2/snipeIT.error.log"
+        echo "        CustomLog /var/log/apache2/access.log combined"
+        echo "</VirtualHost>"
+    } >> $apachefile
+    echo >> $hosts "127.0.0.1 $hostname $fqdn"
+    log "a2ensite $name.conf"
 
-		cat > "$webdir/$name/.env" <<-EOF
-		#Created By Snipe-it Installer
-		APP_TIMEZONE=$(cat /etc/timezone)
-		DB_HOST=localhost
-		DB_DATABASE=snipeit
-		DB_USERNAME=snipeit
-		DB_PASSWORD=$mysqluserpw
-		APP_URL=http://$fqdn
-		APP_KEY=$random32
-		EOF
+    cp $webdir/$name/.env.example $webdir/$name/.env
+
+    sed -i '1 i\#Created By Snipe-it Installer' $webdir/$name/.env
+    sed -i 's,^\(APP_TIMEZONE=\).*,\1'$(cat /etc/timezone)',' $webdir/$name/.env
+    sed -i 's,^\(DB_HOST=\).*,\1'localhost',' $webdir/$name/.env
+    sed -i 's,^\(DB_DATABASE=\).*,\1'snipeit',' $webdir/$name/.env
+    sed -i 's,^\(DB_USERNAME=\).*,\1'snipeit',' $webdir/$name/.env
+    sed -i 's,^\(DB_PASSWORD=\).*,\1'$mysqluserpw',' $webdir/$name/.env
+    sed -i 's,^\(APP_URL=\).*,\1'http://$fqdn',' $webdir/$name/.env
+    sed -i 's,^\(APP_KEY=\).*,\1'$$random32',' $webdir/$name/.env
 }
 
 perms () {
-	chmod_dirs=( "$webdir/$name/storage" )
-	chmod_dirs+=( "$webdir/$name/storage/private_uploads" )
-	chmod_dirs+=( "$webdir/$name/public/uploads" )
-	#Change permissions on directories
-	for chmod_dir in "${chmod_dirs[@]}"
-	do
-		chmod -R 755 "$chmod_dir"
-	done
+    chmod_dirs=( "$webdir/$name/storage" )
+    chmod_dirs+=( "$webdir/$name/storage/private_uploads" )
+    chmod_dirs+=( "$webdir/$name/public/uploads" )
+    #Change permissions on directories
+    for chmod_dir in "${chmod_dirs[@]}"
+    do
+        chmod -R 755 "$chmod_dir"
+    done
 }
-    
+
 log () {
-	eval "$@" |& tee -a /var/log/snipeit-install.log >/dev/null 2>&1
+    eval "$@" |& tee -a /var/log/snipeit-install.log >/dev/null 2>&1
 }
 
 #CentOS Friendly f(x)s
 function isinstalled {
-	if yum list installed "$@" >/dev/null 2>&1; then
-		true
-	else
-		false
-	fi
+    if yum list installed "$@" >/dev/null 2>&1; then
+        true
+    else
+        false
+    fi
 }
 
 if [ -f /etc/lsb-release ]; then
@@ -115,26 +116,26 @@ if [ -f /etc/lsb-release ]; then
     version="$(lsb_release -s -r)"
     codename="$(lsb_release -c -s)"
 elif [ -f /etc/os-release ]; then
-	distro="$(. /etc/os-release && echo $ID)"
-	version="$(. /etc/os-release && echo $VERSION_ID)"
-	#Order is important here.  If /etc/os-release and /etc/centos-release exist, we're on centos 7.
-	#If only /etc/centos-release exist, we're on centos6(or earlier).  Centos-release is less parsable,
-	#so lets assume that it's version 6 (Plus, who would be doing a new install of anything on centos5 at this point..)
+    distro="$(. /etc/os-release && echo $ID)"
+    version="$(. /etc/os-release && echo $VERSION_ID)"
+    #Order is important here.  If /etc/os-release and /etc/centos-release exist, we're on centos 7.
+    #If only /etc/centos-release exist, we're on centos6(or earlier).  Centos-release is less parsable,
+    #so lets assume that it's version 6 (Plus, who would be doing a new install of anything on centos5 at this point..)
 elif [ -f /etc/centos-release ]; then
-	distro="Centos"
-	version="6"
+    distro="Centos"
+    version="6"
 else
-	distro="unsupported"
+    distro="unsupported"
 fi
 
 
 echo "
-	   _____       _                  __________
-	  / ___/____  (_)___  ___        /  _/_  __/
-	  \__ \/ __ \/ / __ \/ _ \______ / /  / /
-	 ___/ / / / / / /_/ /  __/_____// /  / /
-	/____/_/ /_/_/ .___/\___/     /___/ /_/
-	            /_/
+       _____       _                  __________
+      / ___/____  (_)___  ___        /  _/_  __/
+      \__ \/ __ \/ / __ \/ _ \______ / /  / /
+     ___/ / / / / / /_/ /  __/_____// /  / /
+    /____/_/ /_/_/ .___/\___/     /___/ /_/
+                /_/
 "
 
 echo ""
@@ -143,22 +144,22 @@ echo "  Welcome to Snipe-IT Inventory Installer for Centos, Debian and Ubuntu!"
 echo ""
 shopt -s nocasematch
 case $distro in
-        *Ubuntu*)
-                echo "  The installer has detected Ubuntu version $version as the OS."
-                distro=ubuntu
-                ;;
-		*Debian*)
-                echo "  The installer has detected Debian version $version as the OS."
-                distro=debian
-                ;;
-        *centos*|*redhat*|*ol*|*rhel*)
-                echo "  The installer has detected $distro version $version as the OS."
-                distro=centos
-                ;;
-        *)
-                echo "  The installer was unable to determine your OS. Exiting for safety."
-                exit
-                ;;
+    *Ubuntu*)
+        echo "  The installer has detected Ubuntu version $version as the OS."
+        distro=ubuntu
+        ;;
+    *Debian*)
+        echo "  The installer has detected Debian version $version as the OS."
+        distro=debian
+        ;;
+    *centos*|*redhat*|*ol*|*rhel*)
+        echo "  The installer has detected $distro version $version as the OS."
+        distro=centos
+        ;;
+    *)
+        echo "  The installer was unable to determine your OS. Exiting for safety."
+        exit
+        ;;
 esac
 shopt -u nocasematch
 #Get your FQDN.
@@ -166,29 +167,29 @@ shopt -u nocasematch
 echo -n "  Q. What is the FQDN of your server? ($fqdn): "
 read fqdn
 if [ -z "$fqdn" ]; then
-        fqdn="$(hostname --fqdn)"
+    fqdn="$(hostname --fqdn)"
 fi
 echo "     Setting to $fqdn"
 echo ""
 
 #Do you want to set your own passwords, or have me generate random ones?
 until [[ $ans == "yes" ]] || [[ $ans == "no" ]]; do
-echo -n "  Q. Do you want me to automatically create the snipe database user password? (y/n) "
+echo -n "  Q. Do you want to automatically create the database user password? (y/n) "
 read setpw
 
 case $setpw in
-        [yY] | [yY][Ee][Ss] )
-                mysqluserpw="$(echo `< /dev/urandom tr -dc _A-Za-z-0-9 | head -c16`)"
-                ans="yes"
-                ;;
-        [nN] | [n|N][O|o] )
-                echo -n  "  Q. What do you want your snipeit user password to be?"
-                read -s mysqluserpw
-                echo ""
-		ans="no"
-                ;;
-        *) 	echo "  Invalid answer. Please type y or n"
-                ;;
+    [yY] | [yY][Ee][Ss] )
+        mysqluserpw="$(echo `< /dev/urandom tr -dc _A-Za-z-0-9 | head -c16`)"
+        ans="yes"
+        ;;
+    [nN] | [n|N][O|o] )
+        echo -n  "  Q. What do you want your snipeit user password to be?"
+        read -s mysqluserpw
+        echo ""
+    ans="no"
+        ;;
+    *)  echo "  Invalid answer. Please type y or n"
+        ;;
 esac
 done
 
@@ -207,346 +208,347 @@ chmod 700 $dbsetup
 ## TODO: Progress tracker on each step
 
 case $distro in
-	debian)
-		#####################################  Install for Debian ##############################################
-		#Update/upgrade Debian/Ubuntu repositories, get the latest version of git.
-		#Git clone snipeit, create vhost, edit hosts file, create .env file, mysql install
-		#composer install, set permissions, restart apache.
-		#BTW, Debian, I swear, you're such a pain.
+    debian)
+        #####################################  Install for Debian ##############################################
+        #Update/upgrade Debian/Ubuntu repositories, get the latest version of git.
+        #Git clone snipeit, create vhost, edit hosts file, create .env file, mysql install
+        #composer install, set permissions, restart apache.
+        #BTW, Debian, I swear, you're such a pain.
 
-		webdir=/var/www
-		echo -e "\n* Updating Debian packages in the background... ${spin[0]}\n"
-		apt-get update >> /var/log/snipeit-install.log & pid=$! 2>&1
-		wait
-		apt-get upgrade >> /var/log/snipeit-install.log & pid=$! 2>&1
-		wait
-		echo -e "\n* Installing packages... ${spin[0]}\n"
-		echo -e "\n* Going to suppress more messages that you don't need to worry about. Please wait... ${spin[0]}"
-		DEBIAN_FRONTEND=noninteractive apt-get -y install mariadb-server mariadb-client apache2 git unzip php5 php5-mcrypt php5-curl php5-mysql php5-gd php5-ldap libapache2-mod-php5 curl >> /var/log/snipeit-install.log & pid=$! 2>&1
-		progress
-		wait
-		echo -e "\n* Cloning Snipeit, extracting to $webdir/$name..."
-		git clone https://github.com/snipe/snipe-it $webdir/$name >> /var/log/snipeit-install.log & pid=$! 2>&1
-		progress
-		php5enmod mcrypt >> /var/log/snipeit-install.log 2>&1
-		a2enmod rewrite >> /var/log/snipeit-install.log 2>&1
-		vhenvfile
-		wait
-		echo >> $hosts "127.0.0.1 $hostname $fqdn"
-		a2ensite $name.conf
-		echo -e "* Modify the Snipe-It files necessary for a production environment.\n* Securing Mysql"
-		# Have user set own root password when securing install
-		# and just set the snipeit database user at the beginning
-		/usr/bin/mysql_secure_installation
-		echo -e "* Creating Mysql Database and User.\n##  Please Input your MySQL/MariaDB root password: "
-		mysql -u root -p < $dbsetup
-		cd $webdir/$name/
-		curl -sS https://getcomposer.org/installer | php
-		php composer.phar install --no-dev --prefer-source
-		perms
-		service apache2 restart
-		php artisan key:generate
-		php artisan passport:install
-		;;
-	ubuntu)
-		#####################################  Install for Ubuntu  ##############################################
-		#Update/upgrade Debian/Ubuntu repositories, get the latest version of git.
-		#Git clone snipeit, create vhost, .env file, mysql install
-		#composer install, set permissions, restart apache.
-
-		webdir=/var/www
-		echo -ne "\n* Adding MariaDB repo in the background... ${spin[0]}"
-		(echo "deb [arch=amd64,i386] http://ftp.hosteurope.de/mirror/mariadb.org/repo/10.1/ubuntu $codename main" | tee /etc/apt/sources.list.d/mariadb.list >/dev/null 2>&1)
-		log "apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xF1656F24C74CD1D8"
-		echo -ne "\n* Updating with apt-get update in the background... ${spin[0]}"
-		log "apt-get update" & pid=$!
-		[ -f /var/lib/dpkg/lock ] && rm -f /var/lib/dpkg/lock
-		progress
-		echo -ne "\n* Upgrading packages with apt-get upgrade in the background... ${spin[0]}"
-		log "apt-get -y upgrade" & pid=$!
-		progress
-		echo -ne "\n* Setting up LAMP in the background... ${spin[0]}\n"
-		log "DEBIAN_FRONTEND=noninteractive apt-get install -y mariadb-server mariadb-client apache2 libapache2-mod-php curl" & pid=$!
-		progress
-		if [ "$version" == "16.04" ]; then
-			log "apt-get install -y git unzip php php-mcrypt php-curl php-mysql php-gd php-ldap php-zip php-mbstring php-xml" & pid=$!
-			progress
-			log "phpenmod mcrypt"
-			log "phpenmod mbstring"
-			log "a2enmod rewrite"
-		else
-			log "apt-get install -y git unzip php5 php5-mcrypt php5-curl php5-mysql php5-gd php5-ldap" & pid=$!
-			progress
-			log "php5enmod mcrypt"
-			log "a2enmod rewrite"
-		fi
-		echo -ne "\n* Cloning Snipeit, extracting to $webdir/$name... ${spin[0]}"
-		log "git clone https://github.com/snipe/snipe-it $webdir/$name" & pid=$!
-		progress
-		vhenvfile
-		echo -e "* MySQL Phase next.\n"
-		service mysql status >/dev/null || service mysql start
-		/usr/bin/mysql_secure_installation
-		echo -e "* Creating MySQL Database and user.\n* Please Input your MySQL/MariaDB root password created in the previous step.: "
-		mysql -u root -p < $dbsetup
-		echo -e "\n* Securing Mysql\n* Installing and configuring composer"
-		cd $webdir/$name/
-		curl -sS https://getcomposer.org/installer  | php
-		php composer.phar install --no-dev --prefer-source
-		perms
-		chown -R www-data:www-data "/var/www/$name"
-		service apache2 restart
+        webdir=/var/www
+        echo -e "\n* Updating Debian packages in the background... ${spin[0]}\n"
+        apt-get update >> /var/log/snipeit-install.log & pid=$! 2>&1
+        wait
+        apt-get upgrade >> /var/log/snipeit-install.log & pid=$! 2>&1
+        wait
+        echo -e "\n* Installing packages... ${spin[0]}\n"
+        echo -e "\n* Going to suppress more messages that you don't need to worry about. Please wait... ${spin[0]}"
+        DEBIAN_FRONTEND=noninteractive apt-get -y install mariadb-server mariadb-client apache2 git unzip php5 php5-mcrypt php5-curl php5-mysql php5-gd php5-ldap libapache2-mod-php5 curl >> /var/log/snipeit-install.log & pid=$! 2>&1
+        progress
+        wait
+        echo -e "\n* Cloning Snipeit, extracting to $webdir/$name..."
+        git clone https://github.com/snipe/snipe-it $webdir/$name >> /var/log/snipeit-install.log & pid=$! 2>&1
+        progress
+        php5enmod mcrypt >> /var/log/snipeit-install.log 2>&1
+        a2enmod rewrite >> /var/log/snipeit-install.log 2>&1
+        vhenvfile
+        wait
+        echo >> $hosts "127.0.0.1 $hostname $fqdn"
+        a2ensite $name.conf
+        echo -e "* Modify the Snipe-It files necessary for a production environment.\n* Securing Mysql"
+        # Have user set own root password when securing install
+        # and just set the snipeit database user at the beginning
+        /usr/bin/mysql_secure_installation
+        echo -e "* Creating Mysql Database and User.\n##  Please Input your MySQL/MariaDB root password: "
+        mysql -u root -p < $dbsetup
+        cd $webdir/$name/
+        curl -sS https://getcomposer.org/installer | php
+        php composer.phar install --no-dev --prefer-source
+        perms
+        service apache2 restart
         php artisan key:generate
         php artisan passport:install
-		;;
-	centos )
-	if [[ "$version" =~ ^6 ]]; then
-		#####################################  Install for Centos/Redhat 6  ##############################################
+        ;;
+    ubuntu)
+        #####################################  Install for Ubuntu  ##############################################
+        #Update/upgrade Debian/Ubuntu repositories, get the latest version of git.
+        #Git clone snipeit, create vhost, .env file, mysql install
+        #composer install, set permissions, restart apache.
 
-		webdir=/var/www/html
-		#Allow us to get the mysql engine
-		echo ""
-		echo "##  Adding IUS, epel-release and mariaDB repos.";
-		mariadbRepo=/etc/yum.repos.d/MariaDB.repo
-		touch "$mariadbRepo"
-		{
-			echo "[mariadb]"
-			echo "name = MariaDB"
-			echo "baseurl = http://yum.mariadb.org/10.0/centos6-amd64"
-			echo "gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB"
-			echo "gpgcheck=1"
-			echo "enable=1"
-		} >> "$mariadbRepo"
+        webdir=/var/www
+        echo -ne "\n* Adding MariaDB repo in the background... ${spin[0]}"
+        (echo "deb [arch=amd64,i386] http://ftp.hosteurope.de/mirror/mariadb.org/repo/10.1/ubuntu $codename main" | tee /etc/apt/sources.list.d/mariadb.list >/dev/null 2>&1)
+        log "apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xF1656F24C74CD1D8"
+        echo -ne "\n* Updating with apt-get update in the background... ${spin[0]}"
+        log "apt-get update" & pid=$!
+        [ -f /var/lib/dpkg/lock ] && rm -f /var/lib/dpkg/lock
+        progress
+        echo -ne "\n* Upgrading packages with apt-get upgrade in the background... ${spin[0]}"
+        log "apt-get -y upgrade" & pid=$!
+        progress
+        echo -ne "\n* Setting up LAMP in the background... ${spin[0]}\n"
+        log "DEBIAN_FRONTEND=noninteractive apt-get install -y mariadb-server mariadb-client apache2 libapache2-mod-php curl" & pid=$!
+        progress
+        if [ "$version" == "16.04" ]; then
+            log "apt-get install -y git unzip php php-mcrypt php-curl php-mysql php-gd php-ldap php-zip php-mbstring php-xml" & pid=$!
+            progress
+            log "phpenmod mcrypt"
+            log "phpenmod mbstring"
+            log "a2enmod rewrite"
+        else
+            log "apt-get install -y git unzip php5 php5-mcrypt php5-curl php5-mysql php5-gd php5-ldap" & pid=$!
+            progress
+            log "php5enmod mcrypt"
+            log "a2enmod rewrite"
+        fi
+        echo -ne "\n* Cloning Snipeit, extracting to $webdir/$name... ${spin[0]}"
+        log "git clone https://github.com/snipe/snipe-it $webdir/$name" & pid=$!
+        progress
+        vhenvfile
+        echo -e "* MySQL Phase next.\n"
+        service mysql status >/dev/null || service mysql start
+        /usr/bin/mysql_secure_installation
+        echo -e "* Creating MySQL Database and user.\n* Please Input your MySQL/MariaDB root password created in the previous step.: "
+        mysql -u root -p < $dbsetup
+        echo -e "\n* Securing Mysql\n* Installing and configuring composer"
+        cd $webdir/$name/
+        curl -sS https://getcomposer.org/installer  | php
+        php composer.phar install --no-dev --prefer-source
+        perms
+        chown -R www-data:www-data "/var/www/$name"
+        service apache2 restart
+        php artisan key:generate
+        php artisan passport:install
+        ;;
+    centos )
+    if [[ "$version" =~ ^6 ]]; then
+        #####################################  Install for Centos/Redhat 6  ##############################################
 
-		log "yum -y install wget epel-release"
-		log "wget -P "$tmp/" https://centos6.iuscommunity.org/ius-release.rpm"
-		log "rpm -Uvh "$tmp/ius-release*.rpm""
+        webdir=/var/www/html
+        #Allow us to get the mysql engine
+        echo ""
+        echo "##  Adding IUS, epel-release and mariaDB repos.";
+        mariadbRepo=/etc/yum.repos.d/MariaDB.repo
+        touch "$mariadbRepo"
+        {
+            echo "[mariadb]"
+            echo "name = MariaDB"
+            echo "baseurl = http://yum.mariadb.org/10.0/centos6-amd64"
+            echo "gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB"
+            echo "gpgcheck=1"
+            echo "enable=1"
+        } >> "$mariadbRepo"
 
-		#Install PHP and other needed stuff.
-		echo "##  Installing PHP and other needed stuff";
-		PACKAGES="httpd MariaDB-server git unzip php56u php56u-mysqlnd php56u-bcmath php56u-cli php56u-common php56u-embedded php56u-gd php56u-mbstring php56u-mcrypt php56u-ldap"
+        log "yum -y install wget epel-release"
+        log "wget -P "$tmp/" https://centos6.iuscommunity.org/ius-release.rpm"
+        log "rpm -Uvh "$tmp/ius-release*.rpm""
 
-		for p in $PACKAGES;do
-			if isinstalled "$p"; then
-				echo " ## $p already installed"
-			else
-				echo -n " ## installing $p ... "
-				log "yum -y install $p"
-				echo "";
-			fi
-		done;
+        #Install PHP and other needed stuff.
+        echo "##  Installing PHP and other needed stuff";
+        PACKAGES="httpd MariaDB-server git unzip php56u php56u-mysqlnd php56u-bcmath php56u-cli php56u-common php56u-embedded php56u-gd php56u-mbstring php56u-mcrypt php56u-ldap"
 
-		echo -e "\n##  Downloading Snipe-IT from github and putting it in the web directory.";
+        for p in $PACKAGES;do
+            if isinstalled "$p"; then
+                echo " ## $p already installed"
+            else
+                echo -n " ## Installing $p ... "
+                log "yum -y install $p"
+                echo "";
+            fi
+        done;
 
-		log "wget -P $tmp/ https://github.com/snipe/snipe-it/archive/$file"
-		unzip -qo $tmp/$file -d $tmp/
-		cp -R $tmp/$fileName $webdir/$name
+        echo -e "\n##  Downloading Snipe-IT from github and putting it in the web directory.";
 
-		# Make mariaDB start on boot and restart the daemon
-		echo "##  Starting the mariaDB server.";
-		chkconfig mysql on
-		/sbin/service mysql start
+        log "wget -P $tmp/ https://github.com/snipe/snipe-it/archive/$file"
+        unzip -qo $tmp/$file -d $tmp/
+        cp -R $tmp/$fileName $webdir/$name
 
-		echo "##  Securing mariaDB server.";
-		/usr/bin/mysql_secure_installation
+        # Make mariaDB start on boot and restart the daemon
+        echo "##  Starting the mariaDB server.";
+        chkconfig mysql on
+        /sbin/service mysql start
 
-		echo "##  Creating MySQL Database/User."
-		echo "##  Please Input your MySQL/MariaDB root password: "
-		mysql -u root -p < $dbsetup
+        echo "##  Securing mariaDB server.";
+        /usr/bin/mysql_secure_installation
 
-		#Create the new virtual host in Apache and enable rewrite
-		echo "##  Creating the new virtual host in Apache.";
-		apachefile=/etc/httpd/conf.d/$name.conf
+        echo "##  Creating MySQL Database/User."
+        echo "##  Please Input your MySQL/MariaDB root password: "
+        mysql -u root -p < $dbsetup
 
-		{
-			echo ""
-			echo ""
-			echo ""
-			echo "<VirtualHost *:80>"
-			echo "ServerAdmin webmaster@localhost"
-			echo "    <Directory $webdir/$name/public>"
-			echo "        Allow From All"
-			echo "        AllowOverride All"
-			echo "        Options +Indexes"
-			echo "   </Directory>"
-			echo "    DocumentRoot $webdir/$name/public"
-			echo "    ServerName $fqdn"
-			echo "        ErrorLog /var/log/httpd/snipeIT.error.log"
-			echo "        CustomLog /var/log/access.log combined"
-			echo "</VirtualHost>"
-		} >> "$apachefile"
+        #Create the new virtual host in Apache and enable rewrite
+        echo "##  Creating the new virtual host in Apache.";
+        apachefile=/etc/httpd/conf.d/$name.conf
 
-		echo "##  Setting up hosts file.";
-		echo >> $hosts "127.0.0.1 $hostname $fqdn"
+        {
+            echo ""
+            echo ""
+            echo ""
+            echo "<VirtualHost *:80>"
+            echo "ServerAdmin webmaster@localhost"
+            echo "    <Directory $webdir/$name/public>"
+            echo "        Allow From All"
+            echo "        AllowOverride All"
+            echo "        Options +Indexes"
+            echo "   </Directory>"
+            echo "    DocumentRoot $webdir/$name/public"
+            echo "    ServerName $fqdn"
+            echo "        ErrorLog /var/log/httpd/snipeIT.error.log"
+            echo "        CustomLog /var/log/access.log combined"
+            echo "</VirtualHost>"
+        } >> "$apachefile"
 
-		# Make apache start on boot and restart the daemon
-		echo "##  Starting the apache server.";
-		chkconfig httpd on
-		/sbin/service httpd start
+        echo "##  Setting up hosts file.";
+        echo >> $hosts "127.0.0.1 $hostname $fqdn"
 
-		tzone=$(grep ZONE /etc/sysconfig/clock | tr -d '"' | sed 's/ZONE=//g');
-		echo "## Configuring .env file."
+        # Make apache start on boot and restart the daemon
+        echo "##  Starting the apache server.";
+        chkconfig httpd on
+        /sbin/service httpd start
 
-		cat > $webdir/$name/.env <<-EOF
-		#Created By Snipe-it Installer
-		APP_TIMEZONE=$tzone
-		DB_HOST=localhost
-		DB_DATABASE=snipeit
-		DB_USERNAME=snipeit
-		DB_PASSWORD=$mysqluserpw
-		APP_URL=http://$fqdn
-		APP_KEY=$random32
-		DB_DUMP_PATH='/usr/bin'
-		EOF
+        tzone=$(grep ZONE /etc/sysconfig/clock | tr -d '"' | sed 's/ZONE=//g');
+        echo "## Configuring .env file."
 
-		echo "##  Configure composer"
-		cd $webdir/$name
-		curl -sS https://getcomposer.org/installer | php
-		php composer.phar install --no-dev --prefer-source
+        cp $webdir/$name/.env.example $webdir/$name/.env
 
-		perms
-		chown -R apache:apache $webdir/$name
+        sed -i '1 i\#Created By Snipe-it Installer' $webdir/$name/.env
+        sed -i 's,^\(APP_TIMEZONE=\).*,\1'$tzone',' $webdir/$name/.env
+        sed -i 's,^\(DB_HOST=\).*,\1'localhost',' $webdir/$name/.env
+        sed -i 's,^\(DB_DATABASE=\).*,\1'snipeit',' $webdir/$name/.env
+        sed -i 's,^\(DB_USERNAME=\).*,\1'snipeit',' $webdir/$name/.env
+        sed -i 's,^\(DB_PASSWORD=\).*,\1'$mysqluserpw',' $webdir/$name/.env
+        sed -i 's,^\(APP_URL=\).*,\1'http://$fqdn',' $webdir/$name/.env
+        sed -i 's,^\(APP_KEY=\).*,\1'$$random32',' $webdir/$name/.env
 
-                /sbin/service iptables status >/dev/null 2>&1
-                if [ $? = 0 ]; then
-                      #Open http/https port
-                      iptables -I INPUT 1 -p tcp -m tcp --dport 80 -j ACCEPT
-                      iptables -I INPUT 1 -p tcp -m tcp --dport 443 -j ACCEPT
-                      #Save iptables
-                      service iptables save
-                fi
+        echo "##  Configure composer"
+        cd $webdir/$name
+        curl -sS https://getcomposer.org/installer | php
+        php composer.phar install --no-dev --prefer-source
 
-	       service httpd restart
-	       php artisan key:generate
-           php artisan passport:install
+        perms
+        chown -R apache:apache $webdir/$name
 
-	elif [[ "$version" =~ ^7 ]]; then
-		#####################################  Install for Centos/Redhat 7  ##############################################
+        /sbin/service iptables status >/dev/null 2>&1
+        if [ $? = 0 ]; then
+            #Open http/https port
+            iptables -I INPUT 1 -p tcp -m tcp --dport 80 -j ACCEPT
+            iptables -I INPUT 1 -p tcp -m tcp --dport 443 -j ACCEPT
+            #Save iptables
+            service iptables save
+        fi
 
-		webdir=/var/www/html
-
-		#Allow us to get the mysql engine
-		echo -e "\n##  Add IUS, epel-release and mariaDB repos.";
-		log "yum -y install wget epel-release"
-		log "wget -P $tmp/ https://centos7.iuscommunity.org/ius-release.rpm"
-		log "rpm -Uvh $tmp/ius-release*.rpm"
-
-		#Install PHP and other needed stuff.
-		echo "##  Installing PHP and other needed stuff";
-		PACKAGES="httpd mariadb-server git unzip php56u php56u-mysqlnd php56u-bcmath php56u-cli php56u-common php56u-embedded php56u-gd php56u-mbstring php56u-mcrypt php56u-ldap"
-
-		for p in $PACKAGES;do
-			if isinstalled "$p"; then
-				echo " ## $p already installed"
-			else
-				echo -n " ## installing $p ... "
-				log "yum -y install $p"
-			echo "";
-			fi
-		done;
-
-		echo -e "\n##  Downloading Snipe-IT from github and put it in the web directory.";
-
-		log "git clone https://github.com/snipe/snipe-it $webdir/$name"
-
-		# Make mariaDB start on boot and restart the daemon
-		echo "##  Starting the mariaDB server.";
-		systemctl enable mariadb.service
-		systemctl start mariadb.service
-
-		echo "##  Securing mariaDB server.";
-		echo "";
-		echo "";
-		/usr/bin/mysql_secure_installation
-
-		echo "##  Creating MySQL Database/User."
-		echo "##  Please Input your MySQL/MariaDB root password "
-		mysql -u root -p < "$dbsetup"
-
-		##TODO make sure the apachefile doesnt exist isnt already in there
-
-		#Create the new virtual host in Apache and enable rewrite
-		apachefile="/etc/httpd/conf.d/$name.conf"
-
-		{
-			echo "##  Creating the new virtual host in Apache.";
-			echo ""
-			echo ""
-			echo "LoadModule rewrite_module modules/mod_rewrite.so"
-			echo ""
-			echo "<VirtualHost *:80>"
-			echo "ServerAdmin webmaster@localhost"
-			echo "    <Directory $webdir/$name/public>"
-			echo "        Allow From All"
-			echo "        AllowOverride All"
-			echo "        Options +Indexes"
-			echo "   </Directory>"
-			echo "    DocumentRoot $webdir/$name/public"
-			echo "    ServerName $fqdn"
-			echo "        ErrorLog /var/log/httpd/snipeIT.error.log"
-			echo "        CustomLog /var/log/access.log combined"
-			echo "</VirtualHost>"
-		} >> "$apachefile"
-
-##TODO make sure this isnt already in there
-		echo "##  Setting up hosts file.";
-		echo >> $hosts "127.0.0.1 $hostname $fqdn"
-
-		echo "##  Starting the apache server.";
-		# Make apache start on boot and restart the daemon
-		systemctl enable httpd.service
-		systemctl restart httpd.service
-
-		tzone=$(timedatectl | gawk -F'[: ]' ' $9 ~ /zone/ {print $11}');
-		echo "## Configuring .env file."
-
-		cat > $webdir/$name/.env <<-EOF
-		#Created By Snipe-it Installer
-		APP_TIMEZONE=$tzone
-		DB_HOST=localhost
-		DB_DATABASE=snipeit
-		DB_USERNAME=snipeit
-		DB_PASSWORD=$mysqluserpw
-		APP_URL=http://$fqdn
-		APP_KEY=$random32
-		DB_DUMP_PATH='/usr/bin'
-		EOF
-
-		# Change permissions on directories
-
-
-		#Install / configure composer
-		cd $webdir/$name
-
-		curl -sS https://getcomposer.org/installer | php
-		php composer.phar install --no-dev --prefer-source
-
-		perms
-		chown -R apache:apache $webdir/$name
-		# Make SeLinux happy
-		chcon -R -h -t httpd_sys_script_rw_t $webdir/$name/
-
-          	#Check if SELinux is enforcing
-	       	if [ "$(getenforce)" == "Enforcing" ]; then
-	 	       #Add SELinux and firewall exception/rules.
-		       #Required for ldap integration
-	       	       setsebool -P httpd_can_connect_ldap on
-	 	       #Sets SELinux context type so that scripts running in the web server process are allowed read/write access
-	 	       chcon -R -h -t httpd_sys_script_rw_t $webdir/$name/
- 	       	fi
-
-		systemctl restart httpd.service
-		php artisan key:generate
+        service httpd restart
+        php artisan key:generate
         php artisan passport:install
 
-	else
-		echo "Unable to Handle Centos Version #.  Version Found: " $version
-		return 1
-	fi
+    elif [[ "$version" =~ ^7 ]]; then
+        #####################################  Install for Centos/Redhat 7  ##############################################
+
+        webdir=/var/www/html
+
+        #Allow us to get the mysql engine
+        echo -e "\n##  Adding IUS, epel-release and mariaDB repositories.";
+        log "yum -y install wget epel-release"
+        log "wget -P $tmp/ https://centos7.iuscommunity.org/ius-release.rpm"
+        log "rpm -Uvh $tmp/ius-release*.rpm"
+
+        #Install PHP and other requirements
+        echo "##  Installing PHP and other requirements.";
+        PACKAGES="httpd mariadb-server git unzip php71u php71u-mysqlnd php71u-bcmath php71u-cli php71u-common php71u-embedded php71u-gd php71u-mbstring php71u-mcrypt php71u-ldap php71u-json php71u-simplexml"
+
+        for p in $PACKAGES;do
+            if isinstalled "$p"; then
+                echo " ## $p already installed"
+            else
+                echo -n " ## Installing $p ... "
+                log "yum -y install $p"
+            echo "";
+            fi
+        done;
+
+        echo -e "\n##  Cloning Snipe-IT from github to the web directory.";
+
+        log "git clone https://github.com/snipe/snipe-it $webdir/$name"
+
+        # Make mariaDB start on boot and restart the daemon
+        echo "##  Starting the mariaDB server.";
+        systemctl enable mariadb.service
+        systemctl start mariadb.service
+
+        echo "##  Securing mariaDB server.";
+        echo "";
+        echo "";
+        /usr/bin/mysql_secure_installation
+
+        echo "##  Creating MySQL Database/User."
+        echo "##  Please Input your MySQL/MariaDB root password "
+        mysql -u root -p < "$dbsetup"
+
+        ##TODO make sure the apachefile doesnt exist isnt already in there
+
+        #Create the new virtual host in Apache and enable rewrite
+        apachefile="/etc/httpd/conf.d/$name.conf"
+
+        {
+            echo "##  Creating the new virtual host in Apache.";
+            echo ""
+            echo ""
+            echo "LoadModule rewrite_module modules/mod_rewrite.so"
+            echo ""
+            echo "<VirtualHost *:80>"
+            echo "ServerAdmin webmaster@localhost"
+            echo "    <Directory $webdir/$name/public>"
+            echo "        Allow From All"
+            echo "        AllowOverride All"
+            echo "        Options +Indexes"
+            echo "   </Directory>"
+            echo "    DocumentRoot $webdir/$name/public"
+            echo "    ServerName $fqdn"
+            echo "        ErrorLog /var/log/httpd/snipeIT.error.log"
+            echo "        CustomLog /var/log/access.log combined"
+            echo "</VirtualHost>"
+        } >> "$apachefile"
+
+        ##TODO make sure this isnt already in there
+        echo "##  Setting up hosts file.";
+        echo >> $hosts "127.0.0.1 $hostname $fqdn"
+
+        echo "##  Starting the apache server.";
+        # Make apache start on boot and restart the daemon
+        systemctl enable httpd.service
+        systemctl restart httpd.service
+
+        tzone=$(timedatectl | gawk -F'[: ]' ' $9 ~ /zone/ {print $11}');
+        echo "## Configuring .env file."
+
+        cp $webdir/$name/.env.example $webdir/$name/.env
+
+        sed -i '1 i\#Created By Snipe-it Installer' $webdir/$name/.env
+        sed -i 's,^\(APP_TIMEZONE=\).*,\1'$tzone',' $webdir/$name/.env
+        sed -i 's,^\(DB_HOST=\).*,\1'localhost',' $webdir/$name/.env
+        sed -i 's,^\(DB_DATABASE=\).*,\1'snipeit',' $webdir/$name/.env
+        sed -i 's,^\(DB_USERNAME=\).*,\1'snipeit',' $webdir/$name/.env
+        sed -i 's,^\(DB_PASSWORD=\).*,\1'$mysqluserpw',' $webdir/$name/.env
+        sed -i 's,^\(APP_URL=\).*,\1'http://$fqdn',' $webdir/$name/.env
+        sed -i 's,^\(APP_KEY=\).*,\1'$$random32',' $webdir/$name/.env
+
+        #Install / configure composer
+        cd $webdir/$name
+
+        curl -sS https://getcomposer.org/installer | php
+        php composer.phar install --no-dev --prefer-source
+
+        #Set permissions
+        perms
+        chown -R apache:apache $webdir/$name
+
+        #Check if SELinux is enforcing
+        if [ "$(getenforce)" == "Enforcing" ]; then
+            #Add SELinux and firewall exception/rules
+            #Required for ldap integration
+            setsebool -P httpd_can_connect_ldap on
+            #Sets SELinux context type so that scripts running in the web server process are allowed read/write access
+            chcon -R -h -t httpd_sys_script_rw_t $webdir/$name/
+        fi
+
+        systemctl restart httpd.service
+
+        echo "##  Generating the application key."
+        php artisan key:generate --force
+
+        echo "##  Artisan Migrate."
+        php artisan migrate --force
+
+        echo "##  Creating scheduler cron."
+        (crontab -l ; echo "* * * * * /usr/bin/php $webdir/$name/artisan schedule:run >> /dev/null 2>&1") | crontab -
+    
+    else
+        echo "Unable to Handle Centos Version #.  Version Found: " $version
+        return 1
+    fi
 esac
 
 echo ""
-echo "  ***If you want mail capabilities, edit $webdir/$name/.env and edit based on .env.example***"
+echo "  ***If you want mail capabilities, edit $webdir/$name/.env***"
 echo ""
 echo "  ***Open http://$fqdn to login to Snipe-IT.***"
 echo ""

--- a/snipeit.sh
+++ b/snipeit.sh
@@ -307,7 +307,7 @@ case $distro in
         webdir=/var/www/html
         #Allow us to get the mysql engine
         echo ""
-        echo "##  Adding IUS, epel-release and mariaDB repos.";
+        echo "##  Adding IUS, epel-release and mariaDB repositories.";
         mariadbRepo=/etc/yum.repos.d/MariaDB.repo
         touch "$mariadbRepo"
         {
@@ -323,9 +323,9 @@ case $distro in
         log "wget -P "$tmp/" https://centos6.iuscommunity.org/ius-release.rpm"
         log "rpm -Uvh "$tmp/ius-release*.rpm""
 
-        #Install PHP and other needed stuff.
-        echo "##  Installing PHP and other needed stuff";
-        PACKAGES="httpd MariaDB-server git unzip php56u php56u-mysqlnd php56u-bcmath php56u-cli php56u-common php56u-embedded php56u-gd php56u-mbstring php56u-mcrypt php56u-ldap"
+        #Install PHP and other needed stuff
+        echo "##  Installing PHP and other requirements.";
+        PACKAGES="httpd mariadb-server git unzip php71u php71u-mysqlnd php71u-bcmath php71u-cli php71u-common php71u-embedded php71u-gd php71u-mbstring php71u-mcrypt php71u-ldap php71u-json php71u-simplexml"
 
         for p in $PACKAGES;do
             if isinstalled "$p"; then
@@ -337,11 +337,9 @@ case $distro in
             fi
         done;
 
-        echo -e "\n##  Downloading Snipe-IT from github and putting it in the web directory.";
+        echo -e "\n##  Cloning Snipe-IT from github to the web directory.";
 
-        log "wget -P $tmp/ https://github.com/snipe/snipe-it/archive/$file"
-        unzip -qo $tmp/$file -d $tmp/
-        cp -R $tmp/$fileName $webdir/$name
+        log "git clone https://github.com/snipe/snipe-it $webdir/$name"
 
         # Make mariaDB start on boot and restart the daemon
         echo "##  Starting the mariaDB server.";
@@ -417,8 +415,12 @@ case $distro in
         fi
 
         service httpd restart
-        php artisan key:generate
-        php artisan passport:install
+        
+        echo "##  Generating the application key."
+        php artisan key:generate --force
+
+        echo "##  Artisan Migrate."
+        php artisan migrate --force
 
     elif [[ "$version" =~ ^7 ]]; then
         #####################################  Install for Centos/Redhat 7  ##############################################


### PR DESCRIPTION
Hopefully this pr is better.

Fixed various installer issues. V4 was unable to install on centOS 7 and 6.

Global
*Consistent indentation of spaces instead of mixed spaces and tabs.
*Switched to copying .env.example and setting values using sed.

CentOS 7 specific
*Switched centOS 7 installs to PHP7.1. doctrine/inflector v1.2.0 requires php ^7.0
*Added php71u-json required by composer.
*Added php71u-simplexml required by aws-sdk-php.
*Created cron for laravel scheduler.
*Run key:generate before migrations.
*Run migrations during install.
*Remove passport:install. Web setup handles this.

CentOS 6 specific
*Switched centOS 6 installs to PHP7.1. doctrine/inflector v1.2.0 requires php ^7.0
*Added php71u-json required by composer.
*Added php71u-simplexml required by aws-sdk-php.
*Switched to using git clone from wget for getting the application.
*Run key:generate before migrations.
*Run migrations during install.
*Remove passport:install. Web setup handles this.

More pr's to come. Will be testing and fixing installs for other distros.

View the Concise diff because of the indentation changes [here](https://github.com/snipe/snipe-it/pull/4096/files?w=1)