### PR TITLE
Updated SELinux label

### DIFF
--- a/snipeit.sh
+++ b/snipeit.sh
@@ -245,7 +245,8 @@ set_selinux () {
     #Required for ldap integration
     setsebool -P httpd_can_connect_ldap on
     #Sets SELinux context type so that scripts running in the web server process are allowed read/write access
-    chcon -R -h -t httpd_sys_script_rw_t "$APP_PATH"
+    chcon -R -h -t httpd_sys_rw_content_t "$APP_PATH/storage/"
+    chcon -R -h -t httpd_sys_rw_content_t "$APP_PATH/public/"
   fi
 }
 


### PR DESCRIPTION
Changing SELinux label from httpd_sys_script_rw_t to httpd_sys_rw_content_t for the storage and public directory, this change will permit access to write to the log and upload directory.