### PR TITLE
Fix snipeit:unescape not unescaping quotes

### DIFF
--- a/app/Console/Commands/FixDoubleEscape.php
+++ b/app/Console/Commands/FixDoubleEscape.php
@@ -71,7 +71,7 @@ class FixDoubleEscape extends Command
 
                     foreach($classname::where("$field",'LIKE','%&%')->get() as $row) {
                         $this->info('Updating '.$field.' for '.$classname);
-                        $row->{$field} = html_entity_decode($row->{$field});
+                        $row->{$field} = html_entity_decode($row->{$field},ENT_QUOTES);
                         $row->save();
                         $count[$classname][$field]++;
 


### PR DESCRIPTION
Related to #4568 

[html_entity_decode](https://secure.php.net/manual/en/function.html-entity-decode.php) doesn't touch quotes by default and needs the ``ENT_QUOTES`` flag to do so.