### PR TITLE
Fixes the label association (#5510)

### DIFF
--- a/resources/views/custom_fields/fields/edit.blade.php
+++ b/resources/views/custom_fields/fields/edit.blade.php
@@ -105,7 +105,7 @@
           <!-- Show in Email  -->
           <div class="form-group {{ $errors->has('show_in_email') ? ' has-error' : '' }}"  id="show_in_email">
               <div class="col-md-8 col-md-offset-4">
-                  <label for="field_encrypted">
+                  <label for="show_in_email">
                       <input type="checkbox" name="show_in_email" value="1" class="minimal"{{ (Input::old('show_in_email') || $field->show_in_email) ? ' checked="checked"' : '' }}>
                       {{ trans('admin/custom_fields/general.show_in_email') }}
                   </label>


### PR DESCRIPTION
This fixes the label association from #5510 , clicking the label now checks the correct checkbox.