### PR TITLE
Hotfix: Removes the typehint for search term string

### DIFF
--- a/app/Models/Traits/Searchable.php
+++ b/app/Models/Traits/Searchable.php
@@ -53,7 +53,7 @@ trait Searchable {
      * @param  string $search The search term
      * @return array         An array of search terms
      */
-	private function prepeareSearchTerms(string $search) {
+	private function prepeareSearchTerms($search) {
 		return explode(' OR ', $search);
 	}
 


### PR DESCRIPTION
The „string“ typehint only works in PHP >= 7.0.0.
Since we are still supporting versions below that, remove the type hint.

This fixes #5903.