### PR TITLE
Fixed inconsistent or incorrect comment labels

### DIFF
--- a/resources/views/account/view-assets.blade.php
+++ b/resources/views/account/view-assets.blade.php
@@ -205,7 +205,7 @@ View Assets for  {{ $user->present()->fullName() }}
       @endif
 
       <div class="box-body">
-        <!-- checked out licenses table -->
+        <!-- checked out Accessories table -->
 
         <div class="table-responsive">
           <table


### PR DESCRIPTION
Accessories table was labeled 'Checked out License table' likely just a duplicate of the above comment for the actual licenses table. Very minor.