### PR TITLE
Added #6617: View licenses checked out to an asset with the hardware API

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -6,10 +6,12 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\AssetRequest;
 use App\Http\Requests\AssetCheckoutRequest;
 use App\Http\Transformers\AssetsTransformer;
+use App\Http\Transformers\LicensesTransformer;
 use App\Models\Asset;
 use App\Models\AssetModel;
 use App\Models\Company;
 use App\Models\CustomField;
+use App\Models\License;
 use App\Models\Location;
 use App\Models\Setting;
 use App\Models\User;
@@ -332,6 +334,14 @@ class AssetsController extends Controller
 
 
     }
+    public function licenses($id)
+    {
+        $this->authorize('view', Asset::class);
+        $this->authorize('view', License::class);
+        $asset = Asset::where('id', $id)->withTrashed()->first();
+        $licenses = $asset->licenses()->get();
+        return (new LicensesTransformer())->transformLicenses($licenses, $licenses->count());
+     }
 
 
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -305,6 +305,11 @@ Route::group(['prefix' => 'v1','namespace' => 'Api'], function () {
 
     Route::group(['prefix' => 'hardware'], function () {
 
+        Route::get('{asset_id}/licenses',  [
+            'as' => 'api.assets.licenselist',
+            'uses' => 'AssetsController@licenses'
+        ]);
+        
         Route::get( 'bytag/{tag}',  [
             'as' => 'assets.show.bytag',
             'uses' => 'AssetsController@showByTag'


### PR DESCRIPTION
This is the proposed feature to be added for issue #6617. This will add the /hardware/:id/licenses endpoint to view licenses checked out to an asset with the API. 