### PR TITLE
Add 'where' clause to hasManyThrough relationship.

### DIFF
--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -54,7 +54,7 @@ class Location extends SnipeModel
 
     public function assets()
     {
-        return $this->hasManyThrough('\App\Models\Asset', '\App\Models\User', 'location_id', 'assigned_to', 'id');
+        return $this->hasManyThrough('\App\Models\Asset', '\App\Models\User', 'location_id', 'assigned_to', 'id')->where("assets.assigned_type",User::class);
     }
 
     public function locationAssets()


### PR DESCRIPTION
Follows the Taylor™-approved method of putting a polymorphic type constraint on a relationship as per: https://github.com/laravel/framework/pull/12538#issuecomment-191784596

I was seeing live queries where the location was being joined through user's `assigned_to` without the `assigned_type` constraint. An example would be:

Location ID: 17
has users: 50,60,70
listing `->assets` would end up doing this:

grabbing users with a location of 17 (which is correct), and listing their assets. But, it would also join in grabbing assets for *locations* 50,60,70, as well as grabbing assets that were assigned to other assets with id's of 50,60,70...

Based on that explanation, I should be able to create some test data in Tinker and then show the results before and after. Stay tuned.