### PR TITLE
Don't install require-dev packages.

### DIFF
--- a/upgrade.php
+++ b/upgrade.php
@@ -111,7 +111,7 @@ if (file_exists('composer.phar')) {
 } else {
     echo "-- We couldn't find a local composer.phar - trying globally.\n\n";
     $composer_dump = shell_exec('composer dump');
-    $composer = shell_exec('composer install --prefer-source');
+    $composer = shell_exec('composer install --no-dev --prefer-source');
 }
 
 echo $composer_dump."\n\n";


### PR DESCRIPTION
This is already set for a local composer install, but not a global one. They should be consistent.

This caught me out when upgrading since it started pulling down all the dev packages.