### PR TITLE
Change "DB_HOST" in the .env file from "localhost" to "127.0.0.1"

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@ APP_LOCALE=en
 # REQUIRED: DATABASE SETTINGS
 # --------------------------------------------
 DB_CONNECTION=mysql
-DB_HOST=localhost
+DB_HOST=127.0.0.1
 DB_DATABASE=null
 DB_USERNAME=null
 DB_PASSWORD=null


### PR DESCRIPTION
I set up the  default Snipe-IT install as per the online instructions, but I got stuck when I ran into the 'Whoops' page.  In my case, the following solved the issue and might be meaningful for others.  

The Laravel 5 framework  has issues with the default address "localhost".  The fix for me was to:
Change "DB_HOST" in the .env file from "localhost" to "127.0.0.1"

The issue is that "localhost" uses a UNIX socket and can not find the database in the standard directory. However "127.0.0.1" uses TCP (Transmission Control Protocol), which essentially means it runs through the "local internet" on your computer being much more reliable than the UNIX socket in this case.

Solution found and documented here:
https://stackoverflow.com/questions/20723803/pdoexception-sqlstatehy000-2002-no-such-file-or-directory