### PR TITLE
Add attributes to delete asset file button

### DIFF
--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -683,7 +683,7 @@
                         </td>
                         <td>
                           @can('update', \App\Models\Asset::class)
-                            <a class="btn delete-asset btn-danger btn-sm" href="{{ route('delete/assetfile', [$asset->id, $file->id]) }}"><i class="fa fa-trash icon-white"></i></a>
+                            <a class="btn delete-asset btn-danger btn-sm" href="{{ route('delete/assetfile', [$asset->id, $file->id]) }}" data-tooltip="true" data-title="Delete" data-content="Are you sure you wish to delete {{$file->filename}}"><i class="fa fa-trash icon-white"></i></a>
                           @endcan
                         </td>
                       </tr>


### PR DESCRIPTION
This adds attributes to the delete buttons for uploaded files on the View Asset page. The attributes will fill the confirmation modal that prompts users before deleting. They also activate a tooltip on the button.