### PR TITLE
Api tests2

### DIFF
--- a/app/Http/Controllers/Api/AssetModelsController.php
+++ b/app/Http/Controllers/Api/AssetModelsController.php
@@ -32,7 +32,21 @@ class AssetModelsController extends Controller
         $this->authorize('view', AssetModel::class);
         $allowed_columns = ['id','image','name','model_number','eol','notes','created_at','manufacturer','assets_count'];
 
-        $assetmodels = AssetModel::select(['models.id','models.image','models.name','model_number','eol','models.notes','models.created_at','category_id','manufacturer_id','depreciation_id','fieldset_id', 'models.deleted_at'])
+        $assetmodels = AssetModel::select([
+            'models.id',
+            'models.image',
+            'models.name',
+            'model_number',
+            'eol',
+            'models.notes',
+            'models.created_at',
+            'category_id',
+            'manufacturer_id',
+            'depreciation_id',
+            'fieldset_id',
+            'models.deleted_at',
+            'models.updated_at',
+         ])
             ->with('category','depreciation', 'manufacturer','fieldset')
             ->withCount('assets');
 
@@ -137,7 +151,7 @@ class AssetModelsController extends Controller
         $assetmodel->fieldset_id = $request->get("custom_fieldset_id");
 
         if ($assetmodel->save()) {
-            return response()->json(Helper::formatStandardApiResponse('success', $assetmodel, trans('admin/assetmodels/message.update.success')));
+            return response()->json(Helper::formatStandardApiResponse('success', $assetmodel, trans('admin/models/message.update.success')));
         }
 
         return response()->json(Helper::formatStandardApiResponse('error', null, $assetmodel->getErrors()));
@@ -170,7 +184,7 @@ class AssetModelsController extends Controller
         }
 
         $assetmodel->delete();
-        return response()->json(Helper::formatStandardApiResponse('success', null,  trans('admin/assetmodels/message.delete.success')));
+        return response()->json(Helper::formatStandardApiResponse('success', null,  trans('admin/models/message.delete.success')));
 
     }
 

--- a/app/Http/Controllers/Api/LicensesController.php
+++ b/app/Http/Controllers/Api/LicensesController.php
@@ -2,13 +2,15 @@
 
 namespace App\Http\Controllers\Api;
 
-use Illuminate\Http\Request;
+use App\Helpers\Helper;
 use App\Http\Controllers\Controller;
-use App\Http\Transformers\LicensesTransformer;
 use App\Http\Transformers\LicenseSeatsTransformer;
+use App\Http\Transformers\LicensesTransformer;
+use App\Models\Company;
 use App\Models\License;
 use App\Models\LicenseSeat;
-use App\Models\Company;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 
 class LicensesController extends Controller
 {
@@ -121,6 +123,14 @@ class LicensesController extends Controller
     public function store(Request $request)
     {
         //
+        $this->authorize('create', License::class);
+        $license = new License;
+        $license->fill($request->all());
+
+        if($license->save()) {
+            return response()->json(Helper::formatStandardApiResponse('success', $license, trans('admin/licenses/message.create.success')));
+        }
+        return response()->json(Helper::formatStandardApiResponse('error', null, $license->getErrors()));
     }
 
     /**
@@ -132,13 +142,10 @@ class LicensesController extends Controller
      */
     public function show($id)
     {
-        $license = License::find($id);
-        if (isset($license->id)) {
-            $license = $license->load('assignedusers', 'licenseSeats.user', 'licenseSeats.asset');
-            $this->authorize('view', $license);
-            return (new LicensesTransformer)->transformLicense($license);
-        }
-        return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/licenses/message.does_not_exist')), 200);
+        $this->authorize('view', License::class);
+        $license = License::findOrFail($id);
+        $license = $license->load('assignedusers', 'licenseSeats.user', 'licenseSeats.asset');
+        return (new LicensesTransformer)->transformLicense($license);
     }
 
 
@@ -154,6 +161,16 @@ class LicensesController extends Controller
     public function update(Request $request, $id)
     {
         //
+        $this->authorize('edit', License::class);
+
+        $license = License::findOrFail($id);
+        $license->fill($request->all());
+
+        if ($license->save()) {
+            return response()->json(Helper::formatStandardApiResponse('success', $license, trans('admin/licenses/message.update.success')));
+        }
+
+        return Helper::formatStandardApiResponse('error', null, $license->getErrors());
     }
 
     /**
@@ -167,6 +184,23 @@ class LicensesController extends Controller
     public function destroy($id)
     {
         //
+        $license = License::findOrFail($id);
+        $this->authorize('delete', $license);
+
+        if($license->assigned_seats_count == 0) {
+            // Delete the license and the associated license seats
+            DB::table('license_seats')
+                ->where('id', $license->id)
+                ->update(array('assigned_to' => null,'asset_id' => null));
+
+            $licenseSeats = $license->licenseseats();
+            $licenseSeats->delete();
+            $license->delete();
+
+            // Redirect to the licenses management page
+            return response()->json(Helper::formatStandardApiResponse('success', null,  trans('admin/licenses/message.delete.success')));
+        }
+        return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/licenses/message.assoc_users')));
     }
 
     /**

--- a/app/Http/Transformers/AssetModelsTransformer.php
+++ b/app/Http/Transformers/AssetModelsTransformer.php
@@ -34,7 +34,7 @@ class AssetModelsTransformer
                 'id' => (int) $assetmodel->depreciation->id,
                 'name'=> e($assetmodel->depreciation->name)
             ]  : null,
-            'assets_count' => $assetmodel->assets_count,
+            'assets_count' => (int) $assetmodel->assets_count,
             'category' => ($assetmodel->category) ? [
                 'id' => (int) $assetmodel->category->id,
                 'name'=> e($assetmodel->category->name)

--- a/app/Models/AssetModel.php
+++ b/app/Models/AssetModel.php
@@ -55,7 +55,18 @@ class AssetModel extends SnipeModel
      *
      * @var array
      */
-    protected $fillable = ['name','manufacturer_id','category_id','eol', 'user_id', 'fieldset_id', 'model_number', 'notes'];
+    protected $fillable = [
+        'category_id',
+        'depreciation_id',
+        'eol',
+        'fieldset_id',
+        'image',
+        'manufacturer_id',
+        'model_number',
+        'name',
+        'notes',
+        'user_id',
+    ];
 
     public function assets()
     {

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -53,7 +53,15 @@ class Category extends SnipeModel
      *
      * @var array
      */
-    protected $fillable = ['name','category_type', 'user_id', 'use_default_eula','checkin_email','require_acceptance'];
+    protected $fillable = [
+        'category_type',
+        'checkin_email',
+        'eula_text',
+        'name',
+        'require_acceptance',
+        'use_default_eula',
+        'user_id',
+    ];
 
 
     public function has_models()

--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -40,7 +40,6 @@ class License extends Depreciable
         'seats'   => 'required|min:1|max:1000000|integer',
         'license_email'   => 'email|nullable|max:120',
         'license_name'   => 'string|nullable|max:100',
-        'note'   => 'string|nullable',
         'notes'   => 'string|nullable',
         'company_id' => 'integer|nullable',
     );
@@ -51,25 +50,25 @@ class License extends Depreciable
     * @var array
     */
     protected $fillable = [
-        'name',
-        'serial',
-        'purchase_date',
-        'purchase_cost',
-        'order_number',
-        'seats',
-        'notes',
-        'user_id',
-        'depreciation_id',
-        'license_name', //actually licensed_to
-        'license_email',
-        'supplier_id',
-        'expiration_date',
-        'purchase_order',
-        'termination_date',
-        'maintained',
-        'reassignable',
         'company_id',
-        'manufacturer_id'
+        'depreciation_id',
+        'expiration_date',
+        'license_email',
+        'license_name', //actually licensed_to
+        'maintained',
+        'manufacturer_id',
+        'name',
+        'notes',
+        'order_number',
+        'purchase_cost',
+        'purchase_date',
+        'purchase_order',
+        'reassignable',
+        'seats',
+        'serial',
+        'supplier_id',
+        'termination_date',
+        'user_id',
     ];
 
     public static function boot()

--- a/app/Models/Manufacturer.php
+++ b/app/Models/Manufacturer.php
@@ -40,7 +40,14 @@ class Manufacturer extends SnipeModel
      *
      * @var array
      */
-    protected $fillable = ['name','url','support_url','support_phone','support_email'];
+    protected $fillable = [
+        'name',
+        'image',
+        'support_email',
+        'support_phone',
+        'support_url',
+        'url',
+    ];
 
 
 

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -125,6 +125,10 @@ class AuthServiceProvider extends ServiceProvider
             }
         });
 
+        Gate::define('self.api', function($user) {
+            return $user->hasAccess('self.api');
+        });
+
         Gate::define('backend.interact', function ($user) {
             return $user->can('view', \App\Models\Statuslabel::class)
                 || $user->can('view', \App\Models\AssetModel::class)

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -12,11 +12,11 @@
 
 $factory->define(App\Models\Category::class, function (Faker\Generator $faker) {
     return [
-        'user_id' => 1,
+        'checkin_email' => $faker->boolean(),
         'eula_text' => $faker->paragraph(),
         'require_acceptance' => false,
         'use_default_eula' => $faker->boolean(),
-        'checkin_email' => $faker->boolean()
+        'user_id' => 1,
      ];
 });
 

--- a/database/factories/LicenseFactory.php
+++ b/database/factories/LicenseFactory.php
@@ -19,6 +19,10 @@ $factory->define(App\Models\License::class, function (Faker\Generator $faker) {
         'notes'   => 'Created by DB seeder',
         'purchase_date' => $faker->dateTimeBetween('-1 years','now', date_default_timezone_get()),
         'order_number' => $faker->numberBetween(1000000, 50000000),
+        'expiration_date' => $faker->dateTimeBetween('now', '+3 years', date_default_timezone_get())->format('Y-m-d H:i:s'),
+        'reassignable' => $faker->boolean(),
+        'termination_date' => $faker->dateTimeBetween('-1 years','now', date_default_timezone_get())->format('Y-m-d H:i:s'),
+        'supplier_id' => $faker->numberBetween(1,5),
     ];
 });
 

--- a/tests/api/ApiCategoriesCest.php
+++ b/tests/api/ApiCategoriesCest.php
@@ -1,0 +1,145 @@
+<?php
+
+use App\Helpers\Helper;
+use App\Http\Transformers\CategoriesTransformer;
+use App\Models\Category;
+use App\Models\Setting;
+use Illuminate\Support\Facades\Auth;
+
+class ApiCategoriesCest
+{
+    protected $user;
+    protected $timeFormat;
+
+    public function _before(ApiTester $I)
+    {
+        $this->user = \App\Models\User::find(1);
+        $I->haveHttpHeader('Accept', 'application/json');
+        $I->amBearerAuthenticated($I->getToken($this->user));
+    }
+
+    /** @test */
+    public function indexCategorys(ApiTester $I)
+    {
+
+        $I->wantTo('Get a list of categories');
+
+        // call
+        $I->sendGET('/categories?order_by=id&limit=10');
+        $I->seeResponseIsJson();
+        $I->seeResponseCodeIs(200);
+
+        $response = json_decode($I->grabResponse(), true);
+        // dd($response);
+        // sample verify
+        $category = App\Models\Category::withCount('assets','accessories','consumables','components')
+            ->orderByDesc('created_at')->take(10)->get()->shuffle()->first();
+
+        $I->seeResponseContainsJson((new CategoriesTransformer)->transformCategory($category));
+    }
+
+    /** @test */
+    public function createCategory(ApiTester $I, $scenario)
+    {
+        $I->wantTo('Create a new category');
+
+        $temp_category = factory(\App\Models\Category::class)->states('asset-laptop-category')->make([
+            'name' => "Test Category Tag",
+        ]);
+
+        // setup
+        $data = [
+            'category_type' => $temp_category->category_type,
+            'checkin_email' => $temp_category->checkin_email,
+            'eula_text' => $temp_category->eula_text,
+            'name' => $temp_category->name,
+            'require_acceptance' => $temp_category->require_acceptance,
+            'use_default_eula' => $temp_category->use_default_eula,
+        ];
+
+        // create
+        $I->sendPOST('/categories', $data);
+        $I->seeResponseIsJson();
+        $I->seeResponseCodeIs(200);
+    }
+
+    // Put is routed to the same method in the controller
+    // DO we actually need to test both?
+    /** @test */
+    public function updateCategoryWithPatch(ApiTester $I, $scenario)
+    {
+        $I->wantTo('Update an category with PATCH');
+
+        // create
+        $category = factory(\App\Models\Category::class)->states('asset-laptop-category')
+            ->create([
+                'name' => 'Original Category Name',
+        ]);
+        $I->assertInstanceOf(\App\Models\Category::class, $category);
+
+        $temp_category = factory(\App\Models\Category::class)
+            ->states('accessory-mouse-category')->make([
+            'name' => "updated category name",
+        ]);
+
+        $data = [
+            'category_type' => $temp_category->category_type,
+            'checkin_email' => $temp_category->checkin_email,
+            'eula_text' => $temp_category->eula_text,
+            'name' => $temp_category->name,
+            'require_acceptance' => $temp_category->require_acceptance,
+            'use_default_eula' => $temp_category->use_default_eula,
+        ];
+
+        $I->assertNotEquals($category->name, $data['name']);
+
+        // update
+        $I->sendPATCH('/categories/' . $category->id, $data);
+        $I->seeResponseIsJson();
+        $I->seeResponseCodeIs(200);
+
+        $response = json_decode($I->grabResponse());
+
+        $I->assertEquals('success', $response->status);
+        $I->assertEquals(trans('admin/categories/message.update.success'), $response->messages);
+        $I->assertEquals($category->id, $response->payload->id); // category id does not change
+        $I->assertEquals($temp_category->name, $response->payload->name); // category name updated
+        // Some manual copying to compare against
+        $temp_category->created_at = Carbon::parse($response->payload->created_at);
+        $temp_category->updated_at = Carbon::parse($response->payload->updated_at);
+        $temp_category->id = $category->id;
+
+        // verify
+        $I->sendGET('/categories/' . $category->id);
+        $I->seeResponseIsJson();
+        $I->seeResponseCodeIs(200);
+        $I->seeResponseContainsJson((new CategoriesTransformer)->transformCategory($temp_category));
+
+    }
+
+    /** @test */
+    public function deleteCategoryTest(ApiTester $I, $scenario)
+    {
+        $I->wantTo('Delete an category');
+
+        // create
+        $category = factory(\App\Models\Category::class)->states('asset-laptop-category')->create([
+            'name' => "Soon to be deleted"
+        ]);
+        $I->assertInstanceOf(\App\Models\Category::class, $category);
+
+        // delete
+        $I->sendDELETE('/categories/' . $category->id);
+        $I->seeResponseIsJson();
+        $I->seeResponseCodeIs(200);
+
+        $response = json_decode($I->grabResponse());
+        $I->assertEquals('success', $response->status);
+        $I->assertEquals(trans('admin/categories/message.delete.success'), $response->messages);
+
+        // verify, expect a 200
+        $I->sendGET('/categories/' . $category->id);
+        $I->seeResponseCodeIs(200);
+        $I->seeResponseIsJson();
+    }
+}

--- a/tests/api/ApiLicensesCest.php
+++ b/tests/api/ApiLicensesCest.php
@@ -1,0 +1,174 @@
+<?php
+
+use App\Helpers\Helper;
+use App\Http\Transformers\LicensesTransformer;
+use App\Models\License;
+use App\Models\Setting;
+use Illuminate\Support\Facades\Auth;
+
+class ApiLicensesCest
+{
+    protected $license;
+    protected $timeFormat;
+
+    public function _before(ApiTester $I)
+    {
+        $this->user = \App\Models\User::find(1);
+        $I->haveHttpHeader('Accept', 'application/json');
+        $I->amBearerAuthenticated($I->getToken($this->user));
+    }
+
+    /** @test */
+    public function indexLicenses(ApiTester $I)
+    {
+        $I->wantTo('Get a list of licenses');
+
+        // call
+        $I->sendGET('/licenses?limit=10&sort=created_at');
+        $I->seeResponseIsJson();
+        $I->seeResponseCodeIs(200);
+
+        $response = json_decode($I->grabResponse(), true);
+        // sample verify
+        $license = App\Models\License::orderByDesc('created_at')
+            ->withCount('freeSeats')
+            ->take(10)->get()->shuffle()->first();
+        $I->seeResponseContainsJson((new LicensesTransformer)->transformLicense($license));
+    }
+
+    /** @test */
+    public function createLicense(ApiTester $I, $scenario)
+    {
+        $I->wantTo('Create a new license');
+        $scenario->incomplete("Implement create in the api licensescontroller");
+
+        $temp_license = factory(\App\Models\License::class)->states('acrobat')->make([
+            'name' => "Test License Name",
+            'depreciation_id' => 3,
+            'company_id' => 2
+        ]);
+
+        // setup
+        $data = [
+            'company_id' => $temp_license->company_id,
+            'depreciation_id' => $temp_license->depreciation_id,
+            'expiration_date' => $temp_license->expiration_date,
+            'license_email' => $temp_license->license_email,
+            'license_name' => $temp_license->license_name,
+            'maintained' => $temp_license->maintained,
+            'manufacturer_id' => $temp_license->manufacturer_id,
+            'name' => $temp_license->name,
+            'notes' => $temp_license->notes,
+            'order_number' => $temp_license->order_number,
+            'purchase_cost' => $temp_license->purchase_cost,
+            'purchase_date' => $temp_license->purchase_date,
+            'purchase_order' => $temp_license->purchase_order,
+            'reassignable' => $temp_license->reassignable,
+            'seats' => $temp_license->seats,
+            'serial' => $temp_license->serial,
+            'supplier_id' => $temp_license->supplier_id,
+            'termination_date' => $temp_license->termination_date,
+        ];
+
+        // create
+        $I->sendPOST('/licenses', $data);
+        dd($I->grabResponse());
+        $I->seeResponseIsJson();
+        $I->seeResponseCodeIs(200);
+    }
+
+    // Put is routed to the same method in the controller
+    // DO we actually need to test both?
+    /** @test */
+    public function updateLicenseWithPatch(ApiTester $I, $scenario)
+    {
+        $I->wantTo('Update an license with PATCH');
+        $scenario->incomplete("Implement update in the api licensescontroller");
+
+        // create
+        $license = factory(\App\Models\License::class)->states('acrobat')->create([
+            'name' => 'Original License Name',
+            'depreciation_id' => 3,
+            'company_id' => 2
+        ]);
+        $I->assertInstanceOf(\App\Models\License::class, $license);
+
+        $temp_license = factory(\App\Models\License::class)->states('office')->make([
+            'company_id' => 3,
+            'depreciation_id' => 2,
+            'company_id' => 4
+        ]);
+
+        $data = [
+            'company_id' => $temp_license->company_id,
+            'depreciation_id' => $temp_license->depreciation_id,
+            'expiration_date' => $temp_license->expiration_date,
+            'license_email' => $temp_license->license_email,
+            'license_name' => $temp_license->license_name,
+            'maintained' => $temp_license->maintained,
+            'manufacturer_id' => $temp_license->manufacturer_id,
+            'name' => $temp_license->name,
+            'notes' => $temp_license->notes,
+            'order_number' => $temp_license->order_number,
+            'purchase_cost' => $temp_license->purchase_cost,
+            'purchase_date' => $temp_license->purchase_date,
+            'purchase_order' => $temp_license->purchase_order,
+            'reassignable' => $temp_license->reassignable,
+            'seats' => $temp_license->seats,
+            'serial' => $temp_license->serial,
+            'supplier_id' => $temp_license->supplier_id,
+            'termination_date' => $temp_license->termination_date,
+        ];
+
+        $I->assertNotEquals($license->name, $data['name']);
+
+        // update
+        $I->sendPATCH('/licenses/' . $license->id, $data);
+        $I->seeResponseIsJson();
+        $I->seeResponseCodeIs(200);
+
+        $response = json_decode($I->grabResponse());
+        $I->assertEquals('success', $response->status);
+        $I->assertEquals(trans('admin/licenses/message.success.update'), $response->messages);
+        $I->assertEquals($license->id, $response->payload->id); // license id does not change
+        $I->assertEquals($temp_license->company_id, $response->payload->company->id); // company_id updated
+        $I->assertEquals($temp_license->name, $response->payload->name); // license name
+        $temp_license->created_at = Carbon::parse($response->payload->created_at->datetime);
+        $temp_license->updated_at = Carbon::parse($response->payload->updated_at->datetime);
+        $temp_license->id = $license->id;
+        // verify
+        $I->sendGET('/licenses/' . $license->id);
+        $I->seeResponseIsJson();
+        $I->seeResponseCodeIs(200);
+        $I->seeResponseContainsJson((new LicensesTransformer)->transformLicense($temp_license));
+    }
+
+    /** @test */
+    public function deleteLicenseTest(ApiTester $I, $scenario)
+    {
+        $I->wantTo('Delete an license');
+        $scenario->incomplete("Implement destroy in the api licensescontroller");
+
+        // create
+        $license = factory(\App\Models\License::class)->states('acrobat')->create([
+            'name' => "Soon to be deleted"
+        ]);
+        $I->assertInstanceOf(\App\Models\License::class, $license);
+
+        // delete
+        $I->sendDELETE('/licenses/' . $license->id);
+        $I->seeResponseIsJson();
+        $I->seeResponseCodeIs(200);
+
+        $response = json_decode($I->grabResponse());
+        // dd($response);
+        $I->assertEquals('success', $response->status);
+        $I->assertEquals(trans('admin/licenses/message.success.delete'), $response->messages);
+
+        // verify, expect a 200
+        $I->sendGET('/licenses/' . $license->id);
+
+        $I->seeResponseCodeIs(200);
+        $I->seeResponseIsJson();
+    }
+}

--- a/tests/api/ApiLocationsCest.php
+++ b/tests/api/ApiLocationsCest.php
@@ -14,8 +14,6 @@ class ApiLocationsCest
     public function _before(ApiTester $I)
     {
         $this->user = \App\Models\User::find(1);
-        $this->timeFormat = Setting::getSettings()->date_display_format .' '. Setting::getSettings()->time_display_format;
-        $this->dateFormat = Setting::getSettings()->date_display_format;
         $I->haveHttpHeader('Accept', 'application/json');
         $I->amBearerAuthenticated($I->getToken($this->user));
     }
@@ -27,7 +25,7 @@ class ApiLocationsCest
         $I->wantTo('Get a list of locations');
 
         // call
-        $I->sendGET('/locations?limit=1');
+        $I->sendGET('/locations?limit=10');
         $I->seeResponseIsJson();
         $I->seeResponseCodeIs(200);
 
@@ -35,7 +33,7 @@ class ApiLocationsCest
         // sample verify
         $location = App\Models\Location::orderByDesc('created_at')
             ->withCount('assignedAssets', 'assets',  'users')
-            ->take(1)->get()->shuffle()->first();
+            ->take(10)->get()->shuffle()->first();
         $I->seeResponseContainsJson((new LocationsTransformer)->transformLocation($location));
     }
 
@@ -51,6 +49,17 @@ class ApiLocationsCest
         // setup
         $data = [
             'name' => $temp_location->name,
+            'image' => $temp_location->image,
+            'address' => $temp_location->address,
+            'address2' => $temp_location->address2,
+            'city' => $temp_location->city,
+            'state' => $temp_location->state,
+            'country' => $temp_location->country,
+            'zip' => $temp_location->zip,
+            'parent_id' => $temp_location->parent_id,
+            'parent_id' => $temp_location->parent_id,
+            'manager_id' => $temp_location->manager_id,
+            'currency' => $temp_location->currency
         ];
 
         // create
@@ -109,12 +118,13 @@ class ApiLocationsCest
         $temp_location->created_at = Carbon::parse($response->payload->created_at->datetime);
         $temp_location->updated_at = Carbon::parse($response->payload->updated_at->datetime);
         $temp_location->id = $location->id;
+        // dd($temp_location);
         // verify
         $I->sendGET('/locations/' . $location->id);
         $I->seeResponseIsJson();
         $I->seeResponseCodeIs(200);
+        dd((new LocationsTransformer)->transformLocation($temp_location));
         $I->seeResponseContainsJson((new LocationsTransformer)->transformLocation($temp_location));
-        // $I->seeResponseContainsJson($this->generateJsonResponse($temp_location, $location));
     }
 
     /** @test */

--- a/tests/api/ApiLocationsCest.php
+++ b/tests/api/ApiLocationsCest.php
@@ -118,12 +118,11 @@ class ApiLocationsCest
         $temp_location->created_at = Carbon::parse($response->payload->created_at->datetime);
         $temp_location->updated_at = Carbon::parse($response->payload->updated_at->datetime);
         $temp_location->id = $location->id;
-        // dd($temp_location);
+
         // verify
         $I->sendGET('/locations/' . $location->id);
         $I->seeResponseIsJson();
         $I->seeResponseCodeIs(200);
-        dd((new LocationsTransformer)->transformLocation($temp_location));
         $I->seeResponseContainsJson((new LocationsTransformer)->transformLocation($temp_location));
     }
 

--- a/tests/api/ApiManufacturersCest.php
+++ b/tests/api/ApiManufacturersCest.php
@@ -1,0 +1,143 @@
+<?php
+
+use App\Helpers\Helper;
+use App\Http\Transformers\ManufacturersTransformer;
+use App\Models\Manufacturer;
+use App\Models\Setting;
+use Illuminate\Support\Facades\Auth;
+
+class ApiManufacturersCest
+{
+    protected $user;
+    protected $timeFormat;
+
+    public function _before(ApiTester $I)
+    {
+        $this->user = \App\Models\User::find(1);
+        $I->haveHttpHeader('Accept', 'application/json');
+        $I->amBearerAuthenticated($I->getToken($this->user));
+    }
+
+    /** @test */
+    public function indexManufacturers(ApiTester $I)
+    {
+
+        $I->wantTo('Get a list of manufacturers');
+
+        // call
+        $I->sendGET('/manufacturers?order_by=id&limit=10');
+        $I->seeResponseIsJson();
+        $I->seeResponseCodeIs(200);
+
+        $response = json_decode($I->grabResponse(), true);
+        // sample verify
+        $manufacturer = App\Models\Manufacturer::withCount('assets','accessories','consumables','licenses')
+            ->orderByDesc('created_at')->take(10)->get()->shuffle()->first();
+
+        $I->seeResponseContainsJson((new ManufacturersTransformer)->transformManufacturer($manufacturer));
+    }
+
+    /** @test */
+    public function createManufacturer(ApiTester $I, $scenario)
+    {
+        $I->wantTo('Create a new manufacturer');
+
+        $temp_manufacturer = factory(\App\Models\Manufacturer::class)->states('apple')->make([
+            'name' => "Test Manufacturer Tag",
+        ]);
+
+        // setup
+        $data = [
+            'image' => $temp_manufacturer->image,
+            'name' => $temp_manufacturer->name,
+            'support_email' => $temp_manufacturer->support_email,
+            'support_phone' => $temp_manufacturer->support_phone,
+            'support_url' => $temp_manufacturer->support_url,
+            'url' => $temp_manufacturer->url,
+        ];
+
+        // create
+        $I->sendPOST('/manufacturers', $data);
+        $I->seeResponseIsJson();
+        $I->seeResponseCodeIs(200);
+    }
+
+    // Put is routed to the same method in the controller
+    // DO we actually need to test both?
+    /** @test */
+    public function updateManufacturerWithPatch(ApiTester $I, $scenario)
+    {
+        $I->wantTo('Update an manufacturer with PATCH');
+
+        // create
+        $manufacturer = factory(\App\Models\Manufacturer::class)->states('apple')
+            ->create([
+                'name' => 'Original Manufacturer Name',
+        ]);
+        $I->assertInstanceOf(\App\Models\Manufacturer::class, $manufacturer);
+
+        $temp_manufacturer = factory(\App\Models\Manufacturer::class)->states('dell')->make([
+            'name' => "updated manufacturer name",
+        ]);
+
+        $data = [
+            'image' => $temp_manufacturer->image,
+            'name' => $temp_manufacturer->name,
+            'support_email' => $temp_manufacturer->support_email,
+            'support_phone' => $temp_manufacturer->support_phone,
+            'support_url' => $temp_manufacturer->support_url,
+            'url' => $temp_manufacturer->url,
+        ];
+
+        $I->assertNotEquals($manufacturer->name, $data['name']);
+
+        // update
+        $I->sendPATCH('/manufacturers/' . $manufacturer->id, $data);
+        $I->seeResponseIsJson();
+        $I->seeResponseCodeIs(200);
+
+        $response = json_decode($I->grabResponse());
+
+        $I->assertEquals('success', $response->status);
+        $I->assertEquals(trans('admin/manufacturers/message.update.success'), $response->messages);
+        $I->assertEquals($manufacturer->id, $response->payload->id); // manufacturer id does not change
+        $I->assertEquals($temp_manufacturer->name, $response->payload->name); // manufacturer name updated
+        // Some manual copying to compare against
+        $temp_manufacturer->created_at = Carbon::parse($response->payload->created_at);
+        $temp_manufacturer->updated_at = Carbon::parse($response->payload->updated_at);
+        $temp_manufacturer->id = $manufacturer->id;
+
+        // verify
+        $I->sendGET('/manufacturers/' . $manufacturer->id);
+        $I->seeResponseIsJson();
+        $I->seeResponseCodeIs(200);
+        $I->seeResponseContainsJson((new ManufacturersTransformer)->transformManufacturer($temp_manufacturer));
+
+    }
+
+    /** @test */
+    public function deleteManufacturerTest(ApiTester $I, $scenario)
+    {
+        $I->wantTo('Delete an manufacturer');
+
+        // create
+        $manufacturer = factory(\App\Models\Manufacturer::class)->states('apple')->create([
+            'name' => "Soon to be deleted"
+        ]);
+        $I->assertInstanceOf(\App\Models\Manufacturer::class, $manufacturer);
+
+        // delete
+        $I->sendDELETE('/manufacturers/' . $manufacturer->id);
+        $I->seeResponseIsJson();
+        $I->seeResponseCodeIs(200);
+
+        $response = json_decode($I->grabResponse());
+        $I->assertEquals('success', $response->status);
+        $I->assertEquals(trans('admin/manufacturers/message.delete.success'), $response->messages);
+
+        // verify, expect a 200
+        $I->sendGET('/manufacturers/' . $manufacturer->id);
+        $I->seeResponseCodeIs(200);
+        $I->seeResponseIsJson();
+    }
+}


### PR DESCRIPTION
Mostly finish implementing API Tests.

A few outstanding
-ApiComponentsAssetsCest - Not really sure what that one is supposed to do
-Custom fields: Thats all yours :)

The license tests are in, but Create/Update/Destroy are incomplete because these methods are not implemented yet in the controller

I've noticed going through this that there is a discrepency when returning a successful response from an update whether we do:
```
Helper::formatStandardApiResponse('success', $asset, trans('admin/hardware/message.update.success'))
```

or 
```
(Helper::formatStandardApiResponse('success', (new CompaniesTransformer)->transformCompany($company), trans('admin/companies/message.update.success')))
```

which mostly effects the way timestamps are returned.  Not sure which is more preferred.. guessing the second, thoughts?
