### PR TITLE
Fixing #5372: Removing unused bulk operations for components

### DIFF
--- a/app/Http/Controllers/ComponentsController.php
+++ b/app/Http/Controllers/ComponentsController.php
@@ -202,19 +202,6 @@ class ComponentsController extends Controller
         return redirect()->route('components.index')->with('success', trans('admin/components/message.delete.success'));
     }
 
-    public function postBulk($componentId = null)
-    {
-        //$this->authorize('checkout', $component)
-        echo 'Stubbed - not yet complete';
-    }
-
-    public function postBulkSave($componentId = null)
-    {
-        //$this->authorize('edit', Component::class);
-        echo 'Stubbed - not yet complete';
-    }
-
-
     /**
     * Return a view to display component information.
     *

--- a/resources/views/components/index.blade.php
+++ b/resources/views/components/index.blade.php
@@ -18,12 +18,6 @@
   <div class="col-md-12">
     <div class="box box-default">
       <div class="box-body">
-        {{ Form::open([
-             'method' => 'POST',
-             'route' => ['component/bulk-form'],
-             'class' => 'form-inline' ]) }}
-
-
         <table
                 data-columns="{{ \App\Presenters\ComponentPresenter::dataTableLayout() }}"
                 data-cookie-id-table="componentsTable"
@@ -46,8 +40,6 @@
                 "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                 }'>
         </table>
-
-        {{ Form::close() }}
       </div><!-- /.box-body -->
     </div><!-- /.box -->
   </div>

--- a/routes/web/components.php
+++ b/routes/web/components.php
@@ -19,8 +19,6 @@ Route::group([ 'prefix' => 'components','middleware' => ['auth'] ], function () 
         '{componentID}/checkin',
         [ 'as' => 'component.checkin.save', 'uses' => 'ComponentsController@postCheckin' ]
     );
-    Route::post('bulk', [ 'as' => 'component/bulk-form', 'uses' => 'ComponentsController@postBulk' ]);
-    Route::post('bulksave', [ 'as' => 'component/bulk-save', 'uses' => 'ComponentsController@postBulkSave' ]);
 
 });
 


### PR DESCRIPTION
This PR removes the unused bulk operations for components, fixing #5372 and cleaning up the code a bit.

The original issue was caused by the bulk operation form beeing in place, without any operations to be performed. When a user would press Enter after typing a search term, the form was submitted, showing errors.