### PR TITLE
[UNTESTED] Fix to Asset Search when Companyable is involved.

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -83,7 +83,7 @@ class AssetsController extends Controller
             $allowed_columns[]=$field->db_column_name();
         }
 
-        $assets = Company::scopeCompanyables(Asset::select('assets.*'))->with(
+        $assets = Company::scopeCompanyables(Asset::select('assets.*'),"assets.company_id")->with(
             'assetloc', 'assetstatus', 'defaultLoc', 'assetlog', 'company',
             'model.category', 'model.manufacturer', 'model.fieldset','supplier');
         // If we should search on everything


### PR DESCRIPTION
Originally I was looking at extending scopeCompanyables with the appropriate table name each time - so every time you do a 'companyable' list of any table 'x', you would always constrain the search by x.company_id.

But that would end up hitting all kinds of different things, all throughout the code-base, and I would be worried that it would break something somewhere else.

Furthermore, it looks like the `Company::scopeCompanyables()` function doesn't even run in the original Model's context, so it probably wouldn't have worked.

So, instead, this change only affects that one Assets search. We simply pass in an optional parameter to scope-down the search based on company_id to specifically `assets.company.id`. This should hopefully help with some of those failed queries.