### PR TITLE
Matched Asset currency and Asset Maintenance currency in Asset Maintenance view

### DIFF
--- a/resources/views/asset_maintenances/edit.blade.php
+++ b/resources/views/asset_maintenances/edit.blade.php
@@ -96,19 +96,13 @@
         </div>
 
         <!-- Asset Maintenance Cost -->
-        <?php
-        $currency_type=null;
-        if ($item->asset && $item->asset->location) {
-            $currency_type = $item->asset->location->currency;
-        }
-        ?>
         <div class="form-group {{ $errors->has('cost') ? ' has-error' : '' }}">
           <label for="cost" class="col-md-3 control-label">{{ trans('admin/asset_maintenances/form.cost') }}</label>
           <div class="col-md-2">
             <div class="input-group">
               <span class="input-group-addon">
-                @if (isset($currency_type))
-                  {{ $currency_type }}
+                @if (($item->asset) && ($item->asset->location) && ($item->asset->location->currency!=''))
+                  {{ $item->asset->location->currency }}
                 @else
                   {{ $snipeSettings->default_currency }}
                 @endif
@@ -132,8 +126,9 @@
       <div class="box-footer text-right">
         <button type="submit" class="btn btn-success"><i class="fa fa-check icon-white"></i> {{ trans('general.save') }}</button>
       </div>
+    </div> <!-- .box-default -->
     </form>
-    </div>
   </div>
+</div>
 
 @stop

--- a/resources/views/asset_maintenances/edit.blade.php
+++ b/resources/views/asset_maintenances/edit.blade.php
@@ -96,11 +96,23 @@
         </div>
 
         <!-- Asset Maintenance Cost -->
+        <?php
+        $currency_type=null;
+        if ($item->asset && $item->asset->location) {
+            $currency_type = $item->asset->location->currency;
+        }
+        ?>
         <div class="form-group {{ $errors->has('cost') ? ' has-error' : '' }}">
           <label for="cost" class="col-md-3 control-label">{{ trans('admin/asset_maintenances/form.cost') }}</label>
           <div class="col-md-2">
             <div class="input-group">
-              <span class="input-group-addon">{{ $snipeSettings->default_currency }}</span>
+              <span class="input-group-addon">
+                @if (isset($currency_type))
+                  {{ $currency_type }}
+                @else
+                  {{ $snipeSettings->default_currency }}
+                @endif
+              </span>
               <input class="col-md-2 form-control" type="text" name="cost" id="cost" value="{{ Input::old('cost', \App\Helpers\Helper::formatCurrencyOutput($item->cost)) }}" />
               {!! $errors->first('cost', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
             </div>


### PR DESCRIPTION
Hello :)

I was inspired by the Asset editing view. I declared $currency_type variable, if the asset attached to the maitenance exists and has a location, the asset location currency is affected to currency_type.
