### PR TITLE
Use username instead of email address in password reset

### DIFF
--- a/app/Http/Controllers/Auth/ForgotPasswordController.php
+++ b/app/Http/Controllers/Auth/ForgotPasswordController.php
@@ -72,6 +72,6 @@ class ForgotPasswordController extends Controller
 
         // Regardless of response, we do not want to disclose the status of a user account,
         // so we give them a generic "If this exists, we're TOTALLY gonna email you" response
-        return back()->with('success',trans('passwords.sent'));
+        return redirect()->route('login')->with('success',trans('passwords.sent'));
     }
 }

--- a/app/Http/Controllers/Auth/ForgotPasswordController.php
+++ b/app/Http/Controllers/Auth/ForgotPasswordController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Auth;
 use App\Http\Controllers\Controller;
 use Illuminate\Foundation\Auth\SendsPasswordResetEmails;
 use Illuminate\Http\Request;
+use App\Models\User;
 
 class ForgotPasswordController extends Controller
 {
@@ -49,27 +50,28 @@ class ForgotPasswordController extends Controller
      */
     public function sendResetLinkEmail(Request $request)
     {
-        $this->validate($request, ['email' => 'required|email']);
+        $this->validate($request, ['username' => 'required'], ['username.required' => 'Please enter your username.']);
 
-        // We will send the password reset link to this user. Once we have attempted
-        // to send the link, we will examine the response then see the message we
-        // need to show to the user. Finally, we'll send out a proper response.
+
+        // Make sure the user is active, and their password is not controlled via LDAP
         $response = $this->broker()->sendResetLink(
             array_merge(
-                $request->only('email'),
-                ['activated' => '1']
+                $request->only('username'),
+                ['activated' => '1'],
+                ['ldap_import' => '0']
             )
         );
 
         if ($response === \Password::RESET_LINK_SENT) {
-            return redirect()->route('login')->with('status', trans($response));
+            \Log::info('Password reset attempt: User '.$request->input('username').' found, password reset sent');
+        } else {
+            \Log::info('Password reset attempt: User '.$request->input('username').' not found or user is inactive');
         }
 
-        // If an error was returned by the password broker, we will get this message
-        // translated so we can notify a user of the problem. We'll redirect back
-        // to where the users came from so they can attempt this process again.
-        return back()->withErrors(
-            ['email' => trans($response)]
-        );
+
+
+        // Regardless of response, we do not want to disclose the status of a user account,
+        // so we give them a generic "If this exists, we're TOTALLY gonna email you" response
+        return back()->with('success',trans('passwords.sent'));
     }
 }

--- a/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Foundation\Auth\ResetsPasswords;
-use App\Models\User;
 use Illuminate\Http\Request;
 
 
@@ -58,22 +57,17 @@ class ResetPasswordController extends Controller
     }
     
 
-    public function showSnipeResetForm(Request $request, $token = null)
+    public function showResetForm(Request $request, $token = null)
     {
-        // Check that the user is active
-        if ($user = User::where('username', '=',$request->input('username'))->where('activated','=','1')->count() > 0) {
-            return view('auth.passwords.reset')->with(
-                ['token' => $token, 'username' => $request->username]
-            );
-
-        }
-        return redirect()->route('password.request')->withErrors(['username' => 'No matching users']);
+        return view('auth.passwords.reset')->with(
+            ['token' => $token, 'username' => $request->input('username')]
+        );
     }
 
     protected function sendResetFailedResponse(Request $request, $response)
     {
         return redirect()->back()
-            ->withInput($request->only('username'))
+            ->withInput(['username'=>$request->input('username')])
             ->withErrors(['username' => trans($response)]);
     }
 

--- a/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -39,18 +39,42 @@ class ResetPasswordController extends Controller
     {
         $this->middleware('guest');
     }
+
+    protected function rules()
+    {
+        return [
+            'token' => 'required',
+            'username' => 'required',
+            'password' => 'required|confirmed|min:6',
+        ];
+    }
+
+
+    protected function credentials(Request $request)
+    {
+        return $request->only(
+            'username', 'password', 'password_confirmation', 'token'
+        );
+    }
     
 
     public function showSnipeResetForm(Request $request, $token = null)
     {
         // Check that the user is active
-        if ($user = User::where('email', '=',$request->input('email'))->where('activated','=','1')->count() > 0) {
+        if ($user = User::where('username', '=',$request->input('username'))->where('activated','=','1')->count() > 0) {
             return view('auth.passwords.reset')->with(
-                ['token' => $token, 'email' => $request->email]
+                ['token' => $token, 'username' => $request->username]
             );
 
         }
-        return redirect()->route('password.request')->withErrors(['email' => 'No matching users']);
+        return redirect()->route('password.request')->withErrors(['username' => 'No matching users']);
+    }
+
+    protected function sendResetFailedResponse(Request $request, $response)
+    {
+        return redirect()->back()
+            ->withInput($request->only('username'))
+            ->withErrors(['username' => trans($response)]);
     }
 
 }

--- a/resources/lang/en/auth/message.php
+++ b/resources/lang/en/auth/message.php
@@ -19,19 +19,15 @@ return array(
         'success' => 'Account sucessfully created.',
     ),
 
-        'forgot-password' => array(
-            'error'   => 'There was a problem while trying to get a reset password code, please try again.',
-            'success' => 'Password recovery email successfully sent.',
-        ),
-
-        'forgot-password-confirm' => array(
-            'error'   => 'There was a problem while trying to reset your password, please try again.',
-            'success' => 'Your password has been successfully reset.',
-        ),
-
-    'activate' => array(
-        'error'   => 'There was a problem while trying to activate your account, please try again.',
-        'success' => 'Your account has been successfully activated.',
+    'forgot-password' => array(
+        'error'   => 'There was a problem while trying to get a reset password code, please try again.',
+        'success' => 'Password recovery email successfully sent.',
     ),
+
+    'forgot-password-confirm' => array(
+        'error'   => 'There was a problem while trying to reset your password, please try again.',
+        'success' => 'Your password has been successfully reset.',
+    ),
+
 
 );

--- a/resources/lang/en/passwords.php
+++ b/resources/lang/en/passwords.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    'sent'	        => 'Your password link has been sent!',
-    'user'			=> 'No matching active user found with that email.',
+    'sent'	        => 'If a matching username and email address is found, a password reset link will be sent!',
+    'user'			=> 'No matching active user found.',
 ];
 

--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -31,11 +31,11 @@
 
 
 
-                                    <div class="form-group{{ $errors->has('email') ? ' has-error' : '' }}">
+                                    <div class="form-group{{ $errors->has('username') ? ' has-error' : '' }}">
 
                                         <div class="col-md-12">
-                                            <input type="email" class="form-control" name="email" value="{{ old('email') }}" placeholder="{{ trans('admin/users/table.email') }}">
-                                            {!! $errors->first('email', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
+                                            <input type="text" class="form-control" name="username" value="{{ old('username') }}" placeholder="{{ trans('admin/users/table.username') }}">
+                                            {!! $errors->first('username', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
                                         </div>
                                     </div>
 

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -31,12 +31,12 @@
 
                                     <input type="hidden" name="token" value="{{ $token }}">
 
-                                    <div class="form-group{{ $errors->has('email') ? ' has-error' : '' }}">
-                                        <label class="col-md-4 control-label">{{ trans('admin/users/table.email')  }}</label>
+                                    <div class="form-group{{ $errors->has('username') ? ' has-error' : '' }}">
+                                        <label class="col-md-4 control-label">{{ trans('admin/users/table.username')  }}</label>
 
                                         <div class="col-md-6">
-                                            <input type="email" class="form-control" name="email" value="{{ $email or old('email') }}">
-                                            {!! $errors->first('email', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
+                                            <input type="text" class="form-control" name="username" value="{{ $username or old('username') }}">
+                                            {!! $errors->first('username', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
 
                             </div>
                         </div>


### PR DESCRIPTION
### Why?

More and more of our users are using password managers such as 1Password, LastPass, etc. This is *great*, BUT our password reset process has been causing an issue. While it's not exactly our fault, it's causing some confusion and friction with our users.

#### Use Case:

1. User Alice tries to login. Maybe she forgot that she's supposed to login with her username and not her email address, or maybe she just forgot what her password is. Either way, she clicks on the "I forgot my password" link on the login form.

2. Alice enters her email address in the "Send Password Reset Link" screen, and (assuming she has an email address associated with her account, she permitted to login, and is not an imported LDAP user) an email is promptly dispatched to her with a reset link. Huzzah!

3. Alice clicks on the reset link, enters her email address and her new password (default Laravel behavior for that flow). She clicks save, her new password is saved to the Snipe-IT database, and she's logged in. Yay!

4. EXCEPT - Alice uses 1Password. When she clicked the save button in step 3, 1Password helpfully offered to save her new information (which is expected). The problem is that the only form fields on that page are email and password, which means her password manager replaces her username with her email address as the login field without her even realizing it. This results in her login ALWAYS failing when she uses her password manager to login, and her having to reset her password every single time she wants to login, with the process repeating again each time. Alice in the meantime understandably thinks Snipe-IT's login is broken and that makes Alice sad.

#### Summary

This PR changes the forgotten password reset form to use the user's username instead of their email address. 

Additionally, even if the user's username is wrong, they are not active, or they are LDAP-imported, they will see the same message. This is intentional, so that an attacker cannot try attempt a dictionary attack against usernames to gather information on what usernames are valid versus invalid. We do insert an info-level log entry in the app log though, for easier debugging. (We already prevent brute-forcing logins themselves, however if an attacker was trying low-hanging fruit like "john.smith", they could potentially learn more about the usernames in the system than they should before they were locked out.)

<img width="385" alt="screen shot 2018-10-31 at 5 22 51 pm" src="https://user-images.githubusercontent.com/197404/47825909-e03c8a00-dd31-11e8-80f6-ec032514e114.png">

With this change, when she changes her password, her password manager will correctly store the new password with her username instead of updating the record with her (erroneous) email address, or creating a new record that the password manager sees as more recent than the previous (correct username) record.

<img width="350" alt="screen shot 2018-10-31 at 5 24 27 pm" src="https://user-images.githubusercontent.com/197404/47825937-02360c80-dd32-11e8-8252-eec873df4943.png">


#### Caveats

Naturally, if the user doesn't have an email address listed, we can't send them a password reset email and they'll need to have their password reset by an admin.

Also, please don't ask us to allow username OR email address as a solve for this. Many of the Snipe-IT admins use the same email address for multiple people or pseudo-people.