### PR TITLE
fixed the alignment of a couple navbar icons

### DIFF
--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -224,7 +224,7 @@
                        @can('create', \App\Models\Component::class)
                        <li {!! (Request::is('components/create') ? 'class="active"' : '') !!}>
                            <a href="{{ route('components.create') }}">
-                           <i class="fa fa-hdd-o"></i>
+                           <i class="fa fa-hdd-o fa-fw"></i>
                            {{ trans('general.component') }}
                            </a>
                        </li>
@@ -310,7 +310,7 @@
 
                      <li {!! (Request::is('account/requested') ? ' class="active"' : '') !!}>
                          <a href="{{ route('account.requested') }}">
-                             <i class="fa fa-check fa-disk"></i>
+                             <i class="fa fa-check fa-disk fa-fw"></i>
                              Requested Assets
                          </a></li>
 


### PR DESCRIPTION
A couple `fa-fw` classes were missing for some of the top navbar icons, which were then not in line with the rest of the icons in their groups.

![screen shot 2018-06-30 at 15 30 14](https://user-images.githubusercontent.com/8697942/42126129-868f200c-7c7a-11e8-8700-e1ad8d5fa0f8.jpg)

![screen shot 2018-06-30 at 15 30 39](https://user-images.githubusercontent.com/8697942/42126134-93cf7758-7c7a-11e8-9ee5-8bfe2cdb6962.jpg)
