### PR TITLE
Fix LDAP location sync issue in #3993

### DIFF
--- a/app/Http/Controllers/LocationsController.php
+++ b/app/Http/Controllers/LocationsController.php
@@ -89,6 +89,7 @@ class LocationsController extends Controller
         $location->state            = Input::get('state');
         $location->country          = Input::get('country');
         $location->zip              = Input::get('zip');
+        $location->ldap_ou          = Input::get('ldap_ou');
         $location->manager_id       = Input::get('manager_id');
         $location->user_id          = Auth::id();
 


### PR DESCRIPTION
Added a basic sorting stage to the LDAP OU location array during user import, to ensure that locations with large scopes cannot cannibalise the result sets of other locations with sub-scopes. See explanation on #3993.

Also, in `11aa9b2`: fixed a small bug where the LDAP Search OU isn't saved if entered during the creation of a Location (it's currently only saved if submitted through the "Edit" view).