### PR TITLE
Fixing #5772: Brings back the „pending“ state when checking out

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -30,6 +30,7 @@ class Asset extends Depreciable
     const ASSET = 'asset';
     const USER = 'user';
 
+    const ACCEPTANCE_PENDING = 'pending';
     /**
      * Set static properties to determine which checkout/checkin handlers we should use
      */
@@ -192,6 +193,17 @@ class Asset extends Depreciable
             }
         }
         
+        /**
+         * Does the user have to confirm that they accept the asset?
+         *
+         * If so, set the acceptance-status to "pending".
+         * This value is used in the unaccepted assets reports, for example
+         * 
+         * @see https://github.com/snipe/snipe-it/issues/5772
+         */
+        if ($this->requireAcceptance() && $target instanceof User) {
+          $this->accepted = self::ACCEPTANCE_PENDING;
+        }
 
         if ($this->save()) {
             $this->logCheckout($note, $target);


### PR DESCRIPTION
When a user would get an asset checked out for them, and the assets category required acceptance of the asset, the „pending“ state would not get set.

This PR should fix the immediate problem in #5772, allowing new "pending" assets to be shown in the table.