### PR TITLE
snipeit.sh improvements

### DIFF
--- a/snipeit.sh
+++ b/snipeit.sh
@@ -28,62 +28,22 @@ clear
 
 name="snipeit"
 verbose="false"
-hostname="$(hostname)"
 fqdn="$(hostname --fqdn)"
-hosts=/etc/hosts
 
 spin[0]="-"
 spin[1]="\\"
 spin[2]="|"
 spin[3]="/"
 
-# Debian/Ubuntu friendly f(x)s
 progress () {
     echo -n " "
     while kill -0 "$pid" > /dev/null 2>&1; do
         for i in "${spin[@]}"; do
-            echo -ne "\b$i"
+            echo -ne "\\b$i"
             sleep .1
         done
     done
     echo ""
-}
-
-setvhdebian () {
-    find /etc/apache2/mods-enabled -maxdepth 1 -name 'rewrite.load' >/dev/null 2>&1
-    apachefile=/etc/apache2/sites-available/$name.conf
-    {
-        echo "<VirtualHost *:80>"
-        echo "ServerAdmin webmaster@localhost"
-        echo "<Directory $webdir/$name/public>"
-        echo "        Require all granted"
-        echo "        AllowOverride All"
-        echo "   </Directory>"
-        echo "    DocumentRoot $webdir/$name/public"
-        echo "    ServerName $fqdn"
-        echo "        ErrorLog /var/log/apache2/snipeIT.error.log"
-        echo "        CustomLog /var/log/apache2/access.log combined"
-        echo "</VirtualHost>"
-    } >> $apachefile
-    log "a2ensite $name.conf"
-}
-
-setvhcentos () {
-    apachefile=/etc/httpd/conf.d/$name.conf
-    {
-        echo "<VirtualHost *:80>"
-        echo "ServerAdmin webmaster@localhost"
-        echo "    <Directory $webdir/$name/public>"
-        echo "        Allow From All"
-        echo "        AllowOverride All"
-        echo "        Options +Indexes"
-        echo "   </Directory>"
-        echo "    DocumentRoot $webdir/$name/public"
-        echo "    ServerName $fqdn"
-        echo "        ErrorLog /var/log/httpd/snipeIT.error.log"
-        echo "        CustomLog /var/log/access.log combined"
-        echo "</VirtualHost>"
-    } >> "$apachefile"
 }
 
 log () {
@@ -94,20 +54,75 @@ log () {
     fi
 }
 
+installpackages () {
+    case $distro in
+        ubuntu|debian)
+            for p in $PACKAGES; do
+                if dpkg -s "$p" >/dev/null 2>&1; then
+                    echo "  * $p already installed"
+                else
+                    echo "  * Installing $p ... "
+                    log "DEBIAN_FRONTEND=noninteractive apt-get install -y $p"
+                fi
+            done;
+            ;;
+        centos)
+            for p in $PACKAGES; do
+                if yum list installed "$p" >/dev/null 2>&1; then
+                    echo "  * $p already installed"
+                else
+                    echo "  * Installing $p ... "
+                    log "yum -y install $p"
+                fi
+            done;
+            ;;
+        fedora)
+            for p in $PACKAGES; do
+                if dnf list installed "$p" >/dev/null 2>&1; then
+                    echo "  * $p already installed"
+                else
+                    echo "  * Installing $p ... "
+                    log "dnf -y install $p"
+                fi
+            done;
+            ;;
+    esac
+}
+
+createvh () {
+    {
+        echo "<VirtualHost *:80>"
+        echo "  <Directory $webdir/$name/public>"
+        echo "      Allow From All"
+        echo "      AllowOverride All"
+        echo "      Options +Indexes"
+        echo "  </Directory>"
+        echo ""
+        echo "  DocumentRoot $webdir/$name/public"
+        echo "  ServerName $fqdn"
+        echo "</VirtualHost>"
+    } >> "$apachefile"
+}
+
 installsnipeit () {
+    echo "* Creating MariaDB Database/User."
+    echo "* Please Input your MariaDB root password:"
+    mysql -u root -p --execute="CREATE DATABASE snipeit;GRANT ALL PRIVILEGES ON snipeit.* TO snipeit@localhost IDENTIFIED BY '$mysqluserpw';"
+
     echo "* Cloning Snipe-IT from github to the web directory."
     log "git clone https://github.com/snipe/snipe-it $webdir/$name"
 
     echo "* Configuring .env file."
     cp "$webdir/$name/.env.example" "$webdir/$name/.env"
 
+    #TODO escape SED delimiter in variables
     sed -i '1 i\#Created By Snipe-it Installer' "$webdir/$name/.env"
-    sed -i 's,^\(APP_TIMEZONE=\).*,\1'$tzone',' "$webdir/$name/.env"
-    sed -i 's,^\(DB_HOST=\).*,\1'localhost',' "$webdir/$name/.env"
-    sed -i 's,^\(DB_DATABASE=\).*,\1'snipeit',' "$webdir/$name/.env"
-    sed -i 's,^\(DB_USERNAME=\).*,\1'snipeit',' "$webdir/$name/.env"
-    sed -i 's,^\(DB_PASSWORD=\).*,\1'$mysqluserpw',' "$webdir/$name/.env"
-    sed -i 's,^\(APP_URL=\).*,\1'http://$fqdn',' "$webdir/$name/.env"
+    sed -i "s|^\\(APP_TIMEZONE=\\).*|\\1$tzone|" "$webdir/$name/.env"
+    sed -i "s|^\\(DB_HOST=\\).*|\\1localhost|" "$webdir/$name/.env"
+    sed -i "s|^\\(DB_DATABASE=\\).*|\\1snipeit|" "$webdir/$name/.env"
+    sed -i "s|^\\(DB_USERNAME=\\).*|\\1snipeit|" "$webdir/$name/.env"
+    sed -i "s|^\\(DB_PASSWORD=\\).*|\\1$mysqluserpw|" "$webdir/$name/.env"
+    sed -i "s|^\\(APP_URL=\\).*|\\1http://$fqdn|" "$webdir/$name/.env"
 
     echo "* Installing and running composer."
     cd "$webdir/$name/"
@@ -131,27 +146,22 @@ installsnipeit () {
     (crontab -l ; echo "* * * * * /usr/bin/php $webdir/$name/artisan schedule:run >> /dev/null 2>&1") | crontab -
 }
 
-isinstalled () {
-    if yum list installed "$@" >/dev/null 2>&1; then
-        true
-    else
-        false
-    fi
-}
-
-isdnfinstalled () {
-    if dnf list installed "$@" >/dev/null 2>&1; then
-        true
-    else
-        false
-    fi
-}
-
 openfirewalld () {
     if [ "$(firewall-cmd --state)" == "running" ]; then
         echo "* Configuring firewall to allow HTTP traffic only."
         log "firewall-cmd --zone=public --add-port=http/tcp --permanent"
         log "firewall-cmd --reload"
+    fi
+}
+
+configureselinux () {
+    #Check if SELinux is enforcing
+    if [ "$(getenforce)" == "Enforcing" ]; then
+        echo "* Configuring SELinux."
+        #Required for ldap integration
+        setsebool -P httpd_can_connect_ldap on
+        #Sets SELinux context type so that scripts running in the web server process are allowed read/write access
+        chcon -R -h -t httpd_sys_script_rw_t "$webdir/$name/"
     fi
 }
 
@@ -165,7 +175,7 @@ elif [ -f /etc/os-release ]; then
     #Order is important here.  If /etc/os-release and /etc/centos-release exist, we're on centos 7.
     #If only /etc/centos-release exist, we're on centos6(or earlier).  Centos-release is less parsable,
     #so lets assume that it's version 6 (Plus, who would be doing a new install of anything on centos5 at this point..)
-    #/etc/os-release also properly detects fedora
+    #/etc/os-release properly detects fedora
 elif [ -f /etc/centos-release ]; then
     distro="Centos"
     version="6"
@@ -187,11 +197,11 @@ echo "  Welcome to Snipe-IT Inventory Installer for CentOS, Fedora, Debian and U
 echo ""
 shopt -s nocasematch
 case $distro in
-    *Ubuntu*)
+    *ubuntu*)
         echo "  The installer has detected $distro version $version codename $codename."
         distro=ubuntu
         ;;
-    *Debian*)
+    *debian*)
         echo "  The installer has detected $distro version $version codename $codename."
         distro=debian
         ;;
@@ -210,12 +220,8 @@ case $distro in
 esac
 shopt -u nocasematch
 
-echo -n "  Q. What is the FQDN of your server? ($fqdn): "
-read -r fqdn
-if [ -z "$fqdn" ]; then
-    fqdn="$(hostname --fqdn)"
-fi
-echo "     Setting to $fqdn"
+echo ""
+read -rsn1 -p "Press any key to continue."
 echo ""
 
 ans=default
@@ -249,33 +255,24 @@ case $distro in
         webdir=/var/www
         ownergroup=www-data:www-data
         tzone=$(cat /etc/timezone)
+        apachefile=/etc/apache2/sites-available/$name.conf
 
-        echo -n "* Updating with apt-get update."
-        log "apt-get update" & pid=$!
-        progress
-
-        echo -n "* Upgrading packages with apt-get upgrade."
+        echo -n "* Updating installed packages."
+        log "apt-get update"
         log "apt-get -y upgrade" & pid=$!
         progress
 
-        echo -n "* Installing Apache httpd, PHP, MariaDB and other requirements."
-        log "DEBIAN_FRONTEND=noninteractive apt-get install -y mariadb-server mariadb-client apache2 libapache2-mod-php php php-mcrypt php-curl php-mysql php-gd php-ldap php-zip php-mbstring php-xml php-bcmath curl git unzip" & pid=$!
-        progress
+        echo "* Installing Apache httpd, PHP, MariaDB and other requirements."
+        PACKAGES="mariadb-server mariadb-client apache2 libapache2-mod-php php php-mcrypt php-curl php-mysql php-gd php-ldap php-zip php-mbstring php-xml php-bcmath curl git unzip"
+        installpackages
 
+        echo "* Configuring Apache."
+        createvh
         log "a2enmod rewrite"
-
-        echo "* Creating the new virtual host in Apache."
-        setvhdebian
-
-        echo "* Setting up hosts file."
-        echo >> $hosts "127.0.0.1 $hostname $fqdn"
+        log "a2ensite $name.conf"
 
         echo "* Securing MariaDB."
         /usr/bin/mysql_secure_installation
-
-        echo "* Creating MariaDB Database/User."
-        echo "* Please Input your MariaDB root password:"
-        mysql -u root -p --execute="CREATE DATABASE snipeit;GRANT ALL PRIVILEGES ON snipeit.* TO snipeit@localhost IDENTIFIED BY '$mysqluserpw';"
 
         installsnipeit
 
@@ -287,6 +284,7 @@ case $distro in
         webdir=/var/www
         ownergroup=www-data:www-data
         tzone=$(cat /etc/timezone)
+        apachefile=/etc/apache2/sites-available/$name.conf
 
         echo "* Adding MariaDB and ppa:ondrej/php repositories."
         log "apt-get install -y software-properties-common"
@@ -297,32 +295,22 @@ case $distro in
         log "wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg"
         echo "deb https://packages.sury.org/php/ $codename main" > /etc/apt/sources.list.d/php.list
 
-        echo -n "* Updating with apt-get update."
-        log "apt-get update" & pid=$!
-        progress
-
-        echo -n "* Upgrading packages with apt-get upgrade."
+        echo -n "* Updating installed packages."
+        log "apt-get update"
         log "apt-get -y upgrade" & pid=$!
         progress
 
-        echo -n "* Installing Apache httpd, PHP, MariaDB and other requirements."
-        log "DEBIAN_FRONTEND=noninteractive apt-get install -y mariadb-server mariadb-client php7.1 php7.1-mcrypt php7.1-curl php7.1-mysql php7.1-gd php7.1-ldap php7.1-zip php7.1-mbstring php7.1-xml php7.1-bcmath curl git unzip" & pid=$!
-        progress
+        echo "* Installing Apache httpd, PHP, MariaDB and other requirements."
+        PACKAGES="mariadb-server mariadb-client php7.1 php7.1-mcrypt php7.1-curl php7.1-mysql php7.1-gd php7.1-ldap php7.1-zip php7.1-mbstring php7.1-xml php7.1-bcmath curl git unzip"
+        installpackages
 
-        a2enmod rewrite
-
-        echo "* Creating the new virtual host in Apache."
-        setvhdebian
-
-        echo "* Setting up hosts file."
-        echo >> $hosts "127.0.0.1 $hostname $fqdn"
+        echo "* Configuring Apache."
+        createvh
+        log "a2enmod rewrite"
+        log "a2ensite $name.conf"
 
         echo "* Securing MariaDB."
         /usr/bin/mysql_secure_installation
-
-        echo "* Creating MariaDB Database/User."
-        echo "* Please Input your MariaDB root password:"
-        mysql -u root -p --execute="CREATE DATABASE snipeit;GRANT ALL PRIVILEGES ON snipeit.* TO snipeit@localhost IDENTIFIED BY '$mysqluserpw';"
 
         installsnipeit
 
@@ -340,43 +328,34 @@ case $distro in
         webdir=/var/www
         ownergroup=www-data:www-data
         tzone=$(cat /etc/timezone)
+        apachefile=/etc/apache2/sites-available/$name.conf
 
         echo "* Adding MariaDB repository."
-        log "apt-get install software-properties-common"
+        log "apt-get install -y software-properties-common"
         log "apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xF1656F24C74CD1D8"
         log "add-apt-repository 'deb [arch=amd64,i386] http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.1/ubuntu $codename main'"
 
-        echo -n "* Updating with apt-get update."
-        log "apt-get update" & pid=$!
-        progress
-
-        echo -n "* Upgrading packages with apt-get upgrade."
+        echo -n "* Updating installed packages."
+        log "apt-get update"
         log "apt-get -y upgrade" & pid=$!
         progress
 
-        echo -n "* Installing Apache httpd, PHP, MariaDB and other requirements."
-        log "DEBIAN_FRONTEND=noninteractive apt-get install -y mariadb-server mariadb-client apache2 libapache2-mod-php php php-mcrypt php-curl php-mysql php-gd php-ldap php-zip php-mbstring php-xml php-bcmath curl git unzip" & pid=$!
-        progress
+        echo "* Installing Apache httpd, PHP, MariaDB and other requirements."
+        PACKAGES="mariadb-server mariadb-client apache2 libapache2-mod-php php php-mcrypt php-curl php-mysql php-gd php-ldap php-zip php-mbstring php-xml php-bcmath curl git unzip"
+        installpackages
 
+        echo "* Configuring Apache."
+        createvh
         log "phpenmod mcrypt"
         log "phpenmod mbstring"
         log "a2enmod rewrite"
-
-        echo "* Creating the new virtual host in Apache."
-        setvhdebian
-
-        echo "* Setting up hosts file."
-        echo >> $hosts "127.0.0.1 $hostname $fqdn"
+        log "a2ensite $name.conf"
 
         echo "* Starting MariaDB."
         log "service mysql start"
 
         echo "* Securing MariaDB."
         /usr/bin/mysql_secure_installation
-
-        echo "* Creating MariaDB Database/User."
-        echo "* Please Input your MariaDB root password:"
-        mysql -u root -p --execute="CREATE DATABASE snipeit;GRANT ALL PRIVILEGES ON snipeit.* TO snipeit@localhost IDENTIFIED BY '$mysqluserpw';"
 
         installsnipeit
 
@@ -388,45 +367,36 @@ case $distro in
         webdir=/var/www
         ownergroup=www-data:www-data
         tzone=$(cat /etc/timezone)
+        apachefile=/etc/apache2/sites-available/$name.conf
 
         echo "* Adding MariaDB and ppa:ondrej/php repositories."
-        log "apt-get install software-properties-common"
+        log "apt-get install -y software-properties-common"
         log "apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xcbcb082a1bb943db"
         log "add-apt-repository 'deb [arch=amd64,i386,ppc64el] http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.1/ubuntu $codename main'"
         #PHP7 repository
         log "add-apt-repository ppa:ondrej/php -y"
 
-        echo -n "* Updating with apt-get update."
-        log "apt-get update" & pid=$!
-        progress
-
-        echo -n "* Upgrading packages with apt-get upgrade."
+        echo -n "* Updating installed packages."
+        log "apt-get update"
         log "apt-get -y upgrade" & pid=$!
         progress
 
-        echo -n "* Installing Apache httpd, PHP, MariaDB and other requirements."
-        log "DEBIAN_FRONTEND=noninteractive apt-get install -y mariadb-server mariadb-client php7.1 php7.1-mcrypt php7.1-curl php7.1-mysql php7.1-gd php7.1-ldap php7.1-zip php7.1-mbstring php7.1-xml php7.1-bcmath curl git unzip" & pid=$!
-        progress
+        echo "* Installing Apache httpd, PHP, MariaDB and other requirements."
+        PACKAGES="mariadb-server mariadb-client php7.1 php7.1-mcrypt php7.1-curl php7.1-mysql php7.1-gd php7.1-ldap php7.1-zip php7.1-mbstring php7.1-xml php7.1-bcmath curl git unzip"
+        installpackages
 
+        echo "* Configuring Apache."
+        createvh
         log "phpenmod mcrypt"
         log "phpenmod mbstring"
         log "a2enmod rewrite"
-
-        echo "* Creating the new virtual host in Apache."
-        setvhdebian
-
-        echo "* Setting up hosts file."
-        echo >> $hosts "127.0.0.1 $hostname $fqdn"
+        log "a2ensite $name.conf"
 
         echo "* Starting MariaDB."
         log "service mysql start"
 
         echo "* Securing MariaDB."
         /usr/bin/mysql_secure_installation
-
-        echo "* Creating MariaDB Database/User."
-        echo "* Please Input your MariaDB root password:"
-        mysql -u root -p --execute="CREATE DATABASE snipeit;GRANT ALL PRIVILEGES ON snipeit.* TO snipeit@localhost IDENTIFIED BY '$mysqluserpw';"
 
         installsnipeit
 
@@ -444,6 +414,7 @@ case $distro in
         webdir=/var/www/html
         ownergroup=apache:apache
         tzone=$(grep ZONE /etc/sysconfig/clock | tr -d '"' | sed 's/ZONE=//g');
+        apachefile=/etc/httpd/conf.d/$name.conf
 
         echo "* Adding IUS, epel-release and MariaDB repositories."
         mariadbRepo=/etc/yum.repos.d/MariaDB.repo
@@ -463,15 +434,10 @@ case $distro in
 
         echo "* Installing Apache httpd, PHP, MariaDB and other requirements."
         PACKAGES="httpd mariadb-server git unzip php71u php71u-mysqlnd php71u-bcmath php71u-cli php71u-common php71u-embedded php71u-gd php71u-mbstring php71u-mcrypt php71u-ldap php71u-json php71u-simplexml"
+        installpackages
 
-        for p in $PACKAGES; do
-            if isinstalled "$p"; then
-                echo "  * $p already installed"
-            else
-                echo "  * Installing $p ... "
-                log "yum -y install $p"
-            fi
-        done;
+        echo "* Configuring Apache."
+        createvh
 
         echo "* Setting MariaDB to start on boot and starting MariaDB."
         log "chkconfig mysql on"
@@ -480,15 +446,7 @@ case $distro in
         echo "* Securing MariaDB."
         /usr/bin/mysql_secure_installation
 
-        echo "* Creating MariaDB Database/User."
-        echo "* Please Input your MariaDB root password: "
-        mysql -u root -p --execute="CREATE DATABASE snipeit;GRANT ALL PRIVILEGES ON snipeit.* TO snipeit@localhost IDENTIFIED BY '$mysqluserpw';"
-
-        echo "* Creating the new virtual host in Apache."
-        setvhcentos
-
-        echo "* Setting up hosts file."
-        echo >> $hosts "127.0.0.1 $hostname $fqdn"
+        installsnipeit
 
         if /sbin/service iptables status >/dev/null 2>&1; then
             echo "* Configuring iptables."
@@ -496,8 +454,6 @@ case $distro in
             iptables -I INPUT 1 -p tcp -m tcp --dport 443 -j ACCEPT
             service iptables save
         fi
-
-        installsnipeit
 
         echo "* Setting Apache httpd to start on boot and starting service."
         log "chkconfig httpd on"
@@ -508,6 +464,7 @@ case $distro in
         webdir=/var/www/html
         ownergroup=apache:apache
         tzone=$(timedatectl | gawk -F'[: ]' ' $9 ~ /zone/ {print $11}');
+        apachefile=/etc/httpd/conf.d/$name.conf
 
         echo "* Adding IUS, epel-release and MariaDB repositories."
         log "yum -y install wget epel-release"
@@ -516,15 +473,10 @@ case $distro in
 
         echo "* Installing Apache httpd, PHP, MariaDB and other requirements."
         PACKAGES="httpd mariadb-server git unzip php71u php71u-mysqlnd php71u-bcmath php71u-cli php71u-common php71u-embedded php71u-gd php71u-mbstring php71u-mcrypt php71u-ldap php71u-json php71u-simplexml"
+        installpackages
 
-        for p in $PACKAGES; do
-            if isinstalled "$p"; then
-                echo "  * $p already installed"
-            else
-                echo "  * Installing $p ... "
-                log "yum -y install $p"
-            fi
-        done;
+        echo "* Configuring Apache."
+        createvh
 
         echo "* Setting MariaDB to start on boot and starting MariaDB."
         log "systemctl enable mariadb.service"
@@ -533,31 +485,11 @@ case $distro in
         echo "* Securing MariaDB."
         /usr/bin/mysql_secure_installation
 
-        echo "* Creating MariaDB Database/User."
-        echo "* Please Input your MariaDB root password "
-        mysql -u root -p --execute="CREATE DATABASE snipeit;GRANT ALL PRIVILEGES ON snipeit.* TO snipeit@localhost IDENTIFIED BY '$mysqluserpw';"
-
-        #TODO make sure the apachefile doesnt exist isnt already in there
-        echo "* Creating the new virtual host in Apache."
-        setvhcentos
-
-        #TODO make sure this isnt already in there
-        echo "* Setting up hosts file."
-        echo >> $hosts "127.0.0.1 $hostname $fqdn"
-
         installsnipeit
 
-        #open the firewall for HTTP traffic only
         openfirewalld
 
-        #Check if SELinux is enforcing
-        if [ "$(getenforce)" == "Enforcing" ]; then
-            echo "* Configuring SELinux."
-            #Required for ldap integration
-            setsebool -P httpd_can_connect_ldap on
-            #Sets SELinux context type so that scripts running in the web server process are allowed read/write access
-            chcon -R -h -t httpd_sys_script_rw_t $webdir/$name/
-        fi
+        configureselinux
 
         echo "* Setting Apache httpd to start on boot and starting service."
         log "systemctl enable httpd.service"
@@ -573,18 +505,14 @@ case $distro in
         webdir=/var/www/html
         ownergroup=apache:apache
         tzone=$(timedatectl | gawk -F'[: ]' ' $9 ~ /zone/ {print $11}');
+        apachefile=/etc/httpd/conf.d/$name.conf
 
         echo "* Installing Apache httpd, PHP, MariaDB and other requirements."
         PACKAGES="httpd mariadb-server git unzip php php-mysqlnd php-bcmath php-cli php-common php-embedded php-gd php-mbstring php-mcrypt php-ldap php-json php-simplexml"
+        installpackages
 
-        for p in $PACKAGES; do
-            if isdnfinstalled "$p"; then
-                echo "  * $p already installed"
-            else
-                echo "  * Installing $p ... "
-                log "dnf -y install $p"
-            fi
-        done;
+        echo "* Configuring Apache."
+        createvh
 
         echo "* Setting MariaDB to start on boot and starting MariaDB."
         log "systemctl enable mariadb.service"
@@ -593,31 +521,11 @@ case $distro in
         echo "* Securing MariaDB."
         /usr/bin/mysql_secure_installation
 
-        echo "* Creating MariaDB Database/User."
-        echo "* Please Input your MariaDB root password "
-        mysql -u root -p --execute="CREATE DATABASE snipeit;GRANT ALL PRIVILEGES ON snipeit.* TO snipeit@localhost IDENTIFIED BY '$mysqluserpw';"
-
-        #TODO make sure the apachefile doesnt exist isnt already in there
-        echo "* Creating the new virtual host in Apache."
-        setvhcentos
-
-        #TODO make sure this isnt already in there
-        echo "* Setting up hosts file."
-        echo >> $hosts "127.0.0.1 $hostname $fqdn"
-
         installsnipeit
 
-        #open the firewall for HTTP traffic only
         openfirewalld
 
-        #Check if SELinux is enforcing
-        if [ "$(getenforce)" == "Enforcing" ]; then
-            echo "* Configuring SELinux."
-            #Required for ldap integration
-            setsebool -P httpd_can_connect_ldap on
-            #Sets SELinux context type so that scripts running in the web server process are allowed read/write access
-            chcon -R -h -t httpd_sys_script_rw_t $webdir/$name/
-        fi
+        configureselinux
 
         echo "* Setting Apache httpd to start on boot and starting service."
         log "systemctl enable httpd.service"
@@ -633,39 +541,40 @@ case $setupmail in
     [yY] | [yY][Ee][Ss] )
         echo -n "  Outgoing mailserver address:"
         read -r mailhost
-        sed -i 's,^\(MAIL_HOST=\).*,\1'$mailhost',' "$webdir/$name/.env"
+        sed -i "s|^\\(MAIL_HOST=\\).*|\\1$mailhost|" "$webdir/$name/.env"
 
         echo -n "  Server port number:"
         read -r mailport
-        sed -i 's,^\(MAIL_PORT=\).*,\1'$mailport',' "$webdir/$name/.env"
+        sed -i "s|^\\(MAIL_PORT=\\).*|\\1$mailport|" "$webdir/$name/.env"
 
         echo -n "  Username:"
         read -r mailusername
-        sed -i 's,^\(MAIL_USERNAME=\).*,\1'$mailusername',' "$webdir/$name/.env"
+        sed -i "s|^\\(MAIL_USERNAME=\\).*|\\1$mailusername|" "$webdir/$name/.env"
 
         echo -n "  Password:"
         read -rs mailpassword
-        sed -i 's,^\(MAIL_PASSWORD=\).*,\1'$mailpassword',' "$webdir/$name/.env"
+        sed -i "s|^\\(MAIL_PASSWORD=\\).*|\\1$mailpassword|" "$webdir/$name/.env"
+        echo ""
 
         echo -n "  Encryption(null/TLS/SSL):"
         read -r mailencryption
-        sed -i 's,^\(MAIL_ENCRYPTION=\).*,\1'$mailencryption',' "$webdir/$name/.env"
+        sed -i "s|^\\(MAIL_ENCRYPTION=\\).*|\\1$mailencryption|" "$webdir/$name/.env"
 
         echo -n "  From address:"
         read -r mailfromaddr
-        sed -i 's,^\(MAIL_FROM_ADDR=\).*,\1'$mailfromaddr',' "$webdir/$name/.env"
+        sed -i "s|^\\(MAIL_FROM_ADDR=\\).*|\\1$mailfromaddr|" "$webdir/$name/.env"
 
         echo -n "  From name:"
         read -r mailfromname
-        sed -i 's,^\(MAIL_FROM_NAME=\).*,\1'$mailfromname',' "$webdir/$name/.env"
+        sed -i "s|^\\(MAIL_FROM_NAME=\\).*|\\1$mailfromname|" "$webdir/$name/.env"
 
         echo -n "  Reply to address:"
         read -r mailreplytoaddr
-        sed -i 's,^\(MAIL_REPLYTO_ADDR=\).*,\1'$mailreplytoaddr',' "$webdir/$name/.env"
+        sed -i "s|^\\(MAIL_REPLYTO_ADDR=\\).*|\\1$mailreplytoaddr|" "$webdir/$name/.env"
 
         echo -n "  Reply to name:"
         read -r mailreplytoname
-        sed -i 's,^\(MAIL_REPLYTO_NAME=\).*,\1'$mailreplytoname',' "$webdir/$name/.env"
+        sed -i "s|^\\(MAIL_REPLYTO_NAME=\\).*|\\1$mailreplytoname|" "$webdir/$name/.env"
         setupmail="yes"
         ;;
     [nN] | [n|N][O|o] )

--- a/snipeit.sh
+++ b/snipeit.sh
@@ -337,7 +337,7 @@ case $distro in
 
         echo -n "* Updating installed packages."
         log "apt-get update"
-        log "apt-get -y upgrade" & pid=$!
+        log "DEBIAN_FRONTEND=noninteractive apt-get -y upgrade" & pid=$!
         progress
 
         echo "* Installing Apache httpd, PHP, MariaDB and other requirements."
@@ -378,7 +378,7 @@ case $distro in
 
         echo -n "* Updating installed packages."
         log "apt-get update"
-        log "apt-get -y upgrade" & pid=$!
+        log "DEBIAN_FRONTEND=noninteractive apt-get -y upgrade" & pid=$!
         progress
 
         echo "* Installing Apache httpd, PHP, MariaDB and other requirements."

--- a/snipeit.sh
+++ b/snipeit.sh
@@ -221,7 +221,7 @@ esac
 shopt -u nocasematch
 
 echo ""
-read -rsn1 -p "Press any key to continue."
+read -rsn1 -p "  Press any key to continue..."
 echo ""
 
 ans=default
@@ -433,7 +433,7 @@ case $distro in
         log "rpm --import /etc/pki/rpm-gpg/IUS-COMMUNITY-GPG-KEY"
 
         echo "* Installing Apache httpd, PHP, MariaDB and other requirements."
-        PACKAGES="httpd mariadb-server git unzip php71u php71u-mysqlnd php71u-bcmath php71u-cli php71u-common php71u-embedded php71u-gd php71u-mbstring php71u-mcrypt php71u-ldap php71u-json php71u-simplexml"
+        PACKAGES="httpd mariadb-server git unzip php71u php71u-mysqlnd php71u-bcmath php71u-cli php71u-common php71u-embedded php71u-gd php71u-mbstring php71u-mcrypt php71u-ldap php71u-json php71u-simplexml php71u-process"
         installpackages
 
         echo "* Configuring Apache."
@@ -472,7 +472,7 @@ case $distro in
         log "rpm --import /etc/pki/rpm-gpg/IUS-COMMUNITY-GPG-KEY"
 
         echo "* Installing Apache httpd, PHP, MariaDB and other requirements."
-        PACKAGES="httpd mariadb-server git unzip php71u php71u-mysqlnd php71u-bcmath php71u-cli php71u-common php71u-embedded php71u-gd php71u-mbstring php71u-mcrypt php71u-ldap php71u-json php71u-simplexml"
+        PACKAGES="httpd mariadb-server git unzip php71u php71u-mysqlnd php71u-bcmath php71u-cli php71u-common php71u-embedded php71u-gd php71u-mbstring php71u-mcrypt php71u-ldap php71u-json php71u-simplexml php71u-process"
         installpackages
 
         echo "* Configuring Apache."


### PR DESCRIPTION
Please don't merge yet.

Consistent-ish install across all supported operating systems.
Condensed down duplicate code.
Make shellcheck happy.
Fix a couple bugs here and there.

Does anyone know why we manually add `127.0.0.1 hostname fqdn` to /etc/hosts? Why would someone use something other than the current hostname and fqdn?

Removing this does not affect any of the operating systems I tested on.