### PR TITLE
Support `\r`-terminated files better from the Importer

### DIFF
--- a/app/Http/Controllers/Api/ImportController.php
+++ b/app/Http/Controllers/Api/ImportController.php
@@ -72,6 +72,9 @@ class ImportController extends Controller
                 $import->file_path = $file_name;
                 $import->filesize = filesize($path.'/'.$file_name);
                 //TODO: is there a lighter way to do this?
+                if (! ini_get("auto_detect_line_endings")) {
+                    ini_set("auto_detect_line_endings", '1');
+                }
                 $reader = Reader::createFromPath("{$path}/{$file_name}");
                 $import->header_row = $reader->fetchOne(0);
                 // Grab the first row to display via ajax as the user picks fields

--- a/app/Importer/Importer.php
+++ b/app/Importer/Importer.php
@@ -99,7 +99,6 @@ abstract class Importer
         } else {
             $this->csv = Reader::createFromString($file);
         }
-        //$this->csv->setNewLine('\r\n'); //FIXME!
         $this->tempPassword = substr(str_shuffle("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"), 0, 20);
     }
     // Cached Values for import lookups

--- a/app/Importer/Importer.php
+++ b/app/Importer/Importer.php
@@ -91,15 +91,15 @@ abstract class Importer
         $this->fieldMap = $this->defaultFieldMap;
         // By default the importer passes a url to the file.
         // However, for testing we also support passing a string directly
+        if (! ini_get("auto_detect_line_endings")) {
+            ini_set("auto_detect_line_endings", '1');
+        }
         if (is_file($file)) {
             $this->csv = Reader::createFromPath($file);
         } else {
             $this->csv = Reader::createFromString($file);
         }
-        $this->csv->setNewLine('\r\n');
-        if (! ini_get("auto_detect_line_endings")) {
-            ini_set("auto_detect_line_endings", '1');
-        }
+        //$this->csv->setNewLine('\r\n'); //FIXME!
         $this->tempPassword = substr(str_shuffle("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"), 0, 20);
     }
     // Cached Values for import lookups


### PR DESCRIPTION
This is a relatively small set of changes, but the importer is a pretty big deal so I imagine this should be tested pretty carefully.

I was given a weird file that "doesn't import well" to investigate. It turns out, it was using `\r` line-endings. That's pretty ancient, but I suspect it's pretty common to people who might use FileMaker Pro - which would probably be a pretty common use-case for IT departments who decide to hack something together for themselves. So I looked into what might be necessary to natively support these files without any operator intervention.

First off, I injected the 'force auto-detect line-endings' code into the part that does the initial preview of the column headers and the first row. This is so that the initial preview is consistent with the import that fires in the end.

Next, I hoisted the bit that does the same ini_set routine in the actual import to fire *before* the CSV object (Reader) is constructed. This is what the PHPLeague documentation says to do if you have to import "Macintosh" file formats (aka FileMaker Pro).

But the last bit that I did, which might be a little weird, is that I commented-out the manual setting of the DOS-style newlines (`\r\n`) - since our auto-detecting should be obviating that.