### PR TITLE
Only error if checking out to asset with same id

### DIFF
--- a/app/Http/Controllers/AssetsController.php
+++ b/app/Http/Controllers/AssetsController.php
@@ -1232,7 +1232,7 @@ class AssetsController extends Controller
 
         $asset_ids = array_filter(Input::get('selected_assets'));
         foreach ($asset_ids as $asset_id) {
-            if ($target->id == $asset_id) {
+            if ($target->id == $asset_id && request('checkout_to_type')=='asset') {
                 return redirect()->back()->with('error', 'You cannot check an asset out to itself.');
             }
         }


### PR DESCRIPTION
A user with an id of 2 is perfectly fine as a checkout_target of an asset with an id of 2.