### PR TITLE
Fix an issue when trying to checkin a license seat. [ch46]

### DIFF
--- a/app/Http/Controllers/Licenses/LicenseCheckinController.php
+++ b/app/Http/Controllers/Licenses/LicenseCheckinController.php
@@ -91,7 +91,7 @@ class LicenseCheckinController extends Controller
         // Was the asset updated?
         if ($licenseSeat->save()) {
 
-            event(new CheckoutableCheckedIn($license, $return_to, Auth::user(), $request->input('note')));
+            event(new CheckoutableCheckedIn($licenseSeat, $return_to, Auth::user(), $request->input('note')));
 
             if ($backTo=='user') {
                 return redirect()->route("users.show", $return_to->id)->with('success', trans('admin/licenses/message.checkin.success'));

--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -131,7 +131,7 @@ class CheckoutableListener
                 $notificationClass = CheckinLicenseSeatNotification::class;
                 break;
         }
-
+ 
         return new $notificationClass($event->checkoutable, $event->checkedOutTo, $event->checkedInBy, $event->note);  
     }
 

--- a/resources/views/licenses/checkin.blade.php
+++ b/resources/views/licenses/checkin.blade.php
@@ -17,7 +17,7 @@
     <div class="row">
         <!-- left column -->
         <div class="col-md-7">
-            <form class="form-horizontal" method="post" action="{{ route('licenses.checkin.save', $licenseSeat->id) }}" autocomplete="off">
+            <form class="form-horizontal" method="post" action="{{ route('licenses.checkin.save', ['licenseId'=>$licenseSeat->id, 'backTo'=>'user'] ) }}" autocomplete="off">
                 {{csrf_field()}}
 
                 <div class="box box-default">

--- a/resources/views/licenses/checkin.blade.php
+++ b/resources/views/licenses/checkin.blade.php
@@ -17,7 +17,7 @@
     <div class="row">
         <!-- left column -->
         <div class="col-md-7">
-            <form class="form-horizontal" method="post" action="{{ route('licenses.checkin.save', ['licenseId'=>$licenseSeat->id, 'backTo'=>'user'] ) }}" autocomplete="off">
+            <form class="form-horizontal" method="post" action="{{ route('licenses.checkin.save', ['licenseId'=>$licenseSeat->id, 'backTo'=>$backto] ) }}" autocomplete="off">
                 {{csrf_field()}}
 
                 <div class="box box-default">


### PR DESCRIPTION
 When the LicenseCheckinController tried to instantiate a CheckoutableCheckedIn class, was passing the object $license to the constructor, when the object $licenseSeat was spected. 

Also, after the checkin is processed, I return the browser to 'View User' with the Id of the user that makes the checkin, instead of the 'View License'. I think that makes more sense, but if is not ideal I can change it back.