### PR TITLE
Create asset maintenance -  Added orange bar for required asset to edit view

### DIFF
--- a/resources/views/asset_maintenances/edit.blade.php
+++ b/resources/views/asset_maintenances/edit.blade.php
@@ -41,7 +41,7 @@
       </div><!-- /.box-header -->
 
       <div class="box-body">
-        @include ('partials.forms.edit.asset-select', ['translated_name' => trans('admin/asset_maintenances/table.asset_name'), 'fieldname' => 'asset_id'])
+        @include ('partials.forms.edit.asset-select', ['translated_name' => trans('admin/asset_maintenances/table.asset_name'), 'fieldname' => 'asset_id', 'required' => 'true'])
         @include ('partials.forms.edit.supplier-select', ['translated_name' => trans('general.supplier'), 'fieldname' => 'supplier_id', 'required' => 'true'])
         @include ('partials.forms.edit.maintenance_type')
 


### PR DESCRIPTION
Because the asset field is required in the code but it is not viually indicated in edit view of an asset maintenance, I added the orange bar to the edit view.