### PR TITLE
Fixing checking of user permissions when no user-specific permissions set

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -126,12 +126,13 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
 
         $user_permissions = json_decode($this->permissions, true);
 
+        $is_user_section_permissions_set = ($user_permissions != '') && array_key_exists($section, $user_permissions);
         //If the user is explicitly granted, return true
-        if (($user_permissions!='') && ((array_key_exists($section, $user_permissions)) && ($user_permissions[$section]=='1'))) {
+        if ($is_user_section_permissions_set && ($user_permissions[$section]=='1')) {
             return true;
         }
         // If the user is explicitly denied, return false
-        if (($user_permissions=='') || array_key_exists($section, $user_permissions) && ($user_permissions[$section]=='-1')) {
+        if ($is_user_section_permissions_set && ($user_permissions[$section]=='-1')) {
             return false;
         }
 


### PR DESCRIPTION
When a user has no permissions set (=NULL) in the database (like after an
LDAP import) but is a member of a group with permissions, those group
permissions would not have be applied, effectively denying every access
regardless of group permissions.