### PR TITLE
De-normalize new counters from 4.3.0

### DIFF
--- a/app/Console/Commands/SyncAssetCounters.php
+++ b/app/Console/Commands/SyncAssetCounters.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\Asset;
+
+class SyncAssetCounters extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'snipeit:counter-sync';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Syncs checkedout, checked in, and requested counters for assets';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $start = microtime(true);
+        $assets = Asset::withCount('checkins', 'checkouts', 'userRequests')
+            ->withTrashed()->get();
+
+        if ($assets) {
+            if ($assets->count() > 0) {
+                $bar = $this->output->createProgressBar($assets->count());
+                
+                foreach ($assets as $asset) {
+                    $asset->checkin_counter = (int) $asset->checkins_count;
+                    $asset->checkout_counter = (int) $asset->checkouts_count;
+                    $asset->requests_counter = (int) $asset->user_requests_count;
+                    $asset->unsetEventDispatcher();
+                    $asset->save();
+                    $output['info'][] = 'Asset: ' . $asset->id . ' has ' . $asset->checkin_counter . ' checkins, ' . $asset->checkout_counter . ' checkouts, and ' . $asset->requests_counter . ' requests';
+                    $bar->advance();
+                }
+                $bar->finish();
+
+                foreach ($output['info'] as $key => $output_text) {
+                    $this->info($output_text);
+                }
+
+                $time_elapsed_secs = microtime(true) - $start;
+                $this->info('Sync executed in ' . $time_elapsed_secs . ' seconds');
+
+            } else {
+                $this->info('No assets to sync');
+            }
+
+        }
+
+
+
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -29,6 +29,7 @@ class Kernel extends ConsoleKernel
         Commands\ResetDemoSettings::class,
         Commands\SyncAssetLocations::class,
         Commands\RegenerateAssetTags::class,
+        Commands\SyncAssetCounters::class,
     ];
 
     /**

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -77,9 +77,9 @@ class AssetsController extends Controller
             'last_audit_date',
             'next_audit_date',
             'warranty_months',
-            'checkouts_count',
-            'checkins_count',
-            'user_requests_count',
+            'checkout_counter',
+            'checkin_counter',
+            'requests_counter',
         ];
 
         $filter = array();
@@ -95,7 +95,7 @@ class AssetsController extends Controller
 
         $assets = Company::scopeCompanyables(Asset::select('assets.*'),"company_id","assets")
             ->with('location', 'assetstatus', 'assetlog', 'company', 'defaultLoc','assignedTo',
-            'model.category', 'model.manufacturer', 'model.fieldset','supplier')->withCount('checkins', 'checkouts', 'userRequests');
+            'model.category', 'model.manufacturer', 'model.fieldset','supplier');
 
 
         // These are used by the API to query against specific ID numbers.

--- a/app/Http/Controllers/ViewAssetsController.php
+++ b/app/Http/Controllers/ViewAssetsController.php
@@ -181,6 +181,8 @@ class ViewAssetsController extends Controller
         // If it's already requested, cancel the request.
         if ($asset->isRequestedBy(Auth::user())) {
             $asset->cancelRequest();
+            $asset->decrement('requests_counter', 1);
+            
             $logaction->logaction('request canceled');
             $settings->notify(new RequestAssetCancelationNotification($data));
             return redirect()->route('requestable-assets')
@@ -188,8 +190,8 @@ class ViewAssetsController extends Controller
         } else {
 
             $logaction->logaction('requested');
-
             $asset->request();
+            $asset->increment('requests_counter', 1);
             $settings->notify(new RequestAssetNotification($data));
 
 

--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -77,9 +77,9 @@ class AssetsTransformer
             'last_checkout' => Helper::getFormattedDateObject($asset->last_checkout, 'datetime'),
             'expected_checkin' => Helper::getFormattedDateObject($asset->expected_checkin, 'date'),
             'purchase_cost' => Helper::formatCurrencyOutput($asset->purchase_cost),
-            'checkins_count' => (int) $asset->checkins_count,
-            'checkouts_count' => (int) $asset->checkouts_count,
-            'user_requests_count' => (int) $asset->user_requests_count,
+            'checkin_counter' => (int) $asset->checkins_counter,
+            'checkout_counter' => (int) $asset->checkouts_counter,
+            'requests_counter' => (int) $asset->requests_counter,
             'user_can_checkout' => (bool) $asset->availableForCheckout(),
         ];
 

--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -77,8 +77,8 @@ class AssetsTransformer
             'last_checkout' => Helper::getFormattedDateObject($asset->last_checkout, 'datetime'),
             'expected_checkin' => Helper::getFormattedDateObject($asset->expected_checkin, 'date'),
             'purchase_cost' => Helper::formatCurrencyOutput($asset->purchase_cost),
-            'checkin_counter' => (int) $asset->checkins_counter,
-            'checkout_counter' => (int) $asset->checkouts_counter,
+            'checkin_counter' => (int) $asset->checkin_counter,
+            'checkout_counter' => (int) $asset->checkout_counter,
             'requests_counter' => (int) $asset->requests_counter,
             'user_can_checkout' => (bool) $asset->availableForCheckout(),
         ];

--- a/app/Models/Loggable.php
+++ b/app/Models/Loggable.php
@@ -55,9 +55,17 @@ trait Loggable
         if ($log->target_type == Location::class) {
             $log->location_id = $target->id;
         } elseif ($log->target_type == Asset::class) {
-            $log->location_id = $target->rtd_location_id;
+            $log->location_id = $target->location_id;
         } else {
             $log->location_id = $target->location_id;
+        }
+
+        if ($log->item_type == Asset::class) {
+
+            if ($asset = Asset::find($log->item_id)) {
+                \Log::debug('Increment the checkout count for asset: '.$log->item_id);
+                $asset->increment('checkout_counter', 1);
+            }
         }
 
         $log->note = $note;
@@ -121,8 +129,17 @@ trait Loggable
             $log->item_type = License::class;
             $log->item_id = $this->license_id;
         } else {
+
             $log->item_type = static::class;
             $log->item_id = $this->id;
+
+            if (static::class == Asset::class) {
+                if ($asset = Asset::find($log->item_id)) {
+                    \Log::debug('Increment the checkin count for asset: '.$log->item_id);
+                    $asset->increment('checkin_counter', 1);
+                }
+            }
+
         }
 
 

--- a/app/Presenters/AssetPresenter.php
+++ b/app/Presenters/AssetPresenter.php
@@ -182,21 +182,21 @@ class AssetPresenter extends Presenter
                 "title" => trans('general.notes'),
 
             ], [
-                "field" => "checkouts_count",
+                "field" => "checkout_counter",
                 "searchable" => false,
                 "sortable" => true,
                 "visible" => false,
                 "title" => trans('general.checkouts_count')
 
             ],[
-                "field" => "checkins_count",
+                "field" => "checkin_counter",
                 "searchable" => false,
                 "sortable" => true,
                 "visible" => false,
                 "title" => trans('general.checkins_count')
 
             ], [
-                "field" => "user_requests_count",
+                "field" => "requests_counter",
                 "searchable" => false,
                 "sortable" => true,
                 "visible" => false,

--- a/database/migrations/2018_05_14_233638_denorm_counters_on_assets.php
+++ b/database/migrations/2018_05_14_233638_denorm_counters_on_assets.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class DenormCountersOnAssets extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('assets', function (Blueprint $table) {
+            $table->integer('checkin_count')->default(0);
+            $table->integer('checkout_count')->default(0);
+            $table->integer('requests_count')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('assets', function (Blueprint $table) {
+            $table->dropColumn('checkin_count');
+            $table->dropColumn('checkout_count');
+            $table->dropColumn('requests_count');
+        });
+    }
+}

--- a/database/migrations/2018_05_14_233638_denorm_counters_on_assets.php
+++ b/database/migrations/2018_05_14_233638_denorm_counters_on_assets.php
@@ -14,9 +14,9 @@ class DenormCountersOnAssets extends Migration
     public function up()
     {
         Schema::table('assets', function (Blueprint $table) {
-            $table->integer('checkin_count')->default(0);
-            $table->integer('checkout_count')->default(0);
-            $table->integer('requests_count')->default(0);
+            $table->integer('checkin_counter')->default(0);
+            $table->integer('checkout_counter')->default(0);
+            $table->integer('requests_counter')->default(0);
         });
     }
 
@@ -28,9 +28,9 @@ class DenormCountersOnAssets extends Migration
     public function down()
     {
         Schema::table('assets', function (Blueprint $table) {
-            $table->dropColumn('checkin_count');
-            $table->dropColumn('checkout_count');
-            $table->dropColumn('requests_count');
+            $table->dropColumn('checkin_counter');
+            $table->dropColumn('checkout_counter');
+            $table->dropColumn('requests_counter');
         });
     }
 }

--- a/database/migrations/2018_05_16_153409_add_first_counter_totals_to_assets.php
+++ b/database/migrations/2018_05_16_153409_add_first_counter_totals_to_assets.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use App\Models\Asset;
+
+class AddFirstCounterTotalsToAssets extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // This artisan call may take a while
+        Artisan::call('snipeit:counter-sync');
+        $output = Artisan::output();
+        \Log::info($output);
+
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}


### PR DESCRIPTION
This should fix #5511

Added: 

- migration to add new counter fields to assets table
- artisan command to sync those counters
- migration to trigger the artisan command once
- updated log methods for checkin/checkout to increment those values
- updated asset request controller method to increment/decrement requests