### PR TITLE
Fix: Searching for multiple terms on assets

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -621,42 +621,57 @@ class Asset extends Depreciable
      * Run additional, advanced searches.
      * 
      * @param  Illuminate\Database\Eloquent\Builder $query
-     * @param  string  $term The search term
+     * @param  array  $terms The search terms
      * @return Illuminate\Database\Eloquent\Builder
      */
-    public function advancedTextSearch(Builder $query, string $term) {
+    public function advancedTextSearch(Builder $query, array $terms) {
+
+      
       /**
-       * Assigned user
+       * Assigned users
        */
       $query = $query->leftJoin('users as assets_users',function ($leftJoin) {
             $leftJoin->on("assets_users.id", "=", "assets.assigned_to")
                 ->where("assets.assigned_type", "=", User::class);
       });
-      $query = $query
-        ->orWhere('assets_users.first_name', 'LIKE', '%'.$term.'%')
-        ->orWhere('assets_users.last_name', 'LIKE', '%'.$term.'%')
-        ->orWhere('assets_users.username', 'LIKE', '%'.$term.'%')
-        ->orWhereRaw('CONCAT('.DB::getTablePrefix().'assets_users.first_name," ",'.DB::getTablePrefix().'assets_users.last_name) LIKE ?', ["%$term%", "%$term%"]);
+
+      foreach($terms as $term) {
+
+        $query = $query
+          ->orWhere('assets_users.first_name', 'LIKE', '%'.$term.'%')
+          ->orWhere('assets_users.last_name', 'LIKE', '%'.$term.'%')
+          ->orWhere('assets_users.username', 'LIKE', '%'.$term.'%')
+          ->orWhereRaw('CONCAT('.DB::getTablePrefix().'assets_users.first_name," ",'.DB::getTablePrefix().'assets_users.last_name) LIKE ?', ["%$term%", "%$term%"]);      
+
+      }
 
       /**
        * Assigned location
-       */
+       */      
       $query = $query->leftJoin('locations as assets_locations',function ($leftJoin) {
         $leftJoin->on("assets_locations.id","=","assets.assigned_to")
           ->where("assets.assigned_type","=",Location::class);
       });
 
-      $query = $query->orWhere('assets_locations.name', 'LIKE', '%'.$term.'%');
+      foreach($terms as $term) {
+
+        $query = $query->orWhere('assets_locations.name', 'LIKE', '%'.$term.'%');     
+
+      }      
 
       /**
        * Assigned assets
-       */
+       */      
       $query = $query->leftJoin('assets as assigned_assets',function ($leftJoin) {
         $leftJoin->on('assigned_assets.id', '=', 'assets.assigned_to')
           ->where('assets.assigned_type', '=', Asset::class);
       });
 
-      $query = $query->orWhere('assigned_assets.name', 'LIKE', '%'.$term.'%');
+      foreach($terms as $term) {
+
+        $query = $query->orWhere('assigned_assets.name', 'LIKE', '%'.$term.'%');
+                  
+      }
 
       return $query;
     }

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -628,7 +628,7 @@ class Asset extends Depreciable
 
       
       /**
-       * Assigned users
+       * Assigned user
        */
       $query = $query->leftJoin('users as assets_users',function ($leftJoin) {
             $leftJoin->on("assets_users.id", "=", "assets.assigned_to")

--- a/app/Models/Traits/Searchable.php
+++ b/app/Models/Traits/Searchable.php
@@ -42,11 +42,11 @@ trait Searchable {
              */
             $query = $this->searchRelations($query, $term);
 
-            /**
-             * Search for additional attributes defined by the model
-             */
-            $query = $this->advancedTextSearch($query, $term);
         }
+        /**
+         * Search for additional attributes defined by the model
+         */
+        $query = $this->advancedTextSearch($query, $terms);
 
         return $query;
     }
@@ -160,12 +160,12 @@ trait Searchable {
      * This is a noop in this trait, but can be overridden in the implementing model, to allow more advanced searches
      * 
      * @param  Illuminate\Database\Eloquent\Builder $query
-     * @param  string  $term The search term
+     * @param  array  $terms The search terms
      * @return Illuminate\Database\Eloquent\Builder
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function advancedTextSearch(Builder $query, string $term) {
+    public function advancedTextSearch(Builder $query, array $terms) {
         return $query;
     }        
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -440,12 +440,15 @@ class User extends SnipeModel implements AuthenticatableContract, CanResetPasswo
      * Run additional, advanced searches.
      * 
      * @param  Illuminate\Database\Eloquent\Builder $query
-     * @param  string  $term The search term
+     * @param  array  $term The search terms
      * @return Illuminate\Database\Eloquent\Builder
      */
-    public function advancedTextSearch(Builder $query, string $term) {
-        $query = $query->orWhereRaw('CONCAT('.DB::getTablePrefix().'users.first_name," ",'.DB::getTablePrefix().'users.last_name) LIKE ?', ["%$term%", "%$term%"]);
+    public function advancedTextSearch(Builder $query, array $terms) {
 
+        foreach($terms as $term) {
+            $query = $query->orWhereRaw('CONCAT('.DB::getTablePrefix().'users.first_name," ",'.DB::getTablePrefix().'users.last_name) LIKE ?', ["%$term%", "%$term%"]);
+        }
+        
         return $query;
     }     
 


### PR DESCRIPTION
I just noticed a few problems with the new search methods 🙈

Because the `Asset` model joins a few tables for the additional conditions, when the method got called multiple times for multiple search terms, it had problems with joining the tables again and again.

This PR should fix that, by always handing over all search terms together. It also should improve the performance of the search a bit, we were kind of duplicating some queries when searching with multiple search terms. 