### PR TITLE
PHP 7.1 for all

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,13 +56,21 @@ Vagrant.configure("2") do |config|
     stretch.vm.provision :shell, :inline => "chmod 755 snipeit.sh"
   end
 
-  config.vm.define "fedora25" do |fedora25|
-    fedora25.vm.box = "fedora/25-cloud-base"
-    fedora25.vm.hostname = 'fedora25'
-    fedora25.vm.network "public_network", bridge: NETWORK_BRIDGE
-    fedora25.vm.provision :shell, :inline => "dnf -y update"
-    fedora25.vm.provision :shell, :inline => "dnf -y install wget"
-    fedora25.vm.provision :shell, :inline => "wget #{SNIPEIT_SH_URL}"
-    fedora25.vm.provision :shell, :inline => "chmod 755 snipeit.sh"
+  config.vm.define "fedora27" do |fedora27|
+    fedora27.vm.box = "fedora/27-cloud-base"
+    fedora27.vm.hostname = 'fedora27'
+    fedora27.vm.network "public_network", bridge: NETWORK_BRIDGE
+    fedora27.vm.provision :shell, :inline => "dnf -y install wget"
+    fedora27.vm.provision :shell, :inline => "wget #{SNIPEIT_SH_URL}"
+    fedora27.vm.provision :shell, :inline => "chmod 755 snipeit.sh"
+  end
+
+    config.vm.define "fedora26" do |fedora26|
+    fedora26.vm.box = "fedora/26-cloud-base"
+    fedora26.vm.hostname = 'fedora26'
+    fedora26.vm.network "public_network", bridge: NETWORK_BRIDGE
+    fedora26.vm.provision :shell, :inline => "dnf -y install wget"
+    fedora26.vm.provision :shell, :inline => "wget #{SNIPEIT_SH_URL}"
+    fedora26.vm.provision :shell, :inline => "chmod 755 snipeit.sh"
   end
 end

--- a/snipeit.sh
+++ b/snipeit.sh
@@ -304,7 +304,7 @@ done
 case $distro in
   debian)
   if [[ "$version" =~ ^9 ]]; then
-    #####################################  Install for Debian 9 ##############################################
+    # Install for Debian 9.x
     webdir=/var/www
     ownergroup=www-data:www-data
     tzone=$(cat /etc/timezone)
@@ -339,7 +339,7 @@ case $distro in
     echo "* Restarting Apache httpd."
     log "service apache2 restart"
   elif [[ "$version" =~ ^8 ]]; then
-    #####################################  Install for Debian 8 ##############################################
+    # Install for Debian 8.x
     webdir=/var/www
     ownergroup=www-data:www-data
     tzone=$(cat /etc/timezone)
@@ -381,8 +381,8 @@ case $distro in
   fi
   ;;
   ubuntu)
-  if [[ "$version" =~ 1[6-7] ]]; then
-    #####################################  Install for Ubuntu 16-17  ##############################################
+  if [[ "$version" =~ 16.04 ]]; then
+    # Install for Ubuntu 16.04
     webdir=/var/www
     ownergroup=www-data:www-data
     tzone=$(cat /etc/timezone)
@@ -421,8 +421,8 @@ case $distro in
 
     echo "* Restarting Apache httpd."
     log "service apache2 restart"
-  elif [[ "$version" =~ 14 ]]; then
-    #####################################  Install for Ubuntu 14  ##############################################
+  elif [[ "$version" =~ 14.04 ]]; then
+    # Install for Ubuntu 14.04
     webdir=/var/www
     ownergroup=www-data:www-data
     tzone=$(cat /etc/timezone)
@@ -469,7 +469,7 @@ case $distro in
   ;;
   centos)
   if [[ "$version" =~ ^6 ]]; then
-    #####################################  Install for CentOS/Redhat 6  ##############################################
+    # Install for CentOS/Redhat 6.x
     webdir=/var/www/html
     ownergroup=apache:apache
     tzone=$(grep ZONE /etc/sysconfig/clock | tr -d '"' | sed 's/ZONE=//g');
@@ -520,7 +520,7 @@ case $distro in
     log "chkconfig httpd on"
     log "/sbin/service httpd start"
   elif [[ "$version" =~ ^7 ]]; then
-    #####################################  Install for CentOS/Redhat 7  ##############################################
+    # Install for CentOS/Redhat 7
     webdir=/var/www/html
     ownergroup=apache:apache
     tzone=$(timedatectl | gawk -F'[: ]' ' $9 ~ /zone/ {print $11}');
@@ -562,7 +562,8 @@ case $distro in
   fi
   ;;
   fedora)
-    #####################################  Install for Fedora 25+  ##############################################
+  if [ "$version" -ge 26 ]; then
+    # Install for Fedora 26+
     webdir=/var/www/html
     ownergroup=apache:apache
     tzone=$(timedatectl | gawk -F'[: ]' ' $9 ~ /zone/ {print $11}');
@@ -593,6 +594,10 @@ case $distro in
     echo "* Setting Apache httpd to start on boot and starting service."
     log "systemctl enable httpd.service"
     log "systemctl restart httpd.service"
+  else
+    echo "Unsupported Fedora version. Version found: $version"
+    exit 1
+  fi
 esac
 
 setupmail=default

--- a/snipeit.sh
+++ b/snipeit.sh
@@ -310,13 +310,18 @@ case $distro in
     tzone=$(cat /etc/timezone)
     apachefile=/etc/apache2/sites-available/$name.conf
 
+    echo "* Adding PHP repository."
+    log "apt-get install -y apt-transport-https"
+    log "wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg"
+    echo "deb https://packages.sury.org/php/ $codename main" > /etc/apt/sources.list.d/php.list
+
     echo -n "* Updating installed packages."
     log "apt-get update"
     log "apt-get -y upgrade" & pid=$!
     progress
 
     echo "* Installing Apache httpd, PHP, MariaDB and other requirements."
-    PACKAGES="mariadb-server mariadb-client apache2 libapache2-mod-php php php-mcrypt php-curl php-mysql php-gd php-ldap php-zip php-mbstring php-xml php-bcmath curl git unzip"
+    PACKAGES="mariadb-server mariadb-client apache2 libapache2-mod-php7.1 php7.1 php7.1-mcrypt php7.1-curl php7.1-mysql php7.1-gd php7.1-ldap php7.1-zip php7.1-mbstring php7.1-xml php7.1-bcmath curl git unzip"
     install_packages
 
     echo "* Configuring Apache."
@@ -341,11 +346,9 @@ case $distro in
     apachefile=/etc/apache2/sites-available/$name.conf
 
     echo "* Adding MariaDB and ppa:ondrej/php repositories."
-    log "apt-get install -y software-properties-common"
+    log "apt-get install -y software-properties-common apt-transport-https"
     log "apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xcbcb082a1bb943db"
     log "add-apt-repository 'deb [arch=amd64,i386,ppc64el] http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.1/debian $codename main'"
-    #PHP7 repository
-    log "apt-get install -y apt-transport-https"
     log "wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg"
     echo "deb https://packages.sury.org/php/ $codename main" > /etc/apt/sources.list.d/php.list
 
@@ -385,18 +388,18 @@ case $distro in
     tzone=$(cat /etc/timezone)
     apachefile=/etc/apache2/sites-available/$name.conf
 
-    echo "* Adding MariaDB repository."
+    echo "* Adding MariaDB and ppa:ondrej/php repositories."
     log "apt-get install -y software-properties-common"
     log "apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xF1656F24C74CD1D8"
     log "add-apt-repository 'deb [arch=amd64,i386] http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.1/ubuntu $codename main'"
+    log "add-apt-repository -y ppa:ondrej/php"
 
     echo -n "* Updating installed packages."
-    log "apt-get update"
-    log "DEBIAN_FRONTEND=noninteractive apt-get -y upgrade" & pid=$!
+    log "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y upgrade" & pid=$!
     progress
 
     echo "* Installing Apache httpd, PHP, MariaDB and other requirements."
-    PACKAGES="mariadb-server mariadb-client apache2 libapache2-mod-php php php-mcrypt php-curl php-mysql php-gd php-ldap php-zip php-mbstring php-xml php-bcmath curl git unzip"
+    PACKAGES="mariadb-server mariadb-client apache2 libapache2-mod-php7.1 php7.1 php7.1-mcrypt php7.1-curl php7.1-mysql php7.1-gd php7.1-ldap php7.1-zip php7.1-mbstring php7.1-xml php7.1-bcmath curl git unzip"
     install_packages
 
     echo "* Configuring Apache."
@@ -429,7 +432,6 @@ case $distro in
     log "apt-get install -y software-properties-common"
     log "apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xcbcb082a1bb943db"
     log "add-apt-repository 'deb [arch=amd64,i386,ppc64el] http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.1/ubuntu $codename main'"
-    #PHP7 repository
     log "add-apt-repository ppa:ondrej/php -y"
 
     echo -n "* Updating installed packages."


### PR DESCRIPTION
Better than i thought. Switched xenial and stretch to PHP 7.1.x.
Drop support for Fedora 25 as it is EOL.
Drop support for non-LTS Ubuntu versions.

```
vagrant@xenial:~$ php -v
PHP 7.1.16-1+ubuntu16.04.1+deb.sury.org+1 (cli) (built: Apr  5 2018 08:47:00) ( NTS )

vagrant@trusty:~$ php -v
PHP 7.1.16-1+ubuntu14.04.1+deb.sury.org+1 (cli) (built: Apr  5 2018 11:05:50) ( NTS )

[vagrant@centos7 ~]$ php -v
PHP 7.1.16 (cli) (built: Mar 30 2018 09:32:45) ( NTS )

[vagrant@centos6 ~]$ php -v
PHP 7.1.16 (cli) (built: Mar 30 2018 09:32:19) ( NTS )

vagrant@debian9:~$ php -v
PHP 7.1.16-1+0~20180405085419.16+stretch~1.gbp4937aa (cli) (built: Apr  5 2018 08:54:21) ( NTS )

vagrant@debian8:~$ php -v
PHP 7.1.16-1+0~20180405085551.16+jessie~1.gbp4937aa (cli) (built: Apr  5 2018 09:13:06) ( NTS )

[vagrant@fedora27 ~]$ php -v
PHP 7.1.16 (cli) (built: Mar 28 2018 07:11:55) ( NTS )

[vagrant@fedora26 ~]$ php -v
PHP 7.1.16 (cli) (built: Mar 28 2018 07:11:55) ( NTS )
```