### PR TITLE
Add `viewKeys` permission check on Asset page

### DIFF
--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -541,7 +541,13 @@
                     @foreach ($asset->licenseseats as $seat)
                     <tr>
                       <td><a href="{{ route('licenses.show', $seat->license->id) }}">{{ $seat->license->name }}</a></td>
-                      <td>{{ $seat->license->serial }}</td>
+                      <td>
+                          @can('viewKeys', $seat->license)
+                            {!! nl2br(e($seat->license->serial)) !!}
+                          @else
+                           ------------
+                          @endcan
+                      </td>
                       <td>
                         <a href="{{ route('licenses.checkin', $seat->id) }}" class="btn btn-sm bg-purple" data-tooltip="true">{{ trans('general.checkin') }}</a>
                       </td>


### PR DESCRIPTION
This should match up with how the permission is checked on the [license view page](https://github.com/snipe/snipe-it/blob/master/resources/views/licenses/view.blade.php#L119).

Fixes #5132