### PR TITLE
Initialize customFormat to prevent Blade error when creating new fields

### DIFF
--- a/app/Http/Controllers/CustomFieldsController.php
+++ b/app/Http/Controllers/CustomFieldsController.php
@@ -56,7 +56,8 @@ class CustomFieldsController extends Controller
         $this->authorize('create', CustomField::class);
 
         return view("custom_fields.fields.edit",[
-            'predefinedFormats' => Helper::predefined_formats()
+            'predefinedFormats' => Helper::predefined_formats(),
+	    'customFormat' => ''
         ])->with('field', new CustomField());
     }
 


### PR DESCRIPTION
Errors on develop because customFormat is not defined in "create"