### PR TITLE
Fixed checking that email alerts are enabled (#6169)

### DIFF
--- a/app/Console/Commands/SendExpectedCheckinAlerts.php
+++ b/app/Console/Commands/SendExpectedCheckinAlerts.php
@@ -40,7 +40,7 @@ class SendExpectedCheckinAlerts extends Command
     /**
      * Execute the console command.
      *
-     * @return mixed
+     * @return void
      */
     public function handle()
     {
@@ -57,17 +57,11 @@ class SendExpectedCheckinAlerts extends Command
             }
         }
 
-
         // Send a rollup to the admin, if settings dictate
         $recipient = new \App\Models\Recipients\AlertRecipient();
 
-        if (($assets) && ($assets->count() > 0) && ($settings->alert_email!='')) {
+        if (($assets) && ($assets->count() > 0) && ($settings->alerts_enabled && $settings->alert_email != '')) {
             $recipient->notify(new ExpectedCheckinAdminNotification($assets));
         }
-
-
-
-
-
     }
 }


### PR DESCRIPTION
Checking that email alerts are enabled when trying to send expected check-in alerts (fix for issue #6169)