### PR TITLE
Create asset maintenance without asset

### DIFF
--- a/app/Http/Controllers/AssetMaintenancesController.php
+++ b/app/Http/Controllers/AssetMaintenancesController.php
@@ -113,7 +113,7 @@ class AssetMaintenancesController extends Controller
         $assetMaintenance->notes = e($request->input('notes'));
         $asset = Asset::find(e($request->input('asset_id')));
 
-        if (!Company::isCurrentUserHasAccess($asset)) {
+        if (!Company::isCurrentUserHasAccess($asset) && isset($asset)) {
             return static::getInsufficientPermissionsRedirect();
         }
 

--- a/app/Models/AssetMaintenance.php
+++ b/app/Models/AssetMaintenance.php
@@ -53,7 +53,6 @@ class AssetMaintenance extends Model implements ICompanyableChild
             trans('admin/asset_maintenances/general.maintenance') => trans('admin/asset_maintenances/general.maintenance'),
             trans('admin/asset_maintenances/general.repair')      => trans('admin/asset_maintenances/general.repair'),
             trans('admin/asset_maintenances/general.upgrade')     => trans('admin/asset_maintenances/general.upgrade'),
-            'PAT test'      => 'PAT test',
         ];
     }
 

--- a/app/Models/AssetMaintenance.php
+++ b/app/Models/AssetMaintenance.php
@@ -23,7 +23,7 @@ class AssetMaintenance extends Model implements ICompanyableChild
     protected $table = 'asset_maintenances';
     // Declaring rules for form validation
     protected $rules = [
-        'asset_id'               => 'required|integer',
+        'asset_id'               => 'integer',
         'supplier_id'            => 'required|integer',
         'asset_maintenance_type' => 'required',
         'title'                  => 'required|max:100',

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -101,9 +101,6 @@ final class Company extends SnipeModel
 
     public static function isCurrentUserHasAccess($companyable)
     {
-        /*if (is_null($companyable)) {
-            return false;
-        } else*/
         if (!static::isFullMultipleCompanySupportEnabled()) {
             return true;
         } else {

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -101,9 +101,10 @@ final class Company extends SnipeModel
 
     public static function isCurrentUserHasAccess($companyable)
     {
-        if (is_null($companyable)) {
+        /*if (is_null($companyable)) {
             return false;
-        } elseif (!static::isFullMultipleCompanySupportEnabled()) {
+        } else*/
+        if (!static::isFullMultipleCompanySupportEnabled()) {
             return true;
         } else {
             $current_user_company_id = Auth::user()->company_id;

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -129,7 +129,7 @@
                   'deployed': '{{ strtolower(trans('general.deployed')) }}',
                   'deployable': '{{ strtolower(trans('admin/hardware/general.deployable')) }}',
                   'pending': '{{ strtolower(trans('general.pending')) }}'
-                }
+                };
 
                 switch (value.status_meta) {
                     case 'deployed':
@@ -425,8 +425,7 @@
     }
 
     function assetTagLinkFormatter(value, row) {
-
-        if (value) {
+        if (row.asset && row.asset.asset_tag) {
             return '<a href="{{ url('/') }}/hardware/' + row.asset.id + '"> ' + row.asset.asset_tag + '</a>';
         }
     }

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -231,7 +231,7 @@
                 item_destination = 'users';
                 item_icon = 'fa-user';
             } else if (value.type == 'location') {
-                item_destination = 'locations'
+                item_destination = 'locations';
                 item_icon = 'fa-map-marker';
             }
 
@@ -256,7 +256,7 @@
     // Convert line breaks to <br>
     function notesFormatter(value) {
         if (value) {
-            return value.replace(/(?:\r\n|\r|\n)/g, '<br />');;
+            return value.replace(/(?:\r\n|\r|\n)/g, '<br />');
         }
     }
 
@@ -425,7 +425,10 @@
     }
 
     function assetTagLinkFormatter(value, row) {
-        return '<a href="{{ url('/') }}/hardware/' + row.asset.id + '"> ' + row.asset.asset_tag + '</a>';
+
+        if (value) {
+            return '<a href="{{ url('/') }}/hardware/' + row.asset.id + '"> ' + row.asset.asset_tag + '</a>';
+        }
     }
 
     function assetNameLinkFormatter(value, row) {


### PR DESCRIPTION
Hello :)

Create asset maintenance without assigning an asset didn't work. There was the error "Inssufficient permissions".

![image](https://user-images.githubusercontent.com/37537300/39058419-0d927ca8-44bc-11e8-8470-b5c21646765c.png)

I modified :

- AssetMaintenanceController by adding another condition for returning the Inssufficient persmission redirect, 
- AssetMaintenance model by removing the required rule of the asset_id field, 
- Company model, which was involved in the error, by removing the part which is not now relevant,
- The bootstrap-table view, by modifying existing conditions of the assetTagLinkFormatter function.

