### PR TITLE
Feature Request 5607 Notes for Accessory/Consumable Checkout

### DIFF
--- a/resources/views/accessories/checkout.blade.php
+++ b/resources/views/accessories/checkout.blade.php
@@ -79,6 +79,14 @@
                      </div>
                  </div>
              @endif
+          <!-- Note -->
+          <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">
+            <label for="note" class="col-md-3 control-label">{{ trans('admin/hardware/form.notes') }}</label>
+            <div class="col-md-7">
+              <textarea class="col-md-6 form-control" id="note" name="note">{{ Input::old('note', $accessory->note) }}</textarea>
+              {!! $errors->first('note', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
+            </div>
+          </div>
        </div>
        <div class="box-footer">
           <a class="btn btn-link" href="{{ URL::previous() }}">{{ trans('button.cancel') }}</a>

--- a/resources/views/consumables/checkout.blade.php
+++ b/resources/views/consumables/checkout.blade.php
@@ -66,7 +66,14 @@
                 </div>
               </div>
             @endif
-
+          <!-- Note -->
+          <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">
+            <label for="note" class="col-md-3 control-label">{{ trans('admin/hardware/form.notes') }}</label>
+            <div class="col-md-7">
+              <textarea class="col-md-6 form-control" id="note" name="note">{{ Input::old('note', $consumable->note) }}</textarea>
+              {!! $errors->first('note', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
+            </div>
+          </div>
         </div> <!-- .box-body -->
         <div class="box-footer">
           <a class="btn btn-link" href="{{ URL::previous() }}">{{ trans('button.cancel') }}</a>


### PR DESCRIPTION
This was a very small change to include the notes field as seen checkin page for the checkout pages for accessories and consumables. Pretty much dropped in the code from the checkout page and made sure it worked and displayed the notes in the Activity report. 

New Note Section on Accessory Checkout:
![image](https://user-images.githubusercontent.com/6751928/40582857-7269d78e-6136-11e8-93ac-4dc7b66b6a39.png)
New Note Section on Consumable Checkout: 
![image](https://user-images.githubusercontent.com/6751928/40582867-9d3503a8-6136-11e8-81a2-6bbb1435ae0f.png)
Notes Appear in Logs/Activity Report:
![image](https://user-images.githubusercontent.com/6751928/40582870-c4853e1e-6136-11e8-8258-a84ee2fa02f6.png)
