### PR TITLE
Reverse sort order of dashboard recent activity.

### DIFF
--- a/app/Http/Controllers/Api/ReportsController.php
+++ b/app/Http/Controllers/Api/ReportsController.php
@@ -46,7 +46,7 @@ class ReportsController extends Controller
         ];
         
         $sort = in_array($request->input('sort'), $allowed_columns) ? e($request->input('sort')) : 'created_at';
-        $order = $request->input('order') === 'asc' ? 'desc' : 'asc';
+        $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $offset = request('offset', 0);
         $limit = request('limit', 50);
         $total = $actionlogs->count();

--- a/resources/views/reports/activity.blade.php
+++ b/resources/views/reports/activity.blade.php
@@ -20,6 +20,7 @@
                 class="table table-striped snipe-table"
                 id="table"
                 data-url="{{ route('api.activity.index') }}"
+                data-sort-order="desc"
                 data-cookie="true"
                 data-cookie-id-table="activityReportTable">
                     <thead>


### PR DESCRIPTION
The dashboard was showing the oldest activity first, which I don't think is that useful. By switching the sort order it shows the most recent activity first. When I visit the dashboard this is what I want to see.

Happy to discuss if others have a different view?