### PR TITLE
Hotfix: Disabling the event dispatcher broke model validation. (#4912)

### DIFF
--- a/app/Importer/AccessoryImporter.php
+++ b/app/Importer/AccessoryImporter.php
@@ -41,7 +41,9 @@ class AccessoryImporter extends ItemImporter
         $this->log("No Matching Accessory, Creating a new one");
         $accessory = new Accessory();
         $accessory->fill($this->sanitizeItemForStoring($accessory));
-        $accessory->unsetEventDispatcher();
+
+        //FIXME: this disables model validation.  Need to find a way to avoid double-logs without breaking everything.
+        // $accessory->unsetEventDispatcher();
         if ($accessory->save()) {
             $accessory->logCreate('Imported using CSV Importer');
             $this->log('Accessory ' . $this->item["name"] . ' was created');

--- a/app/Importer/AssetImporter.php
+++ b/app/Importer/AssetImporter.php
@@ -106,7 +106,8 @@ class AssetImporter extends ItemImporter
                 $asset->{$custom_field} = $val;
             }
         }
-        $asset->unsetEventDispatcher();
+        //FIXME: this disables model validation.  Need to find a way to avoid double-logs without breaking everything.
+        // $asset->unsetEventDispatcher();
         if ($asset->save()) {
             $asset->logCreate('Imported using csv importer');
             $this->log('Asset ' . $this->item["name"] . ' with serial number ' . $this->item['serial'] . ' was created');

--- a/app/Importer/ComponentImporter.php
+++ b/app/Importer/ComponentImporter.php
@@ -46,6 +46,7 @@ class ComponentImporter extends ItemImporter
         $this->log("No matching component, creating one");
         $component = new Component;
         $component->fill($this->sanitizeItemForStoring($component));
+        //FIXME: this disables model validation.  Need to find a way to avoid double-logs without breaking everything.
         $component->unsetEventDispatcher();
         if ($component->save()) {
             $component->logCreate('Imported using CSV Importer');

--- a/app/Importer/ConsumableImporter.php
+++ b/app/Importer/ConsumableImporter.php
@@ -40,7 +40,7 @@ class ConsumableImporter extends ItemImporter
         $this->log("No matching consumable, creating one");
         $consumable = new Consumable();
         $consumable->fill($this->sanitizeItemForStoring($consumable));
-
+        //FIXME: this disables model validation.  Need to find a way to avoid double-logs without breaking everything.
         $consumable->unsetEventDispatcher();
         if ($consumable->save()) {
             $consumable->logCreate('Imported using CSV Importer');

--- a/app/Importer/LicenseImporter.php
+++ b/app/Importer/LicenseImporter.php
@@ -63,8 +63,8 @@ class LicenseImporter extends ItemImporter
         } else {
             $license->fill($this->sanitizeItemForStoring($license));
         }
-
-        $license->unsetEventDispatcher();
+        //FIXME: this disables model validation.  Need to find a way to avoid double-logs without breaking everything.
+        // $license->unsetEventDispatcher();
         if ($license->save()) {
             $license->logCreate('Imported using csv importer');
             $this->log('License ' . $this->item["name"] . ' with serial number ' . $this->item['serial'] . ' was created');

--- a/tests/unit/ImporterTest.php
+++ b/tests/unit/ImporterTest.php
@@ -23,6 +23,7 @@ class ImporterTest extends BaseTest
 
     public function testDefaultImportAssetWithCustomFields()
     {
+        $this->signIn();
         $csv = <<<'EOT'
 Name,Email,Username,item Name,Category,Model name,Manufacturer,Model Number,Serial,Asset Tag,Location,Notes,Purchase Date,Purchase Cost,Company,Status,Warranty,Supplier,Weight
 Bonnie Nelson,bnelson0@cdbaby.com,bnelson0,eget nunc donec quis,quam,massa id,Linkbridge,6377018600094472,27aa8378-b0f4-4289-84a4-405da95c6147,970882174-8,Daping,"Curabitur in libero ut massa volutpat convallis. Morbi odio odio, elementum eu, interdum eu, tincidunt in, leo. Maecenas pulvinar lobortis est.",2016-04-05,133289.59,Alpha,Undeployable,14,Blogspan,35
@@ -79,6 +80,7 @@ EOT;
 
     public function testUpdateAssetIncludingCustomFields()
     {
+        $this->signIn();
         $csv = <<<'EOT'
 Name,Email,Username,item Name,Category,Model name,Manufacturer,Model Number,Serial,Asset Tag,Location,Notes,Purchase Date,Purchase Cost,Company,Status,Warranty,Supplier,weight
 Bonnie Nelson,bnelson0@cdbaby.com,bnelson0,eget nunc donec quis,quam,massa id,Linkbridge,6377018600094472,27aa8378-b0f4-4289-84a4-405da95c6147,970882174-8,Daping,"Curabitur in libero ut massa volutpat convallis. Morbi odio odio, elementum eu, interdum eu, tincidunt in, leo. Maecenas pulvinar lobortis est.",2016-04-05,133289.59,Alpha,Undeployable,14,Blogspan,95
@@ -143,6 +145,7 @@ EOT;
         // 1) Create model with blank model # and custom field.
         // 2 ) Update custom fields with a csv not including model #
         // 3 ) Not updated.  NULL vs. empty issue.
+        $this->signIn();
         $csv = <<<'EOT'
 Name,Email,Username,item Name,Category,Model name,Manufacturer,Serial,Asset Tag,Location,Notes,Purchase Date,Purchase Cost,Company,Status,Warranty,Supplier
 Bonnie Nelson,bnelson0@cdbaby.com,bnelson0,eget nunc donec quis,quam,massa id,Linkbridge,27aa8378-b0f4-4289-84a4-405da95c6147,970882174-8,Daping,"Curabitur in libero ut massa volutpat convallis. Morbi odio odio, elementum eu, interdum eu, tincidunt in, leo. Maecenas pulvinar lobortis est.",2016-04-05,133289.59,Alpha,Undeployable,14,Blogspan
@@ -205,6 +208,7 @@ EOT;
 
     public function testCustomMappingImport()
     {
+        $this->signIn();
         $csv = <<<'EOT'
 Name,Email,Username,object name,Cat,Model name,Manufacturer,Model Number,Serial,Asset,Loc,Some Notes,Purchase Date,Purchase Cost,comp,Status,Warranty,Supplier
 Bonnie Nelson,bnelson0@cdbaby.com,bnelson0,eget nunc donec quis,quam,massa id,Linkbridge,6377018600094472,27aa8378-b0f4-4289-84a4-405da95c6147,970882174-8,Daping,"Curabitur in libero ut massa volutpat convallis. Morbi odio odio, elementum eu, interdum eu, tincidunt in, leo. Maecenas pulvinar lobortis est.",2016-04-05,133289.59,Alpha,Undeployable,14,Blogspan
@@ -481,6 +485,7 @@ EOT;
 
     public function testDefaultLicenseImport()
     {
+        $this->signIn();
         $csv = <<<'EOT'
 Name,Email,Username,Item name,serial,manufacturer,purchase date,purchase cost,purchase order,order number,Licensed To Name,Licensed to Email,expiration date,maintained,reassignable,seats,company,supplier,notes
 Helen Anderson,cspencer0@privacy.gov.au,cspencer0,Argentum Malachite Athletes Foot Relief,1aa5b0eb-79c5-40b2-8943-5472a6893c3c,"Beer, Leannon and Lubowitz",07/13/2012,$79.66,53008,386436062-5,Cynthia Spencer,cspencer0@gov.uk,01/27/2016,false,no,80,"Haag, Schmidt and Farrell","Hegmann, Mohr and Cremin",Sed ante. Vivamus tortor. Duis mattis egestas metus.


### PR DESCRIPTION
* Hotfix: Disabling the event dispatcher broke model validation.

This resulted in invalid data being imported.  Reenable the event dispatcher for now--this causes double logs, but at least validates properly.

* Actually disable the event dispatcher.

* Sign in where necessary to fix the importer unit test.  This catches the issues found manually in 4912