### PR TITLE
Feature: PostgreSQL support

### DIFF
--- a/app/Http/Requests/AssetRequest.php
+++ b/app/Http/Requests/AssetRequest.php
@@ -46,12 +46,13 @@ class AssetRequest extends Request
 
         $rules['asset_tag'] = ($settings->auto_increment_assets == '1') ? 'max:255' : 'required';
 
-        $model = AssetModel::find($this->request->get('model_id'));
+        if($this->request->get('model_id') != '') {
+            $model = AssetModel::find($this->request->get('model_id'));
 
-        if (($model) && ($model->fieldset)) {
-            $rules += $model->fieldset->validation_rules();
+            if (($model) && ($model->fieldset)) {
+                $rules += $model->fieldset->validation_rules();
+            }
         }
-
 
         return $rules;
 

--- a/app/Models/SnipeModel.php
+++ b/app/Models/SnipeModel.php
@@ -96,6 +96,77 @@ class SnipeModel extends Model
         return;
     }
 
+    public function setFieldSetIdAttribute($value)
+    {
+        if($value == '') {
+            $value = null;
+        }
+        $this->attributes['fieldset_id'] = $value;
+        return;
+    }
+
+    public function setCompanyIdAttribute($value)
+    {
+        if($value == '') {
+            $value = null;
+        }
+        $this->attributes['company_id'] = $value;
+        return;
+    }
+
+    public function setWarrantyMonthsAttribute($value)
+    {
+        if($value == '') {
+            $value = null;
+        }
+        $this->attributes['warranty_months'] = $value;
+        return;
+    }
+
+    public function setRtdLocationIdAttribute($value)
+    {
+        if($value == '') {
+            $value = null;
+        }
+        $this->attributes['rtd_location_id'] = $value;
+        return;
+    }
+
+    public function setDepartmentIdAttribute($value)
+    {
+        if($value == '') {
+            $value = null;
+        }
+        $this->attributes['department_id'] = $value;
+        return;
+    }
+
+    public function setManagerIdAttribute($value)
+    {
+        if($value == '') {
+            $value = null;
+        }
+        $this->attributes['manager_id'] = $value;
+        return;
+    }
+
+    public function setModelIdAttribute($value)
+    {
+        if($value == '') {
+            $value = null;
+        }
+        $this->attributes['model_id'] = $value;
+        return;
+    }
+
+    public function setStatusIdAttribute($value)
+    {
+        if($value == '') {
+            $value = null;
+        }
+        $this->attributes['status_id'] = $value;
+        return;
+    }
 
     //
     public function getDisplayNameAttribute()

--- a/database/migrations/2015_02_10_040958_fix_bad_assigned_to_ids.php
+++ b/database/migrations/2015_02_10_040958_fix_bad_assigned_to_ids.php
@@ -22,9 +22,11 @@ class FixBadAssignedToIds extends Migration {
 			$table->text('notes')->nullable();
 		});
 
-		DB::statement('INSERT into ' . DB::getTablePrefix() . 'status_labels (user_id, name, deployable, pending, archived, notes) VALUES (1,"Pending",0,1,0,"These assets are not yet ready to be deployed, usually because of configuration or waiting on parts.")');
-		DB::statement('INSERT into ' . DB::getTablePrefix() . 'status_labels (user_id, name, deployable, pending, archived, notes) VALUES (1,"Ready to Deploy",1,0,0,"These assets are ready to deploy.")');
-		DB::statement('INSERT into ' . DB::getTablePrefix() . 'status_labels (user_id, name, deployable, pending, archived, notes) VALUES (1,"Archived",0,0,1,"These assets are no longer in circulation or viable.")');
+        DB::table('status_labels')->insert([
+            ['user_id' => 1, 'name' => 'Pending', 'deployable' => 0, 'pending' => 1, 'archived' => 0, 'notes' => 'These assets are not yet ready to be deployed, usually because of configuration or waiting on parts.'],
+            ['user_id' => 1, 'name' => 'Ready to Deploy', 'deployable' => 1, 'pending' => 0, 'archived' => 0, 'notes' => 'These assets are ready to deploy.'],
+            ['user_id' => 1, 'name' => 'Archived', 'deployable' => 0, 'pending' => 0, 'archived' => 1, 'notes' => 'These assets are no longer in circulation or viable.'],
+        ]);
 
 	}
 

--- a/database/migrations/2015_02_10_053310_migrate_data_to_new_statuses.php
+++ b/database/migrations/2015_02_10_053310_migrate_data_to_new_statuses.php
@@ -13,8 +13,7 @@ class MigrateDataToNewStatuses extends Migration {
 	public function up()
 	{
 		// get newly added statuses from last migration
-		$statuses = DB::select('select * from ' . DB::getTablePrefix() . 'status_labels where name="Pending" OR name="Ready to Deploy"');
-
+        $statuses = DB::table('status_labels')->where('name', 'Pending')->orWhere('name', 'Ready to Deploy')->get();
 
 		foreach ($statuses as $status) {
 			if ($status->name =="Pending") {
@@ -25,7 +24,8 @@ class MigrateDataToNewStatuses extends Migration {
 		}
 
 		// Pending
-		$pendings = DB::select('select * from ' . DB::getTablePrefix() . 'assets where status_id IS NULL AND physical=1 ');
+        $pendings = DB::table('assets')->where('status_id', null)->where('physical', '1')->get();
+
 
 			foreach ($pendings as $pending) {
 				DB::update('update ' . DB::getTablePrefix() . 'assets set status_id = ? where status_id IS NULL AND physical=1',$pending_id);
@@ -34,7 +34,7 @@ class MigrateDataToNewStatuses extends Migration {
 
 
 		// Ready to Deploy
-		$rtds = DB::select('select * from ' . DB::getTablePrefix() . 'assets where status_id = 0 AND physical=1 ');
+        $rtds = DB::table('assets')->where('status_id', 0)->where('physical', '1')->get();
 
 		foreach ($rtds as $rtd) {
 				//DB::update('update users set votes = 100 where name = ?', array('John'));

--- a/database/migrations/2015_03_01_231912_update_accepted_at_to_acceptance_id.php
+++ b/database/migrations/2015_03_01_231912_update_accepted_at_to_acceptance_id.php
@@ -18,8 +18,11 @@ class UpdateAcceptedAtToAcceptanceId extends Migration {
 			$table->integer('accepted_id')->nullable()->default(NULL);
 		});
 
-		$results = DB::select('select invitation.id AS invitation_id, acceptance.id AS acceptance_id FROM '.DB::getTablePrefix().'asset_logs invitation INNER JOIN '.DB::getTablePrefix().'asset_logs acceptance ON (invitation.checkedout_to=acceptance.checkedout_to AND invitation.asset_id=acceptance.asset_id) WHERE invitation.action_type="checkout" AND acceptance.action_type="accepted"');
-
+        $results = DB::table('asset_logs as invitation')->join('asset_logs as acceptance', function($join) {
+            $join->on('invitation.checkedout_to', '=', 'acceptance.checkedout_to');
+            $join->on('invitation.asset_id', '=', 'acceptance.asset_id');
+        })->select('invitation.id as invitation_id', 'acceptance.id as acceptance_id')
+            ->where('invitation.action_type', 'checkout')->where('acceptance.action_type', 'accepted')->get();
 
 		foreach ($results as $result) {
 			$update = DB::update('update '.DB::getTablePrefix().'asset_logs set accepted_id=? where id=?', [$result->acceptance_id, $result->invitation_id]);

--- a/database/migrations/2015_06_15_183253_move_email_to_username.php
+++ b/database/migrations/2015_06_15_183253_move_email_to_username.php
@@ -13,7 +13,7 @@ class MoveEmailToUsername extends Migration {
 	public function up()
 	{
 		//
-		DB::update('UPDATE `'.DB::getTablePrefix().'users` SET `username`=`email`');
+        DB::update('UPDATE '.DB::getTablePrefix().'users SET username=email');
 	}
 
 	/**

--- a/database/migrations/2015_07_09_014359_add_currency_to_settings_and_locations.php
+++ b/database/migrations/2015_07_09_014359_add_currency_to_settings_and_locations.php
@@ -18,14 +18,14 @@ class AddCurrencyToSettingsAndLocations extends Migration {
 			$table->string('default_currency',10)->nullable()->default(NULL);
 		});
 
-		DB::update('UPDATE `'.DB::getTablePrefix().'settings` SET `default_currency`="'. trans('general.currency').'"');
+        DB::table('settings')->update(['default_currency' => trans('general.currency')]);
 
 		Schema::table('locations', function(Blueprint $table)
 		{
 			$table->string('currency',10)->nullable()->default(NULL);
 		});
 
-		DB::update('UPDATE `'.DB::getTablePrefix().'locations` SET `currency`="'. trans('general.currency').'"');
+        DB::table('locations')->update(['currency' => trans('general.currency')]);
 
 
 

--- a/database/migrations/2016_12_27_212631_make_asset_assigned_to_polymorphic.php
+++ b/database/migrations/2016_12_27_212631_make_asset_assigned_to_polymorphic.php
@@ -20,7 +20,7 @@ class MakeAssetAssignedToPolymorphic extends Migration
          });
 
         // Prior to this migration, asset's could only be assigned to users.
-        Asset::whereNotNull('assigned_to')->orWhere('assigned_to', '!=', '')->update(['assigned_type' => User::class]);
+        Asset::whereNotNull('assigned_to')->orWhere('assigned_to', '!=', null)->update(['assigned_type' => User::class]);
     }
 
     /**


### PR DESCRIPTION
- Made migrations work with pgsql and added mutators for changing empty integers to null in SnipeModel.php.

There is at least one known issue with this. One of the functional tests fails "tests/functional/AssetsCest.php:failsEmptyValidation".
invalid input syntax for integer: "" (SQL: select * from "models" where "models"."id" =  and "models"."deleted_at" is null limit 1)  
 This is due to the empty Asset page having model id integer as empty string. 

This type of issues were fixed in other places by the mutators in the SnipeModel.php file. But I was unable to figure out why it didn't work in this situation. This issue causes a situation where, if user tries to add an asset without a model, it will fail with no error. Normally it would show an error that tells the user to select a model.


 
