### PR TITLE
Features/1820 high quantity consumables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .couscous
 .DS_Store
-.env*
+.env
 .idea
 /bin/
 /bootstrap/compiled.php

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .couscous
 .DS_Store
-.env
+.env*
 .idea
 /bin/
 /bootstrap/compiled.php

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -689,10 +689,11 @@ class Helper
     public static function formatStandardApiResponse($status, $payload = null, $messages = null) {
 
         $array['status'] = $status;
-        $array['messages'] = $messages;
-        if (($messages) && (count($messages) > 0)) {
-            $array['messages'] = $messages;
-        }
+        //$array['messages'] = $messages;
+        //if (($messages) && (count($messages) > 0)) {
+        //    $array['messages'] = $messages;
+        //}
+        (($messages) && (count($messages) > 0)) ? $array['messages'] = $messages : $array['messages'] = null;
         ($payload) ? $array['payload'] = $payload : $array['payload'] = null;
         return $array;
     }

--- a/app/Http/Controllers/Api/ConsumablesController.php
+++ b/app/Http/Controllers/Api/ConsumablesController.php
@@ -179,6 +179,7 @@ class ConsumablesController extends Controller
         foreach ($consumable->consumableAssignments as $consumable_assignment) {
             $rows[] = [
                 'name' => ($consumable_assignment->user) ? $consumable_assignment->user->present()->nameUrl() : 'Deleted User',
+                'qty' => ($consumable_assignment->qty) ? $consumable_assignment->qty : 0,
                 'created_at' => ($consumable_assignment->created_at->format('Y-m-d H:i:s')=='-0001-11-30 00:00:00') ? '' : $consumable_assignment->created_at->format('Y-m-d H:i:s'),
                 'admin' => ($consumable_assignment->admin) ? $consumable_assignment->admin->present()->nameUrl() : '',
             ];

--- a/app/Http/Controllers/ConsumablesController.php
+++ b/app/Http/Controllers/ConsumablesController.php
@@ -20,6 +20,7 @@ use Str;
 use View;
 use Gate;
 use Image;
+use Validator;
 use App\Http\Requests\ImageUploadRequest;
 
 /**
@@ -260,12 +261,12 @@ class ConsumablesController extends Controller
             // Redirect to the consumable management page with error
             return redirect()->route('checkout/consumable', $consumable)->with('error', trans('admin/consumables/message.checkout.user_does_not_exist'));
         }
-
+        /*
         // Validate data in request
+        $max_to_consume = -1 * 1;
         $max_to_checkout = $consumable->numRemaining();
         $validator = Validator::make($request->all(), [
-            "asset_id"          => "required",
-            "assigned_qty"      => "required|numeric|between:1,$max_to_checkout"
+            "qty"               => "numeric|between:$max_to_consume,$max_to_checkout"
         ]);
 
         if ($validator->fails()) {
@@ -273,15 +274,16 @@ class ConsumablesController extends Controller
                 ->withErrors($validator)
                 ->withInput();
         }
-
+        */
         // Update the consumable data
         $consumable->assigned_to = e(Input::get('assigned_to'));
+        $qty = (e(Input::get('qty')) == 0) ? 1 : e(Input::get('qty'));
 
         $consumable->users()->attach($consumable->id, [
             'consumable_id' => $consumable->id,
             'user_id' => $admin_user->id,
             'assigned_to' => e(Input::get('assigned_to')),
-            'assigned_qty' => e(Input::get('assigned_qty'))
+            'qty' => $qty
         ]);
 
         $logaction = $consumable->logCheckout(e(Input::get('note')), $user);

--- a/app/Models/Consumable.php
+++ b/app/Models/Consumable.php
@@ -110,7 +110,7 @@ class Consumable extends SnipeModel
 
     public function users()
     {
-        return $this->belongsToMany('\App\Models\User', 'consumables_users', 'consumable_id', 'assigned_to')->withPivot('user_id')->withTrashed()->withTimestamps();
+        return $this->belongsToMany('\App\Models\User', 'consumables_users', 'consumable_id', 'assigned_to')->withPivot('user_id', 'qty')->withTrashed()->withTimestamps();
     }
 
     public function hasUsers()
@@ -141,7 +141,11 @@ class Consumable extends SnipeModel
 
     public function numRemaining()
     {
-        $checkedout = $this->users->count();
+        $checkedout = 0;
+        foreach ($this->users as $user) {
+            if($user->pivot->qty > 0)
+                $checkedout += $user->pivot->qty;
+        }
         $total = $this->qty;
         $remaining = $total - $checkedout;
         return $remaining;

--- a/app/Models/ConsumableAssignment.php
+++ b/app/Models/ConsumableAssignment.php
@@ -7,6 +7,7 @@ use Watson\Validating\ValidatingTrait;
 class ConsumableAssignment extends Model
 {
     use CompanyableTrait;
+    use ValidatingTrait;
 
     protected $dates = ['deleted_at'];
     protected $table = 'consumables_users';
@@ -17,7 +18,6 @@ class ConsumableAssignment extends Model
     );
     
     protected $injectUniqueIdentifier = true;
-    use ValidatingTrait;
 
     public function consumable()
     {

--- a/app/Models/ConsumableAssignment.php
+++ b/app/Models/ConsumableAssignment.php
@@ -2,6 +2,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Watson\Validating\ValidatingTrait;
 
 class ConsumableAssignment extends Model
 {
@@ -9,6 +10,14 @@ class ConsumableAssignment extends Model
 
     protected $dates = ['deleted_at'];
     protected $table = 'consumables_users';
+    protected $fillable = ['qty'];
+
+    public $rules = array(
+        'qty'         => 'integer'
+    );
+    
+    protected $injectUniqueIdentifier = true;
+    use ValidatingTrait;
 
     public function consumable()
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -180,7 +180,7 @@ class User extends SnipeModel implements AuthenticatableContract, CanResetPasswo
      */
     public function consumables()
     {
-        return $this->belongsToMany('\App\Models\Consumable', 'consumables_users', 'assigned_to', 'consumable_id')->withPivot('id')->withTrashed();
+        return $this->belongsToMany('\App\Models\Consumable', 'consumables_users', 'assigned_to', 'consumable_id')->withPivot('id', 'qty')->withTrashed();
     }
 
     /**

--- a/database/migrations/2018_02_21_151612_add_consumables_users_qty.php
+++ b/database/migrations/2018_02_21_151612_add_consumables_users_qty.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddConsumablesUsersQty extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('consumables_users', function (Blueprint $table) {
+            //
+            $table->integer('qty')->default(1);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('consumables_users', function (Blueprint $table) {
+            //
+            $table->dropColumn('qty');
+        });
+    }
+}

--- a/resources/views/account/view-assets.blade.php
+++ b/resources/views/account/view-assets.blade.php
@@ -173,13 +173,26 @@ View Assets for  {{ $user->present()->fullName() }}
                   }'>
             <thead>
               <tr>
-                <th class="col-md-12">{{ trans('general.name') }}</th>
+                <th class="col-md-5">{{ trans('general.name') }}</th>
+                <th class="col-md-2">{{ trans('general.quantity') }}</th>
               </tr>
             </thead>
             <tbody>
-              @foreach ($user->consumables as $consumable)
+              <?php 
+              $consumables = array();
+              foreach ($user->consumables as $consumable) {
+                if (array_key_exists($consumable->name, $consumables)) { 
+                  $consumables[$consumable->name] += 1; 
+                }
+                else {
+                  $consumables[$consumable->name] = 1;
+                }
+              }
+              ?>
+              @foreach ($consumables as $name => $quantity)
               <tr>
-                <td>{{ $consumable->name }}</td>
+                <td>{{ $name }}</td>
+                <td>{{ $quantity }}</td>
               </tr>
               @endforeach
             </tbody>

--- a/resources/views/account/view-assets.blade.php
+++ b/resources/views/account/view-assets.blade.php
@@ -182,10 +182,10 @@ View Assets for  {{ $user->present()->fullName() }}
               $consumables = array();
               foreach ($user->consumables as $consumable) {
                 if (array_key_exists($consumable->name, $consumables)) { 
-                  $consumables[$consumable->name] += 1; 
+                  $consumables[$consumable->name] += $consumable->pivot->qty; 
                 }
                 else {
-                  $consumables[$consumable->name] = 1;
+                  $consumables[$consumable->name] = $consumable->pivot->qty;
                 }
               }
               ?>

--- a/resources/views/consumables/checkout.blade.php
+++ b/resources/views/consumables/checkout.blade.php
@@ -40,6 +40,15 @@
           <!-- User -->
             @include ('partials.forms.edit.user-select', ['translated_name' => trans('general.select_user'), 'fieldname' => 'assigned_to', 'required'=> 'true'])
 
+            <div class="form-group {{ $errors->has('assigned_qty') ? ' has-error' : '' }}">
+              <label for="assigned_qty" class="col-md-3 control-label">{{ trans('general.qty') }}
+                <i class='icon-asterisk'></i></label>
+              <div class="col-md-9">
+                <input class="form-control" type="text" name="assigned_qty" id="assigned_qty" style="width: 70px;" placeholder="1" value="{{ Input::old('assigned_qty') }}" />
+                {!! $errors->first('assigned_qty', '<br><span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
+              </div>
+            </div>
+
           @if ($consumable->category->require_acceptance=='1')
           <div class="form-group">
             <div class="col-md-9 col-md-offset-3">

--- a/resources/views/consumables/checkout.blade.php
+++ b/resources/views/consumables/checkout.blade.php
@@ -40,12 +40,12 @@
           <!-- User -->
             @include ('partials.forms.edit.user-select', ['translated_name' => trans('general.select_user'), 'fieldname' => 'assigned_to', 'required'=> 'true'])
 
-            <div class="form-group {{ $errors->has('assigned_qty') ? ' has-error' : '' }}">
-              <label for="assigned_qty" class="col-md-3 control-label">{{ trans('general.qty') }}
+            <div class="form-group {{ $errors->has('qty') ? ' has-error' : '' }}">
+              <label for="qty" class="col-md-3 control-label">{{ trans('general.quantity') }}
                 <i class='icon-asterisk'></i></label>
               <div class="col-md-9">
-                <input class="form-control" type="text" name="assigned_qty" id="assigned_qty" style="width: 70px;" placeholder="1" value="{{ Input::old('assigned_qty') }}" />
-                {!! $errors->first('assigned_qty', '<br><span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
+                <input class="form-control" type="text" name="qty" id="qty" style="width: 70px;" placeholder="1" value="{{ Input::old('qty') }}" />
+                {!! $errors->first('qty', '<br><span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
               </div>
             </div>
 

--- a/resources/views/consumables/view.blade.php
+++ b/resources/views/consumables/view.blade.php
@@ -54,6 +54,7 @@
                 <thead>
                   <tr>
                     <th data-searchable="false" data-sortable="false" data-field="name">{{ trans('general.user') }}</th>
+                    <th data-searchable="false" data-sortable="false" data-field="quantity">{{ trans('general.quantity') }}</th>
                     <th data-searchable="false" data-sortable="false" data-field="created_at">{{ trans('general.date') }}</th>
                     <th data-searchable="false" data-sortable="false" data-field="admin">{{ trans('general.admin') }}</th>
                   </tr>

--- a/resources/views/consumables/view.blade.php
+++ b/resources/views/consumables/view.blade.php
@@ -54,7 +54,7 @@
                 <thead>
                   <tr>
                     <th data-searchable="false" data-sortable="false" data-field="name">{{ trans('general.user') }}</th>
-                    <th data-searchable="false" data-sortable="false" data-field="quantity">{{ trans('general.quantity') }}</th>
+                    <th data-searchable="false" data-sortable="false" data-field="qty">{{ trans('general.quantity') }}</th>
                     <th data-searchable="false" data-sortable="false" data-field="created_at">{{ trans('general.date') }}</th>
                     <th data-searchable="false" data-sortable="false" data-field="admin">{{ trans('general.admin') }}</th>
                   </tr>

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -373,14 +373,25 @@
               <thead>
                 <tr>
                   <th class="col-md-8">{{ trans('general.name') }}</th>
-                  <th class="col-md-4">{{ trans('general.date') }}</th>
+                  <th class="col-md-4">{{ trans('general.quantity') }}</th>
                 </tr>
               </thead>
               <tbody>
-                @foreach ($user->consumables as $consumable)
+                <?php 
+                $consumables = array();
+                foreach ($user->consumables as $consumable) {
+                  if (array_key_exists($consumable->name, $consumables)) { 
+                    $consumables[$consumable->name] += $consumable->pivot->qty; 
+                  }
+                  else {
+                    $consumables[$consumable->name] = $consumable->pivot->qty;
+                  }
+                }
+                ?>
+                @foreach ($consumables as $name => $quantity)
                 <tr>
-                  <td>{!! $consumable->present()->nameUrl() !!}</a></td>
-                  <td>{{ $consumable->created_at }}</td>
+                  <td>{{ $name }}</td>
+                  <td>{{ $quantity }}</td>
                 </tr>
                 @endforeach
               </tbody>


### PR DESCRIPTION
I love this project and greatly appreciate how clean the code is. It was very easy to get familiar with the code base and start contributing. That being said, I'm a bit new to large scale git projects, so some of my commits and merges may be weird. 

I have adjusted the consumables_users table and corresponding consumableAssignment model to include a quantity. The migration sets default =1 so existing assignments still function as intended. I included some basic validation and bounds checking in the consumablesController, and allow for checkout of negative quantities. This signifies consuming the consumable, and this will not increase the number remaining. 
I also changed the account view_assets page to give a sum of each type of consumable checked out to that user rather than a list by name of each time one was assigned. This number changes when consumables are consumed and represents how many of that consumable that user has on hand. This should never be negative.

Hopefully this is a step in the direction you were hoping to go, but is definitely useful in my use case and seems like it will be for others as well, as per issue #1820. Thanks for a great inventory solution!