### PR TITLE
Sync with develop branch.

### DIFF
--- a/upgrade.php
+++ b/upgrade.php
@@ -13,7 +13,9 @@ if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
 }
 
 
-((array_key_exists('1',$argv[1]))) ? $branch = $argv[1] : $branch = 'master';
+// Check if a branch or tag was passed in the command line,
+// otherwise just use master
+(array_key_exists('1', $argv)) ? $branch = $argv[1] : $branch = 'master';
 
 echo "Welcome to the Snipe-IT upgrader.\n\n";
 echo "Please note that this script will not download the latest Snipe-IT \n";


### PR DESCRIPTION
Without this change argv[1] is ignored.

This is because `array_key_exists` expects an array as its second argument so it fails to see the command line argument and always uses master instead of the given branch.

This is correct in develop, but not master. They diverged through separate commits around a month ago.