### PR TITLE
Fixes #5338 - mark required setup fields during setup

### DIFF
--- a/resources/views/setup/user.blade.php
+++ b/resources/views/setup/user.blade.php
@@ -18,7 +18,7 @@ Create a User ::
 
     <!-- Site Name -->
     <div class="row">
-      <div class="form-group col-lg-12 {{ $errors->has('site_name') ? 'error' : '' }}">
+      <div class="form-group col-lg-12 required {{ $errors->has('site_name') ? 'error' : '' }}">
         {{ Form::label('site_name', trans('general.site_name')) }}
         {{ Form::text('site_name', Input::old('site_name'), array('class' => 'form-control','placeholder' => 'Snipe-IT Asset Management')) }}
 
@@ -29,7 +29,7 @@ Create a User ::
   <div class="row">
 
     <!-- Language -->
-    <div class="form-group col-lg-6 {{$errors->has('default_language') ? 'error' : ''}}">
+    <div class="form-group col-lg-6{{  (\App\Helpers\Helper::checkIfRequired(\App\Models\User::class, 'default_language')) ? ' required' : '' }} {{$errors->has('default_language') ? 'error' : ''}}">
       {{ Form::label('locale', trans('admin/settings/general.default_language')) }}
       {!! Form::locales('locale', Input::old('locale', "en"), 'select2') !!}
 
@@ -37,7 +37,7 @@ Create a User ::
     </div>
 
     <!-- Currency -->
-    <div class="form-group col-lg-6 {{$errors->has('default_currency') ? 'error' : ''}}">
+    <div class="form-group col-lg-6{{  (\App\Helpers\Helper::checkIfRequired(\App\Models\User::class, 'default_currency')) ? ' required' : '' }} {{$errors->has('default_currency') ? 'error' : ''}}">
       {{ Form::label('default_currency', trans('admin/settings/general.default_currency')) }}
       {{ Form::text('default_currency', Input::old('default_currency'), array('class' => 'form-control','placeholder' => 'USD', 'maxlength'=>'3', 'style'=>'width: 60px;')) }}
 
@@ -72,14 +72,14 @@ Create a User ::
 
   <div class="row">
 
-    <div class="form-group col-lg-6 {{ $errors->has('auto_increment_prefix') ? 'error' : '' }}">
+    <div class="form-group col-lg-6{{  (\App\Helpers\Helper::checkIfRequired(\App\Models\User::class, 'auto_increment_prefix')) ? ' required' : '' }} {{ $errors->has('auto_increment_prefix') ? 'error' : '' }}">
       {{ Form::label('auto_increment_prefix', trans('admin/settings/general.auto_increment_prefix')) }}
       {{ Form::text('auto_increment_prefix', Input::old('auto_increment_prefix'), array('class' => 'form-control')) }}
 
       {!! $errors->first('auto_increment_prefix', '<span class="alert-msg">:message</span>') !!}
     </div>
 
-    <div class="form-group col-lg-6 {{ $errors->has('zerofill_count') ? 'error' : '' }}">
+    <div class="form-group col-lg-6{{  (\App\Helpers\Helper::checkIfRequired(\App\Models\User::class, 'zerofill_count')) ? ' required' : '' }} {{ $errors->has('zerofill_count') ? 'error' : '' }}">
       {{ Form::label('zerofill_count', trans('admin/settings/general.zerofill_count')) }}
       {{ Form::text('zerofill_count', Input::old('zerofill_count', 5), array('class' => 'form-control')) }}
 
@@ -90,7 +90,7 @@ Create a User ::
 
     <!-- email domain -->
     <div class="row">
-      <div class="form-group col-lg-6 {{ $errors->has('email_domain') ? 'error' : '' }}">
+      <div class="form-group col-lg-6 required {{ $errors->has('email_domain') ? 'error' : '' }}">
         {{ Form::label('email_domain', trans('general.email_domain')) }}
         {{ Form::text('email_domain', Input::old('email_domain'), array('class' => 'form-control','placeholder' => 'example.com')) }}
         <span class="help-block">{{ trans('general.email_domain_help')  }}</span>
@@ -99,7 +99,7 @@ Create a User ::
       </div>
 
       <!-- email format  -->
-      <div class="form-group col-lg-6 {{ $errors->has('email_format') ? 'error' : '' }}">
+      <div class="form-group col-lg-6{{  (\App\Helpers\Helper::checkIfRequired(\App\Models\User::class, 'email_format')) ? ' required' : '' }} {{ $errors->has('email_format') ? 'error' : '' }}">
         {{ Form::label('email_format', trans('general.email_format')) }}
         {!! Form::username_format('email_format', Input::old('email_format', 'filastname'), 'select2') !!}
         {!! $errors->first('email_format', '<span class="alert-msg">:message</span>') !!}
@@ -109,14 +109,14 @@ Create a User ::
     <!-- Name -->
     <div class="row">
       <!-- first name -->
-      <div class="form-group col-lg-6 {{ $errors->has('first_name') ? 'error' : '' }}">
+      <div class="form-group col-lg-6{{  (\App\Helpers\Helper::checkIfRequired(\App\Models\User::class, 'first_name')) ? ' required' : '' }} {{ $errors->has('first_name') ? 'error' : '' }}">
         {{ Form::label('first_name', trans('general.first_name')) }}
         {{ Form::text('first_name', Input::old('first_name'), array('class' => 'form-control','placeholder' => 'Jane')) }}
         {!! $errors->first('first_name', '<span class="alert-msg">:message</span>') !!}
       </div>
 
       <!-- last name -->
-      <div class="form-group col-lg-6 {{ $errors->has('last_name') ? 'error' : '' }}">
+      <div class="form-group col-lg-6 required {{ $errors->has('last_name') ? 'error' : '' }}">
         {{ Form::label('last_name', trans('general.last_name')) }}
         {{ Form::text('last_name', Input::old('last_name'), array('class' => 'form-control','placeholder' => 'Smith')) }}
         {!! $errors->first('last_name', '<span class="alert-msg">:message</span>') !!}
@@ -125,14 +125,14 @@ Create a User ::
 
     <div class="row">
       <!-- email-->
-      <div class="form-group col-lg-6 {{ $errors->has('email') ? 'error' : '' }}">
+      <div class="form-group col-lg-6{{  (\App\Helpers\Helper::checkIfRequired(\App\Models\User::class, 'email')) ? ' required' : '' }} {{ $errors->has('email') ? 'error' : '' }}">
         {{ Form::label('email', trans('admin/users/table.email')) }}
         {{ Form::email('email', config('mail.from.address'), array('class' => 'form-control','placeholder' => 'you@example.com')) }}
         {!! $errors->first('email', '<span class="alert-msg">:message</span>') !!}
       </div>
 
       <!-- username -->
-      <div class="form-group col-lg-6 {{ $errors->has('username') ? 'error' : '' }}">
+      <div class="form-group col-lg-6{{  (\App\Helpers\Helper::checkIfRequired(\App\Models\User::class, 'username')) ? ' required' : '' }} {{ $errors->has('username') ? 'error' : '' }}">
         {{ Form::label('username', trans('admin/users/table.username')) }}
         {{ Form::text('username', Input::old('username'), array('class' => 'form-control','placeholder' => 'jsmith')) }}
         {!! $errors->first('username', '<span class="alert-msg">:message</span>') !!}
@@ -141,14 +141,14 @@ Create a User ::
 
     <div class="row">
       <!-- password -->
-      <div class="form-group col-lg-6 {{ $errors->has('password') ? 'error' : '' }}">
+      <div class="form-group col-lg-6{{  (\App\Helpers\Helper::checkIfRequired(\App\Models\User::class, 'password')) ? ' required' : '' }} {{ $errors->has('password') ? 'error' : '' }}">
         {{ Form::label('password', trans('admin/users/table.password')) }}
         {{ Form::password('password', array('class' => 'form-control')) }}
         {!! $errors->first('password', '<span class="alert-msg">:message</span>') !!}
       </div>
 
       <!-- password confirm -->
-      <div class="form-group col-lg-6 {{ $errors->has('password_confirm') ? 'error' : '' }}">
+      <div class="form-group col-lg-6{{  (\App\Helpers\Helper::checkIfRequired(\App\Models\User::class, 'password')) ? ' required' : '' }} {{ $errors->has('password_confirm') ? 'error' : '' }}">
         {{ Form::label('password_confirmation', trans('admin/users/table.password_confirm')) }}
         {{ Form::password('password_confirm', array('class' => 'form-control')) }}
         {!! $errors->first('password_confirmation', '<span class="alert-msg">:message</span>') !!}


### PR DESCRIPTION
This pull request adds required flags for create user fields during setup. User model rules are used where available, other fields without defined rules (related just to setup steps, e.g. site_name) have been hardcoded in.