### PR TITLE
Fix License Import.

### DIFF
--- a/app/Importer/LicenseImporter.php
+++ b/app/Importer/LicenseImporter.php
@@ -33,10 +33,12 @@ class LicenseImporter extends ItemImporter
     public function createLicenseIfNotExists(array $row)
     {
         $editingLicense = false;
-        $license = License::where('name', $this->item['name'])->first();
+        $license = License::where('name', $this->item['name'])
+                    ->where('serial', $this->item['serial'])
+                    ->first();
         if ($license) {
             if (!$this->updating) {
-                $this->log('A matching License ' . $this->item['name'] . ' already exists');
+                $this->log('A matching License ' . $this->item['name'] . 'with serial ' . $this->item['serial'] . ' already exists');
                 return;
             }
 


### PR DESCRIPTION
The license name is not unique, so keying by license alone was causing issues.  Match using name + serial instead.

Fix #4120