### PR TITLE
Add option to display company names to labels

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -748,6 +748,7 @@ class SettingsController extends Controller
         $setting->labels_fontsize = $request->input('labels_fontsize');
         $setting->labels_pagewidth = $request->input('labels_pagewidth');
         $setting->labels_pageheight = $request->input('labels_pageheight');
+        $setting->labels_display_company_name = $request->input('labels_display_company_name', '0');
 
 
 
@@ -767,12 +768,6 @@ class SettingsController extends Controller
             $setting->labels_display_tag = 1;
         } else {
             $setting->labels_display_tag = 0;
-        }
-        
-         if (Input::has('labels_display_company_name')) {
-            $setting->labels_display_company_name = 1;
-        } else {
-            $setting->labels_display_company_name = 0;
         }
 
         if ($setting->save()) {

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -768,6 +768,12 @@ class SettingsController extends Controller
         } else {
             $setting->labels_display_tag = 0;
         }
+        
+         if (Input::has('labels_display_company_name')) {
+            $setting->labels_display_company_name = 1;
+        } else {
+            $setting->labels_display_company_name = 0;
+        }
 
         if ($setting->save()) {
             return redirect()->route('settings.index')

--- a/database/migrations/2017_11_08_123942_labels_display_company_name.php
+++ b/database/migrations/2017_11_08_123942_labels_display_company_name.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class LabelsDisplayCompanyName extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->tinyInteger('labels_display_company_name')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('settings', function ($table) {
+            $table->dropColumn(
+                'labels_display_company_name'
+            );
+        });
+    }
+}

--- a/database/migrations/2017_11_08_123942_labels_display_company_name.php
+++ b/database/migrations/2017_11_08_123942_labels_display_company_name.php
@@ -14,7 +14,7 @@ class LabelsDisplayCompanyName extends Migration
     public function up()
     {
         Schema::table('settings', function (Blueprint $table) {
-            $table->tinyInteger('labels_display_company_name')->default(0);
+            $table->boolean('labels_display_company_name')->default(0);
         });
     }
 

--- a/resources/lang/en/admin/hardware/form.php
+++ b/resources/lang/en/admin/hardware/form.php
@@ -11,6 +11,7 @@ return array(
     'checkout_date'		=> 'Checkout Date',
     'checkin_date'		=> 'Checkin Date',
     'checkout_to'		=> 'Checkout to',
+	'company_name'      => 'Company Name',
     'cost'				=> 'Purchase Cost',
     'create'			=> 'Create Asset',
     'date'				=> 'Purchase Date',

--- a/resources/lang/en/admin/hardware/form.php
+++ b/resources/lang/en/admin/hardware/form.php
@@ -11,7 +11,6 @@ return array(
     'checkout_date'		=> 'Checkout Date',
     'checkin_date'		=> 'Checkin Date',
     'checkout_to'		=> 'Checkout to',
-	'company_name'      => 'Company Name',
     'cost'				=> 'Purchase Cost',
     'create'			=> 'Create Asset',
     'date'				=> 'Purchase Date',

--- a/resources/views/hardware/labels.blade.php
+++ b/resources/views/hardware/labels.blade.php
@@ -112,33 +112,32 @@
       @endif
 
     <div class="qr_text">
-        <div class="pull-left">
         @if ($settings->qr_text!='')
+        <div class="pull-left">
             <strong>{{ $settings->qr_text }}</strong>
             <br>
-        @endif
         </div>
-	<div class="pull-left">
+        @endif
         @if (($settings->labels_display_company_name=='1') && ($asset->company))
+        <div class="pull-left">
         	C: {{ $asset->company->name }}
+        </div>
         @endif
-    	</div>
-        <div class="pull-left">
         @if (($settings->labels_display_name=='1') && ($asset->name!=''))
+        <div class="pull-left">
             N: {{ $asset->name }}
-        @endif
         </div>
-        <div class="pull-left">
+        @endif
         @if (($settings->labels_display_tag=='1') && ($asset->asset_tag!=''))
-            T: {{ $asset->asset_tag }}
-        @endif
-        </div>
         <div class="pull-left">
-        @if (($settings->labels_display_serial=='1') && ($asset->serial!=''))
-            S: {{ $asset->serial }}
+            T: {{ $asset->asset_tag }}
+        </div>
         @endif
-         </div>
-
+        @if (($settings->labels_display_serial=='1') && ($asset->serial!=''))
+        <div class="pull-left">
+            S: {{ $asset->serial }}
+        </div>
+        @endif
     </div>
 
     @if ((($settings->alt_barcode_enabled=='1') && $settings->alt_barcode!=''))

--- a/resources/views/hardware/labels.blade.php
+++ b/resources/views/hardware/labels.blade.php
@@ -118,6 +118,11 @@
             <br>
         @endif
         </div>
+	<div class="pull-left">
+        @if (($settings->labels_display_company_name=='1') && ($asset->company_id!='0') && (!(is_null($asset->company_id))) && (\App\Models\Company::find($asset->company_id)->name!=''))
+        	C: {{ \App\Models\Company::find($asset->company_id)->name }}
+        @endif
+    	</div>
         <div class="pull-left">
         @if (($settings->labels_display_name=='1') && ($asset->name!=''))
             N: {{ $asset->name }}

--- a/resources/views/hardware/labels.blade.php
+++ b/resources/views/hardware/labels.blade.php
@@ -119,8 +119,8 @@
         @endif
         </div>
 	<div class="pull-left">
-        @if (($settings->labels_display_company_name=='1') && ($asset->company_id!='0') && (!(is_null($asset->company_id))) && (\App\Models\Company::find($asset->company_id)->name!=''))
-        	C: {{ \App\Models\Company::find($asset->company_id)->name }}
+        @if (($settings->labels_display_company_name=='1') && ($asset->company))
+        	C: {{ $asset->company->name }}
         @endif
     	</div>
         <div class="pull-left">

--- a/resources/views/settings/labels.blade.php
+++ b/resources/views/settings/labels.blade.php
@@ -179,6 +179,10 @@
                                         {{ Form::checkbox('labels_display_tag', '1', Input::old('labels_display_tag',   $setting->labels_display_tag),array('class' => 'minimal')) }}
                                         {{ trans('admin/hardware/form.tag') }}
                                     </label>
+                                    <label>
+                                        {{ Form::checkbox('labels_display_company_name', '1', Input::old('labels_display_company_name',   $setting->labels_display_company_name),array('class' => 'minimal')) }}
+                                        {{ trans('admin/hardware/form.company_name') }}
+                                    </label>
                                 </div> <!--/.CHECKBOX-->
                             </div> <!--/.col-md-9-->
                         </div> <!--/.form-group-->

--- a/resources/views/settings/labels.blade.php
+++ b/resources/views/settings/labels.blade.php
@@ -45,7 +45,7 @@
                                 {{ Form::label('labels_per_page', trans('admin/settings/general.labels_per_page')) }}
                             </div>
                             <div class="col-md-9">
-                                {{ Form::text('labels_per_page', Input::old('labels_per_page', $setting->labels_per_page), array('class' => 'form-control','style' => 'width: 100px;')) }}
+                                {{ Form::text('labels_per_page', Input::old('labels_per_page', $setting->labels_per_page), ['class' => 'form-control','style' => 'width: 100px;']) }}
                                 {!! $errors->first('labels_per_page', '<span class="alert-msg">:message</span>') !!}
                             </div>
                         </div>
@@ -56,7 +56,7 @@
                             </div>
                             <div class="col-md-2 form-group">
                                 <div class="input-group">
-                                    {{ Form::text('labels_fontsize', Input::old('labels_fontsize', $setting->labels_fontsize), array('class' => 'form-control')) }}
+                                    {{ Form::text('labels_fontsize', Input::old('labels_fontsize', $setting->labels_fontsize), ['class' => 'form-control']) }}
                                     <div class="input-group-addon">{{ trans('admin/settings/general.text_pt') }}</div>
                                 </div>
                             </div>
@@ -71,13 +71,13 @@
                             </div>
                             <div class="col-md-3 form-group">
                                 <div class="input-group">
-                                    {{ Form::text('labels_width', Input::old('labels_width', $setting->labels_width), array('class' => 'form-control')) }}
+                                    {{ Form::text('labels_width', Input::old('labels_width', $setting->labels_width), ['class' => 'form-control']) }}
                                     <div class="input-group-addon">{{ trans('admin/settings/general.width_w') }}</div>
                                 </div>
                             </div>
                             <div class="col-md-3 form-group" style="margin-left: 10px">
                                 <div class="input-group">
-                                    {{ Form::text('labels_height', Input::old('labels_height', $setting->labels_height), array('class' => 'form-control')) }}
+                                    {{ Form::text('labels_height', Input::old('labels_height', $setting->labels_height), ['class' => 'form-control']) }}
                                     <div class="input-group-addon">{{ trans('admin/settings/general.height_h') }}</div>
                                 </div>
                             </div>
@@ -93,13 +93,13 @@
                             </div>
                             <div class="col-md-3 form-group">
                                 <div class="input-group">
-                                    {{ Form::text('labels_display_sgutter', Input::old('labels_display_sgutter', $setting->labels_display_sgutter), array('class' => 'form-control')) }}
+                                    {{ Form::text('labels_display_sgutter', Input::old('labels_display_sgutter', $setting->labels_display_sgutter), ['class' => 'form-control']) }}
                                     <div class="input-group-addon">{{ trans('admin/settings/general.horizontal') }}</div>
                                 </div>
                             </div>
                             <div class="col-md-3 form-group" style="margin-left: 10px">
                                 <div class="input-group">
-                                    {{ Form::text('labels_display_bgutter', Input::old('labels_display_bgutter', $setting->labels_display_bgutter), array('class' => 'form-control')) }}
+                                    {{ Form::text('labels_display_bgutter', Input::old('labels_display_bgutter', $setting->labels_display_bgutter), ['class' => 'form-control']) }}
                                     <div class="input-group-addon">{{ trans('admin/settings/general.vertical') }}</div>
                                 </div>
                             </div>
@@ -115,21 +115,21 @@
                             </div>
                             <div class="col-md-3 form-group">
                                 <div class="input-group" style="margin-bottom: 15px;">
-                                    {{ Form::text('labels_pmargin_top', Input::old('labels_pmargin_top', $setting->labels_pmargin_top), array('class' => 'form-control')) }}
+                                    {{ Form::text('labels_pmargin_top', Input::old('labels_pmargin_top', $setting->labels_pmargin_top), ['class' => 'form-control']) }}
                                     <div class="input-group-addon">{{ trans('admin/settings/general.top') }}</div>
                                 </div>
                                 <div class="input-group">
-                                    {{ Form::text('labels_pmargin_right', Input::old('labels_pmargin_right', $setting->labels_pmargin_right), array('class' => 'form-control')) }}
+                                    {{ Form::text('labels_pmargin_right', Input::old('labels_pmargin_right', $setting->labels_pmargin_right), ['class' => 'form-control']) }}
                                     <div class="input-group-addon">{{ trans('admin/settings/general.right') }}</div>
                                 </div>
                             </div>
                             <div class="col-md-3 form-group" style="margin-left: 10px; ">
                                 <div class="input-group" style="margin-bottom: 15px;">
-                                    {{ Form::text('labels_pmargin_bottom', Input::old('labels_pmargin_bottom', $setting->labels_pmargin_bottom), array('class' => 'form-control')) }}
+                                    {{ Form::text('labels_pmargin_bottom', Input::old('labels_pmargin_bottom', $setting->labels_pmargin_bottom), ['class' => 'form-control']) }}
                                     <div class="input-group-addon">{{ trans('admin/settings/general.bottom') }}</div>
                                 </div>
                                 <div class="input-group">
-                                    {{ Form::text('labels_pmargin_left', Input::old('labels_pmargin_left', $setting->labels_pmargin_left), array('class' => 'form-control')) }}
+                                    {{ Form::text('labels_pmargin_left', Input::old('labels_pmargin_left', $setting->labels_pmargin_left), ['class' => 'form-control']) }}
                                     <div class="input-group-addon">{{ trans('admin/settings/general.left') }}</div>
                                 </div>
                             </div>
@@ -145,13 +145,13 @@
                             </div>
                             <div class="col-md-3 form-group">
                                 <div class="input-group">
-                                    {{ Form::text('labels_pagewidth', Input::old('labels_pagewidth', $setting->labels_pagewidth), array('class' => 'form-control')) }}
+                                    {{ Form::text('labels_pagewidth', Input::old('labels_pagewidth', $setting->labels_pagewidth), ['class' => 'form-control']) }}
                                     <div class="input-group-addon">{{ trans('admin/settings/general.width_w') }}</div>
                                 </div>
                             </div>
                             <div class="col-md-3 form-group" style="margin-left: 10px">
                                 <div class="input-group">
-                                    {{ Form::text('labels_pageheight', Input::old('labels_pageheight', $setting->labels_pageheight), array('class' => 'form-control')) }}
+                                    {{ Form::text('labels_pageheight', Input::old('labels_pageheight', $setting->labels_pageheight), ['class' => 'form-control']) }}
                                     <div class="input-group-addon">{{ trans('admin/settings/general.height_h') }}</div>
                                 </div>
                             </div>
@@ -168,20 +168,20 @@
                             <div class="col-md-9">
                                 <div class="checkbox">
                                     <label>
-                                        {{ Form::checkbox('labels_display_name', '1', Input::old('labels_display_name',   $setting->labels_display_name),array('class' => 'minimal')) }}
+                                        {{ Form::checkbox('labels_display_name', '1', Input::old('labels_display_name',   $setting->labels_display_name),['class' => 'minimal']) }}
                                         {{ trans('admin/hardware/form.name') }}
                                     </label>
                                     <label>
-                                        {{ Form::checkbox('labels_display_serial', '1', Input::old('labels_display_serial',   $setting->labels_display_serial),array('class' => 'minimal')) }}
+                                        {{ Form::checkbox('labels_display_serial', '1', Input::old('labels_display_serial',   $setting->labels_display_serial),['class' => 'minimal']) }}
                                         {{ trans('admin/hardware/form.serial') }}
                                     </label>
                                     <label>
-                                        {{ Form::checkbox('labels_display_tag', '1', Input::old('labels_display_tag',   $setting->labels_display_tag),array('class' => 'minimal')) }}
+                                        {{ Form::checkbox('labels_display_tag', '1', Input::old('labels_display_tag',   $setting->labels_display_tag),['class' => 'minimal']) }}
                                         {{ trans('admin/hardware/form.tag') }}
                                     </label>
                                     <label>
-                                        {{ Form::checkbox('labels_display_company_name', '1', Input::old('labels_display_company_name',   $setting->labels_display_company_name),array('class' => 'minimal')) }}
-                                        {{ trans('admin/hardware/form.company_name') }}
+                                        {{ Form::checkbox('labels_display_company_name', '1', Input::old('labels_display_company_name',   $setting->labels_display_company_name),['class' => 'minimal']) }}
+                                        {{ trans('admin/companies/table.name') }}
                                     </label>
                                 </div> <!--/.CHECKBOX-->
                             </div> <!--/.col-md-9-->


### PR DESCRIPTION
Feature Request #4374 

This PR will add an option in the labels settings page to show the company name on the asset labels when they are generated. The company name will not shown if the asset has the company_id set to NULL or 0 even if the option is enabled.

As always open to feedback and any changes needed.