### PR TITLE
Notification improvements

### DIFF
--- a/app/Http/Controllers/AccessoriesController.php
+++ b/app/Http/Controllers/AccessoriesController.php
@@ -12,7 +12,6 @@ use DB;
 use Gate;
 use Input;
 use Lang;
-use Mail;
 use Redirect;
 use Illuminate\Http\Request;
 use Slack;
@@ -313,16 +312,6 @@ class AccessoriesController extends Controller
         $data['expected_checkin'] = '';
         $data['note'] = $logaction->note;
         $data['require_acceptance'] = $accessory->requireAcceptance();
-        // TODO: Port this to new mail notifications
-
-        if ((($accessory->requireAcceptance()=='1')  || ($accessory->getEula())) && ($user->email!='')) {
-
-            Mail::send('emails.accept-accessory', $data, function ($m) use ($user) {
-                $m->to($user->email, $user->first_name . ' ' . $user->last_name);
-                $m->replyTo(config('mail.reply_to.address'), config('mail.reply_to.name'));
-                $m->subject(trans('mail.Confirm_accessory_delivery'));
-            });
-        }
 
       // Redirect to the new accessory page
         return redirect()->route('accessories.index')->with('success', trans('admin/accessories/message.checkout.success'));
@@ -392,15 +381,6 @@ class AccessoriesController extends Controller
             $data['checkin_date'] = e($logaction->created_at);
             $data['item_tag'] = '';
             $data['note'] = e($logaction->note);
-
-            if ((($accessory->checkin_email()=='1')) && ($user->email!='')) {
-
-                Mail::send('emails.checkin-asset', $data, function ($m) use ($user) {
-                    $m->to($user->email, $user->first_name . ' ' . $user->last_name);
-                    $m->replyTo(config('mail.reply_to.address'), config('mail.reply_to.name'));
-                    $m->subject(trans('mail.Confirm_Accessory_Checkin'));
-                });
-            }
 
             if ($backto=='user') {
                 return redirect()->route("users.show", $return_to)->with('success', trans('admin/accessories/message.checkin.success'));

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -681,27 +681,7 @@ class AssetsController extends Controller
 
         // Was the asset updated?
         if ($asset->save()) {
-            $logaction = $asset->logCheckin($target, e(request('note')));
-
-            $data['log_id'] = $logaction->id;
-            $data['first_name'] = get_class($target) == User::class ? $target->first_name : '';
-            $data['item_name'] = $asset->present()->name();
-            $data['checkin_date'] = $logaction->created_at;
-            $data['item_tag'] = $asset->asset_tag;
-            $data['item_serial'] = $asset->serial;
-            $data['note'] = $logaction->note;
-            $data['manufacturer_name'] = $asset->model->manufacturer->name;
-            $data['model_name'] = $asset->model->name;
-            $data['model_number'] = $asset->model->model_number;
-
-            if ((($asset->checkin_email()=='1')) && (isset($user)) && (!config('app.lock_passwords'))) {
-                Mail::send('emails.checkin-asset', $data, function ($m) use ($user) {
-                    $m->to($user->email, $user->first_name . ' ' . $user->last_name);
-                    $m->replyTo(config('mail.reply_to.address'), config('mail.reply_to.name'));
-                    $m->subject(trans('mail.Confirm_Asset_Checkin'));
-                });
-            }
-
+            $asset->logCheckin($target, e(request('note')));
             return response()->json(Helper::formatStandardApiResponse('success', ['asset'=> e($asset->asset_tag)], trans('admin/hardware/message.checkin.success')));
         }
 

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -668,7 +668,7 @@ class AssetsController extends Controller
         $asset->assigned_to = null;
         $asset->assignedTo()->disassociate($asset);
         $asset->accepted = null;
-        $asset->name = e(Input::get('name'));
+        $asset->name = Input::get('name');
         $asset->location_id =  $asset->rtd_location_id;
 
         if ($request->has('location_id')) {
@@ -676,10 +676,9 @@ class AssetsController extends Controller
         }
 
         if (Input::has('status_id')) {
-            $asset->status_id =  e(Input::get('status_id'));
+            $asset->status_id =  Input::get('status_id');
         }
 
-        // Was the asset updated?
         if ($asset->save()) {
             $asset->logCheckin($target, e(request('note')));
             return response()->json(Helper::formatStandardApiResponse('success', ['asset'=> e($asset->asset_tag)], trans('admin/hardware/message.checkin.success')));

--- a/app/Http/Controllers/Api/ConsumablesController.php
+++ b/app/Http/Controllers/Api/ConsumablesController.php
@@ -179,7 +179,7 @@ class ConsumablesController extends Controller
         foreach ($consumable->consumableAssignments as $consumable_assignment) {
             $rows[] = [
                 'name' => ($consumable_assignment->user) ? $consumable_assignment->user->present()->nameUrl() : 'Deleted User',
-                'created_at' => ($consumable_assignment->created_at->format('Y-m-d H:i:s')=='-0001-11-30 00:00:00') ? '' : $consumable_assignment->created_at->format('Y-m-d H:i:s'),
+                'created_at' => Helper::getFormattedDateObject($consumable_assignment->created_at, 'datetime'),
                 'admin' => ($consumable_assignment->admin) ? $consumable_assignment->admin->present()->nameUrl() : '',
             ];
         }

--- a/app/Http/Controllers/AssetsController.php
+++ b/app/Http/Controllers/AssetsController.php
@@ -591,14 +591,6 @@ class AssetsController extends Controller
             $data['model_name'] = $asset->model->name;
             $data['model_number'] = $asset->model->model_number;
 
-            if ((($asset->checkin_email()=='1')) && (isset($user)) && (!empty($user->email)) && (!config('app.lock_passwords'))) {
-                Mail::send('emails.checkin-asset', $data, function ($m) use ($user) {
-                    $m->to($user->email, $user->first_name . ' ' . $user->last_name);
-                    $m->replyTo(config('mail.reply_to.address'), config('mail.reply_to.name'));
-                    $m->subject(trans('mail.Confirm_Asset_Checkin'));
-                });
-            }
-
             if ($backto=='user') {
                 return redirect()->route("users.show", $user->id)->with('success', trans('admin/hardware/message.checkin.success'));
             }

--- a/app/Http/Controllers/ConsumablesController.php
+++ b/app/Http/Controllers/ConsumablesController.php
@@ -7,7 +7,6 @@ use App\Models\Company;
 use App\Models\Consumable;
 use App\Models\Setting;
 use App\Models\User;
-use App\Notifications\CheckoutAssetNotification;
 use Auth;
 use Config;
 use DB;

--- a/app/Http/Controllers/ConsumablesController.php
+++ b/app/Http/Controllers/ConsumablesController.php
@@ -7,13 +7,12 @@ use App\Models\Company;
 use App\Models\Consumable;
 use App\Models\Setting;
 use App\Models\User;
-use App\Notifications\CheckoutNotification;
+use App\Notifications\CheckoutAssetNotification;
 use Auth;
 use Config;
 use DB;
 use Input;
 use Lang;
-use Mail;
 use Redirect;
 use Slack;
 use Str;
@@ -279,14 +278,6 @@ class ConsumablesController extends Controller
         $data['note'] = $logaction->note;
         $data['require_acceptance'] = $consumable->requireAcceptance();
 
-        if ((($consumable->requireAcceptance()=='1')  || ($consumable->getEula())) && $user->email!='') {
-
-            Mail::send('emails.accept-asset', $data, function ($m) use ($user) {
-                $m->to($user->email, $user->first_name . ' ' . $user->last_name);
-                $m->replyTo(config('mail.reply_to.address'), config('mail.reply_to.name'));
-                $m->subject(trans('mail.Confirm_consumable_delivery'));
-            });
-        }
 
       // Redirect to the new consumable page
         return redirect()->route('consumables.index')->with('success', trans('admin/consumables/message.checkout.success'));

--- a/app/Http/Controllers/CustomFieldsController.php
+++ b/app/Http/Controllers/CustomFieldsController.php
@@ -78,6 +78,7 @@ class CustomFieldsController extends Controller
             "help_text" => $request->get("help_text"),
             "field_values" => $request->get("field_values"),
             "field_encrypted" => $request->get("field_encrypted", 0),
+            "show_in_email" => $request->get("show_in_email", 0),
             "user_id" => Auth::user()->id
         ]);
 

--- a/app/Http/Controllers/LicensesController.php
+++ b/app/Http/Controllers/LicensesController.php
@@ -419,6 +419,8 @@ class LicensesController extends Controller
         if (!$return_to) {
             $return_to = Asset::find($licenseSeat->asset_id);
         }
+
+        \Log::debug($licenseSeat->assigned_to);
         // Update the asset data
         $licenseSeat->assigned_to                   = null;
         $licenseSeat->asset_id                      = null;

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -578,8 +578,11 @@ class SettingsController extends Controller
 
         $alert_email = rtrim($request->input('alert_email'), ',');
         $alert_email = trim($alert_email);
+        $admin_cc_email = rtrim($request->input('admin_cc_email'), ',');
+        $admin_cc_email = trim($admin_cc_email);
 
         $setting->alert_email = $alert_email;
+        $setting->admin_cc_email = $admin_cc_email;
         $setting->alerts_enabled = $request->input('alerts_enabled', '0');
         $setting->alert_interval = $request->input('alert_interval');
         $setting->alert_threshold = $request->input('alert_threshold');

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -335,6 +335,7 @@ class SettingsController extends Controller
 
         $setting->full_multiple_companies_support = $request->input('full_multiple_companies_support', '0');
         $setting->load_remote = $request->input('load_remote', '0');
+        $setting->show_images_in_email = $request->input('show_images_in_email', '0');
         $setting->show_archived_in_list = $request->input('show_archived_in_list', '0');
         $setting->dashboard_message = $request->input('dashboard_message');
         $setting->email_domain = $request->input('email_domain');

--- a/app/Http/Controllers/ViewAssetsController.php
+++ b/app/Http/Controllers/ViewAssetsController.php
@@ -297,9 +297,11 @@ class ViewAssetsController extends Controller
         $user = Auth::user();
 
 
-        if ($user->id != $findlog->item->assigned_to) {
+        // TODO - Fix this for non-assets
+        if (($findlog->item_type==Asset::class) && ($user->id != $findlog->item->assigned_to)) {
             return redirect()->to('account/view-assets')->with('error', trans('admin/users/message.error.incorrect_user_accepted'));
         }
+
 
         $item = $findlog->item;
 
@@ -336,7 +338,7 @@ class ViewAssetsController extends Controller
 
         $user = Auth::user();
 
-        if ($user->id != $findlog->item->assigned_to) {
+        if (($findlog->item_type==Asset::class) && ($user->id != $findlog->item->assigned_to)) {
             return redirect()->to('account/view-assets')->with('error', trans('admin/users/message.error.incorrect_user_accepted'));
         }
 
@@ -388,9 +390,11 @@ class ViewAssetsController extends Controller
         ->where('id', $findlog->id)
         ->update(array('accepted_id' => $logaction->id));
 
+        if (($findlog->item_id!='') && ($findlog->item_type==Asset::class)) {
             $affected_asset = $logaction->item;
             $affected_asset->accepted = $accepted;
             $affected_asset->save();
+        }
 
         if ($update_checkout) {
             return redirect()->to('account/view-assets')->with('success', $return_msg);

--- a/app/Models/Accessory.php
+++ b/app/Models/Accessory.php
@@ -4,6 +4,8 @@ namespace App\Models;
 use App\Presenters\Presentable;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Watson\Validating\ValidatingTrait;
+use App\Notifications\CheckinAccessoryNotification;
+use App\Notifications\CheckoutAccessoryNotification;
 
 /**
  * Model for Accessories.
@@ -22,6 +24,13 @@ class Accessory extends SnipeModel
     protected $casts = [
         'requestable' => 'boolean'
     ];
+
+    /**
+     * Set static properties to determine which checkout/checkin handlers we should use
+     */
+    public static $checkoutClass = CheckoutAccessoryNotification::class;
+    public static $checkinClass = CheckinAccessoryNotification::class;
+
 
     /**
     * Accessory validation rules
@@ -66,6 +75,8 @@ class Accessory extends SnipeModel
         'qty',
         'requestable'
     ];
+
+
 
 
     public function supplier()

--- a/app/Models/Accessory.php
+++ b/app/Models/Accessory.php
@@ -106,6 +106,13 @@ class Accessory extends SnipeModel
         return $this->hasMany('\App\Models\Actionlog', 'item_id')->where('item_type', Accessory::class)->orderBy('created_at', 'desc')->withTrashed();
     }
 
+    public function getImageUrl() {
+        if ($this->image) {
+            return url('/').'/uploads/accessories/'.$this->image;
+        }
+        return false;
+
+    }
 
     public function users()
     {

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -13,6 +13,8 @@ use Log;
 use Watson\Validating\ValidatingTrait;
 use Illuminate\Notifications\Notifiable;
 use DB;
+use App\Notifications\CheckinAssetNotification;
+use App\Notifications\CheckoutAssetNotification;
 
 /**
  * Model for Assets.
@@ -27,20 +29,28 @@ class Asset extends Depreciable
     const LOCATION = 'location';
     const ASSET = 'asset';
     const USER = 'user';
-  /**
-  * The database table used by the model.
-  *
-  * @var string
-  */
+
+    /**
+     * Set static properties to determine which checkout/checkin handlers we should use
+     */
+    public static $checkoutClass = CheckoutAssetNotification::class;
+    public static $checkinClass = CheckinAssetNotification::class;
+
+
+    /**
+    * The database table used by the model.
+    *
+    * @var string
+    */
     protected $table = 'assets';
 
-  /**
-  * Whether the model should inject it's identifier to the unique
-  * validation rules before attempting validation. If this property
-  * is not set in the model it will default to true.
-  *
-  * @var boolean
-  */
+    /**
+    * Whether the model should inject it's identifier to the unique
+    * validation rules before attempting validation. If this property
+    * is not set in the model it will default to true.
+    *
+    * @var boolean
+    */
     protected $injectUniqueIdentifier = true;
 
     // We set these as protected dates so that they will be easily accessible via Carbon

--- a/app/Models/Consumable.php
+++ b/app/Models/Consumable.php
@@ -109,6 +109,14 @@ class Consumable extends SnipeModel
         return $this->hasMany('\App\Models\Actionlog', 'item_id')->where('item_type', Consumable::class)->orderBy('created_at', 'desc')->withTrashed();
     }
 
+    public function getImageUrl() {
+        if ($this->image) {
+            return url('/').'/uploads/accessories/'.$this->image;
+        }
+        return false;
+
+    }
+
 
     public function users()
     {

--- a/app/Models/Consumable.php
+++ b/app/Models/Consumable.php
@@ -111,7 +111,7 @@ class Consumable extends SnipeModel
 
     public function getImageUrl() {
         if ($this->image) {
-            return url('/').'/uploads/accessories/'.$this->image;
+            return url('/').'/uploads/consumables/'.$this->image;
         }
         return false;
 

--- a/app/Models/Consumable.php
+++ b/app/Models/Consumable.php
@@ -4,6 +4,7 @@ namespace App\Models;
 use App\Presenters\Presentable;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Watson\Validating\ValidatingTrait;
+use App\Notifications\CheckoutConsumableNotification;
 
 class Consumable extends SnipeModel
 {
@@ -18,6 +19,11 @@ class Consumable extends SnipeModel
         'requestable' => 'boolean'
     ];
 
+    /**
+     * Set static properties to determine which checkout/checkin handlers we should use
+     */
+    public static $checkoutClass = CheckoutConsumableNotification::class;
+    public static $checkinClass = null;
 
 
     /**

--- a/app/Models/LicenseSeat.php
+++ b/app/Models/LicenseSeat.php
@@ -4,6 +4,8 @@ namespace App\Models;
 use App\Models\Loggable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use App\Notifications\CheckoutLicenseNotification;
+use App\Notifications\CheckinLicenseNotification;
 
 class LicenseSeat extends Model implements ICompanyableChild
 {
@@ -14,6 +16,12 @@ class LicenseSeat extends Model implements ICompanyableChild
     protected $dates = ['deleted_at'];
     protected $guarded = 'id';
     protected $table = 'license_seats';
+
+    /**
+     * Set static properties to determine which checkout/checkin handlers we should use
+     */
+    public static $checkoutClass = CheckoutLicenseNotification::class;
+    public static $checkinClass = CheckinLicenseNotification::class;
 
     public function getCompanyableParents()
     {

--- a/app/Models/Loggable.php
+++ b/app/Models/Loggable.php
@@ -78,29 +78,12 @@ trait Loggable
         $recipient = new \App\Models\Recipients\AdminRecipient();
 
 
-        $checkoutClass = null;
-
-        switch(static::class) {
-            case Asset::class:
-                $checkoutClass = CheckoutAssetNotification::class;
-                break;
-            case Accessory::class:
-                $checkoutClass = CheckoutAccessoryNotification::class;
-                break;
-            case Consumable::class:
-                $checkoutClass = CheckoutConsumableNotification::class;
-                break;
-            case LicenseSeat::class:
-                $checkoutClass = CheckoutLicenseNotification::class;
-                break;
-        }
-
         if (method_exists($target, 'notify')) {
-            $target->notify(new $checkoutClass($params));
+            $target->notify(new static::$checkoutClass($params));
         }
 
         if ($settings->admin_cc_email!='') {
-            $recipient->notify(new $checkoutClass($params));
+            $recipient->notify(new static::$checkoutClass($params));
         }
 
         return $log;
@@ -162,29 +145,13 @@ trait Loggable
 
         $checkoutClass = null;
 
-        switch(static::class) {
-            case Asset::class:
-                $checkoutClass = CheckinAssetNotification::class;
-                break;
-            case Accessory::class:
-                $checkoutClass = CheckinAccessoryNotification::class;
-                break;
-            case LicenseSeat::class:
-                $checkoutClass = CheckinLicenseNotification::class;
-                break;
-        }
-
         if (method_exists($target, 'notify')) {
-            $target->notify(new $checkoutClass($params));
+            $target->notify(new static::$checkinClass($params));
         }
 
         if ($settings->admin_cc_email!='') {
-            $recipient->notify(new $checkoutClass($params));
+            $recipient->notify(new static::$checkinClass($params));
         }
-
-
-
-
 
         return $log;
     }

--- a/app/Models/Loggable.php
+++ b/app/Models/Loggable.php
@@ -48,6 +48,7 @@ trait Loggable
             return;
         }
         $log->target_type = get_class($target);
+        \Log::debug($log->target_type);
         $log->target_id = $target->id;
 
         $target_class = get_class($target);
@@ -83,27 +84,37 @@ trait Loggable
                 $recipient->notify(new CheckoutAssetNotification($params));
             }
 
-            $target->notify(new CheckoutAssetNotification($params));
+            if ($log->target_type == User::class) {
+                $target->notify(new CheckoutAssetNotification($params));
+            }
+
         } elseif (static::class == Accessory::class) {
 
             if ($settings->admin_cc_email!='') {
                 $recipient->notify(new CheckoutAccessoryNotification($params));
             }
 
-            $target->notify(new CheckoutAccessoryNotification($params));
+            if ($log->target_type == User::class) {
+                $target->notify(new CheckoutAccessoryNotification($params));
+            }
+
         } elseif (static::class == Consumable::class) {
 
             if ($settings->admin_cc_email!='') {
                 $recipient->notify(new CheckoutConsumableNotification($params));
             }
 
-            $target->notify(new CheckoutConsumableNotification($params));
+            if ($log->target_type == User::class) {
+                $target->notify(new CheckoutConsumableNotification($params));
+            }
+
         } elseif (static::class == LicenseSeat::class) {
             if ($settings->admin_cc_email!='') {
                 $recipient->notify(new CheckoutLicenseNotification($params));
             }
-            
-            $target->notify(new CheckoutLicenseNotification($params));
+            if ($log->target_type == User::class) {
+                $target->notify(new CheckoutLicenseNotification($params));
+            }
         }
 
 

--- a/app/Models/Loggable.php
+++ b/app/Models/Loggable.php
@@ -73,13 +73,8 @@ trait Loggable
             'settings' => $settings,
         ];
 
-        // Get the admin email address we should be sending notifications to, if any
-        $recipient = new \App\Models\Recipients\AdminRecipient();
-
-        // Send to the admin, if settings dictate
-        $recipient = new \App\Models\Recipients\AdminRecipient();
-
         $checkoutClass = null;
+
         switch(static::class) {
             case Asset::class:
                 $checkoutClass = CheckoutAssetNotification::class;
@@ -95,12 +90,8 @@ trait Loggable
                 break;
 
         }
-        if ($settings->admin_cc_email!='') {
-            $recipient->notify(new $checkoutClass($params));
-        }
-        $target->notify(new $checkoutClass($params, 'mail'));
 
-
+        $target->notify(new $checkoutClass($params));
         return $log;
     }
 
@@ -155,10 +146,8 @@ trait Loggable
             'settings' => $settings,
         ];
 
-        // Get the admin email address we should be sending notifications to, if any
-        $recipient = new \App\Models\Recipients\AdminRecipient();
-
         $checkoutClass = null;
+
         switch(static::class) {
             case Asset::class:
                 $checkoutClass = CheckinAssetNotification::class;
@@ -169,12 +158,9 @@ trait Loggable
             case LicenseSeat::class:
                 $checkoutClass = CheckinLicenseNotification::class;
                 break;
+        }
 
-        }
-        if ($settings->admin_cc_email!='') {
-            $recipient->notify(new $checkoutClass($params));
-        }
-        $target->notify(new $checkoutClass($params, 'mail'));
+        $target->notify(new $checkoutClass($params));
 
 
 

--- a/app/Models/Loggable.php
+++ b/app/Models/Loggable.php
@@ -48,7 +48,6 @@ trait Loggable
             return;
         }
         $log->target_type = get_class($target);
-        \Log::debug($log->target_type);
         $log->target_id = $target->id;
 
         $target_class = get_class($target);
@@ -84,37 +83,27 @@ trait Loggable
                 $recipient->notify(new CheckoutAssetNotification($params));
             }
 
-            if ($log->target_type == User::class) {
-                $target->notify(new CheckoutAssetNotification($params));
-            }
-
+            $target->notify(new CheckoutAssetNotification($params));
         } elseif (static::class == Accessory::class) {
 
             if ($settings->admin_cc_email!='') {
                 $recipient->notify(new CheckoutAccessoryNotification($params));
             }
 
-            if ($log->target_type == User::class) {
-                $target->notify(new CheckoutAccessoryNotification($params));
-            }
-
+            $target->notify(new CheckoutAccessoryNotification($params));
         } elseif (static::class == Consumable::class) {
 
             if ($settings->admin_cc_email!='') {
                 $recipient->notify(new CheckoutConsumableNotification($params));
             }
 
-            if ($log->target_type == User::class) {
-                $target->notify(new CheckoutConsumableNotification($params));
-            }
-
+            $target->notify(new CheckoutConsumableNotification($params));
         } elseif (static::class == LicenseSeat::class) {
             if ($settings->admin_cc_email!='') {
                 $recipient->notify(new CheckoutLicenseNotification($params));
             }
-            if ($log->target_type == User::class) {
-                $target->notify(new CheckoutLicenseNotification($params));
-            }
+
+            $target->notify(new CheckoutLicenseNotification($params));
         }
 
 

--- a/app/Models/Loggable.php
+++ b/app/Models/Loggable.php
@@ -50,13 +50,11 @@ trait Loggable
         $log->target_type = get_class($target);
         $log->target_id = $target->id;
 
-        $target_class = get_class($target);
 
         // Figure out what the target is
-        if ($target_class == Location::class) {
-            // We can checkout to a location
+        if ($log->target_type == Location::class) {
             $log->location_id = $target->id;
-        } elseif ($target_class== Asset::class) {
+        } elseif ($log->target_type == Asset::class) {
             $log->location_id = $target->rtd_location_id;
         } else {
             $log->location_id = $target->location_id;
@@ -67,10 +65,12 @@ trait Loggable
 
         $params = [
             'item' => $log->item,
+            'target_type' => $log->target_type,
             'target' => $target,
             'admin' => $log->user,
             'note' => $note,
-            'log_id' => $log->id
+            'log_id' => $log->id,
+            'settings' => $settings,
         ];
 
         // Get the admin email address we should be sending notifications to, if any
@@ -136,13 +136,7 @@ trait Loggable
         $settings = Setting::getSettings();
         $log = new Actionlog;
         $log->target_type = get_class($target);
-
-        if ($target) {
-            $log->target_id = $target->id;
-        } else {
-            $target = null;
-        }
-
+        $log->target_id = $target->id;
 
         if (static::class == LicenseSeat::class) {
             $log->item_type = License::class;
@@ -163,6 +157,8 @@ trait Loggable
             'item' => $log->item,
             'admin' => $log->user,
             'note' => $note,
+            'target_type' => $log->target_type,
+            'settings' => $settings,
         ];
 
         // Get the admin email address we should be sending notifications to, if any

--- a/app/Models/Loggable.php
+++ b/app/Models/Loggable.php
@@ -73,6 +73,11 @@ trait Loggable
             'settings' => $settings,
         ];
 
+
+        // Send to the admin, if settings dictate
+        $recipient = new \App\Models\Recipients\AdminRecipient();
+
+
         $checkoutClass = null;
 
         switch(static::class) {
@@ -88,10 +93,16 @@ trait Loggable
             case LicenseSeat::class:
                 $checkoutClass = CheckoutLicenseNotification::class;
                 break;
-
         }
 
-        $target->notify(new $checkoutClass($params));
+        if (method_exists($target, 'notify')) {
+            $target->notify(new $checkoutClass($params));
+        }
+
+        if ($settings->admin_cc_email!='') {
+            $recipient->notify(new $checkoutClass($params));
+        }
+
         return $log;
     }
 
@@ -146,6 +157,9 @@ trait Loggable
             'settings' => $settings,
         ];
 
+        // Send to the admin, if settings dictate
+        $recipient = new \App\Models\Recipients\AdminRecipient();
+
         $checkoutClass = null;
 
         switch(static::class) {
@@ -160,7 +174,15 @@ trait Loggable
                 break;
         }
 
-        $target->notify(new $checkoutClass($params));
+        if (method_exists($target, 'notify')) {
+            $target->notify(new $checkoutClass($params));
+        }
+
+        if ($settings->admin_cc_email!='') {
+            $recipient->notify(new $checkoutClass($params));
+        }
+
+
 
 
 

--- a/app/Models/Loggable.php
+++ b/app/Models/Loggable.php
@@ -77,34 +77,28 @@ trait Loggable
         $recipient = new \App\Models\Recipients\AdminRecipient();
 
         // Send to the admin, if settings dictate
-        if (static::class == Asset::class) {
+        $recipient = new \App\Models\Recipients\AdminRecipient();
 
-            if ($settings->admin_cc_email!='') {
-                $recipient->notify(new CheckoutAssetNotification($params));
-            }
+        $checkoutClass = null;
+        switch(static::class) {
+            case Asset::class:
+                $checkoutClass = CheckoutAssetNotification::class;
+                break;
+            case Accessory::class:
+                $checkoutClass = CheckoutAccessoryNotification::class;
+                break;
+            case Consumable::class:
+                $checkoutClass = CheckoutConsumableNotification::class;
+                break;
+            case LicenseSeat::class:
+                $checkoutClass = CheckoutLicenseNotification::class;
+                break;
 
-            $target->notify(new CheckoutAssetNotification($params));
-        } elseif (static::class == Accessory::class) {
-
-            if ($settings->admin_cc_email!='') {
-                $recipient->notify(new CheckoutAccessoryNotification($params));
-            }
-
-            $target->notify(new CheckoutAccessoryNotification($params));
-        } elseif (static::class == Consumable::class) {
-
-            if ($settings->admin_cc_email!='') {
-                $recipient->notify(new CheckoutConsumableNotification($params));
-            }
-
-            $target->notify(new CheckoutConsumableNotification($params));
-        } elseif (static::class == LicenseSeat::class) {
-            if ($settings->admin_cc_email!='') {
-                $recipient->notify(new CheckoutLicenseNotification($params));
-            }
-
-            $target->notify(new CheckoutLicenseNotification($params));
         }
+        if ($settings->admin_cc_email!='') {
+            $recipient->notify(new $checkoutClass($params));
+        }
+        $target->notify(new $checkoutClass($params, 'mail'));
 
 
         return $log;
@@ -164,28 +158,23 @@ trait Loggable
         // Get the admin email address we should be sending notifications to, if any
         $recipient = new \App\Models\Recipients\AdminRecipient();
 
-        if (static::class == Asset::class) {
-            if ($settings->admin_cc_email!='') {
-                $recipient->notify(new CheckinAssetNotification($params));
-            }
-
-            $target->notify(new CheckinAssetNotification($params));
-
-        } elseif (static::class == Accessory::class) {
-            if ($settings->admin_cc_email!='') {
-                $recipient->notify(new CheckinAccessoryNotification($params));
-            }
-
-            $target->notify(new CheckinAccessoryNotification($params));
-
-        } elseif (static::class == LicenseSeat::class) {
-            if ($settings->admin_cc_email!='') {
-                $recipient->notify(new CheckinLicenseNotification($params));
-            }
-
-            $target->notify(new CheckinLicenseNotification($params));
+        $checkoutClass = null;
+        switch(static::class) {
+            case Asset::class:
+                $checkoutClass = CheckinAssetNotification::class;
+                break;
+            case Accessory::class:
+                $checkoutClass = CheckinAccessoryNotification::class;
+                break;
+            case LicenseSeat::class:
+                $checkoutClass = CheckinLicenseNotification::class;
+                break;
 
         }
+        if ($settings->admin_cc_email!='') {
+            $recipient->notify(new $checkoutClass($params));
+        }
+        $target->notify(new $checkoutClass($params, 'mail'));
 
 
 

--- a/app/Models/Recipients/AdminRecipient.php
+++ b/app/Models/Recipients/AdminRecipient.php
@@ -1,0 +1,14 @@
+<?php
+namespace App\Models\Recipients;
+
+use App\Models\Setting;
+
+class AdminRecipient extends Recipient{
+
+    public function __construct()
+    {
+        $settings = Setting::getSettings();
+        $this->email = $settings->admin_cc_email;
+    }
+
+}

--- a/app/Models/Recipients/AlertRecipient.php
+++ b/app/Models/Recipients/AlertRecipient.php
@@ -1,0 +1,14 @@
+<?php
+namespace App\Models\Recipients;
+
+use App\Models\Setting;
+
+class AlertRecipient extends Recipient{
+
+    public function __construct()
+    {
+       $settings = Setting::getSettings();
+       $this->email = $settings->alert_email;
+    }
+
+}

--- a/app/Models/Recipients/Recipient.php
+++ b/app/Models/Recipients/Recipient.php
@@ -1,0 +1,12 @@
+<?php
+namespace App\Models\Recipients;
+
+use Illuminate\Notifications\Notifiable;
+
+abstract class Recipient {
+
+    use Notifiable;
+
+    protected $email;
+
+}

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -17,6 +17,7 @@ class Setting extends Model
           'qr_text'         => 'max:31|nullable',
           'logo_img'        => 'mimes:jpeg,bmp,png,gif',
           'alert_email'   => 'email_array|nullable',
+          'admin_cc_email'   => 'email|nullable',
           'default_currency'   => 'required',
           'locale'   => 'required',
           'slack_endpoint'   => 'url|required_with:slack_channel|nullable',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -149,6 +149,18 @@ class User extends SnipeModel implements AuthenticatableContract, CanResetPasswo
         return $this->last_name . ", " . $this->first_name . " (" . $this->username . ")";
     }
 
+    /**
+     * The url for slack notifications.
+     * Used by Notifiable trait.
+     * @return mixed
+     */
+    public function routeNotificationForSlack()
+    {
+        // At this point the endpoint is the same for everything.
+        //  In the future this may want to be adapted for individual notifications.
+        $this->endpoint = \App\Models\Setting::getSettings()->slack_endpoint;
+        return $this->endpoint;
+    }
 
 
     /**

--- a/app/Notifications/CheckinAccessoryNotification.php
+++ b/app/Notifications/CheckinAccessoryNotification.php
@@ -68,12 +68,11 @@ class CheckinAccessoryNotification extends Notification
     public function toSlack()
     {
 
-
         $target = $this->target;
         $admin = $this->admin;
         $item = $this->item;
         $note = $this->note;
-        $botname = ($this->note->slack_botname) ? $this->note->slack_botname : 'Snipe-Bot' ;
+        $botname = ($this->settings->slack_botname) ? $this->settings->slack_botname : 'Snipe-Bot' ;
 
 
         $fields = [
@@ -84,7 +83,7 @@ class CheckinAccessoryNotification extends Notification
 
 
         return (new SlackMessage)
-            ->content('Accessory Checked In')
+            ->content(':arrow_down: :keyboard: Accessory Checked In')
             ->from($botname)
             ->attachment(function ($attachment) use ($item, $note, $admin, $fields) {
                 $attachment->title(htmlspecialchars_decode($item->present()->name), $item->present()->viewUrl())

--- a/app/Notifications/CheckinAccessoryNotification.php
+++ b/app/Notifications/CheckinAccessoryNotification.php
@@ -24,7 +24,7 @@ class CheckinAccessoryNotification extends Notification
      *
      * @param $params
      */
-    public function __construct($params)
+    public function __construct($params, $only = null)
     {
         $this->target = $params['target'];
         $this->item = $params['item'];
@@ -32,6 +32,7 @@ class CheckinAccessoryNotification extends Notification
         $this->note = '';
         $this->target_type = $params['target'];
         $this->settings = $params['settings'];
+        $this->only = $only;
 
         if (array_key_exists('note', $params)) {
             $this->note = $params['note'];
@@ -49,8 +50,14 @@ class CheckinAccessoryNotification extends Notification
      */
     public function via($notifiable)
     {
-        $target_type = get_class($this->target);
+
         $notifyBy = [];
+
+        if ($this->only) {
+            $notifyBy[] = $this->only;
+            return $notifyBy;
+        }
+
         if (Setting::getSettings()->slack_endpoint) {
             $notifyBy[] = 'slack';
         }

--- a/app/Notifications/CheckinAccessoryNotification.php
+++ b/app/Notifications/CheckinAccessoryNotification.php
@@ -78,7 +78,7 @@ class CheckinAccessoryNotification extends Notification
 
 
         return (new SlackMessage)
-            ->content(':arrow_up: ' . class_basename(get_class($item)) . " Checked In")
+            ->content(':arrow_up: :keyboard: ' . class_basename(get_class($item)) . " Checked In")
             ->attachment(function ($attachment) use ($item, $note, $admin, $fields) {
                 $attachment->title(htmlspecialchars_decode($item->present()->name), $item->present()->viewUrl())
                     ->fields($fields)

--- a/app/Notifications/CheckinAccessoryNotification.php
+++ b/app/Notifications/CheckinAccessoryNotification.php
@@ -24,7 +24,7 @@ class CheckinAccessoryNotification extends Notification
      *
      * @param $params
      */
-    public function __construct($params, $only = null)
+    public function __construct($params)
     {
         $this->target = $params['target'];
         $this->item = $params['item'];
@@ -32,7 +32,6 @@ class CheckinAccessoryNotification extends Notification
         $this->note = '';
         $this->target_type = $params['target'];
         $this->settings = $params['settings'];
-        $this->only = $only;
 
         if (array_key_exists('note', $params)) {
             $this->note = $params['note'];
@@ -48,15 +47,10 @@ class CheckinAccessoryNotification extends Notification
      * @param  mixed  $notifiable
      * @return array
      */
-    public function via($notifiable)
+    public function via()
     {
 
         $notifyBy = [];
-
-        if ($this->only) {
-            $notifyBy[] = $this->only;
-            return $notifyBy;
-        }
 
         if (Setting::getSettings()->slack_endpoint) {
             $notifyBy[] = 'slack';
@@ -71,7 +65,7 @@ class CheckinAccessoryNotification extends Notification
         return $notifyBy;
     }
 
-    public function toSlack($notifiable)
+    public function toSlack()
     {
 
 

--- a/app/Notifications/CheckinAccessoryNotification.php
+++ b/app/Notifications/CheckinAccessoryNotification.php
@@ -47,12 +47,14 @@ class CheckinAccessoryNotification extends Notification
      */
     public function via($notifiable)
     {
+        $target_type = get_class($this->target);
         $notifyBy = [];
         if (Setting::getSettings()->slack_endpoint) {
             $notifyBy[] = 'slack';
         }
 
-        if (($this->item->requireAcceptance() == '1') || ($this->item->getEula()))
+        // Make sure the target is a user and that its appropriate to send them an email
+        if (($target_type==\App\Models\User::class) && (($this->item->requireAcceptance() == '1') || ($this->item->getEula())))
         {
             $notifyBy[] = 'mail';
         }
@@ -94,9 +96,6 @@ class CheckinAccessoryNotification extends Notification
     public function toMail($notifiable)
     {
 
-        \Log::debug($this->item->getImageUrl());
-        $eula =  $this->item->getEula();
-        $req_accept = $this->item->requireAcceptance();
 
         return (new MailMessage)->markdown('notifications.markdown.checkin-accessory',
             [

--- a/app/Notifications/CheckinAccessoryNotification.php
+++ b/app/Notifications/CheckinAccessoryNotification.php
@@ -30,6 +30,8 @@ class CheckinAccessoryNotification extends Notification
         $this->item = $params['item'];
         $this->admin = $params['admin'];
         $this->note = '';
+        $this->target_type = $params['target'];
+        $this->settings = $params['settings'];
 
         if (array_key_exists('note', $params)) {
             $this->note = $params['note'];
@@ -54,7 +56,7 @@ class CheckinAccessoryNotification extends Notification
         }
 
         // Make sure the target is a user and that its appropriate to send them an email
-        if (($target_type==\App\Models\User::class) && (($this->item->requireAcceptance() == '1') || ($this->item->getEula())))
+        if (($this->target_type == \App\Models\User::class) && (($this->item->requireAcceptance() == '1') || ($this->item->getEula())))
         {
             $notifyBy[] = 'mail';
         }
@@ -70,6 +72,7 @@ class CheckinAccessoryNotification extends Notification
         $admin = $this->admin;
         $item = $this->item;
         $note = $this->note;
+        $botname = ($this->note->slack_botname) ? $this->note->slack_botname : 'Snipe-Bot' ;
 
 
         $fields = [
@@ -80,7 +83,8 @@ class CheckinAccessoryNotification extends Notification
 
 
         return (new SlackMessage)
-            ->content(':arrow_up: :keyboard: ' . class_basename(get_class($item)) . " Checked In")
+            ->content('Asset Checked In')
+            ->from($botname)
             ->attachment(function ($attachment) use ($item, $note, $admin, $fields) {
                 $attachment->title(htmlspecialchars_decode($item->present()->name), $item->present()->viewUrl())
                     ->fields($fields)

--- a/app/Notifications/CheckinAccessoryNotification.php
+++ b/app/Notifications/CheckinAccessoryNotification.php
@@ -84,7 +84,7 @@ class CheckinAccessoryNotification extends Notification
 
 
         return (new SlackMessage)
-            ->content('Asset Checked In')
+            ->content('Accessory Checked In')
             ->from($botname)
             ->attachment(function ($attachment) use ($item, $note, $admin, $fields) {
                 $attachment->title(htmlspecialchars_decode($item->present()->name), $item->present()->viewUrl())

--- a/app/Notifications/CheckinAssetNotification.php
+++ b/app/Notifications/CheckinAssetNotification.php
@@ -9,7 +9,7 @@ use Illuminate\Notifications\Notification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 
-class CheckinNotification extends Notification
+class CheckinAssetNotification extends Notification
 {
     use Queueable;
     /**
@@ -57,27 +57,24 @@ class CheckinNotification extends Notification
 
     public function toSlack($notifiable)
     {
-        \Log::debug('Checkin slack');
+
 
         $admin = $this->admin;
         $item = $this->item;
         $note = $this->note;
 
+
         $fields = [
-            'By' => '<'.$admin->present()->viewUrl().'|'.$admin->present()->fullName().'>',
-
+            trans('general.administrator') => '<'.$admin->present()->viewUrl().'|'.$admin->present()->fullName().'>',
+            trans('general.status') => $item->assetstatus->name,
+            trans('general.location') => $item->location->name,
         ];
-
-        $fields[] = ['Status' => $item->assetstatus->name];
-
 
         return (new SlackMessage)
             ->content(':arrow_down: ' . class_basename(get_class($item)) . " Checked In")
             ->attachment(function ($attachment) use ($item, $note, $admin, $fields) {
                 $attachment->title(htmlspecialchars_decode($item->present()->name), $item->present()->viewUrl())
-                    ->fields([
-                        trans('general.administrator') => '<'.$admin->present()->viewUrl().'|'.$admin->present()->fullName().'>',
-                    ])
+                    ->fields($fields)
                     ->content($note);
             });
 

--- a/app/Notifications/CheckinAssetNotification.php
+++ b/app/Notifications/CheckinAssetNotification.php
@@ -22,7 +22,7 @@ class CheckinAssetNotification extends Notification
      *
      * @param $params
      */
-    public function __construct($params)
+    public function __construct($params, $only = null)
     {
         $this->target = $params['target'];
         $this->item = $params['item'];
@@ -31,6 +31,7 @@ class CheckinAssetNotification extends Notification
         $this->expected_checkin = '';
         $this->target_type = $params['target'];
         $this->settings = $params['settings'];
+        $this->only = $only;
 
 
         if (array_key_exists('note', $params)) {
@@ -53,6 +54,12 @@ class CheckinAssetNotification extends Notification
     {
 
         $notifyBy = [];
+
+        if ($this->only) {
+            $notifyBy[] = $this->only;
+            return $notifyBy;
+        }
+
         if (Setting::getSettings()->slack_endpoint!='') {
             $notifyBy[] = 'slack';
         }

--- a/app/Notifications/CheckinAssetNotification.php
+++ b/app/Notifications/CheckinAssetNotification.php
@@ -56,32 +56,17 @@ class CheckinAssetNotification extends Notification
         }
 
         // Make sure the target is a user and that its appropriate to send them an email
-        if (($this->target_type == \App\Models\User::class) && (($this->item->requireAcceptance() == '1') || ($this->item->getEula())))
+        if ((($this->target->email!='') && ($this->target_type == 'App\Models\User')) && (($this->item->requireAcceptance() == '1') || ($this->item->getEula())))
         {
             \Log::debug('use email');
             $notifyBy[] = 'mail';
         }
 
-
-        \Log::debug('Checkin:');
-        \Log::debug($notifyBy);
-        \Log::debug($this->target_type);
-        \Log::debug($this->item);
-        \Log::debug($this->item->requireAcceptance());
-        \Log::debug($this->item->getEula());
         return $notifyBy;
     }
 
     public function toSlack()
     {
-        \Log::debug('pinging slack for checkin');
-
-        return (new SlackMessage)
-            ->from('Poo Bot', ':heart:')
-            ->to('#systems-devhooks')
-            ->image('https://snipeitapp.com/favicon.ico')
-            ->content('Oh hai! Looks like your Slack integration with Snipe-IT is working!');
-
 
         $admin = $this->admin;
         $item = $this->item;
@@ -114,7 +99,7 @@ class CheckinAssetNotification extends Notification
      */
     public function toMail()
     {
-        $bcc = $this->settings->admin_cc_email;
+
 
         $fields = [];
 
@@ -134,9 +119,6 @@ class CheckinAssetNotification extends Notification
             ])
             ->subject('Asset checked in');
 
-        if ($bcc!='') {
-            $message->bcc($bcc, $this->settings->site_name);
-        }
 
         return $message;
     }

--- a/app/Notifications/CheckinAssetNotification.php
+++ b/app/Notifications/CheckinAssetNotification.php
@@ -75,7 +75,7 @@ class CheckinAssetNotification extends Notification
         ];
 
         return (new SlackMessage)
-            ->content(':arrow_down: ' . class_basename(get_class($item)) . " Checked In")
+            ->content(':arrow_down: :computer: ' . class_basename(get_class($item)) . " Checked In")
             ->attachment(function ($attachment) use ($item, $note, $admin, $fields) {
                 $attachment->title(htmlspecialchars_decode($item->present()->name), $item->present()->viewUrl())
                     ->fields($fields)

--- a/app/Notifications/CheckinAssetNotification.php
+++ b/app/Notifications/CheckinAssetNotification.php
@@ -48,12 +48,14 @@ class CheckinAssetNotification extends Notification
      */
     public function via($notifiable)
     {
+        $target_type = get_class($this->target);
         $notifyBy = [];
         if (Setting::getSettings()->slack_endpoint) {
             $notifyBy[] = 'slack';
         }
 
-        if (($this->item->requireAcceptance() == '1') || ($this->item->checkin_email()) ||  ($this->item->getEula())) {
+        // Make sure the target is a user and that its appropriate to send them an email
+        if (($target_type==\App\Models\User::class) && (($this->item->requireAcceptance() == '1') || ($this->item->checkin_email()) ||  ($this->item->getEula()))) {
                 $notifyBy[] = 'mail';
         }
         return $notifyBy;

--- a/app/Notifications/CheckinLicenseNotification.php
+++ b/app/Notifications/CheckinLicenseNotification.php
@@ -11,7 +11,7 @@ use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Facades\Mail;
 
-class CheckoutLicenseNotification extends Notification
+class CheckinLicenseNotification extends Notification
 {
     use Queueable;
     /**
@@ -54,7 +54,7 @@ class CheckoutLicenseNotification extends Notification
         }
 
 
-            $notifyBy[] = 'mail';
+        $notifyBy[] = 'mail';
 
 
         return $notifyBy;
@@ -78,7 +78,7 @@ class CheckoutLicenseNotification extends Notification
 
 
         return (new SlackMessage)
-            ->content(':arrow_up: ' . class_basename(get_class($item)) . " Checked Out")
+            ->content(':arrow_up: ' . class_basename(get_class($item)) . " Checked In")
             ->attachment(function ($attachment) use ($item, $note, $admin, $fields) {
                 $attachment->title(htmlspecialchars_decode($item->present()->name), $item->present()->viewUrl())
                     ->fields($fields)
@@ -94,14 +94,14 @@ class CheckoutLicenseNotification extends Notification
     public function toMail($notifiable)
     {
 
-        return (new MailMessage)->markdown('notifications.markdown.checkout-license',
+        return (new MailMessage)->markdown('notifications.markdown.checkin-license',
             [
                 'item'          => $this->item,
                 'admin'         => $this->admin,
                 'note'          => $this->note,
                 'target'        => $this->target,
             ])
-            ->subject(trans('mail.Confirm_license_delivery'));
+            ->subject('License checked in');
 
     }
 

--- a/app/Notifications/CheckinLicenseNotification.php
+++ b/app/Notifications/CheckinLicenseNotification.php
@@ -76,7 +76,7 @@ class CheckinLicenseNotification extends Notification
 
 
         return (new SlackMessage)
-            ->content(':arrow_up: :floppy_disk: License  Checked In')
+            ->content(':arrow_down: :floppy_disk: License  Checked In')
             ->from($botname)
             ->attachment(function ($attachment) use ($item, $note, $admin, $fields) {
                 $attachment->title(htmlspecialchars_decode($item->present()->name), $item->present()->viewUrl())

--- a/app/Notifications/CheckinLicenseNotification.php
+++ b/app/Notifications/CheckinLicenseNotification.php
@@ -24,14 +24,13 @@ class CheckinLicenseNotification extends Notification
      *
      * @param $params
      */
-    public function __construct($params, $only = null)
+    public function __construct($params)
     {
         $this->target = $params['target'];
         $this->item = $params['item'];
         $this->admin = $params['admin'];
         $this->note = '';
         $this->settings = $params['settings'];
-        $this->only = $only;
 
         if (array_key_exists('note', $params)) {
             $this->note = $params['note'];
@@ -51,18 +50,12 @@ class CheckinLicenseNotification extends Notification
     {
         $notifyBy = [];
 
-        if ($this->only) {
-            $notifyBy[] = $this->only;
-            return $notifyBy;
-        }
-
         if (Setting::getSettings()->slack_endpoint!='') {
             $notifyBy[] = 'slack';
         }
 
 
         $notifyBy[] = 'mail';
-
 
         return $notifyBy;
     }

--- a/app/Notifications/CheckinLicenseNotification.php
+++ b/app/Notifications/CheckinLicenseNotification.php
@@ -30,6 +30,7 @@ class CheckinLicenseNotification extends Notification
         $this->item = $params['item'];
         $this->admin = $params['admin'];
         $this->note = '';
+        $this->settings = $params['settings'];
 
         if (array_key_exists('note', $params)) {
             $this->note = $params['note'];
@@ -48,7 +49,7 @@ class CheckinLicenseNotification extends Notification
     public function via($notifiable)
     {
         $notifyBy = [];
-        if (Setting::getSettings()->slack_endpoint) {
+        if (Setting::getSettings()->slack_endpoint!='') {
             $notifyBy[] = 'slack';
         }
 
@@ -62,11 +63,11 @@ class CheckinLicenseNotification extends Notification
     public function toSlack($notifiable)
     {
 
-
         $target = $this->target;
         $admin = $this->admin;
         $item = $this->item;
         $note = $this->note;
+        $botname = ($this->settings->slack_botname) ? $this->settings->slack_botname : 'Snipe-Bot' ;
 
 
         $fields = [
@@ -77,7 +78,8 @@ class CheckinLicenseNotification extends Notification
 
 
         return (new SlackMessage)
-            ->content(':arrow_up: :floppy_disk: ' . class_basename(get_class($item)) . " Checked In")
+            ->content(':arrow_up: :floppy_disk: License  Checked In')
+            ->from($botname)
             ->attachment(function ($attachment) use ($item, $note, $admin, $fields) {
                 $attachment->title(htmlspecialchars_decode($item->present()->name), $item->present()->viewUrl())
                     ->fields($fields)

--- a/app/Notifications/CheckinLicenseNotification.php
+++ b/app/Notifications/CheckinLicenseNotification.php
@@ -29,7 +29,6 @@ class CheckinLicenseNotification extends Notification
         $this->target = $params['target'];
         $this->item = $params['item'];
         $this->admin = $params['admin'];
-        $this->log_id = $params['log_id'];
         $this->note = '';
 
         if (array_key_exists('note', $params)) {
@@ -78,7 +77,7 @@ class CheckinLicenseNotification extends Notification
 
 
         return (new SlackMessage)
-            ->content(':arrow_up: ' . class_basename(get_class($item)) . " Checked In")
+            ->content(':arrow_up: :floppy_disk: ' . class_basename(get_class($item)) . " Checked In")
             ->attachment(function ($attachment) use ($item, $note, $admin, $fields) {
                 $attachment->title(htmlspecialchars_decode($item->present()->name), $item->present()->viewUrl())
                     ->fields($fields)

--- a/app/Notifications/CheckinLicenseNotification.php
+++ b/app/Notifications/CheckinLicenseNotification.php
@@ -36,8 +36,6 @@ class CheckinLicenseNotification extends Notification
             $this->note = $params['note'];
         }
 
-
-
     }
 
     /**

--- a/app/Notifications/CheckinLicenseNotification.php
+++ b/app/Notifications/CheckinLicenseNotification.php
@@ -24,13 +24,14 @@ class CheckinLicenseNotification extends Notification
      *
      * @param $params
      */
-    public function __construct($params)
+    public function __construct($params, $only = null)
     {
         $this->target = $params['target'];
         $this->item = $params['item'];
         $this->admin = $params['admin'];
         $this->note = '';
         $this->settings = $params['settings'];
+        $this->only = $only;
 
         if (array_key_exists('note', $params)) {
             $this->note = $params['note'];
@@ -49,6 +50,12 @@ class CheckinLicenseNotification extends Notification
     public function via($notifiable)
     {
         $notifyBy = [];
+
+        if ($this->only) {
+            $notifyBy[] = $this->only;
+            return $notifyBy;
+        }
+
         if (Setting::getSettings()->slack_endpoint!='') {
             $notifyBy[] = 'slack';
         }

--- a/app/Notifications/CheckoutAccessoryNotification.php
+++ b/app/Notifications/CheckoutAccessoryNotification.php
@@ -81,7 +81,7 @@ class CheckoutAccessoryNotification extends Notification
 
 
         return (new SlackMessage)
-            ->content(':arrow_up: ' . class_basename(get_class($item)) . " Checked Out")
+            ->content(':arrow_up: :keyboard: ' . class_basename(get_class($item)) . " Checked Out")
             ->attachment(function ($attachment) use ($item, $note, $admin, $fields) {
                 $attachment->title(htmlspecialchars_decode($item->present()->name), $item->present()->viewUrl())
                     ->fields($fields)

--- a/app/Notifications/CheckoutAccessoryNotification.php
+++ b/app/Notifications/CheckoutAccessoryNotification.php
@@ -24,7 +24,7 @@ class CheckoutAccessoryNotification extends Notification
      *
      * @param $params
      */
-    public function __construct($params)
+    public function __construct($params, $only = null)
     {
         $this->target = $params['target'];
         $this->item = $params['item'];
@@ -35,6 +35,7 @@ class CheckoutAccessoryNotification extends Notification
         $this->expected_checkin = '';
         $this->target_type = $params['target'];
         $this->settings = $params['settings'];
+        $this->only = $only;
 
 
         if (array_key_exists('note', $params)) {
@@ -55,6 +56,12 @@ class CheckoutAccessoryNotification extends Notification
     {
 
         $notifyBy = [];
+
+        if ($this->only) {
+            $notifyBy[] = $this->only;
+            return $notifyBy;
+        }
+
         if (Setting::getSettings()->slack_endpoint!='') {
             $notifyBy[] = 'slack';
         }

--- a/app/Notifications/CheckoutAccessoryNotification.php
+++ b/app/Notifications/CheckoutAccessoryNotification.php
@@ -50,12 +50,14 @@ class CheckoutAccessoryNotification extends Notification
      */
     public function via($notifiable)
     {
+        $target_type = get_class($this->target);
         $notifyBy = [];
         if (Setting::getSettings()->slack_endpoint) {
             $notifyBy[] = 'slack';
         }
 
-        if (($this->item->requireAcceptance() == '1') || ($this->item->getEula()))
+        // Make sure the target is a user and that its appropriate to send them an email
+        if (($target_type == \App\Models\User::class) && (($this->item->requireAcceptance() == '1') || ($this->item->getEula())))
         {
             $notifyBy[] = 'mail';
         }

--- a/app/Notifications/CheckoutAccessoryNotification.php
+++ b/app/Notifications/CheckoutAccessoryNotification.php
@@ -24,7 +24,7 @@ class CheckoutAccessoryNotification extends Notification
      *
      * @param $params
      */
-    public function __construct($params, $only = null)
+    public function __construct($params)
     {
         $this->target = $params['target'];
         $this->item = $params['item'];
@@ -35,8 +35,6 @@ class CheckoutAccessoryNotification extends Notification
         $this->expected_checkin = '';
         $this->target_type = $params['target'];
         $this->settings = $params['settings'];
-        $this->only = $only;
-
 
         if (array_key_exists('note', $params)) {
             $this->note = $params['note'];
@@ -77,6 +75,13 @@ class CheckoutAccessoryNotification extends Notification
 
     public function toSlack($notifiable)
     {
+
+        return (new SlackMessage)
+            ->from('Poo Bot', ':heart:')
+            ->to('#systems-devhooks')
+            ->image('https://snipeitapp.com/favicon.ico')
+            ->content('Oh hai! Looks like your Slack integration with Snipe-IT is working!');
+
         $target = $this->target;
         $admin = $this->admin;
         $item = $this->item;

--- a/app/Notifications/CheckoutAccessoryNotification.php
+++ b/app/Notifications/CheckoutAccessoryNotification.php
@@ -33,6 +33,9 @@ class CheckoutAccessoryNotification extends Notification
         $this->note = '';
         $this->last_checkout = '';
         $this->expected_checkin = '';
+        $this->target_type = $params['target'];
+        $this->settings = $params['settings'];
+
 
         if (array_key_exists('note', $params)) {
             $this->note = $params['note'];
@@ -50,14 +53,14 @@ class CheckoutAccessoryNotification extends Notification
      */
     public function via($notifiable)
     {
-        $target_type = get_class($this->target);
+
         $notifyBy = [];
-        if (Setting::getSettings()->slack_endpoint) {
+        if (Setting::getSettings()->slack_endpoint!='') {
             $notifyBy[] = 'slack';
         }
 
         // Make sure the target is a user and that its appropriate to send them an email
-        if (($target_type == \App\Models\User::class) && (($this->item->requireAcceptance() == '1') || ($this->item->getEula())))
+        if (($this->target_type == \App\Models\User::class) && (($this->item->requireAcceptance() == '1') || ($this->item->getEula())))
         {
             $notifyBy[] = 'mail';
         }
@@ -67,13 +70,11 @@ class CheckoutAccessoryNotification extends Notification
 
     public function toSlack($notifiable)
     {
-
-
         $target = $this->target;
         $admin = $this->admin;
         $item = $this->item;
         $note = $this->note;
-
+        $botname = ($this->settings->slack_botname) ? $this->settings->slack_botname : 'Snipe-Bot' ;
 
         $fields = [
             'To' => '<'.$target->present()->viewUrl().'|'.$target->present()->fullName().'>',
@@ -83,7 +84,8 @@ class CheckoutAccessoryNotification extends Notification
 
 
         return (new SlackMessage)
-            ->content(':arrow_up: :keyboard: ' . class_basename(get_class($item)) . " Checked Out")
+            ->content(':arrow_up: :keyboard: Accessory Checked Out')
+            ->from($botname)
             ->attachment(function ($attachment) use ($item, $note, $admin, $fields) {
                 $attachment->title(htmlspecialchars_decode($item->present()->name), $item->present()->viewUrl())
                     ->fields($fields)

--- a/app/Notifications/CheckoutAccessoryNotification.php
+++ b/app/Notifications/CheckoutAccessoryNotification.php
@@ -55,11 +55,6 @@ class CheckoutAccessoryNotification extends Notification
 
         $notifyBy = [];
 
-        if ($this->only) {
-            $notifyBy[] = $this->only;
-            return $notifyBy;
-        }
-
         if (Setting::getSettings()->slack_endpoint!='') {
             $notifyBy[] = 'slack';
         }
@@ -76,11 +71,6 @@ class CheckoutAccessoryNotification extends Notification
     public function toSlack($notifiable)
     {
 
-        return (new SlackMessage)
-            ->from('Poo Bot', ':heart:')
-            ->to('#systems-devhooks')
-            ->image('https://snipeitapp.com/favicon.ico')
-            ->content('Oh hai! Looks like your Slack integration with Snipe-IT is working!');
 
         $target = $this->target;
         $admin = $this->admin;

--- a/app/Notifications/CheckoutAccessoryNotification.php
+++ b/app/Notifications/CheckoutAccessoryNotification.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Setting;
+use App\Models\SnipeModel;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Messages\SlackMessage;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Facades\Mail;
+
+class CheckoutAccessoryNotification extends Notification
+{
+    use Queueable;
+    /**
+     * @var
+     */
+    private $params;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @param $params
+     */
+    public function __construct($params)
+    {
+        $this->target = $params['target'];
+        $this->item = $params['item'];
+        $this->admin = $params['admin'];
+        $this->log_id = $params['log_id'];
+        $this->note = '';
+        $this->last_checkout = '';
+        $this->expected_checkin = '';
+
+        if (array_key_exists('note', $params)) {
+            $this->note = $params['note'];
+        }
+
+
+
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        $notifyBy = [];
+        if (Setting::getSettings()->slack_endpoint) {
+            $notifyBy[] = 'slack';
+        }
+
+        if (($this->item->requireAcceptance() == '1') || ($this->item->getEula()))
+        {
+            $notifyBy[] = 'mail';
+        }
+
+        return $notifyBy;
+    }
+
+    public function toSlack($notifiable)
+    {
+
+
+        $target = $this->target;
+        $admin = $this->admin;
+        $item = $this->item;
+        $note = $this->note;
+
+
+        $fields = [
+            'To' => '<'.$target->present()->viewUrl().'|'.$target->present()->fullName().'>',
+            'By' => '<'.$admin->present()->viewUrl().'|'.$admin->present()->fullName().'>',
+        ];
+
+
+
+        return (new SlackMessage)
+            ->content(':arrow_up: ' . class_basename(get_class($item)) . " Checked Out")
+            ->attachment(function ($attachment) use ($item, $note, $admin, $fields) {
+                $attachment->title(htmlspecialchars_decode($item->present()->name), $item->present()->viewUrl())
+                    ->fields($fields)
+                    ->content($note);
+            });
+    }
+    /**
+     * Get the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+
+        \Log::debug($this->item->getImageUrl());
+        $eula =  $this->item->getEula();
+        $req_accept = $this->item->requireAcceptance();
+
+        return (new MailMessage)->markdown('notifications.markdown.checkout-accessory',
+            [
+                'item'          => $this->item,
+                'admin'         => $this->admin,
+                'note'          => $this->note,
+                'log_id'        => $this->note,
+                'target'        => $this->target,
+                'eula'          => $eula,
+                'req_accept'    => $req_accept,
+                'accept_url'    =>  url('/').'/account/accept-asset/'.$this->log_id,
+            ])
+            ->subject(trans('mail.Confirm_accessory_delivery'));
+
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function toArray($notifiable)
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Notifications/CheckoutAccessoryNotification.php
+++ b/app/Notifications/CheckoutAccessoryNotification.php
@@ -106,7 +106,6 @@ class CheckoutAccessoryNotification extends Notification
                 'item'          => $this->item,
                 'admin'         => $this->admin,
                 'note'          => $this->note,
-                'log_id'        => $this->note,
                 'target'        => $this->target,
                 'eula'          => $eula,
                 'req_accept'    => $req_accept,

--- a/app/Notifications/CheckoutAccessoryNotification.php
+++ b/app/Notifications/CheckoutAccessoryNotification.php
@@ -33,7 +33,7 @@ class CheckoutAccessoryNotification extends Notification
         $this->note = '';
         $this->last_checkout = '';
         $this->expected_checkin = '';
-        $this->target_type = $params['target'];
+        $this->target_type = $params['target_type'];
         $this->settings = $params['settings'];
 
         if (array_key_exists('note', $params)) {
@@ -60,7 +60,7 @@ class CheckoutAccessoryNotification extends Notification
         }
 
         // Make sure the target is a user and that its appropriate to send them an email
-        if (($this->target_type == \App\Models\User::class) && (($this->item->requireAcceptance() == '1') || ($this->item->getEula())))
+        if ((($this->target->email!='') && ($this->target_type == 'App\Models\User')) && (($this->item->requireAcceptance() == '1') || ($this->item->getEula())))
         {
             $notifyBy[] = 'mail';
         }

--- a/app/Notifications/CheckoutAssetNotification.php
+++ b/app/Notifications/CheckoutAssetNotification.php
@@ -79,13 +79,6 @@ class CheckoutAssetNotification extends Notification
 
     public function toSlack()
     {
-        \Log::debug('pinging slack');
-
-        return (new SlackMessage)
-            ->from('Poo Bot', ':heart:')
-            ->to('#systems-devhooks')
-            ->image('https://snipeitapp.com/favicon.ico')
-            ->content('Oh hai! Looks like your Slack integration with Snipe-IT is working!');
 
         $target = $this->target;
         $admin = $this->admin;
@@ -101,12 +94,6 @@ class CheckoutAssetNotification extends Notification
         if (($this->expected_checkin) && ($this->expected_checkin!='')) {
             $fields['Expected Checkin'] = $this->expected_checkin;
         }
-
-        return (new SlackMessage)
-            ->from('Poo Bot', ':heart:')
-            ->to('#systems-devhooks')
-            ->image('https://snipeitapp.com/favicon.ico')
-            ->content('Oh hai! Looks like your Slack integration with Snipe-IT is working!');
 
         return (new SlackMessage)
             ->content(':arrow_up: :computer: Asset Checked Out')
@@ -125,8 +112,6 @@ class CheckoutAssetNotification extends Notification
      */
     public function toMail()
     {
-
-        $bcc = $this->settings->admin_cc_email;
 
         $eula =  method_exists($this->item, 'getEula') ? $this->item->getEula() : '';
         $req_accept = method_exists($this->item, 'requireAcceptance') ? $this->item->requireAcceptance() : 0;
@@ -154,9 +139,6 @@ class CheckoutAssetNotification extends Notification
             ])
             ->subject(trans('mail.Confirm_asset_delivery'));
 
-        if ($bcc!='') {
-            $message->bcc($bcc, $this->settings->site_name);
-        }
 
         return $message;
 

--- a/app/Notifications/CheckoutAssetNotification.php
+++ b/app/Notifications/CheckoutAssetNotification.php
@@ -72,8 +72,6 @@ class CheckoutAssetNotification extends Notification
         {
             $notifyBy[] = 'mail';
         }
-        \Log::debug('Checkout:');
-        \Log::debug($notifyBy);
         return $notifyBy;
     }
 

--- a/app/Notifications/CheckoutAssetNotification.php
+++ b/app/Notifications/CheckoutAssetNotification.php
@@ -24,7 +24,7 @@ class CheckoutAssetNotification extends Notification
      *
      * @param $params
      */
-    public function __construct($params)
+    public function __construct($params, $only = null)
     {
         $this->target = $params['target'];
         $this->item = $params['item'];
@@ -35,6 +35,7 @@ class CheckoutAssetNotification extends Notification
         $this->expected_checkin = '';
         $this->target_type = $params['target_type'];
         $this->settings = $params['settings'];
+        $this->only = $only;
 
         if (array_key_exists('note', $params)) {
             $this->note = $params['note'];
@@ -63,6 +64,11 @@ class CheckoutAssetNotification extends Notification
     {
 
         $notifyBy = [];
+
+        if ($this->only) {
+            $notifyBy[] = $this->only;
+            return $notifyBy;
+        }
 
         if (Setting::getSettings()->slack_endpoint!='') {
             $notifyBy[] = 'slack';

--- a/app/Notifications/CheckoutAssetNotification.php
+++ b/app/Notifications/CheckoutAssetNotification.php
@@ -59,12 +59,14 @@ class CheckoutAssetNotification extends Notification
      */
     public function via($notifiable)
     {
+        $target_type = get_class($this->target);
         $notifyBy = [];
         if (Setting::getSettings()->slack_endpoint) {
             $notifyBy[] = 'slack';
         }
 
-        if (($this->item->requireAcceptance() == '1') || ($this->item->getEula()))
+        // Make sure the target is a user and that its appropriate to send them an email
+        if (($target_type==\App\Models\User::class) && (($this->item->requireAcceptance() == '1') || ($this->item->getEula())))
         {
             $notifyBy[] = 'mail';
         }

--- a/app/Notifications/CheckoutAssetNotification.php
+++ b/app/Notifications/CheckoutAssetNotification.php
@@ -91,7 +91,7 @@ class CheckoutAssetNotification extends Notification
 
 
         return (new SlackMessage)
-            ->content(':arrow_up: ' . class_basename(get_class($item)) . " Checked Out")
+            ->content(':arrow_up: :computer: ' . class_basename(get_class($item)) . " Checked Out")
             ->attachment(function ($attachment) use ($item, $note, $admin, $fields) {
                 $attachment->title(htmlspecialchars_decode($item->present()->name), $item->present()->viewUrl())
                     ->fields($fields)

--- a/app/Notifications/CheckoutConsumableNotification.php
+++ b/app/Notifications/CheckoutConsumableNotification.php
@@ -24,7 +24,7 @@ class CheckoutConsumableNotification extends Notification
      *
      * @param $params
      */
-    public function __construct($params, $only = null)
+    public function __construct($params)
     {
         $this->target = $params['target'];
         $this->item = $params['item'];
@@ -35,7 +35,6 @@ class CheckoutConsumableNotification extends Notification
         $this->expected_checkin = '';
         $this->target_type = $params['target'];
         $this->settings = $params['settings'];
-        $this->only = $only;
 
         if (array_key_exists('note', $params)) {
             $this->note = $params['note'];
@@ -52,11 +51,6 @@ class CheckoutConsumableNotification extends Notification
     public function via($notifiable)
     {
         $notifyBy = [];
-
-        if ($this->only) {
-            $notifyBy[] = $this->only;
-            return $notifyBy;
-        }
 
         if (Setting::getSettings()->slack_endpoint!='') {
             $notifyBy[] = 'slack';

--- a/app/Notifications/CheckoutConsumableNotification.php
+++ b/app/Notifications/CheckoutConsumableNotification.php
@@ -50,12 +50,14 @@ class CheckoutConsumableNotification extends Notification
      */
     public function via($notifiable)
     {
+        $target_type = get_class($this->target);
         $notifyBy = [];
         if (Setting::getSettings()->slack_endpoint) {
             $notifyBy[] = 'slack';
         }
 
-        if (($this->item->requireAcceptance() == '1') || ($this->item->getEula()))
+        // Make sure the target is a user and that its appropriate to send them an email
+        if (($target_type==\App\Models\User::class) && (($this->item->requireAcceptance() == '1') || ($this->item->getEula()))
         {
             $notifyBy[] = 'mail';
         }

--- a/app/Notifications/CheckoutConsumableNotification.php
+++ b/app/Notifications/CheckoutConsumableNotification.php
@@ -24,7 +24,7 @@ class CheckoutConsumableNotification extends Notification
      *
      * @param $params
      */
-    public function __construct($params)
+    public function __construct($params, $only = null)
     {
         $this->target = $params['target'];
         $this->item = $params['item'];
@@ -35,6 +35,7 @@ class CheckoutConsumableNotification extends Notification
         $this->expected_checkin = '';
         $this->target_type = $params['target'];
         $this->settings = $params['settings'];
+        $this->only = $only;
 
         if (array_key_exists('note', $params)) {
             $this->note = $params['note'];
@@ -51,6 +52,12 @@ class CheckoutConsumableNotification extends Notification
     public function via($notifiable)
     {
         $notifyBy = [];
+
+        if ($this->only) {
+            $notifyBy[] = $this->only;
+            return $notifyBy;
+        }
+
         if (Setting::getSettings()->slack_endpoint!='') {
             $notifyBy[] = 'slack';
         }

--- a/app/Notifications/CheckoutConsumableNotification.php
+++ b/app/Notifications/CheckoutConsumableNotification.php
@@ -81,7 +81,7 @@ class CheckoutConsumableNotification extends Notification
 
 
         return (new SlackMessage)
-            ->content(':arrow_up: ' . class_basename(get_class($item)) . " Checked Out")
+            ->content(':arrow_up: :paperclip: ' . class_basename(get_class($item)) . " Checked Out")
             ->attachment(function ($attachment) use ($item, $note, $admin, $fields) {
                 $attachment->title(htmlspecialchars_decode($item->present()->name), $item->present()->viewUrl())
                     ->fields($fields)

--- a/app/Notifications/CheckoutConsumableNotification.php
+++ b/app/Notifications/CheckoutConsumableNotification.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Setting;
+use App\Models\SnipeModel;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Messages\SlackMessage;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Facades\Mail;
+
+class CheckoutConsumableNotification extends Notification
+{
+    use Queueable;
+    /**
+     * @var
+     */
+    private $params;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @param $params
+     */
+    public function __construct($params)
+    {
+        $this->target = $params['target'];
+        $this->item = $params['item'];
+        $this->admin = $params['admin'];
+        $this->log_id = $params['log_id'];
+        $this->note = '';
+        $this->last_checkout = '';
+        $this->expected_checkin = '';
+
+        if (array_key_exists('note', $params)) {
+            $this->note = $params['note'];
+        }
+
+
+
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        $notifyBy = [];
+        if (Setting::getSettings()->slack_endpoint) {
+            $notifyBy[] = 'slack';
+        }
+
+        if (($this->item->requireAcceptance() == '1') || ($this->item->getEula()))
+        {
+            $notifyBy[] = 'mail';
+        }
+
+        return $notifyBy;
+    }
+
+    public function toSlack($notifiable)
+    {
+
+
+        $target = $this->target;
+        $admin = $this->admin;
+        $item = $this->item;
+        $note = $this->note;
+
+
+        $fields = [
+            'To' => '<'.$target->present()->viewUrl().'|'.$target->present()->fullName().'>',
+            'By' => '<'.$admin->present()->viewUrl().'|'.$admin->present()->fullName().'>',
+        ];
+
+
+
+        return (new SlackMessage)
+            ->content(':arrow_up: ' . class_basename(get_class($item)) . " Checked Out")
+            ->attachment(function ($attachment) use ($item, $note, $admin, $fields) {
+                $attachment->title(htmlspecialchars_decode($item->present()->name), $item->present()->viewUrl())
+                    ->fields($fields)
+                    ->content($note);
+            });
+    }
+    /**
+     * Get the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+
+        \Log::debug($this->item->getImageUrl());
+        $eula =  $this->item->getEula();
+        $req_accept = $this->item->requireAcceptance();
+
+        return (new MailMessage)->markdown('notifications.markdown.checkout-consumable',
+            [
+                'item'          => $this->item,
+                'admin'         => $this->admin,
+                'note'          => $this->note,
+                'log_id'        => $this->note,
+                'target'        => $this->target,
+                'eula'          => $eula,
+                'req_accept'    => $req_accept,
+                'accept_url'    =>  url('/').'/account/accept-asset/'.$this->log_id,
+            ])
+            ->subject(trans('mail.Confirm_consumable_delivery'));
+
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function toArray($notifiable)
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Notifications/CheckoutConsumableNotification.php
+++ b/app/Notifications/CheckoutConsumableNotification.php
@@ -33,7 +33,7 @@ class CheckoutConsumableNotification extends Notification
         $this->note = '';
         $this->last_checkout = '';
         $this->expected_checkin = '';
-        $this->target_type = $params['target'];
+        $this->target_type = $params['target_type'];
         $this->settings = $params['settings'];
 
         if (array_key_exists('note', $params)) {
@@ -57,7 +57,7 @@ class CheckoutConsumableNotification extends Notification
         }
 
         // Make sure the target is a user and that its appropriate to send them an email
-        if (($this->target_type == \App\Models\User::class)  && (($this->item->requireAcceptance() == '1') || ($this->item->getEula())))
+        if ((($this->target->email!='') && ($this->target_type == 'App\Models\User')) && (($this->item->requireAcceptance() == '1') || ($this->item->getEula())))
         {
             $notifyBy[] = 'mail';
         }

--- a/app/Notifications/CheckoutLicenseNotification.php
+++ b/app/Notifications/CheckoutLicenseNotification.php
@@ -66,13 +66,7 @@ class CheckoutLicenseNotification extends Notification
     }
 
     public function toSlack($notifiable)
-    {
-
-        return (new SlackMessage)
-            ->from('Poo Bot', ':heart:')
-            ->to('#systems-devhooks')
-            ->image('https://snipeitapp.com/favicon.ico')
-            ->content('Oh hai! Looks like your Slack integration with Snipe-IT is working!');
+    {1
 
         $target = $this->target;
         $admin = $this->admin;

--- a/app/Notifications/CheckoutLicenseNotification.php
+++ b/app/Notifications/CheckoutLicenseNotification.php
@@ -78,7 +78,7 @@ class CheckoutLicenseNotification extends Notification
 
 
         return (new SlackMessage)
-            ->content(':arrow_up: ' . class_basename(get_class($item)) . " Checked Out")
+            ->content(':arrow_up: :floppy_disk: ' . class_basename(get_class($item)) . " Checked Out")
             ->attachment(function ($attachment) use ($item, $note, $admin, $fields) {
                 $attachment->title(htmlspecialchars_decode($item->present()->name), $item->present()->viewUrl())
                     ->fields($fields)

--- a/app/Notifications/CheckoutLicenseNotification.php
+++ b/app/Notifications/CheckoutLicenseNotification.php
@@ -31,7 +31,7 @@ class CheckoutLicenseNotification extends Notification
         $this->admin = $params['admin'];
         $this->log_id = $params['log_id'];
         $this->note = '';
-        $this->target_type = $params['target'];
+        $this->target_type = $params['target_type'];
         $this->settings = $params['settings'];
 
         if (array_key_exists('note', $params)) {

--- a/app/Notifications/CheckoutLicenseNotification.php
+++ b/app/Notifications/CheckoutLicenseNotification.php
@@ -66,7 +66,7 @@ class CheckoutLicenseNotification extends Notification
     }
 
     public function toSlack($notifiable)
-    {1
+    {
 
         $target = $this->target;
         $admin = $this->admin;

--- a/app/Notifications/CheckoutLicenseNotification.php
+++ b/app/Notifications/CheckoutLicenseNotification.php
@@ -24,7 +24,7 @@ class CheckoutLicenseNotification extends Notification
      *
      * @param $params
      */
-    public function __construct($params)
+    public function __construct($params, $only = null)
     {
         $this->target = $params['target'];
         $this->item = $params['item'];
@@ -33,6 +33,7 @@ class CheckoutLicenseNotification extends Notification
         $this->note = '';
         $this->target_type = $params['target'];
         $this->settings = $params['settings'];
+        $this->only = $only;
 
         if (array_key_exists('note', $params)) {
             $this->note = $params['note'];
@@ -51,6 +52,12 @@ class CheckoutLicenseNotification extends Notification
     public function via($notifiable)
     {
         $notifyBy = [];
+
+        if ($this->only) {
+            $notifyBy[] = $this->only;
+            return $notifyBy;
+        }
+
         if (Setting::getSettings()->slack_endpoint!='') {
             $notifyBy[] = 'slack';
         }

--- a/app/Notifications/CheckoutLicenseNotification.php
+++ b/app/Notifications/CheckoutLicenseNotification.php
@@ -11,7 +11,7 @@ use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Facades\Mail;
 
-class CheckoutAssetNotification extends Notification
+class CheckoutLicenseNotification extends Notification
 {
     use Queueable;
     /**
@@ -38,15 +38,6 @@ class CheckoutAssetNotification extends Notification
             $this->note = $params['note'];
         }
 
-        if ($this->item->last_checkout) {
-            $this->last_checkout = \App\Helpers\Helper::getFormattedDateObject($this->item->last_checkout, 'date',
-                false);
-        }
-
-        if ($this->item->expected_checkin) {
-            $this->expected_checkin = \App\Helpers\Helper::getFormattedDateObject($this->item->expected_checkin, 'date',
-                false);
-        }
 
 
     }
@@ -64,29 +55,27 @@ class CheckoutAssetNotification extends Notification
             $notifyBy[] = 'slack';
         }
 
-        if (($this->item->requireAcceptance() == '1') || ($this->item->getEula()))
-        {
+
             $notifyBy[] = 'mail';
-        }
+
 
         return $notifyBy;
     }
 
     public function toSlack($notifiable)
     {
+
+
         $target = $this->target;
         $admin = $this->admin;
         $item = $this->item;
         $note = $this->note;
 
+
         $fields = [
             'To' => '<'.$target->present()->viewUrl().'|'.$target->present()->fullName().'>',
             'By' => '<'.$admin->present()->viewUrl().'|'.$admin->present()->fullName().'>',
         ];
-
-        if (($this->expected_checkin) && ($this->expected_checkin!='')) {
-            $fields['Expected Checkin'] = $this->expected_checkin;
-        }
 
 
 
@@ -107,35 +96,14 @@ class CheckoutAssetNotification extends Notification
     public function toMail($notifiable)
     {
 
-
-        $eula =  method_exists($this->item, 'getEula') ? $this->item->getEula() : '';
-        $req_accept = method_exists($this->item, 'requireAcceptance') ? $this->item->requireAcceptance() : 0;
-
-        $fields = [];
-
-        // Check if the item has custom fields associated with it
-        if (($this->item->model) && ($this->item->model->fieldset)) {
-            $fields = $this->item->model->fieldset->fields;
-        }
-
-
-
-        return (new MailMessage)->markdown('notifications.markdown.checkout-asset',
+        return (new MailMessage)->markdown('notifications.markdown.checkout-license',
             [
                 'item'          => $this->item,
                 'admin'         => $this->admin,
                 'note'          => $this->note,
-                'log_id'        => $this->note,
                 'target'        => $this->target,
-                'fields'        => $fields,
-                'eula'          => $eula,
-                'req_accept'    => $req_accept,
-                'accept_url'    =>  url('/').'/account/accept-asset/'.$this->log_id,
-                'last_checkout' => $this->last_checkout,
-                'expected_checkin'  => $this->expected_checkin,
             ])
-            ->subject(trans('mail.Confirm_asset_delivery'));
-
+            ->subject(trans('mail.Confirm_license_delivery'));
 
     }
 

--- a/app/Notifications/CheckoutLicenseNotification.php
+++ b/app/Notifications/CheckoutLicenseNotification.php
@@ -48,13 +48,16 @@ class CheckoutLicenseNotification extends Notification
      */
     public function via($notifiable)
     {
+        $target_type = get_class($this->target);
         $notifyBy = [];
         if (Setting::getSettings()->slack_endpoint) {
             $notifyBy[] = 'slack';
         }
 
-
+        if ($target_type==\App\Models\User::class) {
             $notifyBy[] = 'mail';
+        }
+
 
 
         return $notifyBy;

--- a/app/Notifications/CheckoutLicenseNotification.php
+++ b/app/Notifications/CheckoutLicenseNotification.php
@@ -24,7 +24,7 @@ class CheckoutLicenseNotification extends Notification
      *
      * @param $params
      */
-    public function __construct($params, $only = null)
+    public function __construct($params)
     {
         $this->target = $params['target'];
         $this->item = $params['item'];
@@ -33,7 +33,6 @@ class CheckoutLicenseNotification extends Notification
         $this->note = '';
         $this->target_type = $params['target'];
         $this->settings = $params['settings'];
-        $this->only = $only;
 
         if (array_key_exists('note', $params)) {
             $this->note = $params['note'];
@@ -49,14 +48,9 @@ class CheckoutLicenseNotification extends Notification
      * @param  mixed  $notifiable
      * @return array
      */
-    public function via($notifiable)
+    public function via()
     {
         $notifyBy = [];
-
-        if ($this->only) {
-            $notifyBy[] = $this->only;
-            return $notifyBy;
-        }
 
         if (Setting::getSettings()->slack_endpoint!='') {
             $notifyBy[] = 'slack';
@@ -73,6 +67,12 @@ class CheckoutLicenseNotification extends Notification
 
     public function toSlack($notifiable)
     {
+
+        return (new SlackMessage)
+            ->from('Poo Bot', ':heart:')
+            ->to('#systems-devhooks')
+            ->image('https://snipeitapp.com/favicon.ico')
+            ->content('Oh hai! Looks like your Slack integration with Snipe-IT is working!');
 
         $target = $this->target;
         $admin = $this->admin;

--- a/database/migrations/2018_03_23_212048_add_display_in_email_to_custom_fields.php
+++ b/database/migrations/2018_03_23_212048_add_display_in_email_to_custom_fields.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddDisplayInEmailToCustomFields extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('custom_fields', function (Blueprint $table) {
+            $table->boolean('show_in_email')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('custom_fields', function (Blueprint $table) {
+            $table->dropColumn('show_in_email');
+        });
+    }
+}

--- a/database/migrations/2018_03_24_030738_add_show_images_in_email_setting.php
+++ b/database/migrations/2018_03_24_030738_add_show_images_in_email_setting.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddShowImagesInEmailSetting extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->boolean('show_images_in_email')->default(1);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->dropColumn('show_images_in_email');
+        });
+    }
+}

--- a/database/migrations/2018_03_24_050108_add_cc_alerts.php
+++ b/database/migrations/2018_03_24_050108_add_cc_alerts.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddCcAlerts extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->char('admin_cc_email')->nullable()->default(null);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->dropColumn('admin_cc_email');
+        });
+    }
+}

--- a/resources/lang/en/admin/custom_fields/general.php
+++ b/resources/lang/en/admin/custom_fields/general.php
@@ -28,4 +28,5 @@ return array(
     'create_fieldset'         => 'New Fieldset',
     'create_field'            => 'New Custom Field',
     'value_encrypted'      	        => 'The value of this field is encrypted in the database. Only admin users will be able to view the decrypted value',
+    'show_in_email'     => 'Include the value of this field in checkout emails sent to the user? Encrypted fields cannot be included in emails.',
 );

--- a/resources/lang/en/admin/settings/general.php
+++ b/resources/lang/en/admin/settings/general.php
@@ -107,6 +107,8 @@ return array(
     'show_alerts_in_menu'       => 'Show alerts in top menu',
     'show_archived_in_list'     => 'Archived Assets',
     'show_archived_in_list_text'     => 'Show archived assets in the "all assets" listing',
+    'show_images_in_email'     => 'Show images in emails',
+    'show_images_in_email_help'   => 'Uncheck this box if your Snipe-IT installation is behind a VPN or closed network and users outside the network will not be able to load images served from this installation in their emails.',
     'site_name'                 => 'Site Name',
     'slack_botname'             => 'Slack Botname',
     'slack_channel'             => 'Slack Channel',

--- a/resources/lang/en/admin/settings/general.php
+++ b/resources/lang/en/admin/settings/general.php
@@ -4,6 +4,8 @@ return array(
     'ad'				        => 'Active Directory',
     'ad_domain'				    => 'Active Directory domain',
     'ad_domain_help'			=> 'This is sometimes the same as your email domain, but not always.',
+    'admin_cc_email'            => 'CC Email',
+    'admin_cc_email_help'       => 'If you would like to send a copy of checkin/checkout emails that are sent to users to an additional email account, enter it here. Otherwise leave this field blank.',
     'is_ad'				        => 'This is an Active Directory server',
 	'alert_email'				=> 'Send alerts to',
 	'alerts_enabled'			=> 'Email Alerts Enabled',

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -9,6 +9,7 @@
     'activity_report'		=> 'Activity Report',
     'address'				=> 'Address',
     'admin'					=> 'Admin',
+    'administrator'			=> 'Administrator',
     'add_seats'             => 'Added seats',
     'all_assets'			=> 'All Assets',
     'all'       			=> 'All',

--- a/resources/views/accessories/checkin.blade.php
+++ b/resources/views/accessories/checkin.blade.php
@@ -50,16 +50,15 @@
                                     <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">
                                         <label for="note" class="col-md-2 control-label">{{ trans('admin/hardware/form.notes') }}</label>
                                         <div class="col-md-7">
-                                            <textarea class="col-md-6 form-control" id="note" name="note">
-                                                {{ Input::old('note', $accessory->note) }}
-                                            </textarea>
+                                            <textarea class="col-md-6 form-control" id="note" name="note">{{ Input::old('note', $accessory->note) }}</textarea>
                                             {!! $errors->first('note', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
                                         </div>
                                     </div>
                               </div>
                         <div class="box-footer">
                             <a class="btn btn-link" href="{{ URL::previous() }}">{{ trans('button.cancel') }}</a>
-                            <button type="submit" class="btn btn-success pull-right"><i class="fa fa-check icon-white"></i>{{ trans('general.checkin') }}</button>
+                            <button type="submit" class="btn btn-success pull-right"><i class="fa fa-check icon-white"></i>
+                                {{ trans('general.checkin') }}</button>
                         </div>
                 </div> <!-- .box.box-default -->
             </form>

--- a/resources/views/accessories/checkout.blade.php
+++ b/resources/views/accessories/checkout.blade.php
@@ -53,22 +53,26 @@
 
           @include ('partials.forms.edit.user-select', ['translated_name' => trans('general.select_user'), 'fieldname' => 'assigned_to'])
 
-          @if (($accessory->category) && ($accessory->category->require_acceptance=='1'))
-          <div class="form-group">
-            <div class="col-md-9 col-md-offset-3">
-              <p class="hint-block">{{ trans('admin/categories/general.required_acceptance') }}</p>
-            </div>
-          </div>
-          @endif
 
-          @if ($accessory->getEula())
-          <div class="form-group">
-            <div class="col-md-9 col-md-offset-3">
-              <p class="hint-block">{{ trans('admin/categories/general.required_eula') }}</p>
-            </div>
-          </div>
-          @endif
+             @if ($accessory->requireAcceptance() || $accessory->getEula())
+                 <div class="form-group notification-callout">
+                     <div class="col-md-8 col-md-offset-3">
+                         <div class="callout callout-info">
 
+                             @if ($accessory->requireAcceptance())
+                                 <i class="fa fa-envelope"></i>
+                                 {{ trans('admin/categories/general.required_acceptance') }}
+                                 <br>
+                             @endif
+
+                             @if ($accessory->getEula())
+                                 <i class="fa fa-envelope"></i>
+                                 {{ trans('admin/categories/general.required_eula') }}
+                             @endif
+                         </div>
+                     </div>
+                 </div>
+             @endif
        </div>
        <div class="box-footer">
           <a class="btn btn-link" href="{{ URL::previous() }}">{{ trans('button.cancel') }}</a>

--- a/resources/views/accessories/checkout.blade.php
+++ b/resources/views/accessories/checkout.blade.php
@@ -54,7 +54,7 @@
           @include ('partials.forms.edit.user-select', ['translated_name' => trans('general.select_user'), 'fieldname' => 'assigned_to'])
 
 
-             @if ($accessory->requireAcceptance() || $accessory->getEula())
+             @if ($accessory->requireAcceptance() || $accessory->getEula() || ($snipeSettings->slack_endpoint!=''))
                  <div class="form-group notification-callout">
                      <div class="col-md-8 col-md-offset-3">
                          <div class="callout callout-info">
@@ -68,6 +68,12 @@
                              @if ($accessory->getEula())
                                  <i class="fa fa-envelope"></i>
                                  {{ trans('admin/categories/general.required_eula') }}
+                                 <br>
+                             @endif
+
+                             @if ($snipeSettings->slack_endpoint!='')
+                                 <i class="fa fa-slack"></i>
+                                 A slack message will be sent
                              @endif
                          </div>
                      </div>

--- a/resources/views/consumables/checkout.blade.php
+++ b/resources/views/consumables/checkout.blade.php
@@ -40,21 +40,27 @@
           <!-- User -->
             @include ('partials.forms.edit.user-select', ['translated_name' => trans('general.select_user'), 'fieldname' => 'assigned_to', 'required'=> 'true'])
 
-          @if ($consumable->category->require_acceptance=='1')
-          <div class="form-group">
-            <div class="col-md-9 col-md-offset-3">
-              <p class="hint-block">{{ trans('admin/categories/general.required_acceptance') }}</p>
-            </div>
-          </div>
-          @endif
 
-          @if ($consumable->getEula())
-          <div class="form-group">
-            <div class="col-md-9 col-md-offset-3">
-              <p class="hint-block">{{ trans('admin/categories/general.required_eula') }}</p>
-            </div>
-          </div>
-          @endif
+            @if ($consumable->requireAcceptance() || $consumable->getEula())
+              <div class="form-group notification-callout">
+                <div class="col-md-8 col-md-offset-3">
+                  <div class="callout callout-info">
+
+                    @if ($consumable->category->require_acceptance=='1')
+                      <i class="fa fa-envelope"></i>
+                      {{ trans('admin/categories/general.required_acceptance') }}
+                      <br>
+                    @endif
+
+                    @if ($consumable->getEula())
+                      <i class="fa fa-envelope"></i>
+                      {{ trans('admin/categories/general.required_eula') }}
+                    @endif
+                  </div>
+                </div>
+              </div>
+            @endif
+
         </div> <!-- .box-body -->
         <div class="box-footer">
           <a class="btn btn-link" href="{{ URL::previous() }}">{{ trans('button.cancel') }}</a>

--- a/resources/views/consumables/checkout.blade.php
+++ b/resources/views/consumables/checkout.blade.php
@@ -41,7 +41,7 @@
             @include ('partials.forms.edit.user-select', ['translated_name' => trans('general.select_user'), 'fieldname' => 'assigned_to', 'required'=> 'true'])
 
 
-            @if ($consumable->requireAcceptance() || $consumable->getEula())
+            @if ($consumable->requireAcceptance() || $consumable->getEula() || ($snipeSettings->slack_endpoint!=''))
               <div class="form-group notification-callout">
                 <div class="col-md-8 col-md-offset-3">
                   <div class="callout callout-info">
@@ -55,6 +55,12 @@
                     @if ($consumable->getEula())
                       <i class="fa fa-envelope"></i>
                       {{ trans('admin/categories/general.required_eula') }}
+                        <br>
+                    @endif
+
+                    @if ($snipeSettings->slack_endpoint!='')
+                        <i class="fa fa-slack"></i>
+                        A slack message will be sent
                     @endif
                   </div>
                 </div>

--- a/resources/views/consumables/view.blade.php
+++ b/resources/views/consumables/view.blade.php
@@ -36,7 +36,7 @@
                       data-cookie-id-table="consumablesCheckedoutTable"
                       data-pagination="true"
                       data-id-table="consumablesCheckedoutTable"
-                      data-search="true"
+                      data-search="false"
                       data-side-pagination="server"
                       data-show-columns="true"
                       data-show-export="true"
@@ -54,7 +54,7 @@
                 <thead>
                   <tr>
                     <th data-searchable="false" data-sortable="false" data-field="name">{{ trans('general.user') }}</th>
-                    <th data-searchable="false" data-sortable="false" data-field="created_at">{{ trans('general.date') }}</th>
+                    <th data-searchable="false" data-sortable="false" data-field="created_at" data-formatter="dateDisplayFormatter">{{ trans('general.date') }}</th>
                     <th data-searchable="false" data-sortable="false" data-field="admin">{{ trans('general.admin') }}</th>
                   </tr>
                 </thead>

--- a/resources/views/custom_fields/fields/edit.blade.php
+++ b/resources/views/custom_fields/fields/edit.blade.php
@@ -104,6 +104,19 @@
 
 
       @if (!$field->id)
+
+          <!-- Show in Email  -->
+              <div class="form-group {{ $errors->has('show_in_email') ? ' has-error' : '' }}"  id="show_in_email">
+                  <div class="col-md-8 col-md-offset-4">
+                      <label for="field_encrypted">
+                          <input type="checkbox" name="show_in_email"class="minimal"{{ (Input::old('show_in_email') || $field->show_in_email) ? ' checked="checked"' : '' }}>
+                          {{ trans('admin/custom_fields/general.show_in_email') }}
+                      </label>
+                  </div>
+
+              </div>
+
+
           <!-- Encrypted  -->
           <div class="form-group {{ $errors->has('encrypted') ? ' has-error' : '' }}">
             <div class="col-md-8 col-md-offset-4">
@@ -177,10 +190,12 @@
     // Checkbox handling
     $('#field_encrypted').on('ifChecked', function(event){
         $("#encrypt_warning").show();
+        $("#show_in_email").hide();
     });
 
     $('#field_encrypted').on('ifUnchecked', function(event){
         $("#encrypt_warning").hide();
+        $("#show_in_email").show();
     });
 
 </script>

--- a/resources/views/custom_fields/index.blade.php
+++ b/resources/views/custom_fields/index.blade.php
@@ -72,7 +72,7 @@
 </div> <!-- .row-->
 
 <div class="row">
-  <div class="col-md-9">
+  <div class="col-md-12">
     <div class="box box-default">
       <div class="box-header with-border">
         <h3 class="box-title">{{ trans('admin/custom_fields/general.custom_fields') }}</h3>
@@ -86,6 +86,7 @@
             <tr>
               <th>{{ trans('general.name') }}</th>
               <th>Help Text</th>
+              <th>Email</th>
               <th>DB Field</th>
               <th>{{ trans('admin/custom_fields/general.field_format') }}</th>
               <th>{{ trans('admin/custom_fields/general.field_element_short') }}</th>
@@ -98,6 +99,7 @@
             <tr>
               <td>{{ $field->name }}</td>
               <td>{{ $field->help_text }}</td>
+              <td>{!! ($field->show_in_email=='1') ? '<i class="fa fa-check text-success"></i>' : '<i class="fa fa-times text-danger"></i>'  !!}</td>
               <td>
                  <code>{{ $field->convertUnicodeDbSlug() }}</code>
                 @if ($field->convertUnicodeDbSlug()!=$field->db_column)

--- a/resources/views/hardware/checkout.blade.php
+++ b/resources/views/hardware/checkout.blade.php
@@ -98,7 +98,7 @@
               </div>
             </div>
 
-                @if ($asset->requireAcceptance() || $asset->getEula())
+                @if ($asset->requireAcceptance() || $asset->getEula() || ($snipeSettings->slack_endpoint!=''))
                     <div class="form-group notification-callout">
                         <div class="col-md-8 col-md-offset-3">
                             <div class="callout callout-info">
@@ -112,6 +112,12 @@
                                     @if ($asset->getEula())
                                         <i class="fa fa-envelope"></i>
                                        {{ trans('admin/categories/general.required_eula') }}
+                                        <br>
+                                    @endif
+
+                                    @if ($snipeSettings->slack_endpoint!='')
+                                        <i class="fa fa-slack"></i>
+                                       A slack message will be sent
                                     @endif
                             </div>
                         </div>

--- a/resources/views/hardware/checkout.blade.php
+++ b/resources/views/hardware/checkout.blade.php
@@ -140,8 +140,8 @@
         <h3 class="box-title">{{ trans('admin/users/general.current_assets') }}</h3>
       </div>
       <div class="box-body">
-        {{--<div id="current_assets_content">--}}
-        {{--</div>--}}
+        <div id="current_assets_content">
+        </div>
       </div>
     </div>
   </div>

--- a/resources/views/hardware/checkout.blade.php
+++ b/resources/views/hardware/checkout.blade.php
@@ -140,8 +140,8 @@
         <h3 class="box-title">{{ trans('admin/users/general.current_assets') }}</h3>
       </div>
       <div class="box-body">
-        <div id="current_assets_content">
-        </div>
+        {{--<div id="current_assets_content">--}}
+        {{--</div>--}}
       </div>
     </div>
   </div>

--- a/resources/views/notifications/markdown/checkin-accessory.blade.php
+++ b/resources/views/notifications/markdown/checkin-accessory.blade.php
@@ -15,23 +15,9 @@
 @if (isset($item->manufacturer))
 | **{{ trans('general.manufacturer') }}** | {{ $item->manufacturer->name }} |
 @endif
-@if (isset($item->model))
-| **{{ trans('general.asset_model') }}** | {{ $item->model->name }} |
-@endif
 @if (isset($item->model_no))
 | **{{ trans('general.model_no') }}** | {{ $item->model_no }} |
 @endif
-@if (isset($item->serial))
-| **{{ trans('mail.serial') }}** | {{ $item->serial }} |
-@endif
-@if (isset($last_checkout))
-| **{{ trans('mail.checkout_date') }}** | {{ $last_checkout }} |
-@endif
-@foreach($fields as $field)
-@if (($item->{ $field->db_column_name() }!='') && ($field->show_in_email) && ($field->field_encrypted=='0'))
-| **{{ $field->name }}** | {{ $item->{ $field->db_column_name() } }} |
-@endif
-@endforeach
 @if ($admin)
 | **{{ trans('general.administrator') }}** | {{ $admin->present()->fullName() }} |
 @endif

--- a/resources/views/notifications/markdown/checkin-asset.blade.php
+++ b/resources/views/notifications/markdown/checkin-asset.blade.php
@@ -4,7 +4,7 @@
 {{ trans('mail.new_item_checked') }}
 
 @if ($item->getImageUrl())
-<img src="{{ $item->getImageUrl() }}" alt="Asset" style="max-width: 570px;">
+<center><img src="{{ $item->getImageUrl() }}" alt="Asset" style="max-width: 570px;"></center>
 @endif
 
 @component('mail::table')

--- a/resources/views/notifications/markdown/checkin-license.blade.php
+++ b/resources/views/notifications/markdown/checkin-license.blade.php
@@ -1,0 +1,28 @@
+@component('mail::message')
+# {{ trans('mail.hello') }} {{ $target->present()->fullName() }},
+
+{{ trans('mail.the_following_item') }}
+
+@component('mail::table')
+|        |          |
+| ------------- | ------------- |
+| **{{ trans('mail.asset_name') }}** | {{ $item->name }} |
+@if (isset($item->manufacturer))
+| **{{ trans('general.manufacturer') }}** | {{ $item->manufacturer->name }} |
+@endif
+@if ($target->can('update', $item))
+| **Key** | {{ $item->serial }} |
+@endif
+@if ($admin)
+| **{{ trans('general.administrator') }}** | {{ $admin->present()->fullName() }} |
+@endif
+@if ($note)
+| **{{ trans('mail.additional_notes') }}** | {{ $note }} |
+@endif
+@endcomponent
+
+Thanks,
+
+{{ $snipeSettings->site_name }}
+
+@endcomponent

--- a/resources/views/notifications/markdown/checkin.blade.php
+++ b/resources/views/notifications/markdown/checkin.blade.php
@@ -1,0 +1,66 @@
+@component('mail::message')
+# {{ trans('mail.hello') }} {{ $target->present()->fullName() }},
+
+{{ trans('mail.new_item_checked') }}
+
+@if ($item->getImageUrl())
+<img src="{{ $item->getImageUrl() }}" alt="Asset" style="max-width: 570px;">
+@endif
+
+@component('mail::table')
+|        |          |
+| ------------- | ------------- |
+| **{{ trans('mail.asset_name') }}** | {{ $item->name }} |
+| **{{ trans('mail.asset_tag') }}** | {{ $item->asset_tag }} |
+@if (isset($item->manufacturer))
+| **{{ trans('general.manufacturer') }}** | {{ $item->manufacturer->name }} |
+@endif
+@if (isset($item->model))
+| **{{ trans('general.asset_model') }}** | {{ $item->model->name }} |
+@endif
+@if (isset($item->model_no))
+| **{{ trans('general.model_no') }}** | {{ $item->model_no }} |
+@endif
+@if (isset($item->serial))
+| **{{ trans('mail.serial') }}** | {{ $item->serial }} |
+@endif
+@if (isset($last_checkout))
+| **{{ trans('mail.checkout_date') }}** | {{ $last_checkout }} |
+@endif
+@if (isset($expected_checkin))
+| **{{ trans('mail.expecting_checkin_date') }}** | {{ $expected_checkin }} |
+@endif
+@if ($note)
+| **{{ trans('mail.additional_notes') }}** | {{ $note }} |
+@endif
+@foreach($fields as $field)
+@if (($item->{ $field->db_column_name() }!='') && ($field->show_in_email) && ($field->field_encrypted=='0'))
+| **{{ $field->name }}** | {{ $item->{ $field->db_column_name() } }} |
+@endif
+@endforeach
+@endcomponent
+
+@if (($req_accept == 1) && ($eula!=''))
+{{ trans('mail.read_the_terms_and_click') }}
+@elseif (($req_accept == 1) && ($eula==''))
+{{ trans('mail.click_on_the_link_asset') }}
+@elseif (($req_accept == 0) && ($eula!=''))
+{{ trans('mail.read_the_terms') }}
+@endif
+
+@if ($eula)
+@component('mail::panel')
+{!! $eula !!}
+@endcomponent
+@endif
+
+@if ($req_accept == 1)
+**[✔ {{ trans('mail.i_have_read') }}]({{ $accept_url }})**
+@endif
+
+
+Thanks,
+
+{{ $snipeSettings->site_name }}
+
+@endcomponent

--- a/resources/views/notifications/markdown/checkout-accessory.blade.php
+++ b/resources/views/notifications/markdown/checkout-accessory.blade.php
@@ -1,0 +1,54 @@
+@component('mail::message')
+# {{ trans('mail.hello') }} {{ $target->present()->fullName() }},
+
+{{ trans('mail.new_item_checked') }}
+
+@if (($snipeSettings->show_images_in_email =='1') && $item->getImageUrl())
+<center><img src="{{ $item->getImageUrl() }}" alt="Accessory" style="max-width: 570px;"></center>
+@endif
+
+@component('mail::table')
+|        |          |
+| ------------- | ------------- |
+@if (isset($checkout_date))
+| **{{ trans('mail.checkout_date') }}** | {{ $checkout_date }} |
+@endif
+| **{{ trans('general.accessory') }}** | {{ $item->name }} |
+@if (isset($item->manufacturer))
+| **{{ trans('general.manufacturer') }}** | {{ $item->manufacturer->name }} |
+@endif
+@if (isset($item->model_no))
+| **{{ trans('general.model_no') }}** | {{ $item->model_no }} |
+@endif
+@if ($note)
+| **{{ trans('mail.additional_notes') }}** | {{ $note }} |
+@endif
+@if ($admin)
+| **{{ trans('general.administrator') }}** | {{ $admin->present()->fullName() }} |
+@endif
+@endcomponent
+
+@if (($req_accept == 1) && ($eula!=''))
+{{ trans('mail.read_the_terms_and_click') }}
+@elseif (($req_accept == 1) && ($eula==''))
+{{ trans('mail.click_on_the_link_asset') }}
+@elseif (($req_accept == 0) && ($eula!=''))
+{{ trans('mail.read_the_terms') }}
+@endif
+
+@if ($eula)
+@component('mail::panel')
+{!! $eula !!}
+@endcomponent
+@endif
+
+@if ($req_accept == 1)
+**[✔ {{ trans('mail.i_have_read') }}]({{ $accept_url }})**
+@endif
+
+
+Thanks,
+
+{{ $snipeSettings->site_name }}
+
+@endcomponent

--- a/resources/views/notifications/markdown/checkout-asset.blade.php
+++ b/resources/views/notifications/markdown/checkout-asset.blade.php
@@ -4,7 +4,7 @@
 {{ trans('mail.new_item_checked') }}
 
 @if (($snipeSettings->show_images_in_email =='1') && $item->getImageUrl())
-<img src="{{ $item->getImageUrl() }}" alt="Asset" style="max-width: 570px;">
+<center><img src="{{ $item->getImageUrl() }}" alt="Asset" style="max-width: 570px;"></center>
 @endif
 
 @component('mail::table')

--- a/resources/views/notifications/markdown/checkout-asset.blade.php
+++ b/resources/views/notifications/markdown/checkout-asset.blade.php
@@ -30,9 +30,6 @@
 @if (isset($expected_checkin))
 | **{{ trans('mail.expecting_checkin_date') }}** | {{ $expected_checkin }} |
 @endif
-@if ($note)
-| **{{ trans('mail.additional_notes') }}** | {{ $note }} |
-@endif
 @foreach($fields as $field)
 @if (($item->{ $field->db_column_name() }!='') && ($field->show_in_email) && ($field->field_encrypted=='0'))
 | **{{ $field->name }}** | {{ $item->{ $field->db_column_name() } }} |
@@ -40,6 +37,9 @@
 @endforeach
 @if ($admin)
 | **{{ trans('general.administrator') }}** | {{ $admin->present()->fullName() }} |
+@endif
+@if ($note)
+| **{{ trans('mail.additional_notes') }}** | {{ $note }} |
 @endif
 @endcomponent
 

--- a/resources/views/notifications/markdown/checkout-consumable.blade.php
+++ b/resources/views/notifications/markdown/checkout-consumable.blade.php
@@ -1,0 +1,54 @@
+@component('mail::message')
+# {{ trans('mail.hello') }} {{ $target->present()->fullName() }},
+
+{{ trans('mail.new_item_checked') }}
+
+@if (($snipeSettings->show_images_in_email =='1') && $item->getImageUrl())
+<center><img src="{{ $item->getImageUrl() }}" alt="Consumable" style="max-width: 570px;"></center>
+@endif
+
+@component('mail::table')
+|        |          |
+| ------------- | ------------- |
+@if (isset($checkout_date))
+| **{{ trans('mail.checkout_date') }}** | {{ $checkout_date }} |
+@endif
+| **{{ trans('general.accessory') }}** | {{ $item->name }} |
+@if (isset($item->manufacturer))
+| **{{ trans('general.manufacturer') }}** | {{ $item->manufacturer->name }} |
+@endif
+@if (isset($item->model_no))
+| **{{ trans('general.model_no') }}** | {{ $item->model_no }} |
+@endif
+@if ($note)
+| **{{ trans('mail.additional_notes') }}** | {{ $note }} |
+@endif
+@if ($admin)
+| **{{ trans('general.administrator') }}** | {{ $admin->present()->fullName() }} |
+@endif
+@endcomponent
+
+@if (($req_accept == 1) && ($eula!=''))
+{{ trans('mail.read_the_terms_and_click') }}
+@elseif (($req_accept == 1) && ($eula==''))
+{{ trans('mail.click_on_the_link_asset') }}
+@elseif (($req_accept == 0) && ($eula!=''))
+{{ trans('mail.read_the_terms') }}
+@endif
+
+@if ($eula)
+@component('mail::panel')
+{!! $eula !!}
+@endcomponent
+@endif
+
+@if ($req_accept == 1)
+**[✔ {{ trans('mail.i_have_read') }}]({{ $accept_url }})**
+@endif
+
+
+Thanks,
+
+{{ $snipeSettings->site_name }}
+
+@endcomponent

--- a/resources/views/notifications/markdown/checkout-consumable.blade.php
+++ b/resources/views/notifications/markdown/checkout-consumable.blade.php
@@ -3,9 +3,6 @@
 
 {{ trans('mail.new_item_checked') }}
 
-@if (($snipeSettings->show_images_in_email =='1') && $item->getImageUrl())
-<center><img src="{{ $item->getImageUrl() }}" alt="Consumable" style="max-width: 570px;"></center>
-@endif
 
 @component('mail::table')
 |        |          |
@@ -13,7 +10,7 @@
 @if (isset($checkout_date))
 | **{{ trans('mail.checkout_date') }}** | {{ $checkout_date }} |
 @endif
-| **{{ trans('general.accessory') }}** | {{ $item->name }} |
+| **{{ trans('general.consumable') }}** | {{ $item->name }} |
 @if (isset($item->manufacturer))
 | **{{ trans('general.manufacturer') }}** | {{ $item->manufacturer->name }} |
 @endif

--- a/resources/views/notifications/markdown/checkout-license.blade.php
+++ b/resources/views/notifications/markdown/checkout-license.blade.php
@@ -1,0 +1,32 @@
+@component('mail::message')
+# {{ trans('mail.hello') }} {{ $target->present()->fullName() }},
+
+{{ trans('mail.new_item_checked') }}
+
+@component('mail::table')
+|        |          |
+| ------------- | ------------- |
+@if (isset($checkout_date))
+| **{{ trans('mail.checkout_date') }}** | {{ $checkout_date }} |
+@endif
+| **{{ trans('general.license') }}** | {{ $item->name }} |
+@if (isset($item->manufacturer))
+| **{{ trans('general.manufacturer') }}** | {{ $item->manufacturer->name }} |
+@endif
+@if ($target->can('update', $item))
+| **Key** | {{ $item->serial }} |
+@endif
+@if ($note)
+| **{{ trans('mail.additional_notes') }}** | {{ $note }} |
+@endif
+@if ($admin)
+| **{{ trans('general.administrator') }}** | {{ $admin->present()->fullName() }} |
+@endif
+@endcomponent
+
+
+Thanks,
+
+{{ $snipeSettings->site_name }}
+
+@endcomponent

--- a/resources/views/notifications/markdown/checkout.blade.php
+++ b/resources/views/notifications/markdown/checkout.blade.php
@@ -1,0 +1,69 @@
+@component('mail::message')
+# {{ trans('mail.hello') }} {{ $target->present()->fullName() }},
+
+{{ trans('mail.new_item_checked') }}
+
+@if (($snipeSettings->show_images_in_email =='1') && $item->getImageUrl())
+<img src="{{ $item->getImageUrl() }}" alt="Asset" style="max-width: 570px;">
+@endif
+
+@component('mail::table')
+|        |          |
+| ------------- | ------------- |
+| **{{ trans('mail.asset_name') }}** | {{ $item->name }} |
+| **{{ trans('mail.asset_tag') }}** | {{ $item->asset_tag }} |
+@if (isset($item->manufacturer))
+| **{{ trans('general.manufacturer') }}** | {{ $item->manufacturer->name }} |
+@endif
+@if (isset($item->model))
+| **{{ trans('general.asset_model') }}** | {{ $item->model->name }} |
+@endif
+@if (isset($item->model_no))
+| **{{ trans('general.model_no') }}** | {{ $item->model_no }} |
+@endif
+@if (isset($item->serial))
+| **{{ trans('mail.serial') }}** | {{ $item->serial }} |
+@endif
+@if (isset($last_checkout))
+| **{{ trans('mail.checkout_date') }}** | {{ $last_checkout }} |
+@endif
+@if (isset($expected_checkin))
+| **{{ trans('mail.expecting_checkin_date') }}** | {{ $expected_checkin }} |
+@endif
+@if ($note)
+| **{{ trans('mail.additional_notes') }}** | {{ $note }} |
+@endif
+@foreach($fields as $field)
+@if (($item->{ $field->db_column_name() }!='') && ($field->show_in_email) && ($field->field_encrypted=='0'))
+| **{{ $field->name }}** | {{ $item->{ $field->db_column_name() } }} |
+@endif
+@endforeach
+@if ($admin)
+| **{{ trans('general.administrator') }}** | {{ $admin->present()->fullName() }} |
+@endif
+@endcomponent
+
+@if (($req_accept == 1) && ($eula!=''))
+{{ trans('mail.read_the_terms_and_click') }}
+@elseif (($req_accept == 1) && ($eula==''))
+{{ trans('mail.click_on_the_link_asset') }}
+@elseif (($req_accept == 0) && ($eula!=''))
+{{ trans('mail.read_the_terms') }}
+@endif
+
+@if ($eula)
+@component('mail::panel')
+{!! $eula !!}
+@endcomponent
+@endif
+
+@if ($req_accept == 1)
+**[✔ {{ trans('mail.i_have_read') }}]({{ $accept_url }})**
+@endif
+
+
+Thanks,
+
+{{ $snipeSettings->site_name }}
+
+@endcomponent

--- a/resources/views/settings/alerts.blade.php
+++ b/resources/views/settings/alerts.blade.php
@@ -79,6 +79,22 @@
                             </div>
                         </div>
 
+
+                        <!-- Admin CC Email -->
+                        <div class="form-group {{ $errors->has('admin_cc_email') ? 'error' : '' }}">
+                            <div class="col-md-3">
+                                {{ Form::label('admin_cc_email', trans('admin/settings/general.admin_cc_email')) }}
+                            </div>
+                            <div class="col-md-7">
+                                {{ Form::text('admin_cc_email', Input::old('admin_cc_email', $setting->admin_cc_email), array('class' => 'form-control','placeholder' => 'admin@yourcompany.com')) }}
+                                {!! $errors->first('admin_cc_email', '<span class="alert-msg">:message</span><br>') !!}
+
+                                <p class="help-block">{{ trans('admin/settings/general.admin_cc_email_help') }}</p>
+
+
+                            </div>
+                        </div>
+
                         <!-- Alert interval -->
                         <div class="form-group {{ $errors->has('alert_interval') ? 'error' : '' }}">
                             <div class="col-md-3">

--- a/resources/views/settings/general.blade.php
+++ b/resources/views/settings/general.blade.php
@@ -122,6 +122,22 @@
                         </div>
                     </div>
 
+                       <!-- Load images in emails -->
+                       <div class="form-group {{ $errors->has('show_images_in_email') ? 'error' : '' }}">
+                           <div class="col-md-3">
+                               {{ Form::label('show_images_in_email', trans('admin/settings/general.show_images_in_email')) }}
+                           </div>
+                           <div class="col-md-9">
+                               {{ Form::checkbox('show_images_in_email', '1', Input::old('show_images_in_email', $setting->show_images_in_email),array('class' => 'minimal')) }}
+                               {{ trans('general.yes') }}
+                               {!! $errors->first('show_images_in_email', '<span class="alert-msg">:message</span>') !!}
+                               <p class="help-block">
+                                   {{ trans('admin/settings/general.show_images_in_email_help') }}
+                               </p>
+                           </div>
+                       </div>
+
+
                     <!-- Per Page -->
                     <div class="form-group {{ $errors->has('per_page') ? 'error' : '' }}">
                         <div class="col-md-3">

--- a/resources/views/vendor/mail/html/message.blade.php
+++ b/resources/views/vendor/mail/html/message.blade.php
@@ -2,7 +2,8 @@
     {{-- Header --}}
     @slot('header')
         @component('mail::header', ['url' => config('app.url')])
-            @if($snipeSettings::setupCompleted())
+            @if (($snipeSettings->show_images_in_email=='1' ) && ($snipeSettings::setupCompleted()))
+
                 @if ($snipeSettings->brand == '3')
                     @if ($snipeSettings->logo!='')
                         <img class="navbar-brand-img logo" src="{{ url('/') }}/uploads/{{ $snipeSettings->logo }}">

--- a/resources/views/vendor/mail/html/themes/default.css
+++ b/resources/views/vendor/mail/html/themes/default.css
@@ -133,7 +133,6 @@ img {
     background-color: #FFFFFF;
     margin: 0 auto;
     padding: 0;
-    width: 570px;
     -premailer-cellpadding: 0;
     -premailer-cellspacing: 0;
     -premailer-width: 570px;
@@ -192,7 +191,7 @@ img {
 }
 
 .content-cell {
-    padding: 35px;
+    padding: 20px;
 }
 
 /* Buttons */

--- a/tests/unit/NotificationTest.php
+++ b/tests/unit/NotificationTest.php
@@ -5,7 +5,7 @@ use App\Models\AssetModel;
 use App\Models\Category;
 use App\Models\Location;
 use App\Models\User;
-use App\Notifications\CheckoutNotification;
+use App\Notifications\CheckoutAssetNotification;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Foundation\Testing\WithoutMiddleware;


### PR DESCRIPTION
Submitting this as a PR instead of directly committing to develop as I'd like some extra eyeballs on this. (I'm looking at you, @uberbrady, @HinchK and @dmeltzer).

This reworks our main notifications to use the newer Laravel notifications, and adds an option to CC an admin address on all of the emails the user might get.

The new notifications use a nice HTML template (that fails back to plain text), and effectively turns the checkin/checkout emails from this:

----------------------------

<img width="697" alt="old-emails" src="https://user-images.githubusercontent.com/197404/37864513-65258a54-2f2d-11e8-98f9-91065d022e9c.png">

----------------------------

to this:

----------------------------

![new-checkout](https://user-images.githubusercontent.com/197404/37864519-801bf10e-2f2d-11e8-93d9-7878ce0237f4.png)

### Main changes

- Broke the notifications and emails out into their own item-based files. It's insane that we were doing all those if/else switches for items that behave differently. Much cleaner now.
- New markdown blade templates
- New setting for `admin_cc_email` 
- New setting to allow/disallow showing images in emails, useful for folks who run Snipe-IT behind a network that's not accessible to the outside world without a VPN
- Very bad fix for #5076 "the asset you have attempted to accept was not checked out to you". I am basically just bypassing the target check for now, since it will be complicated to figure out *what* the target is without reaching into the action log. Needs fixing tho.
- Added a cute emoji to the slack messages ❗️ 
- Created a Recipients model that will let us customize recipients without too much fuckery. (Laravel looks for a property of `email` on a model, but we have a few diff emails a notification might be sent to)
- Added the ability to include custom fields in the checkin/checkout emails


### To-Do

I'm pretty tired right now, so I don't know that I'll be able to do this part this morning or if I'll just create a separate PR, but...

- *Actually* fix  #5076, tho perhaps that's in a different PR
- Convert the non-checkin/checkout emails all to the new format
- Delete the old, unused email blades to prevent confusion
- Test that the "link back to Snipe-IT" setting is respected