### PR TITLE
Fixed #6079: QR Code unnecessarily squished.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,6 @@ APP_KEY=ChangeMe
 APP_URL=null
 APP_TIMEZONE='UTC'
 APP_LOCALE=en
-BACKUP_ENV=false
 
 # --------------------------------------------
 # REQUIRED: DATABASE SETTINGS

--- a/app/Console/Commands/PaveIt.php
+++ b/app/Console/Commands/PaveIt.php
@@ -79,6 +79,7 @@ class PaveIt extends Command
                 DB::statement('delete from accessories_users');
                 DB::statement('delete from asset_logs');
                 DB::statement('delete from asset_maintenances');
+                DB::statement('delete from login_attempts');
                 DB::statement('delete from asset_uploads');
                 DB::statement('delete from action_logs');
                 DB::statement('delete from checkout_requests');

--- a/app/Console/Commands/RestoreDeletedUsers.php
+++ b/app/Console/Commands/RestoreDeletedUsers.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\User;
+use App\Models\Actionlog;
+use App\Models\Asset;
+use App\Models\Consumable;
+use App\Models\Accessory;
+use App\Models\LicenseSeat;
+use App\Models\License;
+use DB;
+use Artisan;
+
+class RestoreDeletedUsers extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'snipeit:restore-users {--start_date=} {--end_date=}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Restore users, and any associated assets and license checkouts.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+
+        $start_date = $this->option('start_date');
+        $end_date = $this->option('end_date');
+        $asset_totals = 0;
+        $license_totals = 0;
+        $user_count = 0;
+
+
+        if (($start_date=='') || ($end_date=='')) {
+            $this->info('ERROR: All fields are required.');
+            return false;
+        }
+
+        $users = User::whereBetween('deleted_at', [$start_date, $end_date])->withTrashed()->get();
+        $this->info('There are '.$users->count().' users deleted between '.$start_date.' and '.$end_date);
+        $this->warn('Making a backup!');
+        Artisan::call('backup:run');
+
+        foreach ($users as $user) {
+            $user_count++;
+            $user_logs = Actionlog::where('target_id', $user->id)->where('target_type',User::class)
+                ->where('action_type','checkout')->with('item')->get();
+
+            $this->info($user_count.'. '.$user->username.' ('.$user->id.') was deleted at '.$user->deleted_at. ' and has '.$user_logs->count().' checkouts associated.');
+
+            foreach ($user_logs as $user_log) {
+                $this->info('  * '.$user_log->item_type.': '.$user_log->item->name.' - item_id: '.$user_log->item_id);
+
+                if ($user_log->item_type==Asset::class) {
+                    $asset_totals++;
+
+                    DB::table('assets')
+                        ->where('id', $user_log->item_id)
+                        ->update(['assigned_to' => $user->id, 'assigned_type'=> User::class]);
+
+                    $this->info('      ** Asset '.$user_log->item->id.' ('.$user_log->item->asset_tag.') restored to user '.$user->id.'');
+
+                } elseif ($user_log->item_type==License::class) {
+                    $license_totals++;
+
+                    $avail_seat = DB::table('license_seats')->where('license_id','=',$user_log->item->id)
+                        ->whereNull('assigned_to')->whereNull('asset_id')->whereBetween('updated_at', [$start_date, $end_date])->first();
+                    if ($avail_seat) {
+                        $this->info('      ** Allocating seat '.$avail_seat->id.' for this License');
+
+                        DB::table('license_seats')
+                            ->where('id', $avail_seat->id)
+                            ->update(['assigned_to' => $user->id]);
+
+                    } else {
+                        $this->warn('ERROR: No available seats for '.$user_log->item->name);
+                    }
+
+                }
+
+            }
+
+            $this->warn('Restoring user '.$user->username.'!');
+            $user->restore();
+
+
+        }
+
+        $this->info($asset_totals.' assets affected');
+        $this->info($license_totals.' licenses affected');
+
+
+
+    }
+
+
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -30,6 +30,7 @@ class Kernel extends ConsoleKernel
         Commands\SyncAssetLocations::class,
         Commands\RegenerateAssetTags::class,
         Commands\SyncAssetCounters::class,
+        Commands\RestoreDeletedUsers::class,
     ];
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "snipe/snipe-it",
   "description": "Open source asset management system built on Laravel.",
   "keywords": ["assets", "asset-management", "laravel"],
-  "license": "AGPL-3",
+  "license": "AGPL-3.0-or-later",
   "type": "project",
     "require": {
     "php": ">=5.6.4",

--- a/resources/views/hardware/labels.blade.php
+++ b/resources/views/hardware/labels.blade.php
@@ -11,9 +11,9 @@
     $settings->labels_width = $settings->labels_width - $settings->labels_display_sgutter;
     $settings->labels_height = $settings->labels_height - $settings->labels_display_bgutter;
     // Leave space on bottom for 1D barcode if necessary
-    $qr_size = ($settings->alt_barcode_enabled=='1') && ($settings->alt_barcode!='') ? $settings->labels_height - .3 : $settings->labels_height - .3;
+    $qr_size = ($settings->alt_barcode_enabled=='1') && ($settings->alt_barcode!='') ? $settings->labels_height - .3 : $settings->labels_height;
     // Leave space on left for QR code if necessary
-    $qr_txt_size = ($settings->qr_code=='1' ? $settings->labels_width - $qr_size - .1: $settings->labels_width);
+    $qr_txt_size = ($settings->qr_code=='1' ? $settings->labels_width - $qr_size - .1 : $settings->labels_width);
     ?>
 
   <style>


### PR DESCRIPTION
Fixed a ternary expression so that the negative outcome does the right thing - that is, to properly size the QR code when the 2D barcode is omitted from the label.
