### PR TITLE
Add missing policies

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,8 +4,10 @@ namespace App\Models;
 use App\Presenters\Presentable;
 use Illuminate\Auth\Authenticatable;
 use Illuminate\Auth\Passwords\CanResetPassword;
+use Illuminate\Foundation\Auth\Access\Authorizable;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
+use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
 use Watson\Validating\ValidatingTrait;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use App\Http\Traits\UniqueUndeletedTrait;
@@ -16,7 +18,7 @@ class User extends SnipeModel implements AuthenticatableContract, CanResetPasswo
 {
     protected $presenter = 'App\Presenters\UserPresenter';
     use SoftDeletes, ValidatingTrait;
-    use Authenticatable, CanResetPassword, HasApiTokens;
+    use Authenticatable, Authorizable, CanResetPassword, HasApiTokens;
     use UniqueUndeletedTrait;
     use Notifiable;
     use Presentable;

--- a/app/Policies/AccessoryPolicy.php
+++ b/app/Policies/AccessoryPolicy.php
@@ -2,118 +2,12 @@
 
 namespace App\Policies;
 
-use App\Models\Accessory;
-use App\Models\Company;
-use App\Models\User;
-use Illuminate\Auth\Access\HandlesAuthorization;
+use App\Policies\CheckoutablePermissionsPolicy;
 
-class AccessoryPolicy
+class AccessoryPolicy extends CheckoutablePermissionsPolicy
 {
-    use HandlesAuthorization;
-
-    public function before(User $user, $ability, $accessory)
+    protected function columnName()
     {
-        // Lets move all company related checks here.
-        if ($accessory instanceof \App\Models\Accessory && !Company::isCurrentUserHasAccess($accessory)) {
-            return false;
-        }
-        // If an admin, they can do all asset related tasks.
-        if ($user->hasAccess('admin')) {
-            return true;
-        }
-    }
-
-    public function index(User $user)
-    {
-        // dd('here');
-        return $user->hasAccess('accessories.view');
-    }
-    /**
-     * Determine whether the user can view the accessory.
-     *
-     * @param  \App\User  $user
-     * @param  \App\Accessory  $accessory
-     * @return mixed
-     */
-    public function view(User $user, Accessory $accessory = null)
-    {
-        //
-        return $user->hasAccess('accessories.view');
-    }
-
-    /**
-     * Determine whether the user can create accessories.
-     *
-     * @param  \App\User  $user
-     * @return mixed
-     */
-    public function create(User $user)
-    {
-        //
-        return $user->hasAccess('accessories.create');
-    }
-
-    /**
-     * Determine whether the user can update the accessory.
-     *
-     * @param  \App\User  $user
-     * @param  \App\Accessory  $accessory
-     * @return mixed
-     */
-    public function update(User $user, Accessory $accessory = null)
-    {
-        //
-        return $user->hasAccess('accessories.edit');
-    }
-
-    /**
-     * Determine whether the user can delete the accessory.
-     *
-     * @param  \App\User  $user
-     * @param  \App\Accessory  $accessory
-     * @return mixed
-     */
-    public function delete(User $user, Accessory $accessory = null)
-    {
-        //
-        return $user->hasAccess('accessories.delete');
-    }
-
-   /**
-     * Determine whether the user can checkout the accessory.
-     *
-     * @param  \App\User  $user
-     * @param  \App\Accessory  $accessory
-     * @return mixed
-     */
-    public function checkout(User $user, Accessory $accessory = null)
-    {
-        return $user->hasAccess('accessories.checkout');
-    }
-
-   /**
-     * Determine whether the user can checkin the accessory.
-     *
-     * @param  \App\User  $user
-     * @param  \App\Accessory  $accessory
-     * @return mixed
-     */
-    public function checkin(User $user, Accessory $accessory = null)
-    {
-        return $user->hasAccess('accessories.checkin');
-    }
-
-     /**
-     * Determine whether the user can manage the accessory.
-     *
-     * @param  \App\User  $user
-     * @param  \App\Accessory  $accessory
-     * @return mixed
-     */
-    public function manage(User $user, Accessory $accessory = null)
-    {
-        return $user->hasAccess('accessories.checkin')
-             || $user->hasAccess('accessories.edit')
-             || $user->hasAccess('accessories.checkout');
+        return 'accessories';
     }
 }

--- a/app/Policies/AssetModelPolicy.php
+++ b/app/Policies/AssetModelPolicy.php
@@ -4,10 +4,10 @@ namespace App\Policies;
 
 use App\Policies\SnipePermissionsPolicy;
 
-class CategoryPolicy extends SnipePermissionsPolicy
+class AssetModelPolicy extends SnipePermissionsPolicy
 {
     protected function columnName()
     {
-        return 'categories';
+        return 'models';
     }
 }

--- a/app/Policies/AssetPolicy.php
+++ b/app/Policies/AssetPolicy.php
@@ -2,79 +2,18 @@
 
 namespace App\Policies;
 
-use App\Models\Asset;
-use App\Models\Company;
 use App\Models\User;
-use Illuminate\Auth\Access\HandlesAuthorization;
+use App\Policies\CheckoutablePermissionsPolicy;
 
-class AssetPolicy
+class AssetPolicy extends CheckoutablePermissionsPolicy
 {
-    use HandlesAuthorization;
-
-    /**
-     * Create a new policy instance.
-     *
-     * @return void
-     */
-    public function __construct()
+    protected function columnName()
     {
-        //
-    }
-
-    public function before(User $user, $ability, $asset)
-    {
-        // Lets move all company related checks here.
-        if ($asset instanceof \App\Models\Asset && !Company::isCurrentUserHasAccess($asset)) {
-            return false;
-        }
-        // If an admin, they can do all asset related tasks.
-        if ($user->hasAccess('admin')) {
-            return true;
-        }
-    }
-    public function index(User $user)
-    {
-        return $user->hasAccess('assets.view');
-    }
-    public function view(User $user, Asset $asset)
-    {
-        return $user->hasAccess('assets.view');
+        return 'assets';
     }
 
     public function viewRequestable(User $user, Asset $asset = null)
     {
         return $user->hasAccess('assets.view.requestable');
-    }
-
-    public function create(User $user)
-    {
-        return $user->hasAccess('assets.create');
-    }
-
-    public function checkout(User $user, Asset $asset = null)
-    {
-        return $user->hasAccess('assets.checkout');
-    }
-
-    public function checkin(User $user, Asset $asset = null)
-    {
-        return $user->hasAccess('assets.checkin');
-    }
-
-    public function delete(User $user, Asset $asset = null)
-    {
-        return $user->hasAccess('assets.delete');
-    }
-    public function manage(User $user, Asset $asset = null)
-    {
-        return $user->hasAccess('assets.checkin')
-                || $user->hasAccess('assets.edit')
-                || $user->hasAccess('assets.delete')
-                || $user->hasAccess('assets.checkout');
-    }
-
-    public function update(User $user, Asset $asset = null)
-    {
-        return $user->hasAccess('assets.edit');
     }
 }

--- a/app/Policies/CheckoutablePermissionsPolicy.php
+++ b/app/Policies/CheckoutablePermissionsPolicy.php
@@ -1,0 +1,44 @@
+<?php
+namespace App\Policies;
+
+
+use App\Models\User;
+use App\Policies\SnipePermissionsPolicy;
+
+abstract class CheckoutablePermissionsPolicy extends SnipePermissionsPolicy
+{
+   /**
+     * Determine whether the user can checkout the accessory.
+     *
+     * @param  \App\User  $user
+     * @return mixed
+     */
+    public function checkout(User $user, $item = null)
+    {
+        return $user->hasAccess($this->columnName().'.checkout');
+    }
+
+   /**
+     * Determine whether the user can checkin the accessory.
+     *
+     * @param  \App\User  $user
+     * @return mixed
+     */
+    public function checkin(User $user, $item = null)
+    {
+        return $user->hasAccess($this->columnName().'.checkin');
+    }
+
+     /**
+     * Determine whether the user can manage the accessory.
+     *
+     * @param  \App\User  $user
+     * @return mixed
+     */
+    public function manage(User $user, $item = null)
+    {
+        return $user->hasAccess($this->columnName().'.checkin')
+             || $user->hasAccess($this->columnName().'.edit')
+             || $user->hasAccess($this->columnName().'.checkout');
+    }
+}

--- a/app/Policies/ComponentPolicy.php
+++ b/app/Policies/ComponentPolicy.php
@@ -2,113 +2,12 @@
 
 namespace App\Policies;
 
-use App\Models\Company;
-use App\Models\Component;
-use App\Models\User;
-use Illuminate\Auth\Access\HandlesAuthorization;
+use App\Policies\CheckoutablePermissionsPolicy;
 
-class ComponentPolicy
+class ComponentPolicy extends CheckoutablePermissionsPolicy
 {
-    use HandlesAuthorization;
-
-
-    public function before(User $user, $ability, $component)
+    protected function columnName()
     {
-        // Lets move all company related checks here.
-        if ($component instanceof \App\Models\Component && !Company::isCurrentUserHasAccess($component)) {
-            return false;
-        }
-        // If an admin, they can do all asset related tasks.
-        if ($user->hasAccess('admin')) {
-            return true;
-        }
-    }
-    /**
-     * Determine whether the user can view the component.
-     *
-     * @param  \App\User  $user
-     * @param  \App\Component  $component
-     * @return mixed
-     */
-    public function view(User $user, Component $component = null)
-    {
-        //
-        return $user->hasAccess('components.view');
-    }
-
-    /**
-     * Determine whether the user can create components.
-     *
-     * @param  \App\User  $user
-     * @return mixed
-     */
-    public function create(User $user)
-    {
-        //
-        return $user->hasAccess('components.create');
-    }
-
-    /**
-     * Determine whether the user can update the component.
-     *
-     * @param  \App\User  $user
-     * @param  \App\Component  $component
-     * @return mixed
-     */
-    public function update(User $user, Component $component = null)
-    {
-        //
-        return $user->hasAccess('components.edit');
-    }
-
-    /**
-     * Determine whether the user can delete the component.
-     *
-     * @param  \App\User  $user
-     * @param  \App\Component  $component
-     * @return mixed
-     */
-    public function delete(User $user, Component $component = null)
-    {
-        //
-        return $user->hasAccess('components.delete');
-    }
-
-   /**
-     * Determine whether the user can checkout the component.
-     *
-     * @param  \App\User  $user
-     * @param  \App\Accessory  $component
-     * @return mixed
-     */
-    public function checkout(User $user, Component $component = null)
-    {
-        return $user->hasAccess('components.checkout');
-    }
-
-   /**
-     * Determine whether the user can checkin the component.
-     *
-     * @param  \App\User  $user
-     * @param  \App\Component  $component
-     * @return mixed
-     */
-    public function checkin(User $user, Component $component = null)
-    {
-        return $user->hasAccess('components.checkin');
-    }
-
-     /**
-     * Determine whether the user can manage the component.
-     *
-     * @param  \App\User  $user
-     * @param  \App\Component  $component
-     * @return mixed
-     */
-    public function manage(User $user, Component $component = null)
-    {
-        return $user->hasAccess('components.checkin')
-             || $user->hasAccess('components.edit')
-             || $user->hasAccess('components.checkout');
+        return 'components';
     }
 }

--- a/app/Policies/ConsumablePolicy.php
+++ b/app/Policies/ConsumablePolicy.php
@@ -2,118 +2,12 @@
 
 namespace App\Policies;
 
-use App\Models\Company;
-use App\Models\Consumable;
-use App\Models\User;
-use Illuminate\Auth\Access\HandlesAuthorization;
+use App\Policies\CheckoutablePermissionsPolicy;
 
-class ConsumablePolicy
+class ConsumablePolicy extends CheckoutablePermissionsPolicy
 {
-    use HandlesAuthorization;
-
-
-    public function before(User $user, $ability, $consumable)
+    protected function columnName()
     {
-        // Lets move all company related checks here.
-        if ($consumable instanceof \App\Models\Consumable && !Company::isCurrentUserHasAccess($consumable)) {
-            return false;
-        }
-        // If an admin, they can do all asset related tasks.
-        if ($user->hasAccess('admin')) {
-            return true;
-        }
-    }
-    /**
-     * Determine whether the user can view the consumable.
-     *
-     * @param  \App\User  $user
-     * @param  \App\Consumable  $consumable
-     * @return mixed
-     */
-    public function view(User $user, Consumable $consumable = null)
-    {
-        //
-        return $user->hasAccess('consumables.view');
-    }
-
-    /**
-     * Determine whether the user can create consumables.
-     *
-     * @param  \App\User  $user
-     * @return mixed
-     */
-    public function create(User $user)
-    {
-        //
-        return $user->hasAccess('consumables.create');
-    }
-
-    /**
-     * Determine whether the user can update the consumable.
-     *
-     * @param  \App\User  $user
-     * @param  \App\Consumable  $consumable
-     * @return mixed
-     */
-    public function update(User $user, Consumable $consumable = null)
-    {
-        //
-        return $user->hasAccess('consumables.edit');
-    }
-
-    /**
-     * Determine whether the user can delete the consumable.
-     *
-     * @param  \App\User  $user
-     * @param  \App\Consumable  $consumable
-     * @return mixed
-     */
-    public function delete(User $user, Consumable $consumable = null)
-    {
-        //
-        return $user->hasAccess('consumables.delete');
-    }
-
-   /**
-     * Determine whether the user can checkout the consumable.
-     *
-     * @param  \App\User  $user
-     * @param  \App\Accessory  $consumable
-     * @return mixed
-     */
-    public function checkout(User $user, Consumable $consumable = null)
-    {
-        return $user->hasAccess('consumables.checkout');
-    }
-
-   /**
-     * Determine whether the user can checkin the consumable.
-     *
-     * @param  \App\User  $user
-     * @param  \App\Consumable  $consumable
-     * @return mixed
-     */
-    public function checkin(User $user, Consumable $consumable = null)
-    {
-        return $user->hasAccess('consumables.checkin');
-    }
-
-    public function index(User $user)
-    {
-        return $user->hasAccess('consumables.view');
-    }
-
-     /**
-     * Determine whether the user can manage the consumable.
-     *
-     * @param  \App\User  $user
-     * @param  \App\Consumable  $consumable
-     * @return mixed
-     */
-    public function manage(User $user, Consumable $consumable = null)
-    {
-        return $user->hasAccess('consumables.checkin')
-             || $user->hasAccess('consumables.edit')
-             || $user->hasAccess('consumables.checkout');
+        return 'consumables';
     }
 }

--- a/app/Policies/CustomFieldPolicy.php
+++ b/app/Policies/CustomFieldPolicy.php
@@ -4,10 +4,10 @@ namespace App\Policies;
 
 use App\Policies\SnipePermissionsPolicy;
 
-class CategoryPolicy extends SnipePermissionsPolicy
+class CustomFieldPolicy extends SnipePermissionsPolicy
 {
     protected function columnName()
     {
-        return 'categories';
+        return 'customfields';
     }
 }

--- a/app/Policies/DepartmentPolicy.php
+++ b/app/Policies/DepartmentPolicy.php
@@ -4,10 +4,10 @@ namespace App\Policies;
 
 use App\Policies\SnipePermissionsPolicy;
 
-class CategoryPolicy extends SnipePermissionsPolicy
+class DepartmentPolicy extends SnipePermissionsPolicy
 {
     protected function columnName()
     {
-        return 'categories';
+        return 'departments';
     }
 }

--- a/app/Policies/LicensePolicy.php
+++ b/app/Policies/LicensePolicy.php
@@ -2,102 +2,17 @@
 
 namespace App\Policies;
 
-use App\Models\Company;
 use App\Models\License;
-use App\Models\LicenseSeat;
 use App\Models\User;
-use Illuminate\Auth\Access\HandlesAuthorization;
+use App\Policies\CheckoutablePermissionsPolicy;
 
-class LicensePolicy
+class LicensePolicy extends CheckoutablePermissionsPolicy
 {
-    use HandlesAuthorization;
-
-
-    public function before(User $user, $ability, $license)
+    protected function columnName()
     {
-        // Lets move all company related checks here.
-        if ($license instanceof \App\Models\License && !Company::isCurrentUserHasAccess($license)) {
-            return false;
-        }
-        // If an admin, they can do all asset related tasks.
-        if ($user->hasAccess('admin')) {
-            return true;
-        }
-    }
-    /**
-     * Determine whether the user can view the license.
-     *
-     * @param  \App\User  $user
-     * @param  \App\License  $license
-     * @return mixed
-     */
-    public function view(User $user, License $license = null)
-    {
-        //
-        return $user->hasAccess('licenses.view');
+        return 'licenses';
     }
 
-    /**
-     * Determine whether the user can create licenses.
-     *
-     * @param  \App\User  $user
-     * @return mixed
-     */
-    public function create(User $user)
-    {
-        //
-        return $user->hasAccess('licenses.create');
-    }
-
-    /**
-     * Determine whether the user can update the license.
-     *
-     * @param  \App\User  $user
-     * @param  \App\License  $license
-     * @return mixed
-     */
-    public function update(User $user, License $license = null)
-    {
-        //
-        return $user->hasAccess('licenses.edit');
-    }
-
-    /**
-     * Determine whether the user can delete the license.
-     *
-     * @param  \App\User  $user
-     * @param  \App\License  $license
-     * @return mixed
-     */
-    public function delete(User $user, License $license = null)
-    {
-        //
-        return $user->hasAccess('licenses.delete');
-    }
-
-   /**
-     * Determine whether the user can checkout the license.
-     *
-     * @param  \App\User  $user
-     * @param  \App\Accessory  $license
-     * @return mixed
-     */
-    public function checkout(User $user, LicenseSeat $license = null)
-    {
-        return $user->hasAccess('licenses.checkout');
-    }
-
-   /**
-     * Determine whether the user can checkin the license.
-     *
-     * @param  \App\User  $user
-     * @param  \App\License  $license
-     * @return mixed
-     */
-    public function checkin(User $user, LicenseSeat $license = null)
-    {
-        return $user->hasAccess('licenses.checkin');
-    }
    /**
      * Determine whether the user can view license keys
      *
@@ -110,18 +25,4 @@ class LicensePolicy
         return $user->hasAccess('licenses.keys');
     }
 
-     /**
-     * Determine whether the user can manage the license.
-     *
-     * @param  \App\User  $user
-     * @param  \App\License  $license
-     * @return mixed
-     */
-    public function manage(User $user, License $license = null)
-    {
-        return $user->hasAccess('licenses.checkin')
-             || $user->hasAccess('licenses.edit')
-             || $user->hasAccess('licenses.delete')
-             || $user->hasAccess('licenses.checkout');
-    }
 }

--- a/app/Policies/LocationPolicy.php
+++ b/app/Policies/LocationPolicy.php
@@ -2,98 +2,12 @@
 
 namespace App\Policies;
 
-use App\Models\Company;
-use App\Models\Location;
-use App\Models\User;
-use Illuminate\Auth\Access\HandlesAuthorization;
+use App\Policies\SnipePermissionsPolicy;
 
-class LocationPolicy
+class LocationPolicy extends SnipePermissionsPolicy
 {
-    use HandlesAuthorization;
-
-
-    public function before(User $user, $location)
+    protected function columnName()
     {
-        // Lets move all company related checks here.
-        if ($location instanceof \App\Models\Location && !Company::isCurrentUserHasAccess($location)) {
-            return false;
-        }
-        // If an admin, they can do all asset related tasks.
-        if ($user->hasAccess('admin')) {
-            return true;
-        }
-    }
-    /**
-     * Determine whether the user can view the location.
-     *
-     * @param  \App\Models\User  $user
-     * @param  \App\Models\Location  $location
-     * @return mixed
-     */
-    public function view(User $user)
-    {
-        return $user->hasAccess('locations.view');
-    }
-
-    /**
-     * Determine whether the user can create locations.
-     *
-     * @param  \App\Models\\User  $user
-     * @return mixed
-     */
-    public function create(User $user)
-    {
-        return $user->hasAccess('locations.create');
-    }
-
-    /**
-     * Determine whether the user can update the location.
-     *
-     * @param  \App\Models\User  $user
-     * @param  \App\Models\Location  $location
-     * @return mixed
-     */
-    public function update(User $user)
-    {
-        //
-        return $user->hasAccess('locations.edit');
-    }
-
-    /**
-     * Determine whether the user can delete the location.
-     *
-     * @param  \App\Models\User  $user
-     * @param  \App\Models\Location  $location
-     * @return mixed
-     */
-    public function delete(User $user)
-    {
-        //
-        return $user->hasAccess('locations.delete');
-    }
-
-    /**
-     * Determine whether the user can view the location index.
-     *
-     * @param  \App\Models\User  $user
-     * @param  \App\Models\Accessory  $location
-     * @return mixed
-     */
-
-    public function index(User $user)
-    {
-        return $user->hasAccess('locations.view');
-    }
-
-    /**
-     * Determine whether the user can manage the location.
-     *
-     * @param  \App\Models\User  $user
-     * @param  \App\Models\Location  $location
-     * @return mixed
-     */
-    public function manage(User $user)
-    {
-        return $user->hasAccess('locations.edit');
+        return 'locations';
     }
 }

--- a/app/Policies/SnipePermissionsPolicy.php
+++ b/app/Policies/SnipePermissionsPolicy.php
@@ -1,0 +1,90 @@
+<?php
+namespace App\Policies;
+
+use App\Models\Company;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+abstract class SnipePermissionsPolicy
+{
+    // This should return the key of the model in the users json permission string.
+    abstract protected function columnName();
+
+        use HandlesAuthorization;
+
+    public function before(User $user, $ability, $item)
+    {
+        // Lets move all company related checks here.
+        if ($item instanceof \App\Models\SnipeModel && !Company::isCurrentUserHasAccess($item)) {
+            return false;
+        }
+        // If an admin, they can do all asset related tasks.
+        if ($user->hasAccess('admin')) {
+            return true;
+        }
+    }
+
+    public function index(User $user)
+    {
+        // dd('here');
+        return $user->hasAccess($this->columnName().'.view');
+    }
+    /**
+     * Determine whether the user can view the accessory.
+     *
+     * @param  \App\User  $user
+     * @return mixed
+     */
+    public function view(User $user, $item = null)
+    {
+        //
+        return $user->hasAccess($this->columnName().'.view');
+    }
+
+    /**
+     * Determine whether the user can create accessories.
+     *
+     * @param  \App\User  $user
+     * @return mixed
+     */
+    public function create(User $user)
+    {
+        //
+        return $user->hasAccess($this->columnName().'.create');
+    }
+
+    /**
+     * Determine whether the user can update the accessory.
+     *
+     * @param  \App\User  $user
+     * @return mixed
+     */
+    public function update(User $user, $item = null)
+    {
+        //
+        return $user->hasAccess($this->columnName().'.edit');
+    }
+
+    /**
+     * Determine whether the user can delete the accessory.
+     *
+     * @param  \App\User  $user
+     * @return mixed
+     */
+    public function delete(User $user, $item = null)
+    {
+        //
+        return $user->hasAccess($this->columnName().'.delete');
+    }
+
+     /**
+     * Determine whether the user can manage the accessory.
+     *
+     * @param  \App\User  $user
+     * @return mixed
+     */
+    public function manage(User $user, $item = null)
+    {
+        return $user->hasAccess($this->columnName().'.edit');
+    }
+}

--- a/app/Policies/StatuslabelPolicy.php
+++ b/app/Policies/StatuslabelPolicy.php
@@ -4,10 +4,10 @@ namespace App\Policies;
 
 use App\Policies\SnipePermissionsPolicy;
 
-class CategoryPolicy extends SnipePermissionsPolicy
+class StatuslabelPolicy extends SnipePermissionsPolicy
 {
     protected function columnName()
     {
-        return 'categories';
+        return 'statuslabels';
     }
 }

--- a/app/Policies/SupplierPolicy.php
+++ b/app/Policies/SupplierPolicy.php
@@ -4,10 +4,10 @@ namespace App\Policies;
 
 use App\Policies\SnipePermissionsPolicy;
 
-class CategoryPolicy extends SnipePermissionsPolicy
+class SupplierPolicy extends SnipePermissionsPolicy
 {
     protected function columnName()
     {
-        return 'categories';
+        return 'suppliers';
     }
 }

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -2,87 +2,12 @@
 
 namespace App\Policies;
 
-use App\Models\Company;
-use App\Models\User;
-use Illuminate\Auth\Access\HandlesAuthorization;
-use Illuminate\Support\Facades\Auth;
+use App\Policies\SnipePermissionsPolicy;
 
-class UserPolicy
+class UserPolicy extends SnipePermissionsPolicy
 {
-    use HandlesAuthorization;
-
-
-    public function before(User $user, $ability, $targetUser)
+    protected function columnName()
     {
-        // Lets move all company related checks here.
-        if ($targetUser instanceof \App\Models\User && !Company::isCurrentUserHasAccess($targetUser)) {
-            return false;
-        }
-        // If an admin, they can do all user related tasks.
-        if ($user->hasAccess('admin')) {
-            return true;
-        }
-    }
-    /**
-     * Determine whether the user can view the targetUser.
-     *
-     * @param  \App\Models\User  $user
-     * @param  \App\Models\Consumable  $targetUser
-     * @return mixed
-     */
-    public function view(User $user, User $targetUser = null)
-    {
-        //
-        return $user->hasAccess('users.view');
-    }
-
-    /**
-     * Determine whether the user can create users.
-     *
-     * @param  \App\Models\User  $user
-     * @return mixed
-     */
-    public function create(User $user)
-    {
-        return $user->hasAccess('users.create');
-    }
-
-    /**
-     * Determine whether the user can update the targetUser.
-     *
-     * @param  \App\Models\User  $user
-     * @param  \App\Models\User  $targetUser
-     * @return mixed
-     */
-    public function update(User $user, User $targetUser = null)
-    {
-        return $user->hasAccess('users.edit');
-    }
-
-    /**
-     * Determine whether the user can delete the targetUser.
-     *
-     * @param  \App\Models\User  $user
-     * @param  \App\Models\User  $targetUser
-     * @return mixed
-     */
-    public function delete(User $user, User $targetUser = null)
-    {
-        if ($targetUser) {
-            //We can't delete ourselves.
-            if ($user->id == $targetUser->id) {
-                return false;
-            }
-
-            if ((!Auth::user()->isSuperUser()) || (config('app.lock_passwords'))) {
-                return false;
-            }
-        }
-        return $user->hasAccess('users.delete');
-    }
-
-    public function index(User $user)
-    {
-        return $user->hasAccess('users.view');
+        return 'users';
     }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -3,22 +3,32 @@
 namespace App\Providers;
 
 use App\Models\Accessory;
-use Carbon\Carbon;
 use App\Models\Asset;
-use App\Models\Location;
-use App\Models\Component;
+use App\Models\AssetModel;
 use App\Models\Category;
+use App\Models\Component;
 use App\Models\Consumable;
+use App\Models\CustomField;
+use App\Models\Department;
 use App\Models\License;
+use App\Models\Location;
+use App\Models\Statuslabel;
+use App\Models\Supplier;
 use App\Models\User;
 use App\Policies\AccessoryPolicy;
+use App\Policies\AssetModelPolicy;
 use App\Policies\AssetPolicy;
+use App\Policies\CategoryPolicy;
 use App\Policies\ComponentPolicy;
 use App\Policies\ConsumablePolicy;
+use App\Policies\CustomFieldPolicy;
+use App\Policies\DepartmentPolicy;
 use App\Policies\LicensePolicy;
 use App\Policies\LocationPolicy;
-use App\Policies\CategoryPolicy;
+use App\Policies\StatuslabelPolicy;
+use App\Policies\SupplierPolicy;
 use App\Policies\UserPolicy;
+use Carbon\Carbon;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Gate;
 use Laravel\Passport\Passport;
@@ -31,14 +41,19 @@ class AuthServiceProvider extends ServiceProvider
      * @var array
      */
     protected $policies = [
-        Asset::class => AssetPolicy::class,
         Accessory::class => AccessoryPolicy::class,
+        Asset::class => AssetPolicy::class,
+        AssetModel::class => AssetModelPolicy::class,
+        Category::class => CategoryPolicy::class,
         Component::class => ComponentPolicy::class,
         Consumable::class => ConsumablePolicy::class,
+        CustomField::class => CustomFieldPolicy::class,
+        Department::class => DepartmentPolicy::class,
         License::class => LicensePolicy::class,
-        User::class => UserPolicy::class,
         Location::class => LocationPolicy::class,
-        Category::class => CategoryPolicy::class,
+        Statuslabel::class => StatuslabelPolicy::class,
+        Supplier::class => SupplierPolicy::class,
+        User::class => UserPolicy::class,
     ];
 
     /**
@@ -54,7 +69,7 @@ class AuthServiceProvider extends ServiceProvider
             \Laravel\Passport\Console\ClientCommand::class,
             \Laravel\Passport\Console\KeysCommand::class,
         ]);
-        
+
 
         $this->registerPolicies();
         Passport::routes();
@@ -100,6 +115,18 @@ class AuthServiceProvider extends ServiceProvider
             if (($user->hasAccess('self.two_factor')) || ($user->hasAccess('admin'))) {
                 return true;
             }
+        });
+
+        Gate::define('backend.interact', function ($user) {
+            return $user->can('view', \App\Models\Statuslabel::class)
+                || $user->can('view', \App\Models\AssetModel::class)
+                || $user->can('view', \App\Models\Category::class)
+                || $user->can('view', \App\Models\Manufacturer::class)
+                || $user->can('view', \App\Models\Supplier::class)
+                || $user->can('view', \App\Models\Department::class)
+                || $user->can('view', \App\Models\Location::class)
+                || $user->can('view', \App\Models\Company::class)
+                || $user->can('view', \App\Models\Depreciation::class);
         });
     }
 }

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -464,7 +464,7 @@
                 </li>
             @endcan
 
-            @can('manage', \App\Models\Setting::class)
+            @can('backend.interact')
                 <li>
                     <a href="#">
                         <i class="fa fa-gear"></i>
@@ -536,7 +536,7 @@
                 </a>
 
                 <ul class="treeview-menu">
-	                 <li><a href="{{ route('reports.activity') }}" {{ (Request::is('reports/activity') ? ' class="active"' : '') }} >@lang('general.activity_report')</a></li>
+                    <li><a href="{{ route('reports.activity') }}" {{ (Request::is('reports/activity') ? ' class="active"' : '') }} >@lang('general.activity_report')</a></li>
 
                     <li><a href="{{ route('reports.audit') }}" {{ (Request::is('reports.audit') ? ' class="active"' : '') }} >@lang('general.audit_report')</a></li>
 


### PR DESCRIPTION
This commit adds policies for the missing backend/"settings" areas.  The
permissions were implemented a while back but the policies did not, so
authorizing actions was failing.

In addition, this condenses a lot of code in the policies into base
classes.  Most of the files were identical except for table names, so we
move all of the checks into a base class and override the table name in
each policy.