### PR TITLE
Return an error from ldap_search instead of throwing an uncaught Exception

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -67,8 +67,17 @@ class LdapSync extends Command
 
         $summary = array();
 
-        $results = Ldap::findLdapUsers();
-
+	try {    
+            $results = Ldap::findLdapUsers();
+	} catch (\Exception $e) {
+	    if ($this->option('json_summary')) {
+                $json_summary = [ "error" => true, "error_message" => $e->getMessage(), "summary" => [] ];
+                $this->info(json_encode($json_summary));
+            }
+            LOG::error($e);
+            return [];
+        }
+	    
         // Retrieve locations with a mapped OU, and sort them from the shallowest to deepest OU (see #3993)
         $ldap_ou_locations = Location::where('ldap_ou', '!=', '')->get()->toArray();
         $ldap_ou_lengths = array();


### PR DESCRIPTION
This will return the error from the ldap_search called in Models/Ldap.php instead of throwing an exception. Users seem to commonly running into an Exception because of invalid search filters. This will better inform them of that issue without requiring them to enable DEBUG.

This is done when a bind is attempted and the search should be treated the same way.

In the specific case of an invalid search filter a user will see now see this:
![screen shot 2017-12-12 at 12 57 18 pm](https://user-images.githubusercontent.com/422752/33902916-296a092c-df3c-11e7-99cd-ca9118fbf1eb.png)

Instead of:
![screen shot 2017-12-12 at 12 59 23 pm](https://user-images.githubusercontent.com/422752/33902972-50e1ddb8-df3c-11e7-8552-59449a953f2e.png)

