### PR TITLE
Modified the affectation of the value of the password in credential mail sent for the first user sign up

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -192,7 +192,7 @@ class SettingsController extends Controller
                 $data['username'] = $user->username;
                 $data['first_name'] = $user->first_name;
                 $data['last_name'] = $user->last_name;
-                $data['password'] = e($request->input('password'));
+                $data['password'] = $request->input('password');
                 $user->notify(new FirstAdminNotification($data));
 
                 /*Mail::send(['text' => 'emails.firstadmin'], $data, function ($m) use ($data) {

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -192,8 +192,7 @@ class SettingsController extends Controller
                 $data['username'] = $user->username;
                 $data['first_name'] = $user->first_name;
                 $data['last_name'] = $user->last_name;
-                $data['password'] = $user->password;
-
+                $data['password'] = e($request->input('password'));
                 $user->notify(new FirstAdminNotification($data));
 
                 /*Mail::send(['text' => 'emails.firstadmin'], $data, function ($m) use ($data) {


### PR DESCRIPTION
Hello :) 

I notice that when I sign up for the first time (whith the setup) and I check "receive email ... " I receive my password encrypted, whereas it shouldn't be.

I read the code and I found that the affectation of the variable $data is not the same between the save of the first admin (postSaveFirstAdmin function in SettingsController) and the other users (store & apiStore function in UsersController).

postSaveFirstAdmin line 190:
```
if (Input::get('email_creds')=='1') {
  $data = array();
  $data['email'] = $user->email;
  $data['username'] = $user->username;
  $data['first_name'] = $user->first_name;
  $data['last_name'] = $user->last_name;
  $data['password'] = $user->password;

  $user->notify(new FirstAdminNotification($data));
}
```

store line 144
```
if (($request->input('email_user') == 1) && ($request->has('email'))) {
  // Send the credentials through email
  $data = array();
  $data['email'] = e($request->input('email'));
  $data['username'] = e($request->input('username'));
  $data['first_name'] = e($request->input('first_name'));
  $data['last_name'] = e($request->input('last_name'));
  $data['password'] = e($request->input('password'));

  $user->notify(new WelcomeNotification($data));
}
```

apiStore line 195
```
if (Input::get('email_user') == 1) {
  // Send the credentials through email
  $data = array();
  $data['email'] = $request->input('email');
  $data['username'] = $request->input('username');
  $data['first_name'] = $request->input('first_name');
  $data['last_name'] = e($request->input('last_name'));
  $data['password'] = $request->input('password');

  $user->notify(new WelcomeNotification($data));
}
```

Because the password is not encrypted for the other users, I replace the code of the apiStore in the postSaveFirstAdmin.

Is there any problem about the security or anything else ?


Screenshots:
Before:
First sign up
![password_crypted](https://user-images.githubusercontent.com/37537300/39371419-ef3d923e-4a41-11e8-8f51-f7950cc7f3a1.PNG)

Another sign up
![password_noncryptewelcome](https://user-images.githubusercontent.com/37537300/39371435-fd37828c-4a41-11e8-8df4-11e92c43dbba.PNG)

After:
First sign up
![password_aftermodif](https://user-images.githubusercontent.com/37537300/39371444-03288e70-4a42-11e8-9381-715da30e1d7f.PNG)
