### PR TITLE
Need to prefix status_id with `assets.` for uniqueness

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -98,7 +98,7 @@ class AssetsController extends Controller
 
         // These are used by the API to query against specific ID numbers
         if ($request->has('status_id')) {
-            $assets->where('status_id', '=', $request->input('status_id'));
+            $assets->where('assets.status_id', '=', $request->input('status_id'));
         }
 
         if ($request->has('model_id')) {


### PR DESCRIPTION
Fixes `PDOException: SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'status_id' in where clause is ambiguous`