### PR TITLE
Functional Tests Improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,8 +51,8 @@ before_script:
 script:
   - ./vendor/bin/codecept run unit
 #  - ./vendor/bin/codecept run acceptance --env=testing-ci
-  - ./vendor/bin/codecept run functional --env=functional-travis
-#script: ./vendor/bin/codecept run
+  - ./vendor/bin/codecept run functional --env=functional-travis -g func1
+  - ./vendor/bin/codecept run functional --env=functional-travis -g func2
   - ./vendor/bin/codecept run api --env=functional-travis
 
 after_script:

--- a/tests/_envs/functional-travis.yml
+++ b/tests/_envs/functional-travis.yml
@@ -9,3 +9,4 @@ modules:
         dsn: 'mysql:host=localhost;dbname=snipeit_unit'
         user: 'travis'
         password: ''
+        populator: 'mysql -u travis snipeit_unit < tests/_data/dump.sql'

--- a/tests/functional.suite.yml
+++ b/tests/functional.suite.yml
@@ -18,6 +18,10 @@ modules:
             password: ''
             dump: tests/_data/dump.sql
             populate: true
-            cleanup: true
+            populator: 'mysql -u snipeit_laravel snipeittests < tests/_data/dump.sql'
+            cleanup: false
         - REST:
             depends: Laravel5
+groups:
+    func1: tests/functional/func-part-1.txt
+    func2: tests/functional/func-part-2.txt

--- a/tests/functional/CategoriesCest.php
+++ b/tests/functional/CategoriesCest.php
@@ -58,7 +58,7 @@ class CategoriesCest
     {
         $I->wantTo('Ensure I can delete a category');
         $category = factory(App\Models\Category::class)->states('asset-laptop-category')->create([
-            'name'=>"Test Category"
+            'name'=>"Deletable Test Category"
         ]);
         $I->sendDelete(route('categories.destroy', $category->id), ['_token' => csrf_token()]);
         $I->seeResponseCodeIs(200);

--- a/tests/functional/ManufacturersCest.php
+++ b/tests/functional/ManufacturersCest.php
@@ -59,7 +59,7 @@ class ManufacturersCest
     public function allowsDelete(FunctionalTester $I)
     {
         $I->wantTo('Ensure I can delete a manufacturer');
-        $manufacturerId = factory(App\Models\Manufacturer::class)->states('microsoft')->create(['name' => "Test Manufacturer"])->id;
+        $manufacturerId = factory(App\Models\Manufacturer::class)->states('microsoft')->create(['name' => "Deletable Test Manufacturer"])->id;
         $I->sendDelete(route('manufacturers.destroy', $manufacturerId), ['_token' => csrf_token()]);
         $I->seeResponseCodeIs(200);
     }

--- a/tests/functional/func-part-1.txt
+++ b/tests/functional/func-part-1.txt
@@ -1,0 +1,8 @@
+tests/functional/AccessoriesCest.php
+tests/functional/AssetModelsCest.php
+tests/functional/AssetsCest.php
+tests/functional/CategoriesCest.php
+tests/functional/CompaniesCest.php
+tests/functional/ComponentsCest.php
+tests/functional/ConsumablesCest.php
+tests/functional/DepreciationsCest.php

--- a/tests/functional/func-part-2.txt
+++ b/tests/functional/func-part-2.txt
@@ -2,6 +2,6 @@ tests/functional/GroupsCest.php
 tests/functional/LicensesCest.php
 tests/functional/LocationsCest.php
 tests/functional/ManufacturersCest.php
-tests/functional/StatuslabelsCest.php
+tests/functional/StatusLabelsCest.php
 tests/functional/SuppliersCest.php
 tests/functional/UsersCest.php

--- a/tests/functional/func-part-2.txt
+++ b/tests/functional/func-part-2.txt
@@ -1,0 +1,7 @@
+tests/functional/GroupsCest.php
+tests/functional/LicensesCest.php
+tests/functional/LocationsCest.php
+tests/functional/ManufacturersCest.php
+tests/functional/StatuslabelsCest.php
+tests/functional/SuppliersCest.php
+tests/functional/UsersCest.php


### PR DESCRIPTION
- Split functional tests into two groups for travis.  Run them independantly.  This should fix the running out of memory issue.  **Note: This will require adding any new functional test files to one of the two func-part-* files in tests/functional before they run on travis**
- Rely on laravels transaction support for cleaning up between tests instead of reloading the database dump.  This cuts the time required to run functional tests down by 75% (From 2min to 30seconds here).
- Use mysql to populate db directly initially.
