### PR TITLE
Don't change custom fields encryption flag on update

### DIFF
--- a/app/Http/Controllers/Api/CustomFieldsController.php
+++ b/app/Http/Controllers/Api/CustomFieldsController.php
@@ -59,7 +59,13 @@ class CustomFieldsController extends Controller
     {
         $this->authorize('edit', CustomField::class);
         $field = CustomField::findOrFail($id);
-        $data = $request->all();
+        
+        /**
+         * Updated values for the field, 
+         * without the "field_encrypted" flag, preventing the change of encryption status
+         * @var array
+         */
+        $data = $request->except(['field_encrypted']);
 
         $validator = Validator::make($data, $field->validationRules());
         if ($validator->fails()) {

--- a/app/Http/Controllers/CustomFieldsController.php
+++ b/app/Http/Controllers/CustomFieldsController.php
@@ -169,7 +169,6 @@ class CustomFieldsController extends Controller
         $field->name = e($request->get("name"));
         $field->element = e($request->get("element"));
         $field->field_values = e($request->get("field_values"));
-        $field->field_encrypted = e($request->get("field_encrypted", 0));
         $field->user_id = Auth::user()->id;
         $field->help_text = $request->get("help_text");
         $field->show_in_email = $request->get("show_in_email", 0);


### PR DESCRIPTION
This PR removes the ability to change the "field_encrypted" flag on updating a custom field.
That should prevent the custom fields value to ever change from "encrypted" to "not encrypted".

This fixes #5591.