### PR TITLE
Fixing #5470: Checkin emails not working

### DIFF
--- a/app/Notifications/CheckinAccessoryNotification.php
+++ b/app/Notifications/CheckinAccessoryNotification.php
@@ -4,6 +4,7 @@ namespace App\Notifications;
 
 use App\Models\Setting;
 use App\Models\SnipeModel;
+use App\Models\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -56,9 +57,13 @@ class CheckinAccessoryNotification extends Notification
             $notifyBy[] = 'slack';
         }
 
-        // Make sure the target is a user and that its appropriate to send them an email
-        if (($this->target_type == \App\Models\User::class) && (($this->item->requireAcceptance() == '1') || ($this->item->getEula())))
+        /**
+         * Only send checkin notifications to users if the category 
+         * has the corresponding checkbox checked. 
+         */
+        if ($this->item->checkin_email() && $this->target instanceof User && $this->target->email != '')
         {
+            \Log::debug('use email');
             $notifyBy[] = 'mail';
         }
 

--- a/app/Notifications/CheckinAssetNotification.php
+++ b/app/Notifications/CheckinAssetNotification.php
@@ -4,6 +4,7 @@ namespace App\Notifications;
 
 use App\Models\Setting;
 use Illuminate\Bus\Queueable;
+use App\Models\User;
 use Illuminate\Notifications\Notification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -55,8 +56,11 @@ class CheckinAssetNotification extends Notification
             $notifyBy[] = 'slack';
         }
 
-        // Make sure the target is a user and that its appropriate to send them an email
-        if ((($this->target->email!='') && ($this->target_type == 'App\Models\User')) && (($this->item->requireAcceptance() == '1') || ($this->item->getEula())))
+        /**
+         * Only send checkin notifications to users if the category 
+         * has the corresponding checkbox checked.
+         */
+        if ($this->item->checkin_email() && $this->target instanceof User && $this->target->email != '')
         {
             \Log::debug('use email');
             $notifyBy[] = 'mail';

--- a/app/Notifications/CheckinLicenseNotification.php
+++ b/app/Notifications/CheckinLicenseNotification.php
@@ -4,6 +4,7 @@ namespace App\Notifications;
 
 use App\Models\Setting;
 use App\Models\SnipeModel;
+use App\Models\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -53,8 +54,11 @@ class CheckinLicenseNotification extends Notification
             $notifyBy[] = 'slack';
         }
 
-
-        if (($this->target_type == \App\Models\User::class) && (($this->item->requireAcceptance() == '1') || ($this->item->getEula())))
+        /**
+         * Only send checkin notifications to users if the category 
+         * has the corresponding checkbox checked.
+         */
+        if ($this->item->checkin_email() && $this->target instanceof User && $this->target->email != '')
         {
             $notifyBy[] = 'mail';
         }

--- a/app/Notifications/CheckoutAccessoryNotification.php
+++ b/app/Notifications/CheckoutAccessoryNotification.php
@@ -75,6 +75,13 @@ class CheckoutAccessoryNotification extends Notification
             }
 
             /**
+             * Send an email if the item has a EULA, since the user should always receive it
+             */
+            if ($this->item->getEula()) {
+                $notifyBy[1] = 'mail';
+            }
+
+            /**
              * Send an email if an email should be sent at checkin/checkout
              */
             if ($this->item->checkin_email()) {

--- a/app/Notifications/CheckoutAccessoryNotification.php
+++ b/app/Notifications/CheckoutAccessoryNotification.php
@@ -4,6 +4,7 @@ namespace App\Notifications;
 
 use App\Models\Setting;
 use App\Models\SnipeModel;
+use App\Models\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -59,10 +60,27 @@ class CheckoutAccessoryNotification extends Notification
             $notifyBy[] = 'slack';
         }
 
-        // Make sure the target is a user and that its appropriate to send them an email
-        if ((($this->target->email!='') && ($this->target_type == 'App\Models\User')) && (($this->item->requireAcceptance() == '1') || ($this->item->getEula())))
-        {
-            $notifyBy[] = 'mail';
+
+        /**
+         * Only send notifications to users that have email addresses
+         */
+        if ($this->target instanceof User && $this->target->email != '') {
+
+            /**
+             * Send an email if the asset requires acceptance, 
+             * so the user can accept or decline the asset
+             */
+            if ($this->item->requireAcceptance()) {
+                $notifyBy[1] = 'mail';
+            }
+
+            /**
+             * Send an email if an email should be sent at checkin/checkout
+             */
+            if ($this->item->checkin_email()) {
+                $notifyBy[1] = 'mail';
+            }            
+
         }
 
         return $notifyBy;

--- a/app/Notifications/CheckoutAssetNotification.php
+++ b/app/Notifications/CheckoutAssetNotification.php
@@ -82,6 +82,13 @@ class CheckoutAssetNotification extends Notification
             }
 
             /**
+             * Send an email if the item has a EULA, since the user should always receive it
+             */
+            if ($this->item->getEula()) {
+                $notifyBy[1] = 'mail';
+            }            
+
+            /**
              * Send an email if an email should be sent at checkin/checkout
              */
             if ($this->item->checkin_email()) {

--- a/app/Notifications/CheckoutAssetNotification.php
+++ b/app/Notifications/CheckoutAssetNotification.php
@@ -3,6 +3,7 @@
 namespace App\Notifications;
 
 use App\Models\Setting;
+use App\Models\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Messages\SlackMessage;
@@ -67,11 +68,28 @@ class CheckoutAssetNotification extends Notification
             $notifyBy[] = 'slack';
         }
 
-        // Make sure the target is a user and that its appropriate to send them an email
-        if (($this->target_type == \App\Models\User::class) && (($this->item->requireAcceptance() == '1') || ($this->item->getEula())))
-        {
-            $notifyBy[] = 'mail';
+        /**
+         * Only send notifications to users that have email addresses
+         */
+        if ($this->target instanceof User && $this->target->email != '') {
+
+            /**
+             * Send an email if the asset requires acceptance, 
+             * so the user can accept or decline the asset
+             */
+            if ($this->item->requireAcceptance()) {
+                $notifyBy[1] = 'mail';
+            }
+
+            /**
+             * Send an email if an email should be sent at checkin/checkout
+             */
+            if ($this->item->checkin_email()) {
+                $notifyBy[1] = 'mail';
+            }            
+
         }
+
         return $notifyBy;
     }
 

--- a/app/Notifications/CheckoutConsumableNotification.php
+++ b/app/Notifications/CheckoutConsumableNotification.php
@@ -71,6 +71,13 @@ class CheckoutConsumableNotification extends Notification
             }
 
             /**
+             * Send an email if the item has a EULA, since the user should always receive it
+             */
+            if ($this->item->getEula()) {
+                $notifyBy[1] = 'mail';
+            }                  
+
+            /**
              * Send an email if an email should be sent at checkin/checkout
              */
             if ($this->item->checkin_email()) {

--- a/app/Notifications/CheckoutConsumableNotification.php
+++ b/app/Notifications/CheckoutConsumableNotification.php
@@ -4,6 +4,7 @@ namespace App\Notifications;
 
 use App\Models\Setting;
 use App\Models\SnipeModel;
+use App\Models\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -56,10 +57,26 @@ class CheckoutConsumableNotification extends Notification
             $notifyBy[] = 'slack';
         }
 
-        // Make sure the target is a user and that its appropriate to send them an email
-        if ((($this->target->email!='') && ($this->target_type == 'App\Models\User')) && (($this->item->requireAcceptance() == '1') || ($this->item->getEula())))
-        {
-            $notifyBy[] = 'mail';
+        /**
+         * Only send notifications to users that have email addresses
+         */
+        if ($this->target instanceof User && $this->target->email != '') {
+
+            /**
+             * Send an email if the asset requires acceptance, 
+             * so the user can accept or decline the asset
+             */
+            if ($this->item->requireAcceptance()) {
+                $notifyBy[1] = 'mail';
+            }
+
+            /**
+             * Send an email if an email should be sent at checkin/checkout
+             */
+            if ($this->item->checkin_email()) {
+                $notifyBy[1] = 'mail';
+            }            
+
         }
 
         return $notifyBy;

--- a/app/Notifications/CheckoutLicenseNotification.php
+++ b/app/Notifications/CheckoutLicenseNotification.php
@@ -4,6 +4,7 @@ namespace App\Notifications;
 
 use App\Models\Setting;
 use App\Models\SnipeModel;
+use App\Models\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -57,13 +58,28 @@ class CheckoutLicenseNotification extends Notification
             $notifyBy[] = 'slack';
         }
 
-        if (($this->target_type == \App\Models\User::class) && (($this->item->requireAcceptance() == '1') || ($this->item->getEula())))
-        {
-            $notifyBy[] = 'mail';
+        /**
+         * Only send notifications to users that have email addresses
+         */
+        if ($this->target instanceof User && $this->target->email != '') {
+
+            /**
+             * Send an email if the asset requires acceptance, 
+             * so the user can accept or decline the asset
+             */
+            if ($this->item->requireAcceptance()) {
+                $notifyBy[1] = 'mail';
+            }
+
+            /**
+             * Send an email if an email should be sent at checkin/checkout
+             */
+            if ($this->item->checkin_email()) {
+                $notifyBy[1] = 'mail';
+            }            
+
         }
-
-
-
+        
         return $notifyBy;
     }
 

--- a/app/Notifications/CheckoutLicenseNotification.php
+++ b/app/Notifications/CheckoutLicenseNotification.php
@@ -72,6 +72,13 @@ class CheckoutLicenseNotification extends Notification
             }
 
             /**
+             * Send an email if the item has a EULA, since the user should always receive it
+             */
+            if ($this->item->getEula()) {
+                $notifyBy[1] = 'mail';
+            }                  
+
+            /**
              * Send an email if an email should be sent at checkin/checkout
              */
             if ($this->item->checkin_email()) {


### PR DESCRIPTION
This PR fixes the routing of checkin notifications, sending them if the category of the checked in item requires:
1) a notification to be sent to the user on checkin/checkout.

It also fixes the  routing of check**out** notifications, sending them if the category of the checked **out** item requires either 
1) the user to accept the item or
2) a notification to be sent to the user on checkin/checkout or
3) a EULA was set either on the category or globally 

The original issue (#5470) just focuses on the checkin notifications, but the check**out** notifications would have shown the same error.