### PR TITLE
Fix padding on next page with Chrome.

### DIFF
--- a/resources/views/hardware/labels.blade.php
+++ b/resources/views/hardware/labels.blade.php
@@ -82,6 +82,7 @@
     }
     .next-padding {
       margin: {{ $settings->labels_pmargin_top }}in {{ $settings->labels_pmargin_right }}in {{ $settings->labels_pmargin_bottom }}in {{ $settings->labels_pmargin_left }}in;
+      font-size: 0;
     }
   }
 
@@ -152,7 +153,7 @@
 
 @if ($count % $settings->labels_per_page == 0)
 <div class="page-break"></div>
-<div class="next-padding"></div>
+<div class="next-padding">&nbsp;</div>
 @endif
 
 @endforeach


### PR DESCRIPTION
It looks like Chrome (and probably other browsers) is optimising the next-padding div out since it has no content. This means the margin doesn't apply. Adding the nbsp, and making sure it takes up no space itself, is enough to make the margin do the right thing.

I also tried using padding instead of margin, but this results in an extra page at the end of the output (there'd need to be a way to stop page-break and next-padding appearing at the end of the document). I also tried setting a min-height on next-padding, but this had the same issue.