### PR TITLE
Adds permission checks for custom fields and custom fieldsets (#5645)

### DIFF
--- a/app/Http/Controllers/CustomFieldsetsController.php
+++ b/app/Http/Controllers/CustomFieldsetsController.php
@@ -38,6 +38,8 @@ class CustomFieldsetsController extends Controller
     {
         $cfset = CustomFieldset::with('fields')->where('id', '=', $id)->orderBy('id', 'ASC')->first();
 
+        $this->authorize('view', $cfset);
+
         if ($cfset) {
             $custom_fields_list = ["" => "Add New Field to Fieldset"] + CustomField::pluck("name", "id")->toArray();
 
@@ -68,6 +70,8 @@ class CustomFieldsetsController extends Controller
     */
     public function create()
     {
+        $this->authorize('create', CustomFieldset::class);
+
         return view("custom_fields.fieldsets.edit");
     }
 
@@ -81,6 +85,8 @@ class CustomFieldsetsController extends Controller
     */
     public function store(Request $request)
     {
+        $this->authorize('create', CustomFieldset::class);
+
         $cfset = new CustomFieldset(
             [
                 "name" => e($request->get("name")),
@@ -141,6 +147,8 @@ class CustomFieldsetsController extends Controller
     {
         $fieldset = CustomFieldset::find($id);
 
+        $this->authorize('delete', $fieldset);
+
         if ($fieldset) {
             $models = AssetModel::where("fieldset_id", "=", $id);
             if ($models->count() == 0) {
@@ -168,6 +176,8 @@ class CustomFieldsetsController extends Controller
     {
 
         $set = CustomFieldset::find($id);
+
+        $this->authorize('update', $set);
 
         foreach ($set->fields as $field) {
             if ($field->id == Input::get('field_id')) {

--- a/app/Policies/CustomFieldsetPolicy.php
+++ b/app/Policies/CustomFieldsetPolicy.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Policies;
+
+use App\Policies\SnipePermissionsPolicy;
+
+class CustomFieldsetPolicy extends SnipePermissionsPolicy
+{
+    protected function columnName()
+    {
+        return 'customfieldsets';
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -9,6 +9,7 @@ use App\Models\Category;
 use App\Models\Component;
 use App\Models\Consumable;
 use App\Models\CustomField;
+use App\Models\CustomFieldset;
 use App\Models\Department;
 use App\Models\License;
 use App\Models\Location;
@@ -25,6 +26,7 @@ use App\Policies\CategoryPolicy;
 use App\Policies\ComponentPolicy;
 use App\Policies\ConsumablePolicy;
 use App\Policies\CustomFieldPolicy;
+use App\Policies\CustomFieldsetPolicy;
 use App\Policies\DepartmentPolicy;
 use App\Policies\DepreciationPolicy;
 use App\Policies\LicensePolicy;
@@ -56,6 +58,7 @@ class AuthServiceProvider extends ServiceProvider
         Component::class => ComponentPolicy::class,
         Consumable::class => ConsumablePolicy::class,
         CustomField::class => CustomFieldPolicy::class,
+        CustomFieldset::class => CustomFieldsetPolicy::class,
         Department::class => DepartmentPolicy::class,
         Depreciation::class => DepreciationPolicy::class,
         License::class => LicensePolicy::class,
@@ -143,6 +146,7 @@ class AuthServiceProvider extends ServiceProvider
                 || $user->can('view', Company::class)
                 || $user->can('view', Manufacturer::class)
                 || $user->can('view', CustomField::class)
+                || $user->can('view', CustomFieldset::class)                
                 || $user->can('view', Depreciation::class);
         });
     }

--- a/config/permissions.php
+++ b/config/permissions.php
@@ -417,7 +417,32 @@ return array(
         ),
     ),
 
-
+    'Custom Fieldsets' => array(
+        array(
+            'permission' => 'customfieldsets.view',
+            'label'      => 'View',
+            'note'       => '',
+            'display'    => true,
+        ),
+        array(
+            'permission' => 'customfieldsets.create',
+            'label'      => 'Create',
+            'note'       => '',
+            'display'    => true,
+        ),
+        array(
+            'permission' => 'customfieldsets.edit',
+            'label'      => 'Edit',
+            'note'       => '',
+            'display'    => true,
+        ),
+        array(
+            'permission' => 'customfieldsets.delete',
+            'label'      => 'Delete',
+            'note'       => '',
+            'display'    => true,
+        ),
+    ),    
 
     'Suppliers' => array(
         array(

--- a/resources/views/custom_fields/fieldsets/view.blade.php
+++ b/resources/views/custom_fields/fieldsets/view.blade.php
@@ -25,7 +25,10 @@
           name="fieldsets" id="sort" class="table table-responsive todo-list">
           <thead>
             <tr>
+              {{-- Hide the sorting handle if we can't update the fieldset --}}
+              @can('update', $custom_fieldset)
               <th class="col-md-1"></th>
+              @endcan
               <th class="col-md-1">{{ trans('admin/custom_fields/general.order') }}</th>
               <th class="col-md-3">{{ trans('admin/custom_fields/general.field_name') }}</th>
               <th class="col-md-2">{{ trans('admin/custom_fields/general.field_format') }}</th>
@@ -37,7 +40,9 @@
           </thead>
           <tbody>
             @foreach($custom_fieldset->fields as $field)
-            <tr class="cansort" data-index="{{ $field->pivot->custom_field_id }}" id="item_{{ $field->pivot->custom_field_id }}">
+            <tr class="{{ Auth::user()->can('update', $custom_fieldset)?'cansort':'' }}" data-index="{{ $field->pivot->custom_field_id }}" id="item_{{ $field->pivot->custom_field_id }}">
+              {{-- Hide the sorting handle if we can't update the fieldset --}}
+              @can('update', $custom_fieldset)
               <td>
                 <!-- drag handle -->
                 <span class="handle">
@@ -45,6 +50,7 @@
                 <i class="fa fa-ellipsis-v"></i>
                 </span>
               </td>
+              @endcan
               <td class="index">{{$field->pivot->order}}</td>
               <td>{{$field->name}}</td>
               <td>{{$field->format}}</td>
@@ -52,7 +58,9 @@
               <td>{{ $field->field_encrypted=='1' ?  trans('general.yes') : trans('general.no') }}</td>
               <td>{{$field->pivot->required ? "REQUIRED" : "OPTIONAL"}}</td>
               <td>
+                @can('update', $custom_fieldset)
                 <a href="{{ route('fields.disassociate', [$field,$custom_fieldset->id]) }}" class="btn btn-sm btn-danger">Remove</a>
+                @endcan
               </td>
             </tr>
             @endforeach
@@ -60,6 +68,7 @@
           <tfoot>
             <tr>
               <td colspan="5" class="text-right">
+                @can('update', $custom_fieldset)
                 {{ Form::open(['route' =>
                 ["fieldsets.associate",$custom_fieldset->id],
                 'class'=>'form-horizontal',
@@ -70,6 +79,7 @@
                 {{ Form::select("field_id",$custom_fields_list,"",["onchange" => "$('#ordering').submit()"]) }}
                 <span class="alert-msg"><?= $errors->first('field_id'); ?></span>
                 {{ Form::close() }}
+                @endcan
               </td>
             </tr>
           </tfoot>
@@ -82,6 +92,8 @@
 @stop
 
 @section('moar_scripts')
+  @can('update', $custom_fieldset)
+
   <script nonce="{{ csrf_token() }}">
   var fixHelperModified = function(e, tr) {
       var $originals = tr.children();
@@ -119,4 +131,5 @@
       stop: updateIndex
   }).disableSelection();
 </script>
+  @endcan
 @stop

--- a/resources/views/custom_fields/index.blade.php
+++ b/resources/views/custom_fields/index.blade.php
@@ -8,6 +8,7 @@
 
 @section('content')
 
+@can('view', \App\Models\CustomFieldset::class)
 <div class="row">
   <div class="col-md-9">
     <div class="box box-default">
@@ -15,7 +16,9 @@
       <div class="box-header with-border">
         <h3 class="box-title">{{ trans('admin/custom_fields/general.fieldsets') }}</h3>
         <div class="box-tools pull-right">
+          @can('create', \App\Models\CustomFieldset::class)
           <a href="{{ route('fieldsets.create') }}" class="btn btn-sm btn-primary" data-toggle="tooltip" title="Create a new fieldset">{{ trans('admin/custom_fields/general.create_fieldset') }}</a>
+          @endcan
         </div>
       </div><!-- /.box-header -->
 
@@ -62,6 +65,7 @@
                 @endforeach
               </td>
               <td>
+                @can('delete', $fieldset)
                 {{ Form::open(['route' => array('fieldsets.destroy', $fieldset->id), 'method' => 'delete']) }}
                   @if($fieldset->models->count() > 0)
                   <button type="submit" class="btn btn-danger btn-sm disabled" disabled><i class="fa fa-trash"></i></button>
@@ -69,6 +73,7 @@
                   <button type="submit" class="btn btn-danger btn-sm"><i class="fa fa-trash"></i></button>
                   @endif
                 {{ Form::close() }}
+                @endcan
               </td>
             </tr>
             @endforeach
@@ -85,14 +90,17 @@
     <p>{{ trans('admin/custom_fields/general.about_fieldsets_text') }} </p>
   </div>
 </div> <!-- .row-->
-
+@endcan
+@can('view', \App\Models\CustomField::class)
 <div class="row">
   <div class="col-md-12">
     <div class="box box-default">
       <div class="box-header with-border">
         <h3 class="box-title">{{ trans('admin/custom_fields/general.custom_fields') }}</h3>
         <div class="box-tools pull-right">
+          @can('create', \App\Models\CustomField::class)
           <a href="{{ route('fields.create') }}" class="btn btn-sm btn-primary" data-toggle="tooltip" title="Create a new custom field">{{ trans('admin/custom_fields/general.create_field') }}</a>
+          @endcan
         </div>
 
       </div><!-- /.box-header -->
@@ -147,17 +155,19 @@
                 @endforeach
               </td>
               <td>
-                {{ Form::open(array('route' => array('fields.destroy', $field->id), 'method' => 'delete')) }}
                 <nobr>
+                  @can('update', $field)
                 <a href="{{ route('fields.edit', $field->id) }}" class="btn btn-warning btn-sm"><i class="fa fa-pencil"></i></a>
-
-
+                @endcan               
+                @can('delete', $field)
+                {{ Form::open(array('route' => array('fields.destroy', $field->id), 'method' => 'delete', 'style' => 'display:inline-block')) }}
                 @if($field->fieldset->count()>0)
                 <button type="submit" class="btn btn-danger btn-sm disabled" disabled><i class="fa fa-trash"></i></button>
                 @else
                 <button type="submit" class="btn btn-danger btn-sm"><i class="fa fa-trash"></i></button>
                 @endif
                 {{ Form::close() }}
+                @endcan
                 </nobr>
               </td>
             </tr>
@@ -169,6 +179,7 @@
     </div><!-- /.box -->
   </div> <!-- /.col-md-9-->
 </div>
+@endcan
 
 @stop
 @section('moar_scripts')

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -534,13 +534,13 @@
                     </a>
 
                     <ul class="treeview-menu">
-                        @can('view', \App\Models\CustomField::class)
+                        @if(Gate::allows('view', App\Models\CustomField::class) || Gate::allows('view', App\Models\CustomFieldset::class))
                             <li {!! (Request::is('fields*') ? ' class="active"' : '') !!}>
                                 <a href="{{ route('fields.index') }}">
                                     {{ trans('admin/custom_fields/general.custom_fields') }}
                                 </a>
                             </li>
-                        @endcan
+                        @endif
 
                         @can('view', \App\Models\Statuslabel::class)
                             <li {!! (Request::is('statuslabels*') ? ' class="active"' : '') !!}>


### PR DESCRIPTION
This fixes the permission issues from #5645, checking for appropriate permissions before handling the   custom fields requests.

It also adds new permissions for custom fieldsets, since they are two different resources which logically don't really share permissions. ("Should I be allowed to delete custom fieldsets if I can update or delete custom fields?")