### PR TITLE
Update account history query

### DIFF
--- a/resources/views/account/view-assets.blade.php
+++ b/resources/views/account/view-assets.blade.php
@@ -230,7 +230,7 @@ View Assets for  {{ $user->present()->fullName() }}
                   id="table"
                   data-cookie="false"
                   data-cookie-id-table="userHistoryTable-{{ config('version.hash_version') }}"
-                  data-url="{{route('api.activity.index', ['user_id' => $user->id, 'order' => 'desc']) }}">
+                  data-url="{{route('api.activity.index', ['target_id' => $user->id, 'target_type' => 'User', 'order' => 'desc']) }}">
             <thead>
             <tr>
               <th data-field="icon" style="width: 40px;" class="hidden-xs" data-formatter="iconFormatter"></th>


### PR DESCRIPTION
This will limit the action_log records displayed when a user is viewing
their own assets and history since both target_type and target_id must
be set for a where condition to be added to the history query.

Fixes #4180