### PR TITLE
FIXED RecryptFromMycrypt not working really

### DIFF
--- a/app/Console/Commands/RecryptFromMcrypt.php
+++ b/app/Console/Commands/RecryptFromMcrypt.php
@@ -92,8 +92,6 @@ class RecryptFromMcrypt extends Command
                 $this->info('WARNING: Could not backup app keys');
             }
 
-            $this->error($legacy_key);
-
             if($legacy_cipher){
                 $mcrypter = new McryptEncrypter($legacy_key,$legacy_cipher);
             }else{

--- a/app/Console/Commands/RecryptFromMcrypt.php
+++ b/app/Console/Commands/RecryptFromMcrypt.php
@@ -131,12 +131,12 @@ class RecryptFromMcrypt extends Command
                         try {
                             $decrypted_field = $mcrypter->decrypt($asset->{$columnName});
                             $asset->{$columnName} = \Crypt::encrypt($decrypted_field);
+                            $asset->save();
                         } catch (\Exception $e) {
                             $errors[] = ' - ERROR: Could not decrypt field ['.$encrypted_field->name.']: '.$e->getMessage();
                         }
                     }
                 }
-                $asset->save();
                 $bar->advance();
             }
 


### PR DESCRIPTION
tried to upgrade from v3.6 with a base64 key and different rijndael-256 cipher and ran into a bunch of errors. Starting from using an object instead of proiperty name etc.

Anyway. this solution worked for me.

probably would need to detect somehow if the cipher has changed during upgrade and prompt/suggest to enter that in the .env somehow?