### PR TITLE
Public function save() missing array.

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -168,7 +168,7 @@ class Asset extends Depreciable
      *
      * @var array
      */
-    public function save($params = [])
+    public function save(array $params = [])
     {
         $settings = \App\Models\Setting::getSettings();
 


### PR DESCRIPTION
The class was missing as a result that the composer was unable to update and the site returned a 500 error
```
$ composer update
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Nothing to install or update
Package guzzle/guzzle is abandoned, you should avoid using it. Use guzzlehttp/guzzle instead.
Generating optimized autoload files
> Illuminate\Foundation\ComposerScripts::postAutoloadDump
> @php artisan package:discover

In Asset.php line 30:
                                                                               
  Declaration of App\Models\Asset::save($params = Array) should be compatible  
   with Illuminate\Database\Eloquent\Model::save(array $options = Array)       
                                                                               

Script @php artisan package:discover handling the post-autoload-dump event returned with error code 1
```