### PR TITLE
Cleaner re-implementation of loop-detection for asset-assigned-assets

### DIFF
--- a/app/Console/Commands/SyncAssetLocations.php
+++ b/app/Console/Commands/SyncAssetLocations.php
@@ -109,7 +109,7 @@ class SyncAssetLocations extends Command
                     $assigned_asset_asset->unsetEventDispatcher();
                     $assigned_asset_asset->save();
                 } else {
-                    $output['warn'][] ='Asset Assigned asset ' . $assigned_asset_asset->assetLoc()->id. ' ('.$assigned_asset_asset->asset_tag.') does not seem to have a valid location';
+                    $output['warn'][] ='Asset Assigned asset ' . $assigned_asset_asset->id. ' ('.$assigned_asset_asset->asset_tag.') does not seem to have a valid location';
                 }
 
                 $bar->advance();

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -257,22 +257,22 @@ class Asset extends Depreciable
   /**
    * Get the asset's location based on the assigned user
    **/
-    public function assetLoc()
+    public function assetLoc($iterations = 1)
     {
-        static $iterations=0;
         static $first_asset;
         if (!empty($this->assignedType())) {
             if ($this->assignedType() == self::ASSET) {
-                $iterations++;
                 if(!$first_asset) {
                     $first_asset=$this;
                 }
                 if($iterations>10) {
-                    throw new \Exception("Asset assignment Loop for Asset ID: ".$first_asset->id);
+                    $loop_id=$first_asset->id;
+                    $first_asset=null; //reset first_asset for additional use
+                    throw new \Exception("Asset assignment Loop for Asset ID: ".$loop_id);
                 }
                 $assigned_to=Asset::find($this->assigned_to); //have to do this this way because otherwise it errors
                 if ($assigned_to) {
-                    return $assigned_to->assetLoc();
+                    return $assigned_to->assetLoc($iterations + 1);
                 } // Recurse until we have a final location
             }
             if ($this->assignedType() == self::LOCATION) {

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -257,22 +257,19 @@ class Asset extends Depreciable
   /**
    * Get the asset's location based on the assigned user
    **/
-    public function assetLoc($iterations = 1)
+    public function assetLoc($iterations = 1,$first_asset = null)
     {
-        static $first_asset;
         if (!empty($this->assignedType())) {
             if ($this->assignedType() == self::ASSET) {
                 if(!$first_asset) {
                     $first_asset=$this;
                 }
                 if($iterations>10) {
-                    $loop_id=$first_asset->id;
-                    $first_asset=null; //reset first_asset for additional use
-                    throw new \Exception("Asset assignment Loop for Asset ID: ".$loop_id);
+                    throw new \Exception("Asset assignment Loop for Asset ID: ".$first_asset->id);
                 }
                 $assigned_to=Asset::find($this->assigned_to); //have to do this this way because otherwise it errors
                 if ($assigned_to) {
-                    return $assigned_to->assetLoc($iterations + 1);
+                    return $assigned_to->assetLoc($iterations + 1, $first_asset);
                 } // Recurse until we have a final location
             }
             if ($this->assignedType() == self::LOCATION) {


### PR DESCRIPTION
In the Console command, I managed to run into a little bug (I think?) which I think I just fixed.

For `assetLoc()`, I changed the implementation to use a simple optional parameter which is incremented on recursive calls. The other static variable is removed and passed along as an optional parameter as well.

This should fix #4394 

Furthermore, it's a little easier to read. As mentioned in #4394, we could definitely create an array of previously-visited assets, and use that for loop-detection instead - but a maliciously-crafted asset-loop could still end up eating up all memory, and I think that a 10-asset-deep asset-assignment chain is probably a bug anyways.