### PR TITLE
Fix asset->assetLoc() in recursion static iterations not cleared if no further  iteration

### DIFF
--- a/app/Console/Commands/SyncAssetLocations.php
+++ b/app/Console/Commands/SyncAssetLocations.php
@@ -103,13 +103,14 @@ class SyncAssetLocations extends Command
             foreach ($assigned_asset_assets as $assigned_asset_asset) {
 
                 // Check to make sure there aren't any invalid relationships
-                if ($assigned_asset_asset->assetLoc()) {
-                    $assigned_asset_asset->location_id = $assigned_asset_asset->assetLoc()->id;
-                    $output['info'][] ='Setting Asset Assigned asset ' . $assigned_asset_asset->assetLoc()->id. ' ('.$assigned_asset_asset->asset_tag.') location to: ' . $assigned_asset_asset->assetLoc()->id;
+                $assetLoc = $assigned_asset_asset->assetLoc();
+                if ($assetLoc) {
+                    $assigned_asset_asset->location_id = $assetLoc->id;
+                    $output['info'][] ='Setting Asset Assigned asset ' . $assetLoc->id. ' ('.$assigned_asset_asset->asset_tag.') location to: ' . $assetLoc->id;
                     $assigned_asset_asset->unsetEventDispatcher();
                     $assigned_asset_asset->save();
                 } else {
-                    $output['warn'][] ='Asset Assigned asset ' . $assigned_asset_asset->assetLoc()->id. ' ('.$assigned_asset_asset->asset_tag.') does not seem to have a valid location';
+                    $output['warn'][] ='Asset Assigned asset ' . $assetLoc->id. ' ('.$assigned_asset_asset->asset_tag.') does not seem to have a valid location';
                 }
 
                 $bar->advance();

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -277,20 +277,24 @@ class Asset extends Depreciable
             }
             if ($this->assignedType() == self::LOCATION) {
                 if ($this->assignedTo) {
+                    $iterations=0;
                     return $this->assignedTo;
                 }
 
             }
             if ($this->assignedType() == self::USER) {
                 if (($this->assignedTo) && $this->assignedTo->userLoc) {
+                    $iterations=0;
                     return $this->assignedTo->userLoc;
                 }
                 //this makes no sense
+                $iterations=0;
                 return $this->defaultLoc;
 
             }
 
         }
+        $iterations=0;
         return $this->defaultLoc;
     }
 


### PR DESCRIPTION
Ran into asset iteration loop problem while migrating. 

The `static $iterator` was not reset if the method was not going into recursion. 
And while the SyncAssetLocations re-initialized the assetLoc() multiple times, it ended up hitting the loop limit with only 3 linked relations in reality. 