### PR TITLE
Hotfix: Fixes the generation of conditions while searching

### DIFF
--- a/app/Models/Traits/Searchable.php
+++ b/app/Models/Traits/Searchable.php
@@ -68,6 +68,8 @@ trait Searchable {
         
         $table = $this->getTable();
 
+        $firstConditionAdded = false;
+
         foreach($this->getSearchableAttributes() as $column) {
 
             foreach($terms as $term) {
@@ -80,6 +82,19 @@ trait Searchable {
                     continue;
                 }
 
+                /**
+                 * We need to form the query properly, starting with a "where",
+                 * otherwise the generated select is wrong.
+                 *
+                 * @todo  This does the job, but is inelegant and fragile
+                 */
+                if (!$firstConditionAdded) {
+                    $query = $query->where($table . '.' . $column, 'LIKE', '%'.$term.'%');
+
+                    $firstConditionAdded = true;
+                    continue;
+                }
+                
                 $query = $query->orWhere($table . '.' . $column, 'LIKE', '%'.$term.'%');
             }
         }


### PR DESCRIPTION
This PR fixes the generation of where conditions while searching models, so that previous conditions get respected. 
This effectively adds a big "`AND (A=1 OR B=1 OR ...)`" condition to an existing query, instead of "`OR (A=1 OR B=1 OR ...)`".

This fixes #5899.