### PR TITLE
New LDAP system tries to load LDAP configuration before determining

### DIFF
--- a/app/Models/LdapAd.php
+++ b/app/Models/LdapAd.php
@@ -53,8 +53,8 @@ class LdapAd extends LdapAdConfiguration
      */
     public function __construct()
     {
-        parent::__construct();
         if($this->isLdapEnabled()) {
+            parent::__construct();
             $this->ldap = new Adldap();
             $this->ldap->addProvider($this->ldapConfig);
         }


### PR DESCRIPTION
whether or not LDAP is actually enabled.

Variably calling-or-not-calling a parent constructor is a little bit scary, but I think it's okay in this environment.

The direct parent of `LdapAd` is `LdapAdConfiguration`. We really only need to call that parent constructor *if* LDAP is actually enabled. If it's not, it's going to try to load a bunch of tables which may or may not actually exist.

Still, this makes me a little nervous. But I hope it fixes the problem and doesn't break our new LDAP.