### PR TITLE
pear.php.net vulnerability fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ php7.2-dev \
 && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 
-RUN curl -O https://raw.githubusercontent.com/pear/pearweb_phars/master/go-pear.phar
+RUN curl -O http://raw.githubusercontent.com/pear/pearweb_phars/master/go-pear.phar
 RUN php go-pear.phar
 
 RUN pecl install mcrypt-1.0.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ php7.2-dev \
 && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 
-RUN curl -O http://pear.php.net/go-pear.phar
+RUN curl -O https://github.com/pear/pearweb_phars/raw/master/go-pear.phar
 RUN php go-pear.phar
 
 RUN pecl install mcrypt-1.0.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ php7.2-dev \
 && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 
-RUN curl -O https://github.com/pear/pearweb_phars/raw/master/go-pear.phar
+RUN curl -O https://raw.githubusercontent.com/pear/pearweb_phars/master/go-pear.phar
 RUN php go-pear.phar
 
 RUN pecl install mcrypt-1.0.1


### PR DESCRIPTION
### Problem

Attempted to build dev branch Dockerfile and was getting hit with a broken go-pear.phar file (<title>404 Not Found</title>).

### Root Cause

Response from http://pear.php.net came back with the message:

> **PEAR server is down**
A security breach has been found on the http://pear.php.net webserver, with a tainted go-pear.phar discovered. The PEAR website itself has been disabled until a known clean site can be rebuilt. A more detailed announcement will be on the PEAR Blog once it's back online.

### Solution

Updated URL for go-pear.phar so that it's obtained from PEAR's repo.