### PR TITLE
Fix: No Notifications for checking out Consumables

### DIFF
--- a/app/Models/Consumable.php
+++ b/app/Models/Consumable.php
@@ -156,6 +156,10 @@ class Consumable extends SnipeModel
         return $this->belongsToMany('\App\Models\User', 'consumables_users', 'consumable_id', 'assigned_to')->count();
     }
 
+    public function checkin_email()
+    {
+        return $this->category->checkin_email;
+    }    
 
     public function requireAcceptance()
     {

--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -228,7 +228,7 @@ class License extends Depreciable
 
     public function checkin_email()
     {
-        return $this->model->category->checkin_email;
+        return $this->category->checkin_email;
     }
 
     public function requireAcceptance()


### PR DESCRIPTION
Adds the checkin_email method to the Consumable Model, this gets checked when sending checkout notifications.
Without the method, no notifications get sent for checking out consumables.