### PR TITLE
Allow manager_id to be fillable.

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -45,6 +45,7 @@ class User extends SnipeModel implements AuthenticatableContract, CanResetPasswo
         'country',
         'zip',
         'activated',
+        'manager_id',
     ];
 
     protected $casts = [


### PR DESCRIPTION
The API UsersController accepts manager_id, but calls the following:

`$user->fill($request->all());`

This results in manager_id being ignored. I can't see any problem with allowing a user's manager to be modified using the API, so this change allows it.