### PR TITLE
Add ability to retrieve assigned license seats from users API

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -299,9 +299,12 @@ class UsersController extends Controller
      * @param $userId
      * @return string JSON
      */
-    public function license_seats($id)
+    public function licenseSeats($id)
     {
         $this->authorize('view', User::class);
+        $user = User::findOrFail($id);
+        $this->authorize('view', $user);
+
         $seats = LicenseSeat::where('assigned_to', '=', $id)->with('license')->get();
         return (new LicenseSeatsTransformer)->transformLicenseSeats($seats, $seats->count());
     }

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -10,8 +10,10 @@ use App\Models\User;
 use App\Helpers\Helper;
 use App\Http\Requests\SaveUserRequest;
 use App\Models\Asset;
+use App\Models\LicenseSeat;
 use App\Http\Transformers\AssetsTransformer;
 use App\Http\Transformers\SelectlistTransformer;
+use App\Http\Transformers\LicenseSeatsTransformer;
 
 class UsersController extends Controller
 {
@@ -69,7 +71,7 @@ class UsersController extends Controller
         if ($request->has('location_id')) {
             $users = $users->where('users.location_id', '=', $request->input('location_id'));
         }
-        
+
         if ($request->has('group_id')) {
             $users = $users->ByGroup($request->get('group_id'));
         }
@@ -287,5 +289,20 @@ class UsersController extends Controller
         $this->authorize('view', User::class);
         $assets = Asset::where('assigned_to', '=', $id)->with('model')->get();
         return (new AssetsTransformer)->transformAssets($assets, $assets->count());
+    }
+
+    /**
+     * Return JSON containing a list of license seats assigned to a user.
+     *
+     * @author [O. Loesch] [<github@loesch.io]
+     * @since [v4.11]
+     * @param $userId
+     * @return string JSON
+     */
+    public function license_seats($id)
+    {
+        $this->authorize('view', User::class);
+        $seats = LicenseSeat::where('assigned_to', '=', $id)->with('license')->get();
+        return (new LicenseSeatsTransformer)->transformLicenseSeats($seats, $seats->count());
     }
 }

--- a/app/Http/Transformers/LicenseSeatsTransformer.php
+++ b/app/Http/Transformers/LicenseSeatsTransformer.php
@@ -25,7 +25,6 @@ class LicenseSeatsTransformer
         $array = [
             'id' => (int) $seat->id,
             'license_id' => (int) $seat->license->id,
-            'license_name' => (string) $seat->license->name,
             'name' => 'Seat '.$seat_count,
             'assigned_user' => ($seat->user) ? [
                 'id' => (int) $seat->user->id,

--- a/app/Http/Transformers/LicenseSeatsTransformer.php
+++ b/app/Http/Transformers/LicenseSeatsTransformer.php
@@ -25,6 +25,7 @@ class LicenseSeatsTransformer
         $array = [
             'id' => (int) $seat->id,
             'license_id' => (int) $seat->license->id,
+            'license_name' => (string) $seat->license->name,
             'name' => 'Seat '.$seat_count,
             'assigned_user' => ($seat->user) ? [
                 'id' => (int) $seat->user->id,
@@ -37,6 +38,10 @@ class LicenseSeatsTransformer
             'location' => ($seat->location()) ? [
                 'id' => (int) $seat->location()->id,
                 'name'=> e($seat->location()->name)
+            ] : null,
+            'license' => ($seat->license) ? [
+                'id' => (int) $seat->license->id,
+                'name' => e($seat->license->present()->name)
             ] : null,
             'reassignable' => (bool) $seat->license->reassignable,
             'user_can_checkout' => (($seat->assigned_to=='') && ($seat->asset_id=='')) ? true : false,

--- a/routes/api.php
+++ b/routes/api.php
@@ -670,6 +670,13 @@ Route::group(['prefix' => 'v1','namespace' => 'Api'], function () {
             ]
         );
 
+        Route::get('{user}/license_seats',
+            [
+                'as' => 'api.users.licenseseatslist',
+                'uses' => 'UsersController@license_seats'
+            ]
+        );
+
         Route::post('{user}/upload',
             [
                 'as' => 'api.users.uploads',

--- a/routes/api.php
+++ b/routes/api.php
@@ -673,7 +673,7 @@ Route::group(['prefix' => 'v1','namespace' => 'Api'], function () {
         Route::get('{user}/license_seats',
             [
                 'as' => 'api.users.licenseseatslist',
-                'uses' => 'UsersController@license_seats'
+                'uses' => 'UsersController@licenseSeats'
             ]
         );
 


### PR DESCRIPTION
I've been missing this API. I'm not quite sure about the naming though - should the route be `/users/:id/licenses` rather than `/users/:id/license_seats`?

While I don't need them at the moment, I probably add the same methods for consumables and components to have something consistent. Unless this gets rejected oc ;)