### PR TITLE
fix to availCount() (licenseSeatRelation)

### DIFF
--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -268,7 +268,6 @@ class License extends Depreciable
         return $this->licenseSeatsRelation()
             ->whereNull('asset_id')
             ->whereNull('assigned_to')
-            ->whereNull('user_id')
             ->whereNull('deleted_at');
     }
 


### PR DESCRIPTION
`license_seats`.`user_id` represents an overall "owner" of the license; no bearing on seat availability.