### PR TITLE
Language of mail doesn't show as intended by the settings. [ch87]

### DIFF
--- a/app/Http/Controllers/Licenses/LicenseCheckinController.php
+++ b/app/Http/Controllers/Licenses/LicenseCheckinController.php
@@ -91,7 +91,7 @@ class LicenseCheckinController extends Controller
         // Was the asset updated?
         if ($licenseSeat->save()) {
 
-            event(new CheckoutableCheckedIn($license, $return_to, Auth::user(), $request->input('note')));
+            event(new CheckoutableCheckedIn($licenseSeat, $return_to, Auth::user(), $request->input('note')));
 
             if ($backTo=='user') {
                 return redirect()->route("users.show", $return_to->id)->with('success', trans('admin/licenses/message.checkin.success'));

--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -131,7 +131,7 @@ class CheckoutableListener
                 $notificationClass = CheckinLicenseSeatNotification::class;
                 break;
         }
-
+ 
         return new $notificationClass($event->checkoutable, $event->checkedOutTo, $event->checkedInBy, $event->note);  
     }
 

--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -40,10 +40,17 @@ class CheckoutableListener
          */
         $acceptance = $this->getCheckoutAcceptance($event);       
 
-        Notification::send(
-            $this->getNotifiables($event), 
-            $this->getCheckoutNotification($event, $acceptance)
-        );
+        if(!$event->checkedOutTo->locale){
+            Notification::locale(Setting::getSettings()->locale)->send(
+                $this->getNotifiables($event), 
+                $this->getCheckoutNotification($event, $acceptance)
+            );
+        } else {
+            Notification::send(
+                $this->getNotifiables($event), 
+                $this->getCheckoutNotification($event, $acceptance)
+            );
+        }
     }
 
     /**
@@ -60,10 +67,17 @@ class CheckoutableListener
         /**
          * Send the appropriate notification
          */
-        Notification::send(
-            $this->getNotifiables($event), 
-            $this->getCheckinNotification($event)
-        );
+        if(!$event->checkedOutTo->locale){
+            Notification::locale(Setting::getSettings()->locale)->send(
+                $this->getNotifiables($event), 
+                $this->getCheckinNotification($event)
+            );
+        } else {
+            Notification::send(
+                $this->getNotifiables($event), 
+                $this->getCheckinNotification($event)
+            );
+        }
     }      
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -15,11 +15,12 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use App\Http\Traits\UniqueUndeletedTrait;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Passport\HasApiTokens;
+use Illuminate\Contracts\Translation\HasLocalePreference;
 use DB;
 
 
 
-class User extends SnipeModel implements AuthenticatableContract, AuthorizableContract, CanResetPasswordContract
+class User extends SnipeModel implements AuthenticatableContract, AuthorizableContract, CanResetPasswordContract, HasLocalePreference
 {
     protected $presenter = 'App\Presenters\UserPresenter';
     use SoftDeletes, ValidatingTrait;
@@ -642,5 +643,9 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
     public function scopeOrderDepartment($query, $order)
     {
         return $query->leftJoin('departments as departments_users', 'users.department_id', '=', 'departments_users.id')->orderBy('departments_users.name', $order);
+    }
+
+    public function preferredLocale(){
+        return $this->locale;
     }
 }

--- a/app/Notifications/CheckinLicenseSeatNotification.php
+++ b/app/Notifications/CheckinLicenseSeatNotification.php
@@ -96,7 +96,6 @@ class CheckinLicenseSeatNotification extends Notification
      */
     public function toMail($notifiable)
     {
-
         return (new MailMessage)->markdown('notifications.markdown.checkin-license',
             [
                 'item'          => $this->item,

--- a/resources/views/licenses/checkin.blade.php
+++ b/resources/views/licenses/checkin.blade.php
@@ -17,7 +17,7 @@
     <div class="row">
         <!-- left column -->
         <div class="col-md-7">
-            <form class="form-horizontal" method="post" action="{{ route('licenses.checkin.save', $licenseSeat->id) }}" autocomplete="off">
+            <form class="form-horizontal" method="post" action="{{ route('licenses.checkin.save', ['licenseId'=>$licenseSeat->id, 'backTo'=>'user'] ) }}" autocomplete="off">
                 {{csrf_field()}}
 
                 <div class="box box-default">

--- a/resources/views/licenses/checkin.blade.php
+++ b/resources/views/licenses/checkin.blade.php
@@ -17,7 +17,7 @@
     <div class="row">
         <!-- left column -->
         <div class="col-md-7">
-            <form class="form-horizontal" method="post" action="{{ route('licenses.checkin.save', ['licenseId'=>$licenseSeat->id, 'backTo'=>'user'] ) }}" autocomplete="off">
+            <form class="form-horizontal" method="post" action="{{ route('licenses.checkin.save', ['licenseId'=>$licenseSeat->id, 'backTo'=>$backto] ) }}" autocomplete="off">
                 {{csrf_field()}}
 
                 <div class="box box-default">


### PR DESCRIPTION
 Fixes #5554. I will try to explain my solution as clear as I can. When the user doesn't have a language configured in his per-user preferences, the notifications goes out as the application language locale, this is stablished in the config/app.php file (and in an out of the box install, it will be 'en') the Snipe-It locale language is setted in the table Settings, so we need to reach that variable and send the notification with the locale that is configured in the Settings table.

 But when the user have a locale language setted we just need to send de notification as intended, using the method that is explained in the link that you attached. With the HasLocalePreference class and the preferredLocale() function.