### PR TITLE
Importing with CSV into Encrypted Custom [ch86]

### DIFF
--- a/app/Importer/AssetImporter.php
+++ b/app/Importer/AssetImporter.php
@@ -28,8 +28,13 @@ class AssetImporter extends ItemImporter
             foreach ($this->customFields as $customField) {
                 $customFieldValue = $this->array_smart_custom_field_fetch($row, $customField);
                 if ($customFieldValue) {
-                    $this->item['custom_fields'][$customField->db_column_name()] = $customFieldValue;
-                    $this->log('Custom Field '. $customField->name.': '.$customFieldValue);
+                    if($customField->field_encrypted == 1){
+                        $this->item['custom_fields'][$customField->db_column_name()] = \Crypt::encrypt($customFieldValue);
+                        $this->log('Custom Field '. $customField->name.': '.\Crypt::encrypt($customFieldValue));
+                    } else {
+                        $this->item['custom_fields'][$customField->db_column_name()] = $customFieldValue;
+                        $this->log('Custom Field '. $customField->name.': '.$customFieldValue);
+                    }
                 } else {
                     // Clear out previous data.
                     $this->item['custom_fields'][$customField->db_column_name()] = null;


### PR DESCRIPTION
Fixes #5252. The importer wasn't encrypting the custom encrypted fields, when the user exports the data to a CSV, SnipeIt decrypts the field to put it in the file. But when the user imports the file, the importer readed as is, then stored itin the DB decrypted. Hence the error in that field when the user looks at the imported asset.