### PR TITLE
Handle missing Flysystem env vars; let Debugbar autodiscover

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -250,7 +250,7 @@ return [
          * Package Service Providers...
          */
 
-        Barryvdh\Debugbar\ServiceProvider::class,
+        // Barryvdh\Debugbar\ServiceProvider::class, // should be auto-discovered
         Intervention\Image\ImageServiceProvider::class,
         Collective\Html\HtmlServiceProvider::class,
         Spatie\Backup\BackupServiceProvider::class,
@@ -330,7 +330,7 @@ return [
         'Form'      => Collective\Html\FormFacade::class,
         'Html'      => Collective\Html\HtmlFacade::class,
         'Google2FA' => PragmaRX\Google2FALaravel\Facade::class,
-        'Debugbar' => Barryvdh\Debugbar\Facade::class,
+        // 'Debugbar' => Barryvdh\Debugbar\Facade::class, //autodiscover should handle this
         'Image'     => Intervention\Image\ImageManagerStatic::class,
         'Carbon' => Carbon\Carbon::class,
 

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -81,7 +81,7 @@ $config = [
 ];
 
 // When you're dealing with local file storage, the paths will be different than S3
-if  (env('FILESYSTEM_DISK')!='local')
+if  (env('FILESYSTEM_DISK','local')!='local')
 {
     $config['disks']['public'] = $config['disks'][env('FILESYSTEM_DISK')];
     $config['disks']['public']['visibility'] = 'public';


### PR DESCRIPTION
Artisan commands during Docker builds crashed because of references to Debugbar, which is only installed in a 'development' environment via composer. Since Debugbar is can now be auto-discovered under Laravel 5.6 or later, we pull those references out and allow the auto-discover to do its job.

Also, as part of our Flysystem support, we try to set some reasonable defaults for people who are using the 'classic' files-based blob-storage, but we didn't account for a case when the `FILESYSTEM_DISK` env var was not set at all (as it might not be for pre-Snipe-IT-5.0 installations).