### PR TITLE
Remove old helpers

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -137,95 +137,6 @@ class Helper
         return floatval($floatString);
     }
 
-
-    /**
-     * Get the list of models in an array to make a dropdown menu
-     *
-     * @author [A. Gianotto] [<snipe@snipe.net>]
-     * @since [v2.5]
-     * @return Array
-     */
-    public static function modelList()
-    {
-        $models = AssetModel::with('manufacturer')->get();
-        $model_array[''] = trans('general.select_model');
-        foreach ($models as $model) {
-            $model_array[$model->id] = $model->present()->modelName();
-        }
-        return $model_array;
-    }
-
-    /**
-     * Get the list of companies in an array to make a dropdown menu
-     *
-     * @author [A. Gianotto] [<snipe@snipe.net>]
-     * @since [v2.5]
-     * @return Array
-     */
-    public static function companyList()
-    {
-        $company_list = array('' => trans('general.select_company')) + DB::table('companies')
-                ->orderBy('name', 'asc')
-                ->pluck('name', 'id')
-                ->toArray();
-        return $company_list;
-    }
-
-
-    /**
-     * Get the list of categories in an array to make a dropdown menu
-     *
-     * @author [A. Gianotto] [<snipe@snipe.net>]
-     * @since [v2.5]
-     * @return Array
-     */
-    public static function categoryList($category_type = null)
-    {
-        $categories = Category::orderBy('name', 'asc')
-                ->whereNull('deleted_at')
-                ->orderBy('name', 'asc');
-        if (!empty($category_type)) {
-            $categories = $categories->where('category_type', '=', $category_type);
-        }
-        $category_list = array('' => trans('general.select_category')) + $categories->pluck('name', 'id')->toArray();
-        return $category_list;
-    }
-
-
-    /**
-     * Get the list of categories in an array to make a dropdown menu
-     *
-     * @author [A. Gianotto] [<snipe@snipe.net>]
-     * @since [v2.5]
-     * @return Array
-     */
-    public static function departmentList()
-    {
-        $departments = Department::orderBy('name', 'asc')
-            ->whereNull('deleted_at')
-            ->orderBy('name', 'asc');
-
-        return array('' => trans('general.select_department')) + $departments->pluck('name', 'id')->toArray();
-
-    }
-    
-
-    /**
-     * Get the list of suppliers in an array to make a dropdown menu
-     *
-     * @author [A. Gianotto] [<snipe@snipe.net>]
-     * @since [v2.5]
-     * @return Array
-     */
-    public static function suppliersList()
-    {
-        $supplier_list = array('' => trans('general.select_supplier')) + Supplier::orderBy('name', 'asc')
-                ->orderBy('name', 'asc')
-                ->pluck('name', 'id')->toArray();
-        return $supplier_list;
-    }
-
-
     /**
      * Get the list of status labels in an array to make a dropdown menu
      *
@@ -238,37 +149,6 @@ class Helper
         $statuslabel_list = array('' => trans('general.select_statuslabel')) + Statuslabel::orderBy('default_label', 'desc')->orderBy('name','asc')->orderBy('deployable','desc')
                 ->pluck('name', 'id')->toArray();
         return $statuslabel_list;
-    }
-
-
-    /**
-     * Get the list of locations in an array to make a dropdown menu
-     *
-     * @author [A. Gianotto] [<snipe@snipe.net>]
-     * @since [v2.5]
-     * @return Array
-     */
-    public static function locationsList()
-    {
-        $location_list = array('' => trans('general.select_location')) + Location::orderBy('name', 'asc')
-                ->pluck('name', 'id')->toArray();
-        return $location_list;
-    }
-
-
-    /**
-     * Get the list of manufacturers in an array to make a dropdown menu
-     *
-     * @author [A. Gianotto] [<snipe@snipe.net>]
-     * @since [v2.5]
-     * @return Array
-     */
-    public static function manufacturerList()
-    {
-        $manufacturer_list = array('' => trans('general.select_manufacturer')) +
-            Manufacturer::orderBy('name', 'asc')
-                ->pluck('name', 'id')->toArray();
-        return $manufacturer_list;
     }
 
     /**
@@ -287,24 +167,6 @@ class Helper
             + array('undeployable' => trans('admin/hardware/general.undeployable'))
             + array('archived' => trans('admin/hardware/general.archived'));
         return $statuslabel_types;
-    }
-
-    /**
-     * Get the list of managers in an array to make a dropdown menu
-     *
-     * @author [A. Gianotto] [<snipe@snipe.net>]
-     * @since [v2.5]
-     * @return Array
-     */
-    public static function managerList()
-    {
-        $manager_list = array('' => trans('general.select_user')) +
-                        User::where('deleted_at', '=', null)
-                        ->orderBy('last_name', 'asc')
-                        ->orderBy('first_name', 'asc')->get()
-                        ->pluck('complete_name', 'id')->toArray();
-
-        return $manager_list;
     }
 
     /**
@@ -340,54 +202,6 @@ class Helper
         );
         return $category_types;
     }
-
-    /**
-     * Get the list of users in an array to make a dropdown menu
-     *
-     * @author [A. Gianotto] [<snipe@snipe.net>]
-     * @since [v2.5]
-     * @return Array
-     */
-    public static function usersList()
-    {
-        $users_list =   array( '' => trans('general.select_user')) +
-                        Company::scopeCompanyables(User::where('deleted_at', '=', null))
-                        ->where('show_in_list', '=', 1)
-                        ->orderBy('last_name', 'asc')
-                        ->orderBy('first_name', 'asc')->get()
-                        ->pluck('complete_name', 'id')->toArray();
-
-        return $users_list;
-    }
-
-    /**
-     * Get the list of assets in an array to make a dropdown menu
-     *
-     * @author [A. Gianotto] [<snipe@snipe.net>]
-     * @since [v2.5]
-     * @return Array
-     */
-    public static function assetsList()
-    {
-        $assets_list = array('' => trans('general.select_asset')) + Asset::orderBy('name', 'asc')
-                ->whereNull('deleted_at')
-                ->pluck('name', 'id')->toArray();
-        return $assets_list;
-    }
-
-    /**
-     * Get the detailed list of assets in an array to make a dropdown menu
-     *
-     * @author [A. Gianotto] [<snipe@snipe.net>]
-     * @since [v2.5]
-     * @return array
-     */
-    public static function detailedAssetList()
-    {
-        $assets = array('' => trans('general.select_asset')) + Company::scopeCompanyables(Asset::with('assignedTo', 'model'), 'assets.company_id')->get()->pluck('detailed_name', 'id')->toArray();
-        return $assets;
-    }
-
 
     /**
      * Get the list of custom fields in an array to make a dropdown menu

--- a/app/Http/Controllers/AssetModelsController.php
+++ b/app/Http/Controllers/AssetModelsController.php
@@ -372,9 +372,7 @@ class AssetModelsController extends Controller
 
         // Show the page
         $view = View::make('models/edit');
-        $view->with('category_list', Helper::categoryList('asset'));
         $view->with('depreciation_list', Helper::depreciationList());
-        $view->with('manufacturer_list', Helper::manufacturerList());
         $view->with('item', $model);
         $view->with('clone_model', $model_to_clone);
         return $view;
@@ -408,7 +406,7 @@ class AssetModelsController extends Controller
      */
     public function postBulkEdit(Request $request)
     {
-        
+
         $models_raw_array = Input::get('ids');
 
         // Make sure some IDs have been selected
@@ -433,13 +431,8 @@ class AssetModelsController extends Controller
                 $nochange = ['NC' => 'No Change'];
                 $fieldset_list = $nochange + Helper::customFieldsetList();
                 $depreciation_list = $nochange + Helper::depreciationList();
-                $category_list = $nochange + Helper::categoryList('asset');
-                $manufacturer_list = $nochange + Helper::manufacturerList();
-
 
                 return view('models/bulk-edit', compact('models'))
-                    ->with('manufacturer_list', $manufacturer_list)
-                    ->with('category_list', $category_list)
                     ->with('fieldset_list', $fieldset_list)
                     ->with('depreciation_list', $depreciation_list);
             }

--- a/app/Http/Controllers/AssetsController.php
+++ b/app/Http/Controllers/AssetsController.php
@@ -110,12 +110,8 @@ class AssetsController extends Controller
     {
         $this->authorize('create', Asset::class);
         $view = View::make('hardware/edit')
-            ->with('supplier_list', Helper::suppliersList())
-            ->with('model_list', Helper::modelList())
             ->with('statuslabel_list', Helper::statusLabelList())
             ->with('item', new Asset)
-            ->with('manufacturer', Helper::manufacturerList()) //handled in modal now?
-            ->with('category', Helper::categoryList('asset')) //handled in modal now?
             ->with('statuslabel_types', Helper::statusTypeList());
 
         if ($request->has('model_id')) {
@@ -262,7 +258,6 @@ class AssetsController extends Controller
         $this->authorize($item);
 
         return view('hardware/edit', compact('item'))
-            ->with('model_list', Helper::modelList())
             ->with('statuslabel_list', Helper::statusLabelList())
             ->with('statuslabel_types', Helper::statusTypeList());
     }
@@ -1082,11 +1077,7 @@ class AssetsController extends Controller
             } elseif ($request->input('bulk_actions')=='edit') {
                 return view('hardware/bulk')
                 ->with('assets', request('ids'))
-                ->with('statuslabel_list', Helper::statusLabelList())
-                ->with(
-                    'companies_list',
-                    array('' => '') + array('clear' => trans('general.remove_company')) + Helper::companyList()
-                );
+                ->with('statuslabel_list', Helper::statusLabelList());
             }
         }
         return redirect()->back()->with('error', 'No action selected');
@@ -1209,10 +1200,7 @@ class AssetsController extends Controller
     public function getBulkCheckout()
     {
         $this->authorize('checkout', Asset::class);
-        // Filter out assets that are not deployable.
-
-        return view('hardware/bulk-checkout')
-            ->with('users_list', Helper::usersList());
+        return view('hardware/bulk-checkout');
     }
 
     public function postBulkCheckout(Request $request)

--- a/app/Http/Controllers/LocationsController.php
+++ b/app/Http/Controllers/LocationsController.php
@@ -175,8 +175,7 @@ class LocationsController extends Controller
         $location_options = array('' => 'Top Level') + $location_options;
 
         return view('locations/edit', compact('item'))
-            ->with('location_options', $location_options)
-            ->with('manager_list', Helper::managerList());
+            ->with('location_options', $location_options);
     }
 
 

--- a/app/Http/Controllers/ModalController.php
+++ b/app/Http/Controllers/ModalController.php
@@ -13,9 +13,7 @@ class ModalController extends Controller
     }
 
     function model() {
-        return view('modals.model')
-            ->with('manufacturer', Helper::manufacturerList())
-            ->with('category', Helper::categoryList('asset'));
+        return view('modals.model');
     }
 
     function statuslabel() {

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -1011,8 +1011,7 @@ class UsersController extends Controller
             return redirect()->route('users.index')->with('error', $e->getMessage());
         }
 
-        return view('users/ldap')
-              ->with('location_list', Helper::locationsList());
+        return view('users/ldap');
     }
 
 

--- a/resources/views/hardware/bulk.blade.php
+++ b/resources/views/hardware/bulk.blade.php
@@ -86,18 +86,8 @@
 
           <!-- Supplier -->
            @include ('partials.forms.edit.supplier-select', ['translated_name' => trans('general.supplier'), 'fieldname' => 'supplier_id'])
-
-
-        <!-- Company -->
-          <div class="form-group {{ $errors->has('company_id') ? ' has-error' : '' }}">
-            <label for="company_id" class="col-md-3 control-label">
-              {{ trans('general.company') }}
-            </label>
-            <div class="col-md-7">
-              {{ Form::select('company_id', $companies_list , Input::old('company_id'), array('class'=>'select2', 'style'=>'width:350px')) }}
-              {!! $errors->first('company_id', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
-            </div>
-          </div>
+          <!-- Company -->
+          @include ('partials.forms.edit.company-select', ['translated_name' => trans('general.company'), 'fieldname' => 'company_id'])
 
           <!-- Order Number -->
           <div class="form-group {{ $errors->has('order_number') ? ' has-error' : '' }}">

--- a/resources/views/modals/model.blade.php
+++ b/resources/views/modals/model.blade.php
@@ -18,13 +18,17 @@
                 <div class="dynamic-form-row">
                     <div class="col-md-4 col-xs-12"><label for="modal-manufacturer_id">{{ trans('general.manufacturer') }}:
                         </label></div>
-                    <div class="col-md-8 col-xs-12 required">{{ Form::select('manufacturer_id', $manufacturer , '', array('class'=>'select2 parent', 'style'=>'width:100%','id' =>'modal-manufacturer_id')) }}</div>
+                    <div class="col-md-8 col-xs-12 required">
+                        <select class="js-data-ajax" data-endpoint="manufacturers" name="manufacturer_id" style="width: 100%" id="modal-manufactuer_id" />
+                    </div>
                 </div>
 
                 <div class="dynamic-form-row">
                     <div class="col-md-4 col-xs-12"><label for="modal-category_id">{{ trans('general.category') }}:
                         </label></div>
-                    <div class="col-md-8 col-xs-12 required">{{ Form::select('category_id', $category ,'', array('class'=>'select2 parent', 'style'=>'width:100%','id' => 'modal-category_id')) }}</div>
+                    <div class="col-md-8 col-xs-12 required">
+                        <select class="js-data-ajax" data-endpoint="categories/asset" name="category_id" style="width: 100%" id="modal-category_id" />
+                    </div>
                 </div>
 
                 <div class="dynamic-form-row">

--- a/resources/views/models/bulk-edit.blade.php
+++ b/resources/views/models/bulk-edit.blade.php
@@ -17,38 +17,21 @@
     <div class="row">
         <div class="col-md-8 col-md-offset-2">
 
-
-
-
             <form class="form-horizontal" method="post" action="{{ route('models.bulkedit.store') }}" autocomplete="off" role="form">
                 {{ csrf_field() }}
 
                 <div class="box box-default">
+                    <div class="box-header with-border">
+                        @foreach ($models as $model)
+                            <span class="box-title"><b>{{ $model->display_name }}</b> ({{ $model->model_number }})</span><br />
+                        @endforeach
+                    </div>
                     <div class="box-body">
-
-
-
                         <!-- manufacturer -->
-                        <div class="form-group {{ $errors->has('manufacturer_id') ? ' has-error' : '' }}">
-                            <label for="manufacturer_id" class="col-md-3 control-label">
-                                {{ trans('general.manufacturer') }}
-                            </label>
-                            <div class="col-md-7">
-                                {{ Form::select('manufacturer_id', $manufacturer_list , Input::old('manufacturer_id', 'NC'), array('class'=>'select2', 'style'=>'width:350px')) }}
-                                {!! $errors->first('manufacturer_id', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
-                            </div>
-                        </div>
+                        @include ('partials.forms.edit.manufacturer-select', ['translated_name' => trans('general.manufacturer'), 'fieldname' => 'manufacturer_id'])
 
                         <!-- category -->
-                        <div class="form-group {{ $errors->has('category_id') ? ' has-error' : '' }}">
-                            <label for="category_id" class="col-md-3 control-label">
-                                {{ trans('general.category') }}
-                            </label>
-                            <div class="col-md-7">
-                                {{ Form::select('category_id', $category_list , Input::old('category_id', 'NC'), array('class'=>'select2', 'style'=>'width:350px')) }}
-                                {!! $errors->first('category_id', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
-                            </div>
-                        </div>
+                        @include ('partials.forms.edit.category-select', ['translated_name' => trans('admin/categories/general.category_name'), 'fieldname' => 'category_id', 'required' => 'true', 'category_type' => 'asset'])
 
                         <!-- custom fields -->
                         <div class="form-group {{ $errors->has('fieldset_id') ? ' has-error' : '' }}">
@@ -56,12 +39,13 @@
                                 {{ trans('admin/models/general.fieldset') }}
                             </label>
                             <div class="col-md-7">
-                                {{ Form::select('fieldset_id', $fieldset_list , Input::old('fieldset_id', 'NC'), array('class'=>'select2', 'style'=>'width:350px')) }}
-                                {!! $errors->first('fieldset_id', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
+                                {{ Form::select('fieldset_id', $fieldset_list , Input::old('fieldset_id', 'NC'), array('class'=>'select2 js-fieldset-field', 'style'=>'width:350px')) }}
+                                {!! $errors->first('fieldset_id', '<span class="alert-msg"><br><i class="fa fa-times"></i> :message</span>') !!}
                             </div>
                         </div>
 
                         <!-- depreciation -->
+
                         <div class="form-group {{ $errors->has('depreciation_id') ? ' has-error' : '' }}">
                             <label for="category_id" class="col-md-3 control-label">
                                 {{ trans('general.depreciation') }}
@@ -71,10 +55,6 @@
                                 {!! $errors->first('depreciation_id', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
                             </div>
                         </div>
-
-
-
-
 
                         @foreach ($models as $model)
                             <input type="hidden" name="ids[{{ $model->id }}]" value="{{ $model->id }}">


### PR DESCRIPTION
This commit primarily removes most of the Helper/assortedList() functions now that select2 is populating via ajax.

It also ports the model modal create popup to use the new fetch api, and adds support to port other places.  The only way I could make this work was duplicating the select2 options/code from snipeit.js, so this could probably be improved but I'm not entirely sure how these JS files play with each other... pinging @uberbrady for thoughts.