### PR TITLE
Fix asset tag search on create asset page

### DIFF
--- a/resources/views/hardware/edit.blade.php
+++ b/resources/views/hardware/edit.blade.php
@@ -190,7 +190,7 @@
             user_add($(".status_id").val());
         });
 
-        $("form").submit(function (event) {
+        $("#create-form").submit(function (event) {
             event.preventDefault();
             return sendForm();
         });


### PR DESCRIPTION
Fixes #4780 
CSS selector was selecting all forms instead of just asset creation form 