### PR TITLE
Checking out specific seats for licenses

### DIFF
--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -267,7 +267,7 @@
     function licenseSeatInOutFormatter(value, row) {
         // The user is allowed to check the license seat out and it's available
         if ((row.available_actions.checkout == true) && (row.user_can_checkout == true) && ((!row.asset_id) && (!row.assigned_to))) {
-            return '<a href="{{ url('/') }}/licenses/' + row.license_id + '/checkout" class="btn btn-sm bg-maroon" data-tooltip="true" title="Check this item out">{{ trans('general.checkout') }}</a>';
+            return '<a href="{{ url('/') }}/licenses/' + row.license_id + '/checkout/'+row.id+'" class="btn btn-sm bg-maroon" data-tooltip="true" title="Check this item out">{{ trans('general.checkout') }}</a>';
         } else {
             return '<a href="{{ url('/') }}/licenses/' + row.id + '/checkin" class="btn btn-sm bg-purple" data-tooltip="true" title="Check in this license seat.">{{ trans('general.checkin') }}</a>';
         }

--- a/routes/web/licenses.php
+++ b/routes/web/licenses.php
@@ -11,12 +11,12 @@ Route::group([ 'prefix' => 'licenses', 'middleware' => ['auth'] ], function () {
     'as' => 'licenses.freecheckout',
     'uses' => 'LicensesController@getFreeLicense'
     ]);
-    Route::get('{licenseId}/checkout', [
+    Route::get('{licenseId}/checkout/{seatId?}', [
     'as' => 'licenses.checkout',
     'uses' => 'LicensesController@getCheckout'
     ]);
     Route::post(
-        '{licenseId}/checkout',
+        '{licenseId}/checkout/{seatId?}',
         [ 'as' => 'licenses.checkout', 'uses' => 'LicensesController@postCheckout' ]
     );
     Route::get('{licenseId}/checkin/{backto?}', [


### PR DESCRIPTION
 When a user clicks checkout on the seat page in licences, it will specifically checkout that seat for the assigned user or asset.

relates to #4413