### PR TITLE
ref #4042 scale barcode with label size

### DIFF
--- a/app/Http/Controllers/AssetsController.php
+++ b/app/Http/Controllers/AssetsController.php
@@ -675,8 +675,11 @@ class AssetsController extends Controller
                 $header = ['Content-type' => 'image/png'];
                 return response()->file($barcode_file, $header);
             } else {
+                // Calculate barcode width in pixel based on label width (inch)
+                $barcode_width = ($settings->labels_width - $settings->labels_display_sgutter) * 96.000000000001;
+
                 $barcode = new \Com\Tecnick\Barcode\Barcode();
-                $barcode_obj = $barcode->getBarcodeObj($settings->alt_barcode,$asset->asset_tag,300,50);
+                $barcode_obj = $barcode->getBarcodeObj($settings->alt_barcode,$asset->asset_tag,($barcode_width < 300 ? $barcode_width : 300),50);
 
                 file_put_contents($barcode_file, $barcode_obj->getPngData());
                 return response($barcode_obj->getPngData())->header('Content-type', 'image/png');


### PR DESCRIPTION
If the label width is smaller 300px the barcode is not readable. 

I made a fix and scale the barcode along with the label. Maximum is still 300px.