### PR TITLE
LDAP sync improvements and DB query fix.

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -33,6 +33,7 @@ use URL;
 use View;
 use Illuminate\Http\Request;
 use Gate;
+use Artisan;
 
 /**
  * This controller handles all actions related to Users for
@@ -1029,128 +1030,20 @@ class UsersController extends Controller
      */
     public function postLDAP(Request $request)
     {
-        $this->authorize('update', User::class);
-        ini_set('max_execution_time', 600); //600 seconds = 10 minutes
-        ini_set('memory_limit', '500M');
+        // Call Artisan LDAP import command.
+        $location_id = $request->input('location_id');
+        Artisan::call('snipeit:ldap-sync', ['--location_id' => $location_id, '--json_summary' => true]);
 
-        $ldap_result_username = Setting::getSettings()->ldap_username_field;
-        $ldap_result_last_name = Setting::getSettings()->ldap_lname_field;
-        $ldap_result_first_name = Setting::getSettings()->ldap_fname_field;
+        // Collect and parse JSON summary.
+        $ldap_results_json = Artisan::output();
+        $ldap_results = json_decode($ldap_results_json, true);
 
-        $ldap_result_active_flag = Setting::getSettings()->ldap_active_flag_field;
-        $ldap_result_emp_num = Setting::getSettings()->ldap_emp_num;
-        $ldap_result_email = Setting::getSettings()->ldap_email;
-
-        try {
-            $ldapconn = Ldap::connectToLdap();
-        } catch (\Exception $e) {
-            return redirect()->back()->withInput()->with('error', $e->getMessage());
+        // Direct user to appropriate status page.
+        if ($ldap_results['error']) {
+            return redirect()->back()->withInput()->with('error', $ldap_results['error_message']);
+        } else {
+            return redirect()->route('ldap/user')->with('success', "LDAP Import successful.")->with('summary', $ldap_results['summary']);
         }
-
-        try {
-            Ldap::bindAdminToLdap($ldapconn);
-        } catch (\Exception $e) {
-            return redirect()->back()->withInput()->with('error', $e->getMessage());
-        }
-
-        $summary = array();
-
-        $ldap_ou_locations = Location::whereNotNull('ldap_ou')->get();
-
-        $results = Ldap::findLdapUsers();
-
-        // Inject location information fields
-        for ($i = 0; $i < $results["count"]; $i++) {
-            $results[$i]["ldap_location_override"] = false;
-            $results[$i]["location_id"] = 0;
-        }
-
-        // Grab subsets based on location-specific DNs, and overwrite location for these users.
-        foreach ($ldap_ou_locations as $ldap_loc) {
-            $location_users = Ldap::findLdapUsers($ldap_loc->ldap_ou);
-            $usernames = array();
-            for ($i = 0; $i < $location_users["count"]; $i++) {
-                $location_users[$i]["ldap_location_override"] = true;
-                $location_users[$i]["location_id"] = $ldap_loc->id;
-                $usernames[] = $location_users[$i][$ldap_result_username][0];
-            }
-
-            // Delete located users from the general group.
-            foreach ($results as $key => $generic_entry) {
-                if (in_array($generic_entry[$ldap_result_username][0], $location_users)) {
-                    unset($results[$key]);
-                }
-            }
-
-            $global_count = $results['count'];
-            $results = array_merge($location_users, $results);
-            $results['count'] = $global_count;
-        }
-
-        $tmp_pass = substr(str_shuffle("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"), 0, 20);
-        $pass = bcrypt($tmp_pass);
-
-        for ($i = 0; $i < $results["count"]; $i++) {
-            if (empty($ldap_result_active_flag) || $results[$i][$ldap_result_active_flag][0] == "TRUE") {
-
-                $item = array();
-                $item["username"] = isset($results[$i][$ldap_result_username][0]) ? $results[$i][$ldap_result_username][0] : "";
-                $item["employee_number"] = isset($results[$i][$ldap_result_emp_num][0]) ? $results[$i][$ldap_result_emp_num][0] : "";
-                $item["lastname"] = isset($results[$i][$ldap_result_last_name][0]) ? $results[$i][$ldap_result_last_name][0] : "";
-                $item["firstname"] = isset($results[$i][$ldap_result_first_name][0]) ? $results[$i][$ldap_result_first_name][0] : "";
-                $item["email"] = isset($results[$i][$ldap_result_email][0]) ? $results[$i][$ldap_result_email][0] : "" ;
-                $item["ldap_location_override"] = isset($results[$i]["ldap_location_override"]) ? $results[$i]["ldap_location_override"]:"";
-                $item["location_id"] = isset($results[$i]["location_id"]) ? $results[$i]["location_id"]:"";
-
-                if( array_key_exists('useraccountcontrol', $results[$i]) ) {
-                $enabled_accounts = [
-                        '512', '544', '66048', '66080', '262656', '262688', '328192', '328224'
-                    ];
-                    $item['activated'] = ( in_array($results[$i]['useraccountcontrol'][0], $enabled_accounts) ) ? 1 : 0;
-                } else {
-                    $item['activated'] = 0;
-                }
-
-                // User exists
-                $item["createorupdate"] = 'updated';
-                if (!$user = User::where('username', $item["username"])->first()) {
-                    $user = new User;
-                    $user->password = $pass;
-                    $item["createorupdate"] = 'created';
-                }
-
-                 // Create the user if they don't exist.
-                $user->first_name = $item["firstname"];
-                $user->last_name = $item["lastname"];
-                $user->username = $item["username"];
-                $user->email = $item["email"];
-                $user->employee_num = e($item["employee_number"]);
-                $user->activated = $item['activated'];
-                
-                if ($item['ldap_location_override'] == true) {
-                    $user->location_id = $item['location_id'];
-                } else if ($request->input('location_id')!='') {
-                    $user->location_id = e($request->input('location_id'));
-                }
-                $user->notes = 'Imported from LDAP';
-                $user->ldap_import = 1;
-
-                $errors = '';
-
-                if ($user->save()) {
-                    $item["note"] = $item["createorupdate"];
-                    $item["status"]='success';
-                } else {
-                    foreach ($user->getErrors()->getMessages() as $key => $err) {
-                        $errors .='<li>'.$err[0];
-                    }
-                    $item["note"] = $errors;
-                    $item["status"]='error';
-                }
-                array_push($summary, $item);
-            }
-        }
-        return redirect()->route('ldap/user')->with('success', "LDAP Import successful.")->with('summary', $summary);
     }
     
 

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -83,6 +83,11 @@ class Location extends SnipeModel
         // return $this->hasMany('\App\Models\Asset', 'assigned_to')->withTrashed();
     }
 
+    public function setLdapOuAttribute($ldap_ou)
+    {
+        return $this->attributes['ldap_ou'] = empty($ldap_ou) ? null : $ldap_ou;
+    }
+
     public static function getLocationHierarchy($locations, $parent_id = null)
     {
 

--- a/resources/views/locations/edit.blade.php
+++ b/resources/views/locations/edit.blade.php
@@ -47,11 +47,11 @@
 
 <!-- LDAP Search OU -->
 @if ($snipeSettings->ldap_enabled == 1)
-    <div class="form-group {{ $errors->has('currency') ? ' has-error' : '' }}">
+    <div class="form-group {{ $errors->has('ldap_ou') ? ' has-error' : '' }}">
         <label for="ldap_ou" class="col-md-3 control-label">
             {{ trans('admin/locations/table.ldap_ou') }}
         </label>
-        <div class="col-md-7{{  (\App\Helpers\Helper::checkIfRequired($item, 'currency')) ? ' required' : '' }}">
+        <div class="col-md-7{{  (\App\Helpers\Helper::checkIfRequired($item, 'ldap_ou')) ? ' required' : '' }}">
             {{ Form::text('ldap_ou', Input::old('ldap_ou', $item->ldap_ou), array('class' => 'form-control')) }}
             {!! $errors->first('ldap_ou', '<span class="alert-msg">:message</span>') !!}
         </div>


### PR DESCRIPTION
Brought CLI LDAP sync and web LDAP sync in line wrt functionality:

* `UsersController.php` included support for enabling/disabling users based on UAC value in AD, but `LdapSync.php` did not.
* LdapSync.php had a bug fix for use of `$location_users` in place of `$usernames`, but `UsersController.php` did not.

Also fixed the DB query used to get locations with an OU set. The previous query, `whereNotNull('location_ou')` only worked when the location had never had an OU set before. For a location that had an OU set and then removed (by clearing the field), the database stored `''` instead of `NULL`. These locations were erroneously picked up during LDAP user sync, and caused a failure when the invalid (empty-string) OU was used.