### PR TITLE
Licenses rename

### DIFF
--- a/app/Console/Commands/FixDoubleEscape.php
+++ b/app/Console/Commands/FixDoubleEscape.php
@@ -40,7 +40,7 @@ class FixDoubleEscape extends Command
 
         $tables = [
             '\App\Models\Asset' => ['name'],
-            '\App\Models\License' => ['name'],
+            '\App\Models\LicenseModel' => ['name'],
             '\App\Models\Consumable' => ['name'],
             '\App\Models\Accessory' => ['name'],
             '\App\Models\Component' => ['name'],

--- a/app/Console/Commands/ObjectImportCommand.php
+++ b/app/Console/Commands/ObjectImportCommand.php
@@ -168,7 +168,7 @@ class ObjectImportCommand extends Command
         array('email_format', null, InputOption::VALUE_REQUIRED, 'The format of the email addresses that should be generated. Options are firstname.lastname, firstname, filastname', null),
         array('username_format', null, InputOption::VALUE_REQUIRED, 'The format of the username that should be generated. Options are firstname.lastname, firstname, filastname, email', null),
         array('logfile', null, InputOption::VALUE_REQUIRED, 'The path to log output to.  storage/logs/importer.log by default', storage_path('logs/importer.log') ),
-        array('item-type', null, InputOption::VALUE_REQUIRED, 'Item Type To import.  Valid Options are Asset, Consumable, Accessory, License, or User', 'Asset'),
+        array('item-type', null, InputOption::VALUE_REQUIRED, 'Item Type To import.  Valid Options are Asset, Consumable, Accessory, LicenseModel, or User', 'Asset'),
         array('web-importer', null, InputOption::VALUE_NONE, 'Internal: packages output for use with the web importer'),
         array('user_id', null, InputOption::VALUE_REQUIRED, 'ID of user creating items', 1),
         array('update', null, InputOption::VALUE_NONE, 'If a matching item is found, update item information'),

--- a/app/Console/Commands/PaveIt.php
+++ b/app/Console/Commands/PaveIt.php
@@ -14,7 +14,7 @@ use App\Models\Depreciation;
 use App\Models\Group;
 use App\Models\Import;
 use App\Models\LicenseModel;
-use App\Models\LicenseSeat;
+use App\Models\License;
 use App\Models\Location;
 use App\Models\Manufacturer;
 use App\Models\Statuslabel;
@@ -67,7 +67,7 @@ class PaveIt extends Command
                 Department::getQuery()->delete();
                 Depreciation::getQuery()->delete();
                 LicenseModel::getQuery()->delete();
-                LicenseSeat::getQuery()->delete();
+                License::getQuery()->delete();
                 Location::getQuery()->delete();
                 Manufacturer::getQuery()->delete();
                 AssetModel::getQuery()->delete();

--- a/app/Console/Commands/PaveIt.php
+++ b/app/Console/Commands/PaveIt.php
@@ -13,7 +13,7 @@ use App\Models\Department;
 use App\Models\Depreciation;
 use App\Models\Group;
 use App\Models\Import;
-use App\Models\License;
+use App\Models\LicenseModel;
 use App\Models\LicenseSeat;
 use App\Models\Location;
 use App\Models\Manufacturer;
@@ -66,7 +66,7 @@ class PaveIt extends Command
                 Consumable::getQuery()->delete();
                 Department::getQuery()->delete();
                 Depreciation::getQuery()->delete();
-                License::getQuery()->delete();
+                LicenseModel::getQuery()->delete();
                 LicenseSeat::getQuery()->delete();
                 Location::getQuery()->delete();
                 Manufacturer::getQuery()->delete();

--- a/app/Console/Commands/Purge.php
+++ b/app/Console/Commands/Purge.php
@@ -118,7 +118,7 @@ class Purge extends Command
             foreach ($licenseModels as $licenseModel) {
                 $this->info('- LicenseModel "'.$licenseModel->name.'" deleted.');
                 $licenseModel->assetlog()->forceDelete();
-                $licenseModel->licenseseats()->forceDelete();
+                $licenseModel->licenses()->forceDelete();
                 $licenseModel->forceDelete();
             }
 

--- a/app/Console/Commands/Purge.php
+++ b/app/Console/Commands/Purge.php
@@ -8,7 +8,7 @@ use \App\Models\Asset;
 use \App\Models\AssetModel;
 use \App\Models\Location;
 use \App\Models\Company;
-use \App\Models\License;
+use \App\Models\LicenseModel;
 use \App\Models\Accessory;
 use \App\Models\Component;
 use \App\Models\Consumable;
@@ -113,13 +113,13 @@ class Purge extends Command
                 $component->forceDelete();
             }
 
-            $licenses = License::whereNotNull('deleted_at')->withTrashed()->get();
-            $this->info($licenses->count().' licenses purged.');
-            foreach ($licenses as $license) {
-                $this->info('- License "'.$license->name.'" deleted.');
-                $license->assetlog()->forceDelete();
-                $license->licenseseats()->forceDelete();
-                $license->forceDelete();
+            $licenseModels = LicenseModel::whereNotNull('deleted_at')->withTrashed()->get();
+            $this->info($licenseModels->count().' licenses purged.');
+            foreach ($licenseModels as $licenseModel) {
+                $this->info('- LicenseModel "'.$licenseModel->name.'" deleted.');
+                $licenseModel->assetlog()->forceDelete();
+                $licenseModel->licenseseats()->forceDelete();
+                $licenseModel->forceDelete();
             }
 
             $models = AssetModel::whereNotNull('deleted_at')->withTrashed()->get();

--- a/app/Console/Commands/RestoreDeletedUsers.php
+++ b/app/Console/Commands/RestoreDeletedUsers.php
@@ -9,7 +9,7 @@ use App\Models\Asset;
 use App\Models\Consumable;
 use App\Models\Accessory;
 use App\Models\LicenseSeat;
-use App\Models\License;
+use App\Models\LicenseModel;
 use DB;
 use Artisan;
 
@@ -50,7 +50,7 @@ class RestoreDeletedUsers extends Command
         $start_date = $this->option('start_date');
         $end_date = $this->option('end_date');
         $asset_totals = 0;
-        $license_totals = 0;
+        $licenseModel_totals = 0;
         $user_count = 0;
 
 
@@ -83,8 +83,8 @@ class RestoreDeletedUsers extends Command
 
                     $this->info('      ** Asset '.$user_log->item->id.' ('.$user_log->item->asset_tag.') restored to user '.$user->id.'');
 
-                } elseif ($user_log->item_type==License::class) {
-                    $license_totals++;
+                } elseif ($user_log->item_type==LicenseModel::class) {
+                    $licenseModel_totals++;
 
                     $avail_seat = DB::table('license_seats')->where('license_id','=',$user_log->item->id)
                         ->whereNull('assigned_to')->whereNull('asset_id')->whereBetween('updated_at', [$start_date, $end_date])->first();
@@ -110,7 +110,7 @@ class RestoreDeletedUsers extends Command
         }
 
         $this->info($asset_totals.' assets affected');
-        $this->info($license_totals.' licenses affected');
+        $this->info($licenseModel_totals.' licenses affected');
 
 
 

--- a/app/Console/Commands/RestoreDeletedUsers.php
+++ b/app/Console/Commands/RestoreDeletedUsers.php
@@ -8,7 +8,7 @@ use App\Models\Actionlog;
 use App\Models\Asset;
 use App\Models\Consumable;
 use App\Models\Accessory;
-use App\Models\LicenseSeat;
+use App\Models\License;
 use App\Models\LicenseModel;
 use DB;
 use Artisan;

--- a/app/Console/Commands/SendExpirationAlerts.php
+++ b/app/Console/Commands/SendExpirationAlerts.php
@@ -3,7 +3,7 @@
 namespace App\Console\Commands;
 
 use App\Models\Asset;
-use App\Models\License;
+use App\Models\LicenseModel;
 use App\Models\Setting;
 use DB;
 use App\Notifications\ExpiringLicenseNotification;
@@ -55,9 +55,9 @@ class SendExpirationAlerts extends Command
         $this->info(trans_choice('mail.assets_warrantee_alert', $assets->count(), ['count'=>$assets->count(), 'threshold' => $threshold]));
 
         // Expiring licenses
-        $licenses = License::getExpiringLicenses($threshold);
+        $licenseModels = LicenseModel::getExpiringLicenses($threshold);
 
-        $this->info(trans_choice('mail.license_expiring_alert', $licenses->count(), ['count'=>$licenses->count(), 'threshold' => $threshold]));
+        $this->info(trans_choice('mail.license_expiring_alert', $licenseModels->count(), ['count'=>$licenseModels->count(), 'threshold' => $threshold]));
 
         $recipient = new \App\Models\Recipients\AlertRecipient();
 
@@ -68,8 +68,8 @@ class SendExpirationAlerts extends Command
                 $recipient->notify(new ExpiringAssetsNotification($assets, $threshold));
             }
 
-            if ($licenses->count() > 0) {
-                $recipient->notify(new ExpiringLicenseNotification($licenses, $threshold));
+            if ($licenseModels->count() > 0) {
+                $recipient->notify(new ExpiringLicenseNotification($licenseModels, $threshold));
             }
 
 

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -198,7 +198,7 @@ class Helper
             'asset' => 'Asset',
             'consumable' => 'Consumable',
             'component' => 'Component',
-            'license' => 'LicenseModel'
+            'license' => 'License'
         );
         return $category_types;
     }

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -198,7 +198,7 @@ class Helper
             'asset' => 'Asset',
             'consumable' => 'Consumable',
             'component' => 'Component',
-            'license' => 'License'
+            'license' => 'LicenseModel'
         );
         return $category_types;
     }

--- a/app/Http/Controllers/Api/CategoriesController.php
+++ b/app/Http/Controllers/Api/CategoriesController.php
@@ -24,7 +24,7 @@ class CategoriesController extends Controller
         $allowed_columns = ['id', 'name','category_type', 'category_type','use_default_eula','eula_text', 'require_acceptance','checkin_email', 'assets_count', 'accessories_count', 'consumables_count', 'components_count','licenses_count', 'image'];
 
         $categories = Category::select(['id', 'created_at', 'updated_at', 'name','category_type','use_default_eula','eula_text', 'require_acceptance','checkin_email','image'])
-            ->withCount('assets as assets_count', 'accessories as accessories_count', 'consumables as consumables_count', 'components as components_count','licenses as licenses_count');
+            ->withCount('assets as assets_count', 'accessories as accessories_count', 'consumables as consumables_count', 'components as components_count','licenseModels as licenses_count');
 
         if ($request->filled('search')) {
             $categories = $categories->TextSearch($request->input('search'));

--- a/app/Http/Controllers/Api/LicensesController.php
+++ b/app/Http/Controllers/Api/LicensesController.php
@@ -7,7 +7,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Transformers\LicenseSeatsTransformer;
 use App\Http\Transformers\LicensesTransformer;
 use App\Models\Company;
-use App\Models\License;
+use App\Models\LicenseModel;
 use App\Models\LicenseSeat;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -24,61 +24,61 @@ class LicensesController extends Controller
      */
     public function index(Request $request)
     {
-        $this->authorize('view', License::class);
-        $licenses = Company::scopeCompanyables(License::with('company', 'manufacturer', 'freeSeats', 'supplier','category')->withCount('freeSeats as free_seats_count'));
+        $this->authorize('view', LicenseModel::class);
+        $licenseModels = Company::scopeCompanyables(LicenseModel::with('company', 'manufacturer', 'freeSeats', 'supplier','category')->withCount('freeSeats as free_seats_count'));
 
 
         if ($request->filled('company_id')) {
-            $licenses->where('company_id','=',$request->input('company_id'));
+            $licenseModels->where('company_id','=',$request->input('company_id'));
         }
 
         if ($request->filled('name')) {
-            $licenses->where('licenses.name','=',$request->input('name'));
+            $licenseModels->where('licenses.name','=',$request->input('name'));
         }
 
         if ($request->filled('product_key')) {
-            $licenses->where('licenses.serial','=',$request->input('product_key'));
+            $licenseModels->where('licenses.serial','=',$request->input('product_key'));
         }
 
         if ($request->filled('order_number')) {
-            $licenses->where('order_number','=',$request->input('order_number'));
+            $licenseModels->where('order_number','=',$request->input('order_number'));
         }
 
         if ($request->filled('purchase_order')) {
-            $licenses->where('purchase_order','=',$request->input('purchase_order'));
+            $licenseModels->where('purchase_order','=',$request->input('purchase_order'));
         }
 
         if ($request->filled('license_name')) {
-            $licenses->where('license_name','=',$request->input('license_name'));
+            $licenseModels->where('license_name','=',$request->input('license_name'));
         }
 
         if ($request->filled('license_email')) {
-            $licenses->where('license_email','=',$request->input('license_email'));
+            $licenseModels->where('license_email','=',$request->input('license_email'));
         }
 
         if ($request->filled('manufacturer_id')) {
-            $licenses->where('manufacturer_id','=',$request->input('manufacturer_id'));
+            $licenseModels->where('manufacturer_id','=',$request->input('manufacturer_id'));
         }
 
         if ($request->filled('supplier_id')) {
-            $licenses->where('supplier_id','=',$request->input('supplier_id'));
+            $licenseModels->where('supplier_id','=',$request->input('supplier_id'));
         }
 
         if ($request->filled('category_id')) {
-            $licenses->where('category_id','=',$request->input('category_id'));
+            $licenseModels->where('category_id','=',$request->input('category_id'));
         }
 
         if ($request->filled('depreciation_id')) {
-            $licenses->where('depreciation_id','=',$request->input('depreciation_id'));
+            $licenseModels->where('depreciation_id','=',$request->input('depreciation_id'));
         }
 
         if ($request->filled('supplier_id')) {
-            $licenses->where('supplier_id','=',$request->input('supplier_id'));
+            $licenseModels->where('supplier_id','=',$request->input('supplier_id'));
         }
 
 
         if ($request->filled('search')) {
-            $licenses = $licenses->TextSearch($request->input('search'));
+            $licenseModels = $licenseModels->TextSearch($request->input('search'));
         }
 
 
@@ -89,30 +89,30 @@ class LicensesController extends Controller
 
         switch ($request->input('sort')) {
                 case 'manufacturer':
-                    $licenses = $licenses->leftJoin('manufacturers', 'licenses.manufacturer_id', '=', 'manufacturers.id')->orderBy('manufacturers.name', $order);
+                    $licenseModels = $licenseModels->leftJoin('manufacturers', 'licenses.manufacturer_id', '=', 'manufacturers.id')->orderBy('manufacturers.name', $order);
                 break;
             case 'supplier':
-                $licenses = $licenses->leftJoin('suppliers', 'licenses.supplier_id', '=', 'suppliers.id')->orderBy('suppliers.name', $order);
+                $licenseModels = $licenseModels->leftJoin('suppliers', 'licenses.supplier_id', '=', 'suppliers.id')->orderBy('suppliers.name', $order);
                 break;
             case 'category':
-                $licenses = $licenses->leftJoin('categories', 'licenses.category_id', '=', 'categories.id')->orderBy('categories.name', $order);
+                $licenseModels = $licenseModels->leftJoin('categories', 'licenses.category_id', '=', 'categories.id')->orderBy('categories.name', $order);
                 break;
             case 'company':
-                $licenses = $licenses->leftJoin('companies', 'licenses.company_id', '=', 'companies.id')->orderBy('companies.name', $order);
+                $licenseModels = $licenseModels->leftJoin('companies', 'licenses.company_id', '=', 'companies.id')->orderBy('companies.name', $order);
                 break;
             default:
                 $allowed_columns = ['id','name','purchase_cost','expiration_date','purchase_order','order_number','notes','purchase_date','serial','company','category','license_name','license_email','free_seats_count','seats'];
                 $sort = in_array($request->input('sort'), $allowed_columns) ? e($request->input('sort')) : 'created_at';
-                $licenses = $licenses->orderBy($sort, $order);
+                $licenseModels = $licenseModels->orderBy($sort, $order);
                 break;
         }
 
 
 
-        $total = $licenses->count();
+        $total = $licenseModels->count();
 
-        $licenses = $licenses->skip($offset)->take($limit)->get();
-        return (new LicensesTransformer)->transformLicenses($licenses, $total);
+        $licenseModels = $licenseModels->skip($offset)->take($limit)->get();
+        return (new LicensesTransformer)->transformLicenses($licenseModels, $total);
 
     }
 
@@ -130,14 +130,14 @@ class LicensesController extends Controller
     public function store(Request $request)
     {
         //
-        $this->authorize('create', License::class);
-        $license = new License;
-        $license->fill($request->all());
+        $this->authorize('create', LicenseModel::class);
+        $licenseModel = new LicenseModel;
+        $licenseModel->fill($request->all());
 
-        if($license->save()) {
-            return response()->json(Helper::formatStandardApiResponse('success', $license, trans('admin/licenses/message.create.success')));
+        if($licenseModel->save()) {
+            return response()->json(Helper::formatStandardApiResponse('success', $licenseModel, trans('admin/licenses/message.create.success')));
         }
-        return response()->json(Helper::formatStandardApiResponse('error', null, $license->getErrors()));
+        return response()->json(Helper::formatStandardApiResponse('error', null, $licenseModel->getErrors()));
     }
 
     /**
@@ -149,10 +149,10 @@ class LicensesController extends Controller
      */
     public function show($id)
     {
-        $this->authorize('view', License::class);
-        $license = License::findOrFail($id);
-        $license = $license->load('assignedusers', 'licenseSeats.user', 'licenseSeats.asset');
-        return (new LicensesTransformer)->transformLicense($license);
+        $this->authorize('view', LicenseModel::class);
+        $licenseModel = LicenseModel::findOrFail($id);
+        $licenseModel = $licenseModel->load('assignedusers', 'licenseSeats.user', 'licenseSeats.asset');
+        return (new LicensesTransformer)->transformLicense($licenseModel);
     }
 
 
@@ -168,16 +168,16 @@ class LicensesController extends Controller
     public function update(Request $request, $id)
     {
         //
-        $this->authorize('update', License::class);
+        $this->authorize('update', LicenseModel::class);
 
-        $license = License::findOrFail($id);
-        $license->fill($request->all());
+        $licenseModel = LicenseModel::findOrFail($id);
+        $licenseModel->fill($request->all());
 
-        if ($license->save()) {
-            return response()->json(Helper::formatStandardApiResponse('success', $license, trans('admin/licenses/message.update.success')));
+        if ($licenseModel->save()) {
+            return response()->json(Helper::formatStandardApiResponse('success', $licenseModel, trans('admin/licenses/message.update.success')));
         }
 
-        return Helper::formatStandardApiResponse('error', null, $license->getErrors());
+        return Helper::formatStandardApiResponse('error', null, $licenseModel->getErrors());
     }
 
     /**
@@ -191,18 +191,18 @@ class LicensesController extends Controller
     public function destroy($id)
     {
         //
-        $license = License::findOrFail($id);
-        $this->authorize('delete', $license);
+        $licenseModel = LicenseModel::findOrFail($id);
+        $this->authorize('delete', $licenseModel);
 
-        if($license->assigned_seats_count == 0) {
-            // Delete the license and the associated license seats
+        if($licenseModel->assigned_seats_count == 0) {
+            // Delete the licenseModel and the associated licenseModel seats
             DB::table('license_seats')
-                ->where('id', $license->id)
+                ->where('id', $licenseModel->id)
                 ->update(array('assigned_to' => null,'asset_id' => null));
 
-            $licenseSeats = $license->licenseseats();
+            $licenseSeats = $licenseModel->licenseseats();
             $licenseSeats->delete();
-            $license->delete();
+            $licenseModel->delete();
 
             // Redirect to the licenses management page
             return response()->json(Helper::formatStandardApiResponse('success', null,  trans('admin/licenses/message.delete.success')));
@@ -221,9 +221,9 @@ class LicensesController extends Controller
     public function seats(Request $request, $licenseId)
     {
 
-        if ($license = License::find($licenseId)) {
+        if ($licenseModel = LicenseModel::find($licenseId)) {
 
-            $this->authorize('view', $license);
+            $this->authorize('view', $licenseModel);
 
             $seats = LicenseSeat::where('license_id', $licenseId)->with('license', 'user', 'asset');
 

--- a/app/Http/Controllers/Api/LicensesController.php
+++ b/app/Http/Controllers/Api/LicensesController.php
@@ -225,7 +225,7 @@ class LicensesController extends Controller
 
             $this->authorize('view', $licenseModel);
 
-            $seats = License::where('license_id', $licenseId)->with('license', 'user', 'asset');
+            $seats = License::where('license_id', $licenseId)->with('model', 'user', 'asset');
 
             $offset = request('offset', 0);
             $limit = request('limit', 50);

--- a/app/Http/Controllers/Api/LicensesController.php
+++ b/app/Http/Controllers/Api/LicensesController.php
@@ -25,7 +25,7 @@ class LicensesController extends Controller
     public function index(Request $request)
     {
         $this->authorize('view', LicenseModel::class);
-        $licenseModels = Company::scopeCompanyables(LicenseModel::with('company', 'manufacturer', 'freeSeats', 'supplier','category')->withCount('freeSeats as free_seats_count'));
+        $licenseModels = Company::scopeCompanyables(LicenseModel::with('company', 'manufacturer', 'freeLicenses', 'supplier','category')->withCount('freeLicenses as free_license_count'));
 
 
         if ($request->filled('company_id')) {
@@ -194,13 +194,13 @@ class LicensesController extends Controller
         $licenseModel = LicenseModel::findOrFail($id);
         $this->authorize('delete', $licenseModel);
 
-        if($licenseModel->assigned_seats_count == 0) {
+        if($licenseModel->assigned_license_count == 0) {
             // Delete the licenseModel and the associated licenseModel seats
             DB::table('license_seats')
                 ->where('id', $licenseModel->id)
                 ->update(array('assigned_to' => null,'asset_id' => null));
 
-            $license = $licenseModel->licenseseats();
+            $license = $licenseModel->licenses();
             $license->delete();
             $licenseModel->delete();
 

--- a/app/Http/Controllers/Api/LicensesController.php
+++ b/app/Http/Controllers/Api/LicensesController.php
@@ -8,7 +8,7 @@ use App\Http\Transformers\LicenseSeatsTransformer;
 use App\Http\Transformers\LicensesTransformer;
 use App\Models\Company;
 use App\Models\LicenseModel;
-use App\Models\LicenseSeat;
+use App\Models\License;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
@@ -200,8 +200,8 @@ class LicensesController extends Controller
                 ->where('id', $licenseModel->id)
                 ->update(array('assigned_to' => null,'asset_id' => null));
 
-            $licenseSeats = $licenseModel->licenseseats();
-            $licenseSeats->delete();
+            $license = $licenseModel->licenseseats();
+            $license->delete();
             $licenseModel->delete();
 
             // Redirect to the licenses management page
@@ -225,7 +225,7 @@ class LicensesController extends Controller
 
             $this->authorize('view', $licenseModel);
 
-            $seats = LicenseSeat::where('license_id', $licenseId)->with('license', 'user', 'asset');
+            $seats = License::where('license_id', $licenseId)->with('license', 'user', 'asset');
 
             $offset = request('offset', 0);
             $limit = request('limit', 50);

--- a/app/Http/Controllers/Api/LicensesController.php
+++ b/app/Http/Controllers/Api/LicensesController.php
@@ -151,7 +151,7 @@ class LicensesController extends Controller
     {
         $this->authorize('view', LicenseModel::class);
         $licenseModel = LicenseModel::findOrFail($id);
-        $licenseModel = $licenseModel->load('assignedusers', 'licenseSeats.user', 'licenseSeats.asset');
+        $licenseModel = $licenseModel->load('assignedusers', 'licenses.user', 'licenses.asset');
         return (new LicensesTransformer)->transformLicense($licenseModel);
     }
 

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -55,8 +55,8 @@ class UsersController extends Controller
             'users.username',
             'users.zip',
 
-        ])->with('manager', 'groups', 'userloc', 'company', 'department','assets','licenses','accessories','consumables')
-            ->withCount('assets as assets_count','licenses as licneses_count','accessories as accessories_count','consumables as consumables_count');
+        ])->with('manager', 'groups', 'userloc', 'company', 'department','assets','licenseModels','accessories','consumables')
+            ->withCount('assets as assets_count','licenseModels as licenses_count','accessories as accessories_count','consumables as consumables_count');
         $users = Company::scopeCompanyables($users);
 
 

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -34,7 +34,7 @@ class DashboardController extends Controller
 
             $counts['asset'] = \App\Models\Asset::count();
             $counts['accessory'] = \App\Models\Accessory::count();
-            $counts['license'] = \App\Models\License::assetcount();
+            $counts['license'] = \App\Models\LicenseModel::assetcount();
             $counts['consumable'] = \App\Models\Consumable::count();
             $counts['grand_total'] =  $counts['asset'] +  $counts['accessory'] +  $counts['license'] +  $counts['consumable'];
 

--- a/app/Http/Controllers/Licenses/LicenseCheckinController.php
+++ b/app/Http/Controllers/Licenses/LicenseCheckinController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers\Licenses;
 
 use App\Models\Asset;
-use App\Models\License;
+use App\Models\LicenseModel;
 use App\Models\LicenseSeat;
 use App\Models\User;
 use Illuminate\Http\Request;
@@ -28,12 +28,12 @@ class LicenseCheckinController extends Controller
     public function create($seatId = null, $backTo = null)
     {
         // Check if the asset exists
-        if (is_null($licenseSeat = LicenseSeat::find($seatId)) || is_null($license = License::find($licenseSeat->license_id))) {
+        if (is_null($licenseSeat = LicenseSeat::find($seatId)) || is_null($licenseModel = LicenseModel::find($licenseSeat->license_id))) {
             // Redirect to the asset management page with error
             return redirect()->route('licenses.index')->with('error', trans('admin/licenses/message.not_found'));
         }
 
-        $this->authorize('checkout', $license);
+        $this->authorize('checkout', $licenseModel);
         return view('licenses/checkin', compact('licenseSeat'))->with('backto', $backTo);
     }
 
@@ -57,12 +57,12 @@ class LicenseCheckinController extends Controller
             return redirect()->route('licenses.index')->with('error', trans('admin/licenses/message.not_found'));
         }
 
-        $license = License::find($licenseSeat->license_id);
-        $this->authorize('checkout', $license);
+        $licenseModel = LicenseModel::find($licenseSeat->license_id);
+        $this->authorize('checkout', $licenseModel);
 
-        if (!$license->reassignable) {
+        if (!$licenseModel->reassignable) {
             // Not allowed to checkin
-            Session::flash('error', 'License not reassignable.');
+            Session::flash('error', 'LicenseModel not reassignable.');
             return redirect()->back()->withInput();
         }
 
@@ -95,7 +95,7 @@ class LicenseCheckinController extends Controller
             return redirect()->route("licenses.show", $licenseSeat->license_id)->with('success', trans('admin/licenses/message.checkin.success'));
         }
 
-        // Redirect to the license page with error
+        // Redirect to the licenseModel page with error
         return redirect()->route("licenses.index")->with('error', trans('admin/licenses/message.checkin.error'));
     }
 

--- a/app/Http/Controllers/Licenses/LicenseCheckoutController.php
+++ b/app/Http/Controllers/Licenses/LicenseCheckoutController.php
@@ -33,7 +33,7 @@ class LicenseCheckoutController extends Controller
         if ($licenseModel = LicenseModel::find($licenseId)) {
 
             // If the licenseModel is valid, check that there is an available seat
-            if ($licenseModel->avail_seats_count < 1) {
+            if ($licenseModel->avail_license_count < 1) {
                 return redirect()->route('licenses.index')->with('error', 'There are no available seats for this licenseModel');
             }
         }
@@ -75,7 +75,7 @@ class LicenseCheckoutController extends Controller
 
     protected function findLicenseToCheckout(LicenseModel $licenseModel, $seatId)
     {
-        $license = License::find($seatId) ?? $licenseModel->freeSeat();
+        $license = License::find($seatId) ?? $licenseModel->freeLicense();
 
         if (!$license) {
             if ($seatId) {

--- a/app/Http/Controllers/Licenses/LicenseCheckoutController.php
+++ b/app/Http/Controllers/Licenses/LicenseCheckoutController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers\Licenses;
 
 use App\Http\Requests\LicenseCheckoutRequest;
 use App\Models\Asset;
-use App\Models\License;
+use App\Models\LicenseModel;
 use App\Models\LicenseSeat;
 use App\Models\User;
 use Illuminate\Http\Request;
@@ -29,17 +29,17 @@ class LicenseCheckoutController extends Controller
      */
     public function create($licenseId)
     {
-        // Check that the license is valid
-        if ($license = License::find($licenseId)) {
+        // Check that the licenseModel is valid
+        if ($licenseModel = LicenseModel::find($licenseId)) {
 
-            // If the license is valid, check that there is an available seat
-            if ($license->avail_seats_count < 1) {
-                return redirect()->route('licenses.index')->with('error', 'There are no available seats for this license');
+            // If the licenseModel is valid, check that there is an available seat
+            if ($licenseModel->avail_seats_count < 1) {
+                return redirect()->route('licenses.index')->with('error', 'There are no available seats for this licenseModel');
             }
         }
 
-        $this->authorize('checkout', $license);
-        return view('licenses/checkout', compact('license'));
+        $this->authorize('checkout', $licenseModel);
+        return view('licenses/checkout', compact('licenseModel'));
     }
 
 
@@ -56,13 +56,13 @@ class LicenseCheckoutController extends Controller
 
     public function store(LicenseCheckoutRequest $request, $licenseId, $seatId = null)
     {
-        if (!$license = License::find($licenseId)) {
+        if (!$licenseModel = LicenseModel::find($licenseId)) {
             return redirect()->route('licenses.index')->with('error', trans('admin/licenses/message.not_found'));
         }
 
-        $this->authorize('checkout', $license);
+        $this->authorize('checkout', $licenseModel);
 
-        $licenseSeat = $this->findLicenseSeatToCheckout($license, $seatId);
+        $licenseSeat = $this->findLicenseSeatToCheckout($licenseModel, $seatId);
         $licenseSeat->user_id = Auth::id();
 
         $checkoutMethod = 'checkoutTo'.ucwords(request('checkout_to_type'));

--- a/app/Http/Controllers/Licenses/LicenseFilesController.php
+++ b/app/Http/Controllers/Licenses/LicenseFilesController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers\Licenses;
 
 use App\Http\Requests\AssetFileRequest;
 use App\Models\Actionlog;
-use App\Models\License;
+use App\Models\LicenseModel;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Input;
 use Illuminate\Support\Facades\Response;
@@ -27,34 +27,34 @@ class LicenseFilesController extends Controller
      */
     public function store(AssetFileRequest $request, $licenseId = null)
     {
-        $license = License::find($licenseId);
-        // the license is valid
+        $licenseModel = LicenseModel::find($licenseId);
+        // the licenseModel is valid
         $destinationPath = config('app.private_uploads').'/licenses';
 
-        if (isset($license->id)) {
-            $this->authorize('update', $license);
+        if (isset($licenseModel->id)) {
+            $this->authorize('update', $licenseModel);
 
             if (Input::hasFile('file')) {
                 $upload_success = false;
                 foreach (Input::file('file') as $file) {
                     $extension = $file->getClientOriginalExtension();
-                    $filename = 'license-'.$license->id.'-'.str_random(8).'-'.str_slug(basename($file->getClientOriginalName(), '.'.$extension)).'.'.$extension;
+                    $filename = 'license-'.$licenseModel->id.'-'.str_random(8).'-'.str_slug(basename($file->getClientOriginalName(), '.'.$extension)).'.'.$extension;
 
                     $upload_success = $file->storeAs('storage/private_uploads/licenses', $filename);
 
                     //Log the upload to the log
-                    $license->logUpload($filename, e($request->input('notes')));
+                    $licenseModel->logUpload($filename, e($request->input('notes')));
                 }
                 // This being called from a modal seems to confuse redirect()->back()
                 // It thinks we should go to the dashboard.  As this is only used
                 // from the modal at present, hardcode the redirect.  Longterm
                 // maybe we evaluate something else.
                 if ($upload_success) {
-                    return redirect()->route('licenses.show', $license->id)->with('success', trans('admin/licenses/message.upload.success'));
+                    return redirect()->route('licenses.show', $licenseModel->id)->with('success', trans('admin/licenses/message.upload.success'));
                 }
-                return redirect()->route('licenses.show', $license->id)->with('error', trans('admin/licenses/message.upload.error'));
+                return redirect()->route('licenses.show', $licenseModel->id)->with('error', trans('admin/licenses/message.upload.error'));
             }
-            return redirect()->route('licenses.show', $license->id)->with('error', trans('admin/licenses/message.upload.nofiles'));
+            return redirect()->route('licenses.show', $licenseModel->id)->with('error', trans('admin/licenses/message.upload.nofiles'));
         }
         // Prepare the error message
         return redirect()->route('licenses.index')
@@ -74,13 +74,13 @@ class LicenseFilesController extends Controller
      */
     public function destroy($licenseId = null, $fileId = null)
     {
-        $license = License::find($licenseId);
+        $licenseModel = LicenseModel::find($licenseId);
 
         $rel_path = 'storage/private_uploads/licenses';
 
         // the asset is valid
-        if (isset($license->id)) {
-            $this->authorize('update', $license);
+        if (isset($licenseModel->id)) {
+            $this->authorize('update', $licenseModel);
             $log = Actionlog::find($fileId);
             if (file_exists(base_path().'/'.$rel_path.'/'.$log->filename)) {
                 Storage::delete($rel_path.'/'.$log->filename);
@@ -109,11 +109,11 @@ class LicenseFilesController extends Controller
     public function show($licenseId = null, $fileId = null, $download = true)
     {
 
-        $license = License::find($licenseId);
+        $licenseModel = LicenseModel::find($licenseId);
 
-        // the license is valid
-        if (isset($license->id)) {
-            $this->authorize('view', $license);
+        // the licenseModel is valid
+        if (isset($licenseModel->id)) {
+            $this->authorize('view', $licenseModel);
             $log = Actionlog::find($fileId);
             $file = $log->get_src('licenses');
 

--- a/app/Http/Controllers/Licenses/LicensesController.php
+++ b/app/Http/Controllers/Licenses/LicensesController.php
@@ -209,8 +209,8 @@ class LicensesController extends Controller
                 ->where('id', $licenseModel->id)
                 ->update(array('assigned_to' => null,'asset_id' => null));
 
-            $licenseSeats = $licenseModel->licenseseats();
-            $licenseSeats->delete();
+            $licenses = $licenseModel->licenseseats();
+            $licenses->delete();
             $licenseModel->delete();
 
             // Redirect to the licenses management page

--- a/app/Http/Controllers/Licenses/LicensesController.php
+++ b/app/Http/Controllers/Licenses/LicensesController.php
@@ -2,7 +2,7 @@
 namespace App\Http\Controllers\Licenses;
 
 use App\Http\Controllers\Controller;
-use App\Models\License;
+use App\Models\LicenseModel;
 use Illuminate\Support\Facades\DB;
 use App\Models\Company;
 use App\Helpers\Helper;
@@ -30,7 +30,7 @@ class LicensesController extends Controller
      */
     public function index()
     {
-        $this->authorize('view', License::class);
+        $this->authorize('view', LicenseModel::class);
         return view('licenses/index');
     }
 
@@ -46,7 +46,7 @@ class LicensesController extends Controller
      */
     public function create()
     {
-        $this->authorize('create', License::class);
+        $this->authorize('create', LicenseModel::class);
         $maintained_list = [
             '' => 'Maintained',
             '1' => 'Yes',
@@ -56,7 +56,7 @@ class LicensesController extends Controller
         return view('licenses/edit')
             ->with('depreciation_list', Helper::depreciationList())
             ->with('maintained_list', $maintained_list)
-            ->with('item', new License);
+            ->with('item', new LicenseModel);
 
     }
 
@@ -74,36 +74,36 @@ class LicensesController extends Controller
      */
     public function store(Request $request)
     {
-        $this->authorize('create', License::class);
+        $this->authorize('create', LicenseModel::class);
         // create a new model instance
-        $license = new License();
-        // Save the license data
-        $license->company_id        = Company::getIdForCurrentUser($request->input('company_id'));
-        $license->depreciation_id   = $request->input('depreciation_id');
-        $license->expiration_date   = $request->input('expiration_date');
-        $license->license_email     = $request->input('license_email');
-        $license->license_name      = $request->input('license_name');
-        $license->maintained        = $request->input('maintained', 0);
-        $license->manufacturer_id   = $request->input('manufacturer_id');
-        $license->name              = $request->input('name');
-        $license->notes             = $request->input('notes');
-        $license->order_number      = $request->input('order_number');
-        $license->purchase_cost     = $request->input('purchase_cost');
-        $license->purchase_date     = $request->input('purchase_date');
-        $license->purchase_order    = $request->input('purchase_order');
-        $license->purchase_order    = $request->input('purchase_order');
-        $license->reassignable      = $request->input('reassignable', 0);
-        $license->seats             = $request->input('seats');
-        $license->serial            = $request->input('serial');
-        $license->supplier_id       = $request->input('supplier_id');
-        $license->category_id       = $request->input('category_id');
-        $license->termination_date  = $request->input('termination_date');
-        $license->user_id           = Auth::id();
+        $licenseModel = new LicenseModel();
+        // Save the licenseModel data
+        $licenseModel->company_id        = Company::getIdForCurrentUser($request->input('company_id'));
+        $licenseModel->depreciation_id   = $request->input('depreciation_id');
+        $licenseModel->expiration_date   = $request->input('expiration_date');
+        $licenseModel->license_email     = $request->input('license_email');
+        $licenseModel->license_name      = $request->input('license_name');
+        $licenseModel->maintained        = $request->input('maintained', 0);
+        $licenseModel->manufacturer_id   = $request->input('manufacturer_id');
+        $licenseModel->name              = $request->input('name');
+        $licenseModel->notes             = $request->input('notes');
+        $licenseModel->order_number      = $request->input('order_number');
+        $licenseModel->purchase_cost     = $request->input('purchase_cost');
+        $licenseModel->purchase_date     = $request->input('purchase_date');
+        $licenseModel->purchase_order    = $request->input('purchase_order');
+        $licenseModel->purchase_order    = $request->input('purchase_order');
+        $licenseModel->reassignable      = $request->input('reassignable', 0);
+        $licenseModel->seats             = $request->input('seats');
+        $licenseModel->serial            = $request->input('serial');
+        $licenseModel->supplier_id       = $request->input('supplier_id');
+        $licenseModel->category_id       = $request->input('category_id');
+        $licenseModel->termination_date  = $request->input('termination_date');
+        $licenseModel->user_id           = Auth::id();
 
-        if ($license->save()) {
+        if ($licenseModel->save()) {
             return redirect()->route("licenses.index")->with('success', trans('admin/licenses/message.create.success'));
         }
-        return redirect()->back()->withInput()->withErrors($license->getErrors());
+        return redirect()->back()->withInput()->withErrors($licenseModel->getErrors());
     }
 
     /**
@@ -118,7 +118,7 @@ class LicensesController extends Controller
      */
     public function edit($licenseId = null)
     {
-        if (is_null($item = License::find($licenseId))) {
+        if (is_null($item = LicenseModel::find($licenseId))) {
             return redirect()->route('licenses.index')->with('error', trans('admin/licenses/message.does_not_exist'));
         }
 
@@ -150,37 +150,37 @@ class LicensesController extends Controller
      */
     public function update(Request $request, $licenseId = null)
     {
-        if (is_null($license = License::find($licenseId))) {
+        if (is_null($licenseModel = LicenseModel::find($licenseId))) {
             return redirect()->route('licenses.index')->with('error', trans('admin/licenses/message.does_not_exist'));
         }
 
-        $this->authorize('update', $license);
+        $this->authorize('update', $licenseModel);
 
-        $license->company_id        = Company::getIdForCurrentUser($request->input('company_id'));
-        $license->depreciation_id   = $request->input('depreciation_id');
-        $license->expiration_date   = $request->input('expiration_date');
-        $license->license_email     = $request->input('license_email');
-        $license->license_name      = $request->input('license_name');
-        $license->maintained        = $request->input('maintained',0);
-        $license->name              = $request->input('name');
-        $license->notes             = $request->input('notes');
-        $license->order_number      = $request->input('order_number');
-        $license->purchase_cost     = $request->input('purchase_cost');
-        $license->purchase_date     = $request->input('purchase_date');
-        $license->purchase_order    = $request->input('purchase_order');
-        $license->reassignable      = $request->input('reassignable', 0);
-        $license->serial            = $request->input('serial');
-        $license->termination_date  = $request->input('termination_date');
-        $license->seats             = e($request->input('seats'));
-        $license->manufacturer_id   =  $request->input('manufacturer_id');
-        $license->supplier_id       = $request->input('supplier_id');
-        $license->category_id       = $request->input('category_id');
+        $licenseModel->company_id        = Company::getIdForCurrentUser($request->input('company_id'));
+        $licenseModel->depreciation_id   = $request->input('depreciation_id');
+        $licenseModel->expiration_date   = $request->input('expiration_date');
+        $licenseModel->license_email     = $request->input('license_email');
+        $licenseModel->license_name      = $request->input('license_name');
+        $licenseModel->maintained        = $request->input('maintained',0);
+        $licenseModel->name              = $request->input('name');
+        $licenseModel->notes             = $request->input('notes');
+        $licenseModel->order_number      = $request->input('order_number');
+        $licenseModel->purchase_cost     = $request->input('purchase_cost');
+        $licenseModel->purchase_date     = $request->input('purchase_date');
+        $licenseModel->purchase_order    = $request->input('purchase_order');
+        $licenseModel->reassignable      = $request->input('reassignable', 0);
+        $licenseModel->serial            = $request->input('serial');
+        $licenseModel->termination_date  = $request->input('termination_date');
+        $licenseModel->seats             = e($request->input('seats'));
+        $licenseModel->manufacturer_id   =  $request->input('manufacturer_id');
+        $licenseModel->supplier_id       = $request->input('supplier_id');
+        $licenseModel->category_id       = $request->input('category_id');
 
-        if ($license->save()) {
+        if ($licenseModel->save()) {
             return redirect()->route('licenses.show', ['license' => $licenseId])->with('success', trans('admin/licenses/message.update.success'));
         }
-        // If we can't adjust the number of seats, the error is flashed to the session by the event handler in License.php
-        return redirect()->back()->withInput()->withErrors($license->getErrors());
+        // If we can't adjust the number of seats, the error is flashed to the session by the event handler in LicenseModelModel.php
+        return redirect()->back()->withInput()->withErrors($licenseModel->getErrors());
     }
 
     /**
@@ -195,27 +195,27 @@ class LicensesController extends Controller
      */
     public function destroy($licenseId)
     {
-        // Check if the license exists
-        if (is_null($license = License::find($licenseId))) {
-            // Redirect to the license management page
+        // Check if the licenseModel exists
+        if (is_null($licenseModel = LicenseModel::find($licenseId))) {
+            // Redirect to the licenseModel management page
             return redirect()->route('licenses.index')->with('error', trans('admin/licenses/message.not_found'));
         }
 
-        $this->authorize('delete', $license);
+        $this->authorize('delete', $licenseModel);
 
-        if ($license->assigned_seats_count == 0) {
-            // Delete the license and the associated license seats
+        if ($licenseModel->assigned_seats_count == 0) {
+            // Delete the licenseModel and the associated licenseModel seats
             DB::table('license_seats')
-                ->where('id', $license->id)
+                ->where('id', $licenseModel->id)
                 ->update(array('assigned_to' => null,'asset_id' => null));
 
-            $licenseSeats = $license->licenseseats();
+            $licenseSeats = $licenseModel->licenseseats();
             $licenseSeats->delete();
-            $license->delete();
+            $licenseModel->delete();
 
             // Redirect to the licenses management page
             return redirect()->route('licenses.index')->with('success', trans('admin/licenses/message.delete.success'));
-            // Redirect to the license management page
+            // Redirect to the licenseModel management page
         }
         // There are still licenses in use.
         return redirect()->route('licenses.index')->with('error', trans('admin/licenses/message.assoc_users'));
@@ -235,11 +235,11 @@ class LicensesController extends Controller
     public function show($licenseId = null)
     {
 
-        $license = License::with('assignedusers', 'licenseSeats.user', 'licenseSeats.asset')->find($licenseId);
+        $licenseModel = LicenseModel::with('assignedusers', 'licenseSeats.user', 'licenseSeats.asset')->find($licenseId);
 
-        if ($license) {
-            $this->authorize('view', $license);
-            return view('licenses/view', compact('license'));
+        if ($licenseModel) {
+            $this->authorize('view', $licenseModel);
+            return view('licenses/view', compact('licenseModel'));
         }
         return redirect()->route('licenses.index')
             ->with('error', trans('admin/licenses/message.does_not_exist'));
@@ -248,11 +248,11 @@ class LicensesController extends Controller
 
     public function getClone($licenseId = null)
     {
-        if (is_null($license_to_clone = License::find($licenseId))) {
+        if (is_null($license_to_clone = LicenseModel::find($licenseId))) {
             return redirect()->route('licenses.index')->with('error', trans('admin/licenses/message.does_not_exist'));
         }
 
-        $this->authorize('create', License::class);
+        $this->authorize('create', LicenseModel::class);
 
         $maintained_list = [
             '' => 'Maintained',
@@ -260,14 +260,14 @@ class LicensesController extends Controller
             '0' => 'No'
         ];
         //clone the orig
-        $license = clone $license_to_clone;
-        $license->id = null;
-        $license->serial = null;
+        $licenseModel = clone $license_to_clone;
+        $licenseModel->id = null;
+        $licenseModel->serial = null;
 
         // Show the page
         return view('licenses/edit')
         ->with('depreciation_list', Helper::depreciationList())
-        ->with('item', $license)
+        ->with('item', $licenseModel)
         ->with('maintained_list', $maintained_list);
     }
 }

--- a/app/Http/Controllers/Licenses/LicensesController.php
+++ b/app/Http/Controllers/Licenses/LicensesController.php
@@ -203,13 +203,13 @@ class LicensesController extends Controller
 
         $this->authorize('delete', $licenseModel);
 
-        if ($licenseModel->assigned_seats_count == 0) {
+        if ($licenseModel->assigned_license_count == 0) {
             // Delete the licenseModel and the associated licenseModel seats
             DB::table('license_seats')
                 ->where('id', $licenseModel->id)
                 ->update(array('assigned_to' => null,'asset_id' => null));
 
-            $licenses = $licenseModel->licenseseats();
+            $licenses = $licenseModel->licenses();
             $licenses->delete();
             $licenseModel->delete();
 

--- a/app/Http/Controllers/Licenses/LicensesController.php
+++ b/app/Http/Controllers/Licenses/LicensesController.php
@@ -235,7 +235,7 @@ class LicensesController extends Controller
     public function show($licenseId = null)
     {
 
-        $licenseModel = LicenseModel::with('assignedusers', 'licenseSeats.user', 'licenseSeats.asset')->find($licenseId);
+        $licenseModel = LicenseModel::with('assignedusers', 'licenses.user', 'licenses.asset')->find($licenseId);
 
         if ($licenseModel) {
             $this->authorize('view', $licenseModel);

--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -8,7 +8,7 @@ use App\Models\Asset;
 use App\Models\AssetMaintenance;
 use App\Models\CustomField;
 use App\Models\Depreciation;
-use App\Models\License;
+use App\Models\LicenseModel;
 use App\Models\Setting;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Response;
@@ -226,11 +226,11 @@ class ReportsController extends Controller
     public function getLicenseReport()
     {
         $this->authorize('reports.view');
-        $licenses = License::with('depreciation')->orderBy('created_at', 'DESC')
+        $licenseModels = LicenseModel::with('depreciation')->orderBy('created_at', 'DESC')
                            ->with('company')
                            ->get();
 
-        return view('reports/licenses', compact('licenses'));
+        return view('reports/licenses', compact('licenseModels'));
     }
 
     /**
@@ -244,7 +244,7 @@ class ReportsController extends Controller
     public function exportLicenseReport()
     {
         $this->authorize('reports.view');
-        $licenses = License::orderBy('created_at', 'DESC')->get();
+        $licenseModels = LicenseModel::orderBy('created_at', 'DESC')->get();
 
         $rows     = [ ];
         $header   = [
@@ -261,17 +261,17 @@ class ReportsController extends Controller
         $header = array_map('trim', $header);
         $rows[] = implode($header, ', ');
 
-        // Row per license
-        foreach ($licenses as $license) {
+        // Row per licenseModel
+        foreach ($licenseModels as $licenseModel) {
             $row   = [ ];
-            $row[] = e($license->name);
-            $row[] = e($license->serial);
-            $row[] = e($license->seats);
-            $row[] = $license->remaincount();
-            $row[] = $license->expiration_date;
-            $row[] = $license->purchase_date;
-            $row[] = ($license->depreciation!='') ? '' : e($license->depreciation->name);
-            $row[] = '"' . Helper::formatCurrencyOutput($license->purchase_cost) . '"';
+            $row[] = e($licenseModel->name);
+            $row[] = e($licenseModel->serial);
+            $row[] = e($licenseModel->seats);
+            $row[] = $licenseModel->remaincount();
+            $row[] = $licenseModel->expiration_date;
+            $row[] = $licenseModel->purchase_date;
+            $row[] = ($licenseModel->depreciation!='') ? '' : e($licenseModel->depreciation->name);
+            $row[] = '"' . Helper::formatCurrencyOutput($licenseModel->purchase_cost) . '"';
 
             $rows[] = implode($row, ',');
         }

--- a/app/Http/Controllers/Users/BulkUsersController.php
+++ b/app/Http/Controllers/Users/BulkUsersController.php
@@ -8,7 +8,7 @@ use App\Models\Accessory;
 use App\Models\Actionlog;
 use App\Models\Asset;
 use App\Models\Group;
-use App\Models\LicenseSeat;
+use App\Models\License;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -185,7 +185,7 @@ class BulkUsersController extends Controller
 
         $this->logItemCheckinAndDelete($assets, Asset::class);
         $this->logItemCheckinAndDelete($accessories, Accessory::class);
-        $this->logItemCheckinAndDelete($licenses, LicenseSeat::class);
+        $this->logItemCheckinAndDelete($licenses, License::class);
 
         Asset::whereIn('id', $assets->pluck('id'))->update([
             'status_id'     => e(request('status_id')),
@@ -194,7 +194,7 @@ class BulkUsersController extends Controller
         ]);
 
 
-        LicenseSeat::whereIn('id', $licenses->pluck('id'))->update(['assigned_to' => null]);
+        License::whereIn('id', $licenses->pluck('id'))->update(['assigned_to' => null]);
 
         foreach ($users as $user) {
             $user->accessories()->sync([]);

--- a/app/Http/Controllers/Users/UsersController.php
+++ b/app/Http/Controllers/Users/UsersController.php
@@ -13,7 +13,7 @@ use App\Models\Company;
 use App\Models\Group;
 use App\Models\Ldap;
 use App\Models\LicenseModel;
-use App\Models\LicenseSeat;
+use App\Models\License;
 use App\Models\Location;
 use App\Models\Setting;
 use App\Models\User;

--- a/app/Http/Controllers/Users/UsersController.php
+++ b/app/Http/Controllers/Users/UsersController.php
@@ -12,7 +12,7 @@ use App\Models\Asset;
 use App\Models\Company;
 use App\Models\Group;
 use App\Models\Ldap;
-use App\Models\License;
+use App\Models\LicenseModel;
 use App\Models\LicenseSeat;
 use App\Models\Location;
 use App\Models\Setting;

--- a/app/Http/Controllers/Users/UsersController.php
+++ b/app/Http/Controllers/Users/UsersController.php
@@ -351,7 +351,7 @@ class UsersController extends Controller
                     ->with('error', 'This user still has ' . $assetsCount . ' assets associated with them.');
             }
 
-            if (($licensesCount = $user->licenses()->count()) > 0) {
+            if (($licensesCount = $user->licenseModels()->count()) > 0) {
                 // Redirect to the user management page
                 return redirect()->route('users.index')
                     ->with('error', 'This user still has ' . $licensesCount . ' licenses associated with them.');
@@ -588,7 +588,7 @@ class UsersController extends Controller
                         ($user->userloc) ? $user->userloc->name : '',
                         ($user->department) ? $user->department->name : '',
                         $user->assets->count(),
-                        $user->licenses->count(),
+                        $user->licenseModels->count(),
                         $user->accessories->count(),
                         $user->consumables->count(),
                         $user_groups,
@@ -628,7 +628,7 @@ class UsersController extends Controller
         $accessories = $show_user->accessories()->get();
         $consumables = $show_user->consumables()->get();
         return view('users/print')->with('assets', $assets)
-            ->with('licenses', $show_user->licenses()->get())
+            ->with('licenses', $show_user->licenseModels()->get())
             ->with('accessories', $accessories)
             ->with('consumables', $consumables)
             ->with('show_user', $show_user);

--- a/app/Http/Requests/LicenseCheckoutRequest.php
+++ b/app/Http/Requests/LicenseCheckoutRequest.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Requests;
 
-use App\Models\LicenseSeat;
+use App\Models\License;
 use Illuminate\Foundation\Http\FormRequest;
 
 class LicenseCheckoutRequest extends FormRequest

--- a/app/Http/Transformers/LicenseSeatsTransformer.php
+++ b/app/Http/Transformers/LicenseSeatsTransformer.php
@@ -2,7 +2,7 @@
 namespace App\Http\Transformers;
 
 use App\Models\LicenseSeat;
-use App\Models\License;
+use App\Models\LicenseModel;
 use Gate;
 use Illuminate\Database\Eloquent\Collection;
 use App\Helpers\Helper;
@@ -44,11 +44,11 @@ class LicenseSeatsTransformer
         ];
 
         $permissions_array['available_actions'] = [
-            'checkout' => Gate::allows('checkout', License::class) ? true : false,
-            'checkin' => Gate::allows('checkin', License::class) ? true : false,
-            'clone' => Gate::allows('create', License::class) ? true : false,
-            'update' => Gate::allows('update', License::class) ? true : false,
-            'delete' => Gate::allows('delete', License::class) ? true : false,
+            'checkout' => Gate::allows('checkout', LicenseModel::class) ? true : false,
+            'checkin' => Gate::allows('checkin', LicenseModel::class) ? true : false,
+            'clone' => Gate::allows('create', LicenseModel::class) ? true : false,
+            'update' => Gate::allows('update', LicenseModel::class) ? true : false,
+            'delete' => Gate::allows('delete', LicenseModel::class) ? true : false,
         ];
 
         $array += $permissions_array;

--- a/app/Http/Transformers/LicenseSeatsTransformer.php
+++ b/app/Http/Transformers/LicenseSeatsTransformer.php
@@ -1,7 +1,7 @@
 <?php
 namespace App\Http\Transformers;
 
-use App\Models\LicenseSeat;
+use App\Models\License;
 use App\Models\LicenseModel;
 use Gate;
 use Illuminate\Database\Eloquent\Collection;
@@ -21,7 +21,7 @@ class LicenseSeatsTransformer
         return (new DatatablesTransformer)->transformDatatables($array, $total);
     }
 
-    public function transformLicenseSeat (LicenseSeat $seat, $seat_count)
+    public function transformLicenseSeat (License $seat, $seat_count)
     {
         $array = [
             'id' => (int) $seat->id,

--- a/app/Http/Transformers/LicensesTransformer.php
+++ b/app/Http/Transformers/LicensesTransformer.php
@@ -18,30 +18,30 @@ class LicensesTransformer
         return (new DatatablesTransformer)->transformDatatables($array, $total);
     }
 
-    public function transformLicense (LicenseModel $license)
+    public function transformLicense (LicenseModel $licenseModel)
     {
         $array = [
-            'id' => (int) $license->id,
-            'name' => e($license->name),
-            'company' => ($license->company) ? ['id' => (int) $license->company->id,'name'=> e($license->company->name)] : null,
-            'manufacturer' =>  ($license->manufacturer) ? ['id' => (int) $license->manufacturer->id,'name'=> e($license->manufacturer->name)] : null,
-            'product_key' => (Gate::allows('viewKeys', LicenseModel::class)) ? e($license->serial) : '------------',
-            'order_number' => e($license->order_number),
-            'purchase_order' => e($license->purchase_order),
-            'purchase_date' => Helper::getFormattedDateObject($license->purchase_date, 'date'),
-            'purchase_cost' => e($license->purchase_cost),
-            'notes' => e($license->notes),
-            'expiration_date' => Helper::getFormattedDateObject($license->expiration_date, 'date'),
-            'seats' => (int) $license->seats,
-            'free_seats_count' => (int) $license->free_license_count,
-            'license_name' =>  e($license->license_name),
-            'license_email' => e($license->license_email),
-            'maintained' => ($license->maintained == 1) ? true : false,
-            'supplier' =>  ($license->supplier) ? ['id' => (int)  $license->supplier->id,'name'=> e($license->supplier->name)] : null,
-            'category' =>  ($license->category) ? ['id' => (int)  $license->category->id,'name'=> e($license->category->name)] : null,
-            'created_at' => Helper::getFormattedDateObject($license->created_at, 'datetime'),
-            'updated_at' => Helper::getFormattedDateObject($license->updated_at, 'datetime'),
-            'user_can_checkout' => (bool) ($license->free_license_count > 0),
+            'id' => (int) $licenseModel->id,
+            'name' => e($licenseModel->name),
+            'company' => ($licenseModel->company) ? ['id' => (int) $licenseModel->company->id,'name'=> e($licenseModel->company->name)] : null,
+            'manufacturer' =>  ($licenseModel->manufacturer) ? ['id' => (int) $licenseModel->manufacturer->id,'name'=> e($licenseModel->manufacturer->name)] : null,
+            'product_key' => (Gate::allows('viewKeys', LicenseModel::class)) ? e($licenseModel->serial) : '------------',
+            'order_number' => e($licenseModel->order_number),
+            'purchase_order' => e($licenseModel->purchase_order),
+            'purchase_date' => Helper::getFormattedDateObject($licenseModel->purchase_date, 'date'),
+            'purchase_cost' => e($licenseModel->purchase_cost),
+            'notes' => e($licenseModel->notes),
+            'expiration_date' => Helper::getFormattedDateObject($licenseModel->expiration_date, 'date'),
+            'seats' => (int) $licenseModel->licenses->count(),
+            'free_seats_count' => (int) $licenseModel->freeLicenses->count(),
+            'license_name' =>  e($licenseModel->license_name),
+            'license_email' => e($licenseModel->license_email),
+            'maintained' => ($licenseModel->maintained == 1) ? true : false,
+            'supplier' =>  ($licenseModel->supplier) ? ['id' => (int)  $licenseModel->supplier->id,'name'=> e($licenseModel->supplier->name)] : null,
+            'category' =>  ($licenseModel->category) ? ['id' => (int)  $licenseModel->category->id,'name'=> e($licenseModel->category->name)] : null,
+            'created_at' => Helper::getFormattedDateObject($licenseModel->created_at, 'datetime'),
+            'updated_at' => Helper::getFormattedDateObject($licenseModel->updated_at, 'datetime'),
+            'user_can_checkout' => (bool) ($licenseModel->freeLicenses->count() > 0),
         ];
 
         $permissions_array['available_actions'] = [

--- a/app/Http/Transformers/LicensesTransformer.php
+++ b/app/Http/Transformers/LicensesTransformer.php
@@ -1,7 +1,7 @@
 <?php
 namespace App\Http\Transformers;
 
-use App\Models\License;
+use App\Models\LicenseModel;
 use Gate;
 use Illuminate\Database\Eloquent\Collection;
 use App\Helpers\Helper;
@@ -18,14 +18,14 @@ class LicensesTransformer
         return (new DatatablesTransformer)->transformDatatables($array, $total);
     }
 
-    public function transformLicense (License $license)
+    public function transformLicense (LicenseModel $license)
     {
         $array = [
             'id' => (int) $license->id,
             'name' => e($license->name),
             'company' => ($license->company) ? ['id' => (int) $license->company->id,'name'=> e($license->company->name)] : null,
             'manufacturer' =>  ($license->manufacturer) ? ['id' => (int) $license->manufacturer->id,'name'=> e($license->manufacturer->name)] : null,
-            'product_key' => (Gate::allows('viewKeys', License::class)) ? e($license->serial) : '------------',
+            'product_key' => (Gate::allows('viewKeys', LicenseModel::class)) ? e($license->serial) : '------------',
             'order_number' => e($license->order_number),
             'purchase_order' => e($license->purchase_order),
             'purchase_date' => Helper::getFormattedDateObject($license->purchase_date, 'date'),
@@ -45,11 +45,11 @@ class LicensesTransformer
         ];
 
         $permissions_array['available_actions'] = [
-            'checkout' => Gate::allows('checkout', License::class) ? true : false,
-            'checkin' => Gate::allows('checkin', License::class) ? true : false,
-            'clone' => Gate::allows('create', License::class) ? true : false,
-            'update' => Gate::allows('update', License::class) ? true : false,
-            'delete' => Gate::allows('delete', License::class) ? true : false,
+            'checkout' => Gate::allows('checkout', LicenseModel::class) ? true : false,
+            'checkin' => Gate::allows('checkin', LicenseModel::class) ? true : false,
+            'clone' => Gate::allows('create', LicenseModel::class) ? true : false,
+            'update' => Gate::allows('update', LicenseModel::class) ? true : false,
+            'delete' => Gate::allows('delete', LicenseModel::class) ? true : false,
         ];
 
         $array += $permissions_array;

--- a/app/Http/Transformers/LicensesTransformer.php
+++ b/app/Http/Transformers/LicensesTransformer.php
@@ -33,7 +33,7 @@ class LicensesTransformer
             'notes' => e($license->notes),
             'expiration_date' => Helper::getFormattedDateObject($license->expiration_date, 'date'),
             'seats' => (int) $license->seats,
-            'free_seats_count' => (int) $license->free_seats_count,
+            'free_seats_count' => (int) $license->free_license_count,
             'license_name' =>  e($license->license_name),
             'license_email' => e($license->license_email),
             'maintained' => ($license->maintained == 1) ? true : false,
@@ -41,7 +41,7 @@ class LicensesTransformer
             'category' =>  ($license->category) ? ['id' => (int)  $license->category->id,'name'=> e($license->category->name)] : null,
             'created_at' => Helper::getFormattedDateObject($license->created_at, 'datetime'),
             'updated_at' => Helper::getFormattedDateObject($license->updated_at, 'datetime'),
-            'user_can_checkout' => (bool) ($license->free_seats_count > 0),
+            'user_can_checkout' => (bool) ($license->free_license_count > 0),
         ];
 
         $permissions_array['available_actions'] = [

--- a/app/Importer/LicenseImporter.php
+++ b/app/Importer/LicenseImporter.php
@@ -73,7 +73,7 @@ class LicenseImporter extends ItemImporter
             if ($licenseModel->seats > 0) {
                 $checkout_target = $this->item['checkout_target'];
                 $asset = Asset::where('asset_tag', $asset_tag)->first();
-                $targetLicense = $licenseModel->licenseSeats()->first();
+                $targetLicense = $licenseModel->licenses()->first();
                 if ($checkout_target) {
                     $targetLicense->assigned_to = $checkout_target->id;
                     if ($asset) {

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -645,7 +645,7 @@ class Asset extends Depreciable
      * @since [v4.0]
      * @return \Illuminate\Database\Eloquent\Relations\Relation
      */
-    public function licenseseats()
+    public function licenses()
     {
         return $this->hasMany('\App\Models\License', 'asset_id');
     }

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -635,7 +635,7 @@ class Asset extends Depreciable
      */
     public function licenses()
     {
-        return $this->belongsToMany('\App\Models\License', 'license_seats', 'asset_id', 'license_id');
+        return $this->belongsToMany('\App\Models\LicenseModel', 'license_seats', 'asset_id', 'license_id');
     }
 
     /**

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -647,7 +647,7 @@ class Asset extends Depreciable
      */
     public function licenseseats()
     {
-        return $this->hasMany('\App\Models\LicenseSeat', 'asset_id');
+        return $this->hasMany('\App\Models\License', 'asset_id');
     }
 
     /**

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -633,7 +633,7 @@ class Asset extends Depreciable
      * @since [v4.0]
      * @return \Illuminate\Database\Eloquent\Relations\Relation
      */
-    public function licenses()
+    public function licenseModels()
     {
         return $this->belongsToMany('\App\Models\LicenseModel', 'license_seats', 'asset_id', 'license_id');
     }

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -100,7 +100,7 @@ class Category extends SnipeModel
      * @since [v4.3]
      * @return \Illuminate\Database\Eloquent\Relations\Relation
      */
-    public function licenses()
+    public function licenseModels()
     {
         return $this->hasMany('\App\Models\LicenseModel');
     }

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -102,7 +102,7 @@ class Category extends SnipeModel
      */
     public function licenses()
     {
-        return $this->hasMany('\App\Models\License');
+        return $this->hasMany('\App\Models\LicenseModel');
     }
 
     /**

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -192,7 +192,7 @@ final class Company extends SnipeModel
 
     public function licenses()
     {
-        return $this->hasMany(License::class, 'company_id');
+        return $this->hasMany(LicenseModel::class, 'company_id');
     }
     public function accessories()
     {

--- a/app/Models/Depreciation.php
+++ b/app/Models/Depreciation.php
@@ -70,6 +70,7 @@ class Depreciation extends SnipeModel
      */
     public function licenses()
     {
-        return $this->hasMany('\App\Models\License', 'depreciation_id');
+
+        return $this->hasMany('\App\Models\LicenseModel', 'depreciation_id');
     }     
 }

--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -7,7 +7,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use App\Notifications\CheckoutLicenseNotification;
 use App\Notifications\CheckinLicenseNotification;
 
-class LicenseSeat extends Model implements ICompanyableChild
+class License extends Model implements ICompanyableChild
 {
     use CompanyableChildTrait;
     use SoftDeletes;

--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -35,7 +35,7 @@ class License extends Model implements ICompanyableChild
      * @since [v1.0]
      * @return \Illuminate\Database\Eloquent\Relations\Relation
      */
-    public function license()
+    public function model()
     {
         return $this->belongsTo('\App\Models\LicenseModel', 'license_id');
     }

--- a/app/Models/LicenseModel.php
+++ b/app/Models/LicenseModel.php
@@ -3,7 +3,7 @@ namespace App\Models;
 
 use App\Models\Actionlog;
 use App\Models\Company;
-use App\Models\LicenseSeat;
+use App\Models\License;
 use App\Models\Loggable;
 use App\Models\Traits\Searchable;
 use App\Presenters\Presentable;
@@ -177,7 +177,7 @@ class LicenseModel extends Depreciable
         // Else we're adding seats.
         DB::transaction(function () use ($license, $oldSeats, $newSeats) {
             for ($i = $oldSeats; $i < $newSeats; $i++) {
-                $license->licenseSeatsRelation()->save(new LicenseSeat, ['user_id' => Auth::id()]);
+                $license->licenseSeatsRelation()->save(new License, ['user_id' => Auth::id()]);
             }
         });
         // On initail create, we shouldn't log the addition of seats.
@@ -410,7 +410,7 @@ class LicenseModel extends Depreciable
      */
     public static function assetcount()
     {
-        return LicenseSeat::whereNull('deleted_at')
+        return License::whereNull('deleted_at')
                    ->count();
     }
 
@@ -426,7 +426,7 @@ class LicenseModel extends Depreciable
      */
     public function totalSeatsByLicenseID()
     {
-        return LicenseSeat::where('license_id', '=', $this->id)
+        return License::where('license_id', '=', $this->id)
                    ->whereNull('deleted_at')
                    ->count();
     }
@@ -443,7 +443,7 @@ class LicenseModel extends Depreciable
      */
     public function licenseSeatsRelation()
     {
-        return $this->hasMany(LicenseSeat::class)->whereNull('deleted_at')->selectRaw('license_id, count(*) as count')->groupBy('license_id');
+        return $this->hasMany(License::class)->whereNull('deleted_at')->selectRaw('license_id, count(*) as count')->groupBy('license_id');
     }
 
     /**
@@ -471,7 +471,7 @@ class LicenseModel extends Depreciable
      */
     public static function availassetcount()
     {
-        return LicenseSeat::whereNull('assigned_to')
+        return License::whereNull('assigned_to')
                    ->whereNull('asset_id')
                    ->whereNull('deleted_at')
                    ->count();
@@ -578,7 +578,7 @@ class LicenseModel extends Depreciable
      */
     public function licenseseats()
     {
-        return $this->hasMany('\App\Models\LicenseSeat');
+        return $this->hasMany('\App\Models\License');
     }
 
     /**
@@ -624,7 +624,7 @@ class LicenseModel extends Depreciable
      */
     public function freeSeats()
     {
-        return $this->hasMany('\App\Models\LicenseSeat')->whereNull('assigned_to')->whereNull('deleted_at')->whereNull('asset_id');
+        return $this->hasMany('\App\Models\License')->whereNull('assigned_to')->whereNull('deleted_at')->whereNull('asset_id');
     }
 
     /**

--- a/app/Models/LicenseModel.php
+++ b/app/Models/LicenseModel.php
@@ -14,7 +14,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Session;
 use Watson\Validating\ValidatingTrait;
 
-class License extends Depreciable
+class LicenseModel extends Depreciable
 {
     protected $presenter = 'App\Presenters\LicensePresenter';
 
@@ -166,7 +166,7 @@ class License extends Depreciable
             }
             // Log Deletion of seats.
             $logAction = new Actionlog;
-            $logAction->item_type = License::class;
+            $logAction->item_type = LicenseModel::class;
             $logAction->item_id = $license->id;
             $logAction->user_id = Auth::id() ?: 1; // We don't have an id while running the importer from CLI.
             $logAction->note = "deleted ${change} seats";
@@ -184,7 +184,7 @@ class License extends Depreciable
         if ($license->id) {
             //Log the addition of license to the log.
             $logAction = new Actionlog();
-            $logAction->item_type = License::class;
+            $logAction->item_type = LicenseModel::class;
             $logAction->item_id = $license->id;
             $logAction->user_id = Auth::id() ?: 1; // Importer.
             $logAction->note = "added ${change} seats";
@@ -192,6 +192,16 @@ class License extends Depreciable
             $logAction->logaction('add seats');
         }
         return true;
+    }
+
+
+    /**
+     * Default Foreign Key relationship--reimplemented because we renamed model compared to table
+     * @return string
+     */
+    public function getForeignKey()
+    {
+        return 'license_id';
     }
 
     /**
@@ -356,7 +366,7 @@ class License extends Depreciable
     public function assetlog()
     {
         return $this->hasMany('\App\Models\Actionlog', 'item_id')
-            ->where('item_type', '=', License::class)
+            ->where('item_type', '=', LicenseModel::class)
             ->orderBy('created_at', 'desc');
     }
 
@@ -370,7 +380,7 @@ class License extends Depreciable
     public function uploads()
     {
         return $this->hasMany('\App\Models\Actionlog', 'item_id')
-            ->where('item_type', '=', License::class)
+            ->where('item_type', '=', LicenseModel::class)
             ->where('action_type', '=', 'uploaded')
             ->whereNotNull('filename')
             ->orderBy('created_at', 'desc');
@@ -629,7 +639,7 @@ class License extends Depreciable
     public static function getExpiringLicenses($days = 60)
     {
 
-        return License::whereNotNull('expiration_date')
+        return LicenseModel::whereNotNull('expiration_date')
         ->whereNull('deleted_at')
         ->whereRaw(DB::raw('DATE_SUB(`expiration_date`,INTERVAL '.$days.' DAY) <= DATE(NOW()) '))
         ->where('expiration_date', '>', date("Y-m-d"))

--- a/app/Models/LicenseModel.php
+++ b/app/Models/LicenseModel.php
@@ -154,7 +154,7 @@ class LicenseModel extends Depreciable
         // On Create, we just make one for each of the seats.
         $change = abs($oldCount - $newCount);
         if ($oldCount > $newCount) {
-            $licenseModel->load('licenseseats.user');
+            $licenseModel->load('licenses.user');
 
             // Need to delete seats... lets see if if we have enough.
             $seatsAvailableForDelete = $licenseModel->licenses->reject(function ($seat) {
@@ -441,7 +441,7 @@ class LicenseModel extends Depreciable
      * We do this to eager load the "count" of seats from the controller.
      * Otherwise calling "count()" on each model results in n+1 sadness.
      *
-     * @author A. Gianotto <snipe@snipe.net>
+     * @author Daniel Meltzer <dmeltzer.devel@gmail.com>
      * @since [v2.0]
      * @return \Illuminate\Database\Eloquent\Relations\Relation
      */

--- a/app/Models/LicenseSeat.php
+++ b/app/Models/LicenseSeat.php
@@ -37,7 +37,7 @@ class LicenseSeat extends Model implements ICompanyableChild
      */
     public function license()
     {
-        return $this->belongsTo('\App\Models\License', 'license_id');
+        return $this->belongsTo('\App\Models\LicenseModel', 'license_id');
     }
 
     /**

--- a/app/Models/Loggable.php
+++ b/app/Models/Loggable.php
@@ -96,7 +96,7 @@ trait Loggable
     {
         // We need to special case licenses because of license_seat vs license.  So much for clean polymorphism :
         if (static::class == LicenseSeat::class) {
-            $log->item_type = License::class;
+            $log->item_type = LicenseModel::class;
             $log->item_id = $this->license_id;
         } else {
             $log->item_type = static::class;
@@ -118,7 +118,7 @@ trait Loggable
         $log->target_id = $target->id;
 
         if (static::class == LicenseSeat::class) {
-            $log->item_type = License::class;
+            $log->item_type = LicenseModel::class;
             $log->item_id = $this->license_id;
         } else {
 
@@ -177,7 +177,7 @@ trait Loggable
         $log = new Actionlog;
         $location = Location::find($location_id);
         if (static::class == LicenseSeat::class) {
-            $log->item_type = License::class;
+            $log->item_type = LicenseModel::class;
             $log->item_id = $this->license_id;
         } else {
             $log->item_type = static::class;
@@ -216,7 +216,7 @@ trait Loggable
         }
         $log = new Actionlog;
         if (static::class == LicenseSeat::class) {
-            $log->item_type = License::class;
+            $log->item_type = LicenseModel::class;
             $log->item_id = $this->license_id;
         } else {
             $log->item_type = static::class;
@@ -239,7 +239,7 @@ trait Loggable
     {
         $log = new Actionlog;
         if (static::class == LicenseSeat::class) {
-            $log->item_type = License::class;
+            $log->item_type = LicenseModel::class;
             $log->item_id = $this->license_id;
         } else {
             $log->item_type = static::class;

--- a/app/Models/Loggable.php
+++ b/app/Models/Loggable.php
@@ -95,7 +95,7 @@ trait Loggable
     private function determineLogItemType($log)
     {
         // We need to special case licenses because of license_seat vs license.  So much for clean polymorphism :
-        if (static::class == LicenseSeat::class) {
+        if (static::class == License::class) {
             $log->item_type = LicenseModel::class;
             $log->item_id = $this->license_id;
         } else {
@@ -117,7 +117,7 @@ trait Loggable
         $log->target_type = get_class($target);
         $log->target_id = $target->id;
 
-        if (static::class == LicenseSeat::class) {
+        if (static::class == License::class) {
             $log->item_type = LicenseModel::class;
             $log->item_id = $this->license_id;
         } else {
@@ -176,7 +176,7 @@ trait Loggable
     {
         $log = new Actionlog;
         $location = Location::find($location_id);
-        if (static::class == LicenseSeat::class) {
+        if (static::class == License::class) {
             $log->item_type = LicenseModel::class;
             $log->item_id = $this->license_id;
         } else {
@@ -215,7 +215,7 @@ trait Loggable
             $user_id = Auth::user()->id;
         }
         $log = new Actionlog;
-        if (static::class == LicenseSeat::class) {
+        if (static::class == License::class) {
             $log->item_type = LicenseModel::class;
             $log->item_id = $this->license_id;
         } else {
@@ -238,7 +238,7 @@ trait Loggable
     public function logUpload($filename, $note)
     {
         $log = new Actionlog;
-        if (static::class == LicenseSeat::class) {
+        if (static::class == License::class) {
             $log->item_type = LicenseModel::class;
             $log->item_id = $this->license_id;
         } else {

--- a/app/Models/Manufacturer.php
+++ b/app/Models/Manufacturer.php
@@ -78,7 +78,7 @@ class Manufacturer extends SnipeModel
 
     public function licenses()
     {
-        return $this->hasMany('\App\Models\License', 'manufacturer_id');
+        return $this->hasMany('\App\Models\LicenseModel', 'manufacturer_id');
     }
 
     public function accessories()

--- a/app/Models/Supplier.php
+++ b/app/Models/Supplier.php
@@ -160,7 +160,7 @@ class Supplier extends SnipeModel
      */
     public function licenses()
     {
-        return $this->hasMany('\App\Models\License', 'supplier_id');
+        return $this->hasMany('\App\Models\LicenseModel', 'supplier_id');
     }
 
     /**

--- a/app/Models/Supplier.php
+++ b/app/Models/Supplier.php
@@ -82,7 +82,7 @@ class Supplier extends SnipeModel
     }
 
     /**
-     * Sets the license seat count attribute
+     * Sets the license count attribute
      *
      * @todo I don't see the licenseSeatsRelation here?
      *
@@ -90,10 +90,10 @@ class Supplier extends SnipeModel
      * @since [v1.0]
      * @return \Illuminate\Database\Eloquent\Relations\Relation
      */
-    public function getLicenseSeatsCountAttribute()
+    public function getLicenseCountAttribute()
     {
-        if ($this->licenseSeatsRelation->first()) {
-            return $this->licenseSeatsRelation->first()->count;
+        if ($this->licenseRelation->first()) {
+            return $this->licenseRelation->first()->count;
         }
 
         return 0;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -309,7 +309,7 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
      * @since [v1.0]
      * @return \Illuminate\Database\Eloquent\Relations\Relation
      */
-    public function licenses()
+    public function licenseModels()
     {
         return $this->belongsToMany('\App\Models\LicenseModel', 'license_seats', 'assigned_to', 'license_id')->withPivot('id');
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -311,7 +311,7 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
      */
     public function licenses()
     {
-        return $this->belongsToMany('\App\Models\License', 'license_seats', 'assigned_to', 'license_id')->withPivot('id');
+        return $this->belongsToMany('\App\Models\LicenseModel', 'license_seats', 'assigned_to', 'license_id')->withPivot('id');
     }
 
     /**

--- a/app/Observers/LicenseObserver.php
+++ b/app/Observers/LicenseObserver.php
@@ -2,7 +2,7 @@
 
 namespace App\Observers;
 
-use App\Models\License;
+use App\Models\LicenseModel;
 use App\Models\Setting;
 use App\Models\Actionlog;
 use Auth;
@@ -15,11 +15,11 @@ class LicenseObserver
      * @param  License  $license
      * @return void
      */
-    public function updated(License $license)
+    public function updated(LicenseModel $license)
     {
 
         $logAction = new Actionlog();
-        $logAction->item_type = License::class;
+        $logAction->item_type = LicenseModel::class;
         $logAction->item_id = $license->id;
         $logAction->created_at =  date("Y-m-d H:i:s");
         $logAction->user_id = Auth::id();
@@ -34,11 +34,11 @@ class LicenseObserver
      * @param  License  $license
      * @return void
      */
-    public function created(License $license)
+    public function created(LicenseModel $license)
     {
 
         $logAction = new Actionlog();
-        $logAction->item_type = License::class;
+        $logAction->item_type = LicenseModel::class;
         $logAction->item_id = $license->id;
         $logAction->created_at =  date("Y-m-d H:i:s");
         $logAction->user_id = Auth::id();
@@ -52,10 +52,10 @@ class LicenseObserver
      * @param  License  $license
      * @return void
      */
-    public function deleting(License $license)
+    public function deleting(LicenseModel $license)
     {
         $logAction = new Actionlog();
-        $logAction->item_type = License::class;
+        $logAction->item_type = LicenseModel::class;
         $logAction->item_id = $license->id;
         $logAction->created_at =  date("Y-m-d H:i:s");
         $logAction->user_id = Auth::id();

--- a/app/Policies/LicensePolicy.php
+++ b/app/Policies/LicensePolicy.php
@@ -2,7 +2,7 @@
 
 namespace App\Policies;
 
-use App\Models\License;
+use App\Models\LicenseModel;
 use App\Models\User;
 use App\Policies\CheckoutablePermissionsPolicy;
 
@@ -13,14 +13,15 @@ class LicensePolicy extends CheckoutablePermissionsPolicy
         return 'licenses';
     }
 
-   /**
+    /**
      * Determine whether the user can view license keys
      *
-     * @param  \App\Models\User  $user
-     * @param  \App\Models\License  $license
+     * @param  \App\Models\User $user
+     * @param LicenseModel $licenseModel
      * @return mixed
      */
-    public function viewKeys(User $user, License $license = null)
+    public function viewKeys(User $user, LicenseModel
+    $licenseModel = null)
     {
         return $user->hasAccess('licenses.keys');
     }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,8 +2,8 @@
 namespace App\Providers;
 
 
+use App\Models\LicenseModel;
 use Illuminate\Support\ServiceProvider;
-use Log;
 use Illuminate\Support\Facades\Schema;
 use App\Observers\AssetObserver;
 use App\Observers\LicenseObserver;
@@ -11,7 +11,6 @@ use App\Observers\AccessoryObserver;
 use App\Observers\ConsumableObserver;
 use App\Observers\ComponentObserver;
 use App\Models\Asset;
-use App\Models\License;
 use App\Models\Accessory;
 use App\Models\Consumable;
 use App\Models\Component;
@@ -40,7 +39,7 @@ class AppServiceProvider extends ServiceProvider
         Accessory::observe(AccessoryObserver::class);
         Component::observe(ComponentObserver::class);
         Consumable::observe(ConsumableObserver::class);
-        License::observe(LicenseObserver::class);
+        LicenseModel::observe(LicenseObserver::class);
 
 
     }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -2,23 +2,7 @@
 
 namespace App\Providers;
 
-use App\Models\Accessory;
-use App\Models\Asset;
-use App\Models\AssetModel;
-use App\Models\Category;
-use App\Models\Component;
-use App\Models\Consumable;
-use App\Models\CustomField;
-use App\Models\CustomFieldset;
-use App\Models\Department;
-use App\Models\License;
-use App\Models\Location;
-use App\Models\Depreciation;
-use App\Models\Statuslabel;
-use App\Models\Supplier;
-use App\Models\Manufacturer;
-use App\Models\Company;
-use App\Models\User;
+use App\Models;
 use App\Policies\AccessoryPolicy;
 use App\Policies\AssetModelPolicy;
 use App\Policies\AssetPolicy;
@@ -51,23 +35,23 @@ class AuthServiceProvider extends ServiceProvider
      * @var array
      */
     protected $policies = [
-        Accessory::class => AccessoryPolicy::class,
-        Asset::class => AssetPolicy::class,
-        AssetModel::class => AssetModelPolicy::class,
-        Category::class => CategoryPolicy::class,
-        Component::class => ComponentPolicy::class,
-        Consumable::class => ConsumablePolicy::class,
-        CustomField::class => CustomFieldPolicy::class,
-        CustomFieldset::class => CustomFieldsetPolicy::class,
-        Department::class => DepartmentPolicy::class,
-        Depreciation::class => DepreciationPolicy::class,
-        License::class => LicensePolicy::class,
-        Location::class => LocationPolicy::class,
-        Statuslabel::class => StatuslabelPolicy::class,
-        Supplier::class => SupplierPolicy::class,
-        User::class => UserPolicy::class,
-        Manufacturer::class => ManufacturerPolicy::class,
-        Company::class => CompanyPolicy::class,
+        Models\Accessory::class => AccessoryPolicy::class,
+        Models\Asset::class => AssetPolicy::class,
+        Models\AssetModel::class => AssetModelPolicy::class,
+        Models\Category::class => CategoryPolicy::class,
+        Models\Component::class => ComponentPolicy::class,
+        Models\Consumable::class => ConsumablePolicy::class,
+        Models\CustomField::class => CustomFieldPolicy::class,
+        Models\CustomFieldset::class => CustomFieldsetPolicy::class,
+        Models\Department::class => DepartmentPolicy::class,
+        Models\Depreciation::class => DepreciationPolicy::class,
+        Models\LicenseModel::class => LicensePolicy::class,
+        Models\Location::class => LocationPolicy::class,
+        Models\Statuslabel::class => StatuslabelPolicy::class,
+        Models\Supplier::class => SupplierPolicy::class,
+        Models\User::class => UserPolicy::class,
+        Models\Manufacturer::class => ManufacturerPolicy::class,
+        Models\Company::class => CompanyPolicy::class,
     ];
 
     /**
@@ -140,18 +124,18 @@ class AuthServiceProvider extends ServiceProvider
         });
 
         Gate::define('backend.interact', function ($user) {
-            return $user->can('view', Statuslabel::class)
-                || $user->can('view', AssetModel::class)
-                || $user->can('view', Category::class)
-                || $user->can('view', Manufacturer::class)
-                || $user->can('view', Supplier::class)
-                || $user->can('view', Department::class)
-                || $user->can('view', Location::class)
-                || $user->can('view', Company::class)
-                || $user->can('view', Manufacturer::class)
-                || $user->can('view', CustomField::class)
-                || $user->can('view', CustomFieldset::class)                
-                || $user->can('view', Depreciation::class);
+            return $user->can('view', Models\Statuslabel::class)
+                || $user->can('view', Models\AssetModel::class)
+                || $user->can('view', Models\Category::class)
+                || $user->can('view', Models\Manufacturer::class)
+                || $user->can('view', Models\Supplier::class)
+                || $user->can('view', Models\Department::class)
+                || $user->can('view', Models\Location::class)
+                || $user->can('view', Models\Company::class)
+                || $user->can('view', Models\Manufacturer::class)
+                || $user->can('view', Models\CustomField::class)
+                || $user->can('view', Models\CustomFieldset::class)
+                || $user->can('view', Models\Depreciation::class);
         });
     }
 }

--- a/app/Providers/ValidationServiceProvider.php
+++ b/app/Providers/ValidationServiceProvider.php
@@ -4,18 +4,6 @@ namespace App\Providers;
 use Validator;
 use Illuminate\Support\ServiceProvider;
 use DB;
-use Log;
-use Illuminate\Support\Facades\Schema;
-use App\Observers\AssetObserver;
-use App\Observers\LicenseObserver;
-use App\Observers\AccessoryObserver;
-use App\Observers\ConsumableObserver;
-use App\Observers\ComponentObserver;
-use App\Models\Asset;
-use App\Models\License;
-use App\Models\Accessory;
-use App\Models\Consumable;
-use App\Models\Component;
 
 
 /**

--- a/database/factories/ActionLogFactory.php
+++ b/database/factories/ActionLogFactory.php
@@ -79,7 +79,7 @@ $factory->defineAs(Actionlog::class, 'asset-checkout-location', function (Faker\
 // This doesn't work - we need to assign a seat
 $factory->defineAs(Actionlog::class, 'license-checkout-asset', function (Faker\Generator $faker) {
     $target = Asset::inRandomOrder()->RTD()->first();
-    $item = License::inRandomOrder()->first();
+    $item = \App\Models\LicenseModel::inRandomOrder()->first();
     $user_id = rand(1,2); // keep it simple - make it one of the two superadmins
 
     return [

--- a/database/factories/LicenseFactory.php
+++ b/database/factories/LicenseFactory.php
@@ -9,7 +9,7 @@
 |
 */
 
-$factory->define(App\Models\License::class, function (Faker\Generator $faker) {
+$factory->define(App\Models\LicenseModel::class, function (Faker\Generator $faker) {
 
     return [
         'user_id' => 1,
@@ -27,7 +27,7 @@ $factory->define(App\Models\License::class, function (Faker\Generator $faker) {
 });
 
 // 1
-$factory->state(App\Models\License::class, 'photoshop', function ($faker) {
+$factory->state(App\Models\LicenseModel::class, 'photoshop', function ($faker) {
     $data =  [
         'name' => 'Photoshop',
         'manufacturer_id' => 9,
@@ -43,7 +43,7 @@ $factory->state(App\Models\License::class, 'photoshop', function ($faker) {
 });
 
 // 2
-$factory->state(App\Models\License::class, 'acrobat', function ($faker) {
+$factory->state(App\Models\LicenseModel::class, 'acrobat', function ($faker) {
 
     $data =  [
         'name' => 'Acrobat',
@@ -58,7 +58,7 @@ $factory->state(App\Models\License::class, 'acrobat', function ($faker) {
 });
 
 // 3
-$factory->state(App\Models\License::class, 'indesign', function ($faker) {
+$factory->state(App\Models\LicenseModel::class, 'indesign', function ($faker) {
     $data =  [
         'name' => 'InDesign',
         'manufacturer_id' => 9,
@@ -73,7 +73,7 @@ $factory->state(App\Models\License::class, 'indesign', function ($faker) {
 
 
 // 4
-$factory->state(App\Models\License::class, 'office', function ($faker) {
+$factory->state(App\Models\LicenseModel::class, 'office', function ($faker) {
     $data =  [
         'name' => 'Office',
         'manufacturer_id' => 2,

--- a/database/migrations/2018_05_04_075235_add_update_license_category.php
+++ b/database/migrations/2018_05_04_075235_add_update_license_category.php
@@ -1,10 +1,10 @@
 <?php
 
+use App\Models\LicenseModel;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 use App\Models\Category;
-use App\Models\License;
 
 class AddUpdateLicenseCategory extends Migration
 {
@@ -22,7 +22,7 @@ class AddUpdateLicenseCategory extends Migration
         $category->category_type = 'license';
 
         if ($category->save()) {
-            License::whereNull('category_id')->withTrashed()
+            LicenseModel::whereNull('category_id')->withTrashed()
                 ->update(['category_id' => $category->id]);
         }
 
@@ -38,7 +38,7 @@ class AddUpdateLicenseCategory extends Migration
 
         App\Models\Category::where('name', 'Misc Software')->forceDelete();
 
-        License::whereNotNull('category_id')
+        LicenseModel::whereNotNull('category_id')
             ->update(['category_id' => null]);
     }
 }

--- a/database/seeds/LicenseSeeder.php
+++ b/database/seeds/LicenseSeeder.php
@@ -1,17 +1,18 @@
 <?php
+
+use App\Models\LicenseModel;
 use Illuminate\Database\Seeder;
-use App\Models\License;
 use App\Models\LicenseSeat;
 
 class LicenseSeeder extends Seeder
 {
     public function run()
     {
-        License::truncate();
+        LicenseModel::truncate();
         LicenseSeat::truncate();
-        factory(License::class, 1)->states('photoshop')->create();
-        factory(License::class, 1)->states('acrobat')->create();
-        factory(License::class, 1)->states('indesign')->create();
-        factory(License::class, 1)->states('office')->create();
+        factory(LicenseModel::class, 1)->states('photoshop')->create();
+        factory(LicenseModel::class, 1)->states('acrobat')->create();
+        factory(LicenseModel::class, 1)->states('indesign')->create();
+        factory(LicenseModel::class, 1)->states('office')->create();
     }
 }

--- a/database/seeds/LicenseSeeder.php
+++ b/database/seeds/LicenseSeeder.php
@@ -2,14 +2,14 @@
 
 use App\Models\LicenseModel;
 use Illuminate\Database\Seeder;
-use App\Models\LicenseSeat;
+use App\Models\License;
 
 class LicenseSeeder extends Seeder
 {
     public function run()
     {
         LicenseModel::truncate();
-        LicenseSeat::truncate();
+        License::truncate();
         factory(LicenseModel::class, 1)->states('photoshop')->create();
         factory(LicenseModel::class, 1)->states('acrobat')->create();
         factory(LicenseModel::class, 1)->states('indesign')->create();

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -55,7 +55,7 @@
       <div class="icon">
         <i class="fa fa-floppy-o"></i>
       </div>
-        @can('view', \App\Models\License::class)
+        @can('view', \App\Models\LicenseModel::class)
           <a href="{{ route('licenses.index') }}" class="small-box-footer">{{ trans('general.moreinfo') }} <i class="fa fa-arrow-circle-right"></i></a>
         @endcan
     </div>
@@ -126,7 +126,7 @@
                             @endcan
                         </div>
                         <div class="col-md-3">
-                            @can('create', \App\Models\License::class)
+                            @can('create', \App\Models\LicenseModel::class)
                                 <a class="btn bg-maroon" style="width: 100%" href="{{ route('licenses.create') }}">New License</a>
                             @endcan
                         </div>

--- a/resources/views/hardware/qr-view.blade.php
+++ b/resources/views/hardware/qr-view.blade.php
@@ -185,11 +185,11 @@
                         </tr>
                     </thead>
                     <tbody>
-                        @foreach ($asset->licenseseats as $seat)
+                        @foreach ($asset->licenses as $license)
                         <tr>
-                            <td><a href="{{ route('licenses.show', $seat->license->id) }}">{{ $seat->license->name }}</a></td>
-                            <td>{{ $seat->license->serial }}</td>
-                            <td><a href="{{ route('licenses.checkin', $seat->id) }}" class="btn-flat info">{{ trans('general.checkin') }}</a>
+                            <td><a href="{{ route('licenses.show', $license->licenseModel->id) }}">{{ $license->licenseModel->name }}</a></td>
+                            <td>{{ $license->licenseModel->serial }}</td>
+                            <td><a href="{{ route('licenses.checkin', $license->id) }}" class="btn-flat info">{{ trans('general.checkin') }}</a>
                             </td>
                         </tr>
                         @endforeach

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -553,7 +553,7 @@
           <div class="row">
             <div class="col-md-12">
               <!-- Licenses assets table -->
-              @if ($asset->licenses->count() > 0)
+              @if ($asset->licensesModels->count() > 0)
                 <table class="table">
                   <thead>
                     <tr>

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -563,7 +563,7 @@
                     </tr>
                   </thead>
                   <tbody>
-                    @foreach ($asset->licenseseats as $seat)
+                    @foreach ($asset->licenses as $seat)
                     <tr>
                       <td><a href="{{ route('licenses.show', $seat->license->id) }}">{{ $seat->license->name }}</a></td>
                       <td>

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -143,7 +143,7 @@
                       </a>
                   </li>
                   @endcan
-                  @can('view', \App\Models\License::class)
+                  @can('view', \App\Models\LicenseModel::class)
                   <li {!! (Request::is('licenses*') ? ' class="active"' : '') !!}>
                       <a href="{{ route('licenses.index') }}">
                           <i class="fa fa-floppy-o"></i>
@@ -202,7 +202,7 @@
                               </a>
                       </li>
                        @endcan
-                       @can('create', \App\Models\License::class)
+                       @can('create', \App\Models\LicenseModel::class)
                        <li {!! (Request::is('licenses/create') ? 'class="active"' : '') !!}>
                            <a href="{{ route('licenses.create') }}">
                                <i class="fa fa-floppy-o fa-fw"></i>
@@ -480,7 +480,7 @@
                 </ul>
               </li>
               @endcan
-              @can('view', \App\Models\License::class)
+              @can('view', \App\Models\LicenseModel::class)
               <li{!! (Request::is('licenses*') ? ' class="active"' : '') !!}>
                   <a href="{{ route('licenses.index') }}">
                     <i class="fa fa-floppy-o"></i>

--- a/resources/views/licenses/checkin.blade.php
+++ b/resources/views/licenses/checkin.blade.php
@@ -17,12 +17,12 @@
     <div class="row">
         <!-- left column -->
         <div class="col-md-7">
-            <form class="form-horizontal" method="post" action="{{ route('licenses.checkin.save', $licenseSeat->id) }}" autocomplete="off">
+            <form class="form-horizontal" method="post" action="{{ route('licenses.checkin.save', $license->id) }}" autocomplete="off">
                 {{csrf_field()}}
 
                 <div class="box box-default">
                     <div class="box-header with-border">
-                        <h3 class="box-title"> {{ $licenseSeat->license->name }}</h3>
+                        <h3 class="box-title"> {{ $license->license->name }}</h3>
                     </div>
                     <div class="box-body">
 
@@ -30,7 +30,7 @@
             <div class="form-group">
                 <label class="col-sm-2 control-label">{{ trans('admin/hardware/form.name') }}</label>
                 <div class="col-md-6">
-                    <p class="form-control-static">{{ $licenseSeat->license->name }}</p>
+                    <p class="form-control-static">{{ $license->license->name }}</p>
                 </div>
             </div>
 
@@ -38,7 +38,7 @@
             <div class="form-group">
                 <label class="col-sm-2 control-label">{{ trans('admin/hardware/form.serial') }}</label>
                 <div class="col-md-6">
-                    <p class="form-control-static">{{ $licenseSeat->license->serial }}</p>
+                    <p class="form-control-static">{{ $license->license->serial }}</p>
                 </div>
             </div>
 
@@ -46,7 +46,7 @@
             <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">
                 <label for="note" class="col-md-2 control-label">{{ trans('admin/hardware/form.notes') }}</label>
                 <div class="col-md-7">
-                    <textarea class="col-md-6 form-control" id="note" name="note">{{ Input::old('note', $licenseSeat->note) }}</textarea>
+                    <textarea class="col-md-6 form-control" id="note" name="note">{{ Input::old('note', $license->note) }}</textarea>
                     {!! $errors->first('note', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
                 </div>
             </div>

--- a/resources/views/licenses/checkout.blade.php
+++ b/resources/views/licenses/checkout.blade.php
@@ -21,7 +21,7 @@
 
             <div class="box box-default">
                 <div class="box-header with-border">
-                    <h3 class="box-title"> {{ $license->name }}</h3>
+                    <h3 class="box-title"> {{ $licenseModel->name }}</h3>
                 </div>
                 <div class="box-body">
 
@@ -29,7 +29,7 @@
                     <div class="form-group">
                         <label class="col-sm-3 control-label">{{ trans('admin/hardware/form.name') }}</label>
                         <div class="col-md-6">
-                            <p class="form-control-static">{{ $license->name }}</p>
+                            <p class="form-control-static">{{ $licenseModel->name }}</p>
                         </div>
                     </div>
 
@@ -37,7 +37,7 @@
                     <div class="form-group">
                         <label class="col-sm-3 control-label">{{ trans('admin/hardware/form.serial') }}</label>
                         <div class="col-md-9">
-                            <p class="form-control-static" style="word-wrap: break-word;">{{ $license->serial }}</p>
+                            <p class="form-control-static" style="word-wrap: break-word;">{{ $licenseModel->serial }}</p>
                         </div>
                     </div>
 
@@ -59,24 +59,24 @@
                 </div>
 
 
-                @if ($license->requireAcceptance() || $license->getEula() || ($snipeSettings->slack_endpoint!=''))
+                @if ($licenseModel->requireAcceptance() || $licenseModel->getEula() || ($snipeSettings->slack_endpoint!=''))
                     <div class="form-group notification-callout">
                         <div class="col-md-8 col-md-offset-3">
                             <div class="callout callout-info">
 
-                                @if ($license->requireAcceptance())
+                                @if ($licenseModel->requireAcceptance())
                                     <i class="fa fa-envelope"></i>
                                     {{ trans('admin/categories/general.required_acceptance') }}
                                     <br>
                                 @endif
 
-                                @if ($license->getEula())
+                                @if ($licenseModel->getEula())
                                     <i class="fa fa-envelope"></i>
                                     {{ trans('admin/categories/general.required_eula') }}
                                     <br>
                                 @endif
 
-                                @if (($license->category) && ($license->category->checkin_email))
+                                @if (($licenseModel->category) && ($licenseModel->category->checkin_email))
                                     <i class="fa fa-envelope"></i>
                                     {{ trans('admin/categories/general.checkin_email_notification') }}
                                     <br>

--- a/resources/views/licenses/index.blade.php
+++ b/resources/views/licenses/index.blade.php
@@ -8,7 +8,7 @@
 
 
 @section('header_right')
-@can('create', \App\Models\License::class)
+@can('create', \App\Models\LicenseModel::class)
     <a href="{{ route('licenses.create') }}" class="btn btn-primary pull-right">
       {{ trans('general.create') }}
     </a>

--- a/resources/views/licenses/view.blade.php
+++ b/resources/views/licenses/view.blade.php
@@ -3,20 +3,20 @@
 {{-- Page title --}}
 @section('title')
 {{ trans('admin/licenses/general.view') }}
- - {{ $license->name }}
+ - {{ $licenseModel->name }}
 @parent
 @stop
 
 {{-- Right header --}}
 @section('header_right')
 <div class="btn-group pull-right">
-  @can('update', $license)
+  @can('update', $licenseModel)
     <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">{{ trans('button.actions') }}
         <span class="caret"></span>
     </button>
     <ul class="dropdown-menu">
-        <li><a href="{{ route('licenses.edit', ['license' => $license->id]) }}">{{ trans('admin/licenses/general.edit') }}</a></li>
-        <li><a href="{{ route('clone/license', $license->id) }}">{{ trans('admin/licenses/general.clone') }}</a></li>
+        <li><a href="{{ route('licenses.edit', ['license' => $licenseModel->id]) }}">{{ trans('admin/licenses/general.edit') }}</a></li>
+        <li><a href="{{ route('clone/license', $licenseModel->id) }}">{{ trans('admin/licenses/general.clone') }}</a></li>
     </ul>
    @endcan
 </div>
@@ -56,9 +56,9 @@
                         data-sort-order="asc"
                         data-sort-name="name"
                         class="table table-striped snipe-table"
-                        data-url="{{ route('api.license.seats',['license_id' => $license->id]) }}"
+                        data-url="{{ route('api.license.seats',['license_id' => $licenseModel->id]) }}"
                         data-export-options='{
-                        "fileName": "export-seats-{{ str_slug($license->name) }}-{{ date('Y-m-d') }}",
+                        "fileName": "export-seats-{{ str_slug($licenseModel->name) }}-{{ date('Y-m-d') }}",
                         "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                         }'>
                 </table>
@@ -71,41 +71,41 @@
               <div class="table">
                 <table class="table">
                   <tbody>
-                    @if (!is_null($license->company))
+                    @if (!is_null($licenseModel->company))
                     <tr>
                       <td>{{ trans('general.company') }}</td>
-                      <td>{{ $license->company->name }}</td>
+                      <td>{{ $licenseModel->company->name }}</td>
                     </tr>
                     @endif
 
-                    @if ($license->manufacturer)
+                    @if ($licenseModel->manufacturer)
                       <tr>
                         <td>{{ trans('admin/hardware/form.manufacturer') }}:</td>
                         <td><p style="line-height: 23px;">
                           @can('view', \App\Models\Manufacturer::class)
-                            <a href="{{ route('manufacturers.show', $license->manufacturer->id) }}">
-                              {{ $license->manufacturer->name }}
+                            <a href="{{ route('manufacturers.show', $licenseModel->manufacturer->id) }}">
+                              {{ $licenseModel->manufacturer->name }}
                             </a>
                           @else
-                            {{ $license->manufacturer->name }}
+                            {{ $licenseModel->manufacturer->name }}
                           @endcan
 
-                          @if ($license->manufacturer->url)
-                            <br><i class="fa fa-globe"></i> <a href="{{ $license->manufacturer->url }}" rel="noopener">{{ $license->manufacturer->url }}</a>
+                          @if ($licenseModel->manufacturer->url)
+                            <br><i class="fa fa-globe"></i> <a href="{{ $licenseModel->manufacturer->url }}" rel="noopener">{{ $licenseModel->manufacturer->url }}</a>
                           @endif
 
-                          @if ($license->manufacturer->support_url)
+                          @if ($licenseModel->manufacturer->support_url)
                             <br><i class="fa fa-life-ring"></i>
-                              <a href="{{ $license->manufacturer->support_url }}"  rel="noopener">{{ $license->manufacturer->support_url }}</a>
+                              <a href="{{ $licenseModel->manufacturer->support_url }}"  rel="noopener">{{ $licenseModel->manufacturer->support_url }}</a>
                           @endif
 
-                          @if ($license->manufacturer->support_phone)
+                          @if ($licenseModel->manufacturer->support_phone)
                             <br><i class="fa fa-phone"></i>
-                              <a href="tel:{{ $license->manufacturer->support_phone }}">{{ $license->manufacturer->support_phone }}</a>
+                              <a href="tel:{{ $licenseModel->manufacturer->support_phone }}">{{ $licenseModel->manufacturer->support_phone }}</a>
                           @endif
 
-                          @if ($license->manufacturer->support_email)
-                            <br><i class="fa fa-envelope"></i> <a href="mailto:{{ $license->manufacturer->support_email }}">{{ $license->manufacturer->support_email }}</a>
+                          @if ($licenseModel->manufacturer->support_email)
+                            <br><i class="fa fa-envelope"></i> <a href="mailto:{{ $licenseModel->manufacturer->support_email }}">{{ $licenseModel->manufacturer->support_email }}</a>
                           @endif
                           </p>
                         </td>
@@ -113,12 +113,12 @@
                     @endif
 
 
-                      @if (!is_null($license->serial))
+                      @if (!is_null($licenseModel->serial))
                       <tr>
                         <td>{{ trans('admin/licenses/form.license_key') }}: </td>
                         <td style="word-wrap: break-word;overflow-wrap: break-word;word-break: break-word;">
-                          @can('viewKeys', $license)
-                            {!! nl2br(e($license->serial)) !!}
+                          @can('viewKeys', $licenseModel)
+                            {!! nl2br(e($licenseModel->serial)) !!}
                           @else
                            ------------
                           @endcan
@@ -127,57 +127,57 @@
                       </tr>
                       @endif
 
-                    @if ($license->category)
+                    @if ($licenseModel->category)
                       <tr>
                         <td>{{ trans('general.category') }}: </td>
                         <td style="word-wrap: break-word;overflow-wrap: break-word;word-break: break-word;">
-                          <a href="{{ route('categories.show', $license->category->id) }}">{{ $license->category->name }}</a>
+                          <a href="{{ route('categories.show', $licenseModel->category->id) }}">{{ $licenseModel->category->name }}</a>
                         </td>
                       </tr>
                     @endif
 
 
-                    @if ($license->license_name!='')
+                    @if ($licenseModel->license_name!='')
                     <tr>
                       <td>{{ trans('admin/licenses/form.to_name') }}: </td>
-                      <td>{{ $license->license_name }}</td>
+                      <td>{{ $licenseModel->license_name }}</td>
                     </tr>
                     @endif
 
-                    @if ($license->license_email!='')
+                    @if ($licenseModel->license_email!='')
                     <tr>
                       <td>{{ trans('admin/licenses/form.to_email') }}:</td>
-                      <td>{{ $license->license_email }}</td>
+                      <td>{{ $licenseModel->license_email }}</td>
                     </tr>
                     @endif
 
-                    @if ($license->supplier_id)
+                    @if ($licenseModel->supplier_id)
                     <tr>
                       <td>{{ trans('general.supplier') }}:
                       </td>
                       <td>
-                        <a href="{{ route('suppliers.show', $license->supplier_id) }}">
-                          {{ $license->supplier->name }}
+                        <a href="{{ route('suppliers.show', $licenseModel->supplier_id) }}">
+                          {{ $licenseModel->supplier->name }}
                         </a>
                       </td>
                     </tr>
                     @endif
 
-                    @if (isset($license->expiration_date))
+                    @if (isset($licenseModel->expiration_date))
                     <tr>
                       <td>{{ trans('admin/licenses/form.expiration') }}:</td>
-                      <td>{{ $license->expiration_date }}</td>
+                      <td>{{ $licenseModel->expiration_date }}</td>
                     </tr>
                     @endif
 
-                    @if ($license->depreciation)
+                    @if ($licenseModel->depreciation)
                       <tr>
                         <td>
                           {{ trans('admin/hardware/form.depreciation') }}:
                         </td>
                         <td>
-                          {{ $license->depreciation->name }}
-                          ({{ $license->depreciation->months }}
+                          {{ $licenseModel->depreciation->name }}
+                          ({{ $licenseModel->depreciation->months }}
                           {{ trans('admin/hardware/form.months') }}
                           )
                         </td>
@@ -187,7 +187,7 @@
                           {{ trans('admin/hardware/form.depreciates_on') }}:
                         </td>
                         <td>
-                          {{ $license->depreciated_date()->format("Y-m-d") }}
+                          {{ $licenseModel->depreciated_date()->format("Y-m-d") }}
                         </td>
                       </tr>
 
@@ -196,68 +196,68 @@
                           {{ trans('admin/hardware/form.fully_depreciated') }}:
                         </td>
                         <td>
-                        @if ($license->time_until_depreciated()->y > 0)
-                          {{ $license->time_until_depreciated()->y }}
+                        @if ($licenseModel->time_until_depreciated()->y > 0)
+                          {{ $licenseModel->time_until_depreciated()->y }}
                           {{ trans('admin/hardware/form.years') }},
                         @endif
-                        {{ $license->time_until_depreciated()->m }}
+                        {{ $licenseModel->time_until_depreciated()->m }}
                         {{ trans('admin/hardware/form.months') }}
                         </td>
                       </tr>
                     @endif
 
-                    @if ($license->purchase_order)
+                    @if ($licenseModel->purchase_order)
                     <tr>
                       <td>
                         {{ trans('admin/licenses/form.purchase_order') }}:
                       </td>
                       <td>
-                        {{ $license->purchase_order }}
+                        {{ $licenseModel->purchase_order }}
                       </td>
                     </tr>
                     @endif
 
-                    @if (isset($license->purchase_date))
+                    @if (isset($licenseModel->purchase_date))
                     <tr>
                       <td>{{ trans('general.purchase_date') }}:</td>
-                      <td>{{ $license->purchase_date }}</td>
+                      <td>{{ $licenseModel->purchase_date }}</td>
                     </tr>
                     @endif
 
-                    @if ($license->purchase_cost > 0)
+                    @if ($licenseModel->purchase_cost > 0)
                     <tr>
                       <td>{{ trans('general.purchase_cost') }}:</td>
                       <td>
                         {{ $snipeSettings->default_currency }}
-                        {{ \App\Helpers\Helper::formatCurrencyOutput($license->purchase_cost) }}
+                        {{ \App\Helpers\Helper::formatCurrencyOutput($licenseModel->purchase_cost) }}
                       </td>
                     </tr>
                     @endif
 
-                    @if ($license->order_number)
+                    @if ($licenseModel->order_number)
                     <tr>
                       <td>{{ trans('general.order_number') }}:</td>
-                      <td>{{ $license->order_number }}</td>
+                      <td>{{ $licenseModel->order_number }}</td>
                     </tr>
                     @endif
 
-                    @if (($license->seats) && ($license->seats) > 0)
+                    @if (($licenseModel->seats) && ($licenseModel->seats) > 0)
                     <tr>
                       <td>{{ trans('admin/licenses/form.seats') }}:</td>
-                      <td>{{ $license->seats }}</td>
+                      <td>{{ $licenseModel->seats }}</td>
                     </tr>
                     @endif
 
                     <tr>
                       <td>{{ trans('admin/licenses/form.reassignable') }}:</td>
-                      <td>{{ $license->reassignable ? 'Yes' : 'No' }}</td>
+                      <td>{{ $licenseModel->reassignable ? 'Yes' : 'No' }}</td>
                     </tr>
 
-                    @if ($license->notes)
+                    @if ($licenseModel->notes)
                     <tr>
                       <td>{{ trans('general.notes') }}:</td>
                       <td>
-                        {!! nl2br(e($license->notes)) !!}
+                        {!! nl2br(e($licenseModel->notes)) !!}
                       </td>
                     </tr>
                     @endif
@@ -286,7 +286,7 @@
                 data-sort-name="name"
                 class="table table-striped snipe-table"
                 data-export-options='{
-                    "fileName": "export-license-uploads-{{ str_slug($license->name) }}-{{ date('Y-m-d') }}",
+                    "fileName": "export-license-uploads-{{ str_slug($licenseModel->name) }}-{{ date('Y-m-d') }}",
                     "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","delete","download","icon"]
                     }'>
             <thead>
@@ -301,8 +301,8 @@
               </tr>
             </thead>
             <tbody>
-            @if ($license->uploads->count() > 0)
-              @foreach ($license->uploads as $file)
+            @if ($licenseModel->uploads->count() > 0)
+              @foreach ($licenseModel->uploads as $file)
               <tr>
                 <td><i class="{{ \App\Helpers\Helper::filetype_icon($file->filename) }} icon-med"></i></td>
                 <td>
@@ -318,17 +318,17 @@
                 <td>
                 @if ($file->filename)
                     @if ( \App\Helpers\Helper::checkUploadIsImage($file->get_src('licenses')))
-                      <a href="{{ route('show.licensefile', ['licenseId' => $license->id, 'fileId' => $file->id, 'download' => 'false']) }}" data-toggle="lightbox" data-type="image"><img src="{{ route('show.licensefile', ['licenseId' => $license->id, 'fileId' => $file->id]) }}" class="img-thumbnail" style="max-width: 50px;"></a>
+                      <a href="{{ route('show.licensefile', ['licenseId' => $licenseModel->id, 'fileId' => $file->id, 'download' => 'false']) }}" data-toggle="lightbox" data-type="image"><img src="{{ route('show.licensefile', ['licenseId' => $licenseModel->id, 'fileId' => $file->id]) }}" class="img-thumbnail" style="max-width: 50px;"></a>
                     @endif
                 @endif
                 </td>
                 <td>
                   @if ($file->filename)
-                    <a href="{{ route('show.licensefile', [$license->id, $file->id, 'download' => 'true']) }}" class="btn btn-default"><i class="fa fa-download"></i></a>
+                    <a href="{{ route('show.licensefile', [$licenseModel->id, $file->id, 'download' => 'true']) }}" class="btn btn-default"><i class="fa fa-download"></i></a>
                   @endif
                 </td>
                 <td>
-                  <a class="btn delete-asset btn-danger btn-sm" href="{{ route('delete/licensefile', [$license->id, $file->id]) }}" data-content="Are you sure you wish to delete this file?" data-title="Delete {{ $file->filename }}?"><i class="fa fa-trash icon-white"></i></a>
+                  <a class="btn delete-asset btn-danger btn-sm" href="{{ route('delete/licensefile', [$licenseModel->id, $file->id]) }}" data-content="Are you sure you wish to delete this file?" data-title="Delete {{ $file->filename }}?"><i class="fa fa-trash icon-white"></i></a>
                 </td>
               </tr>
               @endforeach
@@ -358,10 +358,10 @@
                       data-show-export="true"
                       data-sort-order="desc"
                       data-export-options='{
-                       "fileName": "export-{{ str_slug($license->name) }}-history-{{ date('Y-m-d') }}",
+                       "fileName": "export-{{ str_slug($licenseModel->name) }}-history-{{ date('Y-m-d') }}",
                        "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                      }'
-                      data-url="{{ route('api.activity.index', ['item_id' => $license->id, 'item_type' => 'license']) }}">
+                      data-url="{{ route('api.activity.index', ['item_id' => $licenseModel->id, 'item_type' => 'license']) }}">
 
                 <thead>
                 <tr>
@@ -386,8 +386,8 @@
   </div>  <!-- /.col -->
 </div> <!-- /.row -->
 
-@can('update', \App\Models\License::class)
-  @include ('modals.upload-file', ['item_type' => 'license', 'item_id' => $license->id])
+@can('update', \App\Models\LicenseModel::class)
+  @include ('modals.upload-file', ['item_type' => 'license', 'item_id' => $licenseModel->id])
 @endcan
 
 @stop

--- a/resources/views/reports/licenses.blade.php
+++ b/resources/views/reports/licenses.blade.php
@@ -47,7 +47,7 @@
                         </thead>
 
                         <tbody>
-                            @foreach ($licenses as $license)
+                            @foreach ($licenseModels as $license)
                             <tr>
                                 <td>{{ is_null($license->company) ? '' : $license->company->name }}</td>
                                 <td>{{ $license->name }}</td>

--- a/resources/views/users/confirm-bulk-delete.blade.php
+++ b/resources/views/users/confirm-bulk-delete.blade.php
@@ -76,7 +76,7 @@ Bulk Checkin &amp; Delete
                       {{ number_format($user->accessories()->count())  }}
                     </td>
                     <td>
-                      {{ number_format($user->licenses()->count())  }}
+                      {{ number_format($user->licenseModels()->count())  }}
                     </td>
                   </tr>
                   @endforeach

--- a/tests/api/ApiCategoriesCest.php
+++ b/tests/api/ApiCategoriesCest.php
@@ -31,7 +31,7 @@ class ApiCategoriesCest
 
         $response = json_decode($I->grabResponse(), true);
         // sample verify
-        $category = App\Models\Category::withCount('assets as assets_count','accessories as accessories_count','consumables as consumables_count','components as components_count','licenses as licenses_count')
+        $category = App\Models\Category::withCount('assets as assets_count','accessories as accessories_count','consumables as consumables_count','components as components_count','licenseModels as licenses_count')
             ->orderByDesc('id')->take(10)->get()->shuffle()->first();
         $I->seeResponseContainsJson($I->removeTimestamps((new CategoriesTransformer)->transformCategory($category)));
     }

--- a/tests/api/ApiLicensesCest.php
+++ b/tests/api/ApiLicensesCest.php
@@ -144,9 +144,9 @@ class ApiLicensesCest
         $licenseModel = factory(\App\Models\LicenseModel::class)->states('acrobat')->create([
             'name' => "Soon to be deleted"
         ]);
-        $licenseSeat = $licenseModel->freeSeat();
-        $licenseSeat->assigned_to = $this->user->id;
-        $licenseSeat->save();
+        $license = $licenseModel->freeSeat();
+        $license->assigned_to = $this->user->id;
+        $license->save();
         $I->assertInstanceOf(\App\Models\LicenseModel::class, $licenseModel);
 
         // delete

--- a/tests/api/ApiLicensesCest.php
+++ b/tests/api/ApiLicensesCest.php
@@ -29,6 +29,7 @@ class ApiLicensesCest
         $licenseModel = App\Models\LicenseModel::orderByDesc('created_at')
             ->withCount('freeLicenses')
             ->take(10)->get()->shuffle()->first();
+
         $I->seeResponseContainsJson($I->removeTimestamps((new LicensesTransformer)->transformLicense($licenseModel)));
     }
 

--- a/tests/api/ApiLicensesCest.php
+++ b/tests/api/ApiLicensesCest.php
@@ -27,7 +27,7 @@ class ApiLicensesCest
         $response = json_decode($I->grabResponse(), true);
         // sample verify
         $licenseModel = App\Models\LicenseModel::orderByDesc('created_at')
-            ->withCount('freeSeats')
+            ->withCount('freeLicenses')
             ->take(10)->get()->shuffle()->first();
         $I->seeResponseContainsJson($I->removeTimestamps((new LicensesTransformer)->transformLicense($licenseModel)));
     }
@@ -144,7 +144,7 @@ class ApiLicensesCest
         $licenseModel = factory(\App\Models\LicenseModel::class)->states('acrobat')->create([
             'name' => "Soon to be deleted"
         ]);
-        $license = $licenseModel->freeSeat();
+        $license = $licenseModel->freeLicense();
         $license->assigned_to = $this->user->id;
         $license->save();
         $I->assertInstanceOf(\App\Models\LicenseModel::class, $licenseModel);

--- a/tests/api/ApiUsersCest.php
+++ b/tests/api/ApiUsersCest.php
@@ -32,7 +32,7 @@ class ApiUsersCest
         $response = json_decode($I->grabResponse(), true);
         // sample verify
         $user = App\Models\User::orderByDesc('created_at')
-            ->withCount('assets as assets_count', 'licenses as licenses_count', 'accessories as accessories_count', 'consumables as consumables_count')
+            ->withCount('assets as assets_count', 'licenseModels as licenses_count', 'accessories as accessories_count', 'consumables as consumables_count')
             ->take(10)->get()->shuffle()->first();
         $I->seeResponseContainsJson($I->removeTimestamps((new UsersTransformer)->transformUser($user)));
     }

--- a/tests/functional/LicensesCest.php
+++ b/tests/functional/LicensesCest.php
@@ -1,7 +1,7 @@
 <?php
 
 
-use App\Models\License;
+use App\Models\LicenseModel;
 
 class LicensesCest
 {
@@ -48,27 +48,27 @@ class LicensesCest
 
     public function passesCorrectValidation(FunctionalTester $I)
     {
-        $license = factory(App\Models\License::class)->states('photoshop')->make([
+        $licenseModel = factory(App\Models\LicenseModel::class)->states('photoshop')->make([
             'name' => 'Test License',
             'company_id' => 3,
         ]);
         $values = [
-            'company_id'        => $license->company_id,
+            'company_id'        => $licenseModel->company_id,
             'expiration_date'   => '2018-01-01',
-            'license_email'     => $license->license_email,
-            'license_name'      => $license->license_name,
+            'license_email'     => $licenseModel->license_email,
+            'license_name'      => $licenseModel->license_name,
             'maintained'        => true,
-            'manufacturer_id'   => $license->manufacturer_id,
-            'category_id'       => $license->category_id,
-            'name'              => $license->name,
-            'notes'             => $license->notes,
-            'order_number'      => $license->order_number,
-            'purchase_cost'     => $license->purchase_cost,
+            'manufacturer_id'   => $licenseModel->manufacturer_id,
+            'category_id'       => $licenseModel->category_id,
+            'name'              => $licenseModel->name,
+            'notes'             => $licenseModel->notes,
+            'order_number'      => $licenseModel->order_number,
+            'purchase_cost'     => $licenseModel->purchase_cost,
             'purchase_date'     => '2016-01-01',
-            'purchase_order'    => $license->purchase_order,
+            'purchase_order'    => $licenseModel->purchase_order,
             'reassignable'      => true,
-            'seats'             => $license->seats,
-            'serial'            => $license->serial,
+            'seats'             => $licenseModel->seats,
+            'serial'            => $licenseModel->serial,
             'termination_date'  => '2020-01-01',
         ];
 
@@ -83,7 +83,7 @@ class LicensesCest
     public function allowsDelete(FunctionalTester $I)
     {
         $I->wantTo('Ensure I can delete a license');
-        $I->sendDelete(route('licenses.destroy', License::doesntHave('assignedUsers')->first()->id), ['_token' => csrf_token()]);
+        $I->sendDelete(route('licenses.destroy', LicenseModel::doesntHave('assignedUsers')->first()->id), ['_token' => csrf_token()]);
         $I->seeResponseCodeIs(200);
     }
 

--- a/tests/unit/CompanyTest.php
+++ b/tests/unit/CompanyTest.php
@@ -48,7 +48,7 @@ class CompanyTest extends BaseTest
      public function testACompanyCanHaveLicenses()
      {
          $company = $this->createValidCompany();
-         factory(App\Models\License::class, 1)->states('acrobat')->create([
+         factory(App\Models\LicenseModel::class, 1)->states('acrobat')->create([
              'company_id'=>$company->id,
              'manufacturer_id' => factory(App\Models\Manufacturer::class)->states('adobe')->create()->id,
              'category_id' => factory(App\Models\Category::class)->states('license-office-category')->create()->id

--- a/tests/unit/DepreciationTest.php
+++ b/tests/unit/DepreciationTest.php
@@ -44,6 +44,6 @@ class DepreciationTest extends BaseTest
              'category_id' => $category->id
          ]);
 
-         $this->assertEquals(5,$depreciation->has_licenses());
+         $this->assertEquals(5,$depreciation->licenses()->count());
      }
 }

--- a/tests/unit/DepreciationTest.php
+++ b/tests/unit/DepreciationTest.php
@@ -39,7 +39,7 @@ class DepreciationTest extends BaseTest
      {
          $category = $this->createValidCategory('license-graphics-category');
          $depreciation = $this->createValidDepreciation('computer', ['name' => 'New Depreciation']);
-         $licenses = factory(App\Models\License::class, 5)->states('photoshop')->create([
+         $licenses = factory(App\Models\LicenseModel::class, 5)->states('photoshop')->create([
              'depreciation_id'=>$depreciation->id,
              'category_id' => $category->id
          ]);

--- a/tests/unit/PermissionsTest.php
+++ b/tests/unit/PermissionsTest.php
@@ -1,14 +1,6 @@
 <?php
 
-use App\Models\Accessory;
-use App\Models\Asset;
-use App\Models\Component;
-use App\Models\Consumable;
-use App\Models\License;
 use App\Models\User;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
-use Illuminate\Foundation\Testing\WithoutMiddleware;
 
 class PermissionsTest extends BaseTest
 {


### PR DESCRIPTION
Another one in my series of changes to make @tilldeeke hate trying to keep his branch up to date :)

This is an attempt to start the process of unifying how we think about various item types.  It moves licenses/licenseseats to be renamed licensemodel/license, to bring it inline with assets, as well as renaming assorted methods/relationships.  This particular patchset does not do anything to adjust how we interact with licenses vs. assets--Licenses are still interacted with through the model much more readily than assets are, but it does seek to unify the terminology.

If we were to proceed down this road, I think I'd continue with the following approach:
1) Move Accessories/Consumables/Components to a similar setup.  This would involve a bit more database work/adjustments, as we'd want to create a row in the database for each item regardless of it's checked out status.  This would open the door as well to having specific serial numbers/item level data for accessories/consumables/etc.  
2) Evaluate what the changes might be if we thought about looking at assets more in the way we look at everything else--that is: Approaching the checkout process from the assetmodel level in most cases, and focusing the code such that "I want to checkout a macbook pro to this user" is more facilitated than "I want to checkout this macbook pro to this user"--While still allowing for the latter.
3) Once doing that, taking another pass through everything and identifying what behavior has now become common/can be extracted to a common checkoutable trait.
4) Evaluate at this point whether or not a Checkouts model/database table makes sense, and what it may look like.