### PR TITLE
Small UI Tweaks to Accessories

### DIFF
--- a/resources/views/accessories/checkin.blade.php
+++ b/resources/views/accessories/checkin.blade.php
@@ -56,19 +56,10 @@
                                             {!! $errors->first('note', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
                                         </div>
                                     </div>
-                                    <!-- Form actions -->
-                                        <div class="form-group">
-                                            <label class="col-md-2 control-label"></label>
-                                            <div class="col-md-7">
-                                                <a class="btn btn-link" href="{{ URL::previous() }}">{{ trans('button.cancel') }}</a>
-                                                <button type="submit" class="btn btn-success"><i class="fa fa-check icon-white"></i>{{ trans('general.checkin') }}</button>
-                                            </div>
-                                        </div>
-
-                        </form>
-                    </div>
-                        <div class="box-footer text-right">
-                            <button type="submit" class="btn btn-success"><i class="fa fa-check icon-white"></i> {{ trans('general.save') }}</button>
+                              </div>
+                        <div class="box-footer">
+                            <a class="btn btn-link" href="{{ URL::previous() }}">{{ trans('button.cancel') }}</a>
+                            <button type="submit" class="btn btn-success pull-right"><i class="fa fa-check icon-white"></i>{{ trans('general.checkin') }}</button>
                         </div>
                 </div> <!-- .box.box-default -->
             </form>

--- a/resources/views/accessories/checkout.blade.php
+++ b/resources/views/accessories/checkout.blade.php
@@ -79,8 +79,9 @@
           @endif
 
        </div>
-       <div class="box-footer text-right">
-         <button type="submit" class="btn btn-success"><i class="fa fa-check icon-white"></i> {{ trans('general.save') }}</button>
+       <div class="box-footer">
+          <a class="btn btn-link" href="{{ URL::previous() }}">{{ trans('button.cancel') }}</a>
+          <button type="submit" class="btn btn-success pull-right"><i class="fa fa-check icon-white"></i> {{ trans('general.checkout') }}</button>
        </div>
     </div> <!-- .box.box-default -->
   </form>


### PR DESCRIPTION
- Fix #4145 - Change save button on the checkout page for accessories
- Fix #4144 - Remove extra save button on the checkin page for accessories
- Move buttons to box-footer
- Add cancel button to checkout page