### PR TITLE
Only use location currency if it's actually set.

### DIFF
--- a/resources/views/reports/depreciation.blade.php
+++ b/resources/views/reports/depreciation.blade.php
@@ -99,7 +99,7 @@
 
                 @if ($asset->purchase_cost > 0)
                   <td class="align-right">
-                    @if ($asset->location )
+                    @if ($asset->location && $asset->location->currency)
                     {{ $asset->location->currency }}
                     @else
                     {{ $snipeSettings->default_currency }}
@@ -107,7 +107,7 @@
                     {{ \App\Helpers\Helper::formatCurrencyOutput($asset->purchase_cost) }}
                   </td>
                   <td class="align-right">
-                    @if ($asset->location )
+                    @if ($asset->location && $asset->location->currency)
                     {{ $asset->location->currency }}
                     @else
                     {{ $snipeSettings->default_currency }}
@@ -116,7 +116,7 @@
                     {{ \App\Helpers\Helper::formatCurrencyOutput($asset->getDepreciatedValue()) }}
                   </td>
                   <td class="align-right">
-                    @if ($asset->location)
+                    @if ($asset->location && $asset->location->currency)
                     {{ $asset->location->currency }}
                     @else
                     {{ $snipeSettings->default_currency }}


### PR DESCRIPTION
This changes the depreciation report to only use the currency on a location if it's actually set to something. Previously, if an asset had a location it would use the currency even if it was blank rather than falling back to the default.