### PR TITLE
Update dark-green.css

### DIFF
--- a/public/assets/css/themes/dark-green.css
+++ b/public/assets/css/themes/dark-green.css
@@ -19,6 +19,9 @@ a, a:link, a:visited, .btn-primary.hover {
 #assetsListingTable>tbody>tr.selected>td {
     background-color: var(--back-main);
 }
+body {
+    color: var(--text-main);
+}
 .box, .box.box-default {
     border-top: 3px solid var(--header);
     border-top-color: var(--header);
@@ -70,7 +73,7 @@ a, a:link, a:visited, .btn-primary.hover {
     background-color: var(--back-main);
     color: var(--text-main);
 }
-h1 {
+h1, h2, h3, h4, h5, h6, p {
     color: var(--text-main);
 }
 .help-block {


### PR DESCRIPTION
Adjusted heading tags to encompass h2~h6, as some besides h1 are in use, and we weren't calling them previously.

Also calling body directly now, as some text not inside another continuous class exists on the consumables page.