### PR TITLE
Sudo isnt available on every distro.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,4 +10,4 @@ fi
 
 wget https://raw.githubusercontent.com/snipe/snipe-it/master/snipeit.sh
 chmod 744 snipeit.sh
-sudo ./snipeit.sh 2>&1 | sudo tee -a /var/log/snipeit-install.log
+./snipeit.sh 2>&1 | tee -a /var/log/snipeit-install.log


### PR DESCRIPTION
Not needed since we check if we are running as root at the start. Sudo isn't installed on Debian when root has a password.