### PR TITLE
Fixed #5944 - added logo option for print-assets page

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -169,11 +169,7 @@ class SettingsController extends Controller
         $settings->alerts_enabled = 1;
         $settings->pwd_secure_min = 10;
         $settings->brand = 1;
-
-        if (!config('app.lock_passwords')) {
-            $settings->locale = $request->input('locale', 'en');
-        }
-
+        $settings->locale = $request->input('locale', 'en');
         $settings->default_currency = $request->input('default_currency', "USD");
         $settings->user_id = 1;
         $settings->email_domain = $request->input('email_domain');
@@ -405,6 +401,8 @@ class SettingsController extends Controller
         $setting->footer_text = $request->input('footer_text');
         $setting->skin = $request->input('skin');
         $setting->show_url_in_emails = $request->input('show_url_in_emails', '0');
+        $setting->logo_print_assets = $request->input('logo_print_assets', '0');
+
 
 
         // Only allow the site name and CSS to be changed if lock_passwords is false
@@ -541,7 +539,9 @@ class SettingsController extends Controller
             return redirect()->to('admin')->with('error', trans('admin/settings/message.update.error'));
         }
 
-        $setting->locale = $request->input('locale', 'en');
+        if (!config('app.lock_passwords')) {
+            $setting->locale = $request->input('locale', 'en');
+        }
         $setting->default_currency = $request->input('default_currency', '$');
         $setting->date_display_format = $request->input('date_display_format');
         $setting->time_display_format = $request->input('time_display_format');

--- a/database/migrations/2018_07_24_154348_add_logo_to_print_assets.php
+++ b/database/migrations/2018_07_24_154348_add_logo_to_print_assets.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddLogoToPrintAssets extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->boolean('logo_print_assets')->default('0');
+        });
+
+
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->dropColumn('logo_print_assets');
+        });
+    }
+}

--- a/resources/lang/en/admin/settings/general.php
+++ b/resources/lang/en/admin/settings/general.php
@@ -88,6 +88,8 @@ return array(
     'login_remote_user_custom_logout_url_text' => 'Custom logout URL',
     'login_remote_user_custom_logout_url_help' => 'If a url is provided here, users will get redirected to this URL after the user logs out of Snipe-IT. This is useful to close the user sessions of your Authentication provider correctly.',
     'logo'                    	=> 'Logo',
+    'logo_print_assets'         => 'Use in Print',
+    'logo_print_assets_help'    => 'Use branding on printable asset lists ',
     'full_multiple_companies_support_help_text' => 'Restricting users (including admins) assigned to companies to their company\'s assets.',
     'full_multiple_companies_support_text' => 'Full Multiple Companies Support',
     'show_in_model_list'   => 'Show in Model Dropdowns',

--- a/resources/views/settings/branding.blade.php
+++ b/resources/views/settings/branding.blade.php
@@ -93,7 +93,20 @@
                                 {!! $errors->first('brand', '<span class="alert-msg">:message</span>') !!}
                             </div>
                         </div>
-                        <!-- remote load -->
+
+                        <!-- Include logo in print assets -->
+                        <div class="form-group">
+                            <div class="col-md-3">
+                                {{ Form::label('logo_print_assets', trans('admin/settings/general.logo_print_assets')) }}
+                            </div>
+                            <div class="col-md-9">
+                                {{ Form::checkbox('logo_print_assets', '1', Input::old('logo_print_assets', $setting->logo_print_assets),array('class' => 'minimal')) }}
+                                {{ trans('admin/settings/general.logo_print_assets_help') }}
+                            </div>
+                        </div>
+
+
+                        <!-- show urls in emails-->
                         <div class="form-group">
                             <div class="col-md-3">
                                 {{ Form::label('show_url_in_emails', trans('admin/settings/general.show_url_in_emails')) }}

--- a/resources/views/settings/general.blade.php
+++ b/resources/views/settings/general.blade.php
@@ -118,7 +118,7 @@
                         </div>
                         <div class="col-md-9">
                             {{ Form::checkbox('load_remote', '1', Input::old('load_remote', $setting->load_remote),array('class' => 'minimal')) }}
-                            {{ trans('admin/settings/general.load_remote_help_text') }}
+                            <p class="help-block">{{ trans('admin/settings/general.load_remote_help_text') }}</p>
                         </div>
                     </div>
 

--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -22,10 +22,34 @@
             padding: 3px;
             font-size: 12px;
         }
+
+        .print-logo {
+            max-height: 40px;
+        }
+
     </style>
 </head>
 <body>
-<h3>Assigned to {{ $show_user->present()->fullName() }}</h3>
+
+@if ($snipeSettings->logo_print_assets=='1')
+    @if ($snipeSettings->brand == '3')
+
+        <h3>
+        @if ($snipeSettings->logo!='')
+            <img class="print-logo" src="{{ url('/') }}/uploads/{{ $snipeSettings->logo }}">
+        @endif
+        {{ $snipeSettings->site_name }}
+        </h3>
+    @elseif ($snipeSettings->brand == '2')
+        @if ($snipeSettings->logo!='')
+            <img class="print-logo" src="{{ url('/') }}/uploads/{{ $snipeSettings->logo }}">
+        @endif
+    @else
+      <h3>{{ $snipeSettings->site_name }}</h3>
+    @endif
+@endif
+
+<h4>Assigned to {{ $show_user->present()->fullName() }}</h4>
 
 @if ($assets->count() > 0)
     @php


### PR DESCRIPTION
This adds an additional setting to allow the logo branding style to be used in the "print assets assigned to this user page", fixing #5944.

It also prevents folks from changing the display language in demo mode, which I admit should have been in a separate PR.