### PR TITLE
Allows custom field encryption to be changed

### DIFF
--- a/app/Http/Controllers/Api/CustomFieldsController.php
+++ b/app/Http/Controllers/Api/CustomFieldsController.php
@@ -66,6 +66,12 @@ class CustomFieldsController extends Controller
             return response()->json(Helper::formatStandardApiResponse('error', null, $validator->errors()));
         }
 
+        /**
+         * Encrypted field should not be shown in emails
+         */
+        if ($request->input('field_encrypted') == 1) {
+            $data['show_in_email'] = 0;
+        }        
 
         /**
          * Change the encryption status of the field

--- a/app/Http/Controllers/Api/CustomFieldsController.php
+++ b/app/Http/Controllers/Api/CustomFieldsController.php
@@ -66,6 +66,20 @@ class CustomFieldsController extends Controller
             return response()->json(Helper::formatStandardApiResponse('error', null, $validator->errors()));
         }
 
+
+        /**
+         * Change the encryption status of the field
+         */
+        if ($request->input('field_encrypted') != $field->field_encrypted) {
+            if ($request->input('field_encrypted') == 0) {
+                $field->decryptValues();
+            }
+
+            if ($request->input('field_encrypted') == 1) {
+                $field->encryptValues();
+            }            
+        }
+
         $field->fill($data);
 
         if ($field->save()) {

--- a/app/Http/Controllers/CustomFieldsController.php
+++ b/app/Http/Controllers/CustomFieldsController.php
@@ -172,6 +172,13 @@ class CustomFieldsController extends Controller
         $field->show_in_email = $request->get("show_in_email", 0);
 
         /**
+         * Encrypted field should not be shown in emails
+         */
+        if ($request->input('field_encrypted') == 1) {
+            $field->show_in_email = 0;
+        }
+
+        /**
          * Change the encryption status of the field
          */
         if ($request->input('field_encrypted') != $field->field_encrypted) {

--- a/app/Http/Controllers/CustomFieldsController.php
+++ b/app/Http/Controllers/CustomFieldsController.php
@@ -182,47 +182,13 @@ class CustomFieldsController extends Controller
          * Change the encryption status of the field
          */
         if ($request->input('field_encrypted') != $field->field_encrypted) {
+            if ($request->input('field_encrypted') == 0) {
+                $field->decryptValues();
+            }
 
-          /**
-           * Get all assets that use this specific custom field
-           */
-          $field->load('fieldset.models.assets');
-
-          $assets = $field->fieldset->flatMap(function($fieldset) {
-              return $fieldset->models;
-          })->flatMap(function($assetModel) {
-              return $assetModel->assets;
-          });
-
-          /**
-           * Decrypt the field in every asset if it should be unencrypted
-           */
-          if ($request->input('field_encrypted') == 0) {
-
-            $assets->each(function($asset) use($field) {
-              $currentValue = $asset->{$field->db_column};
-
-              $asset->{$field->db_column} = decrypt($currentValue);
-              
-              $asset->save();
-            });
-
-          }
-
-          /**
-           * Encrypt the field in every asset if it should be encrypted
-           */          
-          if($request->input('field_encrypted') == 1) {
-
-            $assets->each(function($asset) use($field) {
-              $currentValue = $asset->{$field->db_column};
-
-              $asset->{$field->db_column} = encrypt($currentValue);
-              
-              $asset->save();
-            });
-
-          }
+            if ($request->input('field_encrypted') == 1) {
+                $field->encryptValues();
+            }            
         }
 
         /**

--- a/app/Models/CustomField.php
+++ b/app/Models/CustomField.php
@@ -259,6 +259,59 @@ class CustomField extends Model
         return false;
     }
 
+    /**
+     * Get all assets that use this specific custom field
+     * 
+     * @return Collection
+     */
+    public function getAssets() 
+    {
+        $this->load('fieldset.models.assets');
+
+        $assets = $this->fieldset->flatMap(function($fieldset) {
+            return $fieldset->models;
+        })->flatMap(function($assetModel) {
+            return $assetModel->assets;
+        });
+
+        return $assets;
+    }
+
+    /**
+     * Decrypts all values for this field
+     *
+     * @return void
+     */
+    public function decryptValues()
+    {
+        $assets = $this->getAssets();
+
+        $assets->each(function($asset) {
+            $currentValue = $asset->{$this->db_column};
+
+            $asset->{$this->db_column} = decrypt($currentValue);
+            
+            $asset->save();
+        });
+    }
+
+    /**
+     * Encrypts all values for this field
+     *
+     * @return void
+     */
+    public function encryptValues()
+    {
+        $assets = $this->getAssets();
+
+        $assets->each(function($asset) {
+            $currentValue = $asset->{$this->db_column};
+
+            $asset->{$this->db_column} = encrypt($currentValue);
+            
+            $asset->save();
+        });
+    }
 
     /**
      * Convert non-UTF-8 or weirdly encoded text into something that

--- a/resources/views/custom_fields/fields/edit.blade.php
+++ b/resources/views/custom_fields/fields/edit.blade.php
@@ -103,7 +103,7 @@
           </div>
 
           <!-- Show in Email  -->
-          <div class="form-group {{ $errors->has('show_in_email') ? ' has-error' : '' }}"  id="show_in_email">
+          <div class="form-group {{ $errors->has('show_in_email') ? ' has-error' : '' }}"  id="show_in_email" style="display:{{ (Input::old('field_encrypted') || $field->field_encrypted) ? 'none' : 'block' }}">
               <div class="col-md-8 col-md-offset-4">
                   <label for="show_in_email">
                       <input type="checkbox" name="show_in_email" value="1" class="minimal"{{ (Input::old('show_in_email') || $field->show_in_email) ? ' checked="checked"' : '' }}>

--- a/resources/views/custom_fields/fields/edit.blade.php
+++ b/resources/views/custom_fields/fields/edit.blade.php
@@ -113,12 +113,6 @@
 
           </div>
 
-
-      @if (!$field->id)
-
-
-
-
           <!-- Encrypted  -->
           <div class="form-group {{ $errors->has('encrypted') ? ' has-error' : '' }}">
             <div class="col-md-8 col-md-offset-4">
@@ -128,13 +122,12 @@
               </label>
             </div>
 
-            <div class="col-md-6 col-md-offset-4" id="encrypt_warning" style="display:none;">
+            <div class="col-md-6 col-md-offset-4" id="encrypt_warning" style="display:{{ (Input::old('field_encrypted') || $field->field_encrypted) ? 'block' : 'none' }}">
               <div class="callout callout-danger">
                 <p><i class="fa fa-warning"></i> {{ trans('admin/custom_fields/general.encrypt_field_help') }}</p>
               </div>
             </div>
           </div>
-          @endif
 
 
       </div> <!-- /.box-body-->


### PR DESCRIPTION
This allows the user to change the encryption of a custom field after it was created.

When the encryption status is updated, every asset is updated as well, with the now correctly encrypted/unencrypted value.

This should fix #5591.