### PR TITLE
Add write-only `image_source` field for asset create/edit API endpoint

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -20,6 +20,7 @@ use App\Models\Consumable;
 use App\Models\Asset;
 use App\Models\Setting;
 use Crypt;
+use Image;
 use Illuminate\Contracts\Encryption\DecryptException;
 
 class Helper
@@ -703,4 +704,47 @@ class Helper
         }
         return $password;
     }
+
+    /**
+     * Process base64 encoded image data and save it on supplied path
+     *
+     * @param string $image_data base64 encoded image data with mime type
+     * @param string $save_path path to a folder where the image should be saved
+     * @return string path to uploaded image or false if something went wrong
+     */
+    public static function processUploadedImage(String $image_data, String $save_path) {
+        if ($image_data != null && $save_path != null) {
+            // After modification, the image is prefixed by mime info like the following:
+            // data:image/jpeg;base64,; This causes the image library to be unhappy, so we need to remove it.
+            $header = explode(';', $image_data, 2)[0];
+            // Grab the image type from the header while we're at it.
+            $extension = substr($header, strpos($header, '/')+1);
+            // Start reading the image after the first comma, postceding the base64.
+            $image = substr($image_data, strpos($image_data, ',')+1);
+
+            $file_name = str_random(25).".".$extension;
+
+            $directory= public_path($save_path);
+            // Check if the uploads directory exists.  If not, try to create it.
+            if (!file_exists($directory)) {
+                mkdir($directory, 0755, true);
+            }
+
+            $path = public_path($save_path.$file_name);
+
+            try {
+                Image::make($image)->resize(500, 500, function ($constraint) {
+                    $constraint->aspectRatio();
+                    $constraint->upsize();
+                })->save($path);
+            } catch (\Exception $e) {
+                return false;
+            }
+
+            return $file_name;
+        }
+
+        return false;
+    }
+
 }

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -387,7 +387,7 @@ class AssetsController extends Controller
                 $asset->use_text .= ' → '.$asset->assigned->getFullNameAttribute();
             }
 
-            
+
             if ($asset->assetstatus->getStatuslabelType()=='pending') {
                 $asset->use_text .=  '('.$asset->assetstatus->getStatuslabelType().')';
             }
@@ -436,6 +436,22 @@ class AssetsController extends Controller
         $asset->requestable             = $request->get('requestable', 0);
         $asset->rtd_location_id         = $request->get('rtd_location_id', null);
 
+        if ($request->has('image_source') && $request->input('image_source') != "") {
+            $saved_image_path = Helper::processUploadedImage(
+                $request->input('image_source'), 'uploads/assets/'
+            );
+
+            if (!$saved_image_path) {
+                return response()->json(Helper::formatStandardApiResponse(
+                        'error',
+                        null,
+                        trans('admin/hardware/message.create.error')
+                    ), 200);
+            }
+
+            $asset->image = $saved_image_path;
+        }
+
         // Update custom fields in the database.
         // Validation for these fields is handled through the AssetRequest form request
         $model = AssetModel::find($request->get('model_id'));
@@ -457,6 +473,11 @@ class AssetsController extends Controller
             if (isset($target)) {
                 $asset->checkOut($target, Auth::user(), date('Y-m-d H:i:s'), '', 'Checked out on asset creation', e($request->get('name')));
             }
+
+            if ($asset->image) {
+                $asset->image = $asset->getImageUrl();
+            }
+
             return response()->json(Helper::formatStandardApiResponse('success', $asset, trans('admin/hardware/message.create.success')));
         }
 
@@ -487,6 +508,25 @@ class AssetsController extends Controller
             ($request->filled('company_id')) ?
                 $asset->company_id = Company::getIdForCurrentUser($request->get('company_id')) : '';
 
+            if ($request->has('image_source')) {
+                if ($request->input('image_source') == "") {
+                    $asset->image = null;
+                } else {
+                    $saved_image_path = Helper::processUploadedImage(
+                        $request->input('image_source'), 'uploads/assets/'
+                    );
+
+                    if (!$saved_image_path) {
+                        return response()->json(Helper::formatStandardApiResponse(
+                            'error',
+                            null,
+                            trans('admin/hardware/message.update.error')
+                        ), 200);
+                    }
+
+                    $asset->image = $saved_image_path;
+                }
+            }
 
             // Update custom fields
             if (($model = AssetModel::find($asset->model_id)) && (isset($model->fieldset))) {
@@ -510,6 +550,10 @@ class AssetsController extends Controller
 
                 if (isset($target)) {
                     $asset->checkOut($target, Auth::user(), date('Y-m-d H:i:s'), '', 'Checked out on asset update', e($request->get('name')), $location);
+                }
+
+                if ($asset->image) {
+                    $asset->image = $asset->getImageUrl();
                 }
 
                 return response()->json(Helper::formatStandardApiResponse('success', $asset, trans('admin/hardware/message.update.success')));


### PR DESCRIPTION
Tested with `Content-Type: application/x-www-form-urlencoded` and file
attached as base64 encoded string after mime type in field `image_source`.