### PR TITLE
Add title field in Asset Maintenances list/filter/export

### DIFF
--- a/app/Presenters/AssetMaintenancesPresenter.php
+++ b/app/Presenters/AssetMaintenancesPresenter.php
@@ -71,6 +71,11 @@ class AssetMaintenancesPresenter extends Presenter
                 "sortable" => true,
                 "title" => trans('admin/asset_maintenances/form.asset_maintenance_type'),
             ], [
+                "field" => "title",
+                "searchable" => true,
+                "sortable" => true,
+                "title" => trans('admin/asset_maintenances/form.title'),
+            ], [
                 "field" => "created_at",
                 "searchable" => true,
                 "sortable" => true,


### PR DESCRIPTION
As you can see in the picture, the title field is missing in the list, the filters and the export.
<img width="1180" alt="titlefield" src="https://user-images.githubusercontent.com/37537300/38088741-2d18a25c-335d-11e8-92b7-49c47457ada7.png">