### PR TITLE
Valo/ch37/cannot log in with generated password from

### DIFF
--- a/app/Importer/Importer.php
+++ b/app/Importer/Importer.php
@@ -440,4 +440,13 @@ abstract class Importer
 
         return $this;
     }
+
+    public function fetchHumanBoolean($value)
+    {
+        if (($value =='1') || (strtolower($value) =='true') || (strtolower($value) =='yes'))
+        {
+            return '1';
+        }
+        return '0';
+    }
 }

--- a/app/Importer/UserImporter.php
+++ b/app/Importer/UserImporter.php
@@ -65,7 +65,7 @@ class UserImporter extends ItemImporter
         $this->log("No matching user, creating one");
         $user = new User();
         $user->fill($this->sanitizeItemForStoring($user));
-        // dd($user->fill($this->sanitizeItemForStoring($user)));
+
         if ($user->save()) {
             // $user->logCreate('Imported using CSV Importer');
             $this->log("User " . $this->item["name"] . ' was created');

--- a/app/Importer/UserImporter.php
+++ b/app/Importer/UserImporter.php
@@ -38,7 +38,7 @@ class UserImporter extends ItemImporter
         $this->item['email'] = $this->findCsvMatch($row, 'email');
         $this->item['phone'] = $this->findCsvMatch($row, 'phone_number');
         $this->item['jobtitle'] = $this->findCsvMatch($row, 'jobtitle');
-        $this->item['activated'] = ($this->findCsvMatch($row, 'activated')) ? 1 : 0;
+        $this->item['activated'] = ($this->fetchHumanBoolean($this->findCsvMatch($row, 'activated')) == '1') ? '1' : 0;
         $this->item['employee_num'] = $this->findCsvMatch($row, 'employee_num');
         $this->item['department_id'] = $this->createOrFetchDepartment($this->findCsvMatch($row, 'department'));
         $this->item['manager_id'] = $this->fetchManager($this->findCsvMatch($row, 'manager_first_name'), $this->findCsvMatch($row, 'manager_last_name'));

--- a/app/Importer/UserImporter.php
+++ b/app/Importer/UserImporter.php
@@ -38,7 +38,7 @@ class UserImporter extends ItemImporter
         $this->item['email'] = $this->findCsvMatch($row, 'email');
         $this->item['phone'] = $this->findCsvMatch($row, 'phone_number');
         $this->item['jobtitle'] = $this->findCsvMatch($row, 'jobtitle');
-        $this->item['activated'] = $this->findCsvMatch($row, 'activated');
+        $this->item['activated'] = ($this->findCsvMatch($row, 'activated')) ? 1 : 0;
         $this->item['employee_num'] = $this->findCsvMatch($row, 'employee_num');
         $this->item['department_id'] = $this->createOrFetchDepartment($this->findCsvMatch($row, 'department'));
         $this->item['manager_id'] = $this->fetchManager($this->findCsvMatch($row, 'manager_first_name'), $this->findCsvMatch($row, 'manager_last_name'));
@@ -60,11 +60,12 @@ class UserImporter extends ItemImporter
         }
         // This needs to be applied after the update logic, otherwise we'll overwrite user passwords
         // Issue #5408
-        $this->item['password'] = $this->tempPassword;
+        $this->item['password'] = bcrypt($this->tempPassword);
 
         $this->log("No matching user, creating one");
         $user = new User();
         $user->fill($this->sanitizeItemForStoring($user));
+        // dd($user->fill($this->sanitizeItemForStoring($user)));
         if ($user->save()) {
             // $user->logCreate('Imported using CSV Importer');
             $this->log("User " . $this->item["name"] . ' was created');

--- a/app/Importer/UserImporter.php
+++ b/app/Importer/UserImporter.php
@@ -38,7 +38,7 @@ class UserImporter extends ItemImporter
         $this->item['email'] = $this->findCsvMatch($row, 'email');
         $this->item['phone'] = $this->findCsvMatch($row, 'phone_number');
         $this->item['jobtitle'] = $this->findCsvMatch($row, 'jobtitle');
-        $this->item['activated'] = ($this->fetchHumanBoolean($this->findCsvMatch($row, 'activated')) == '1') ? '1' : 0;
+        $this->item['activated'] = $this->fetchHumanBoolean($this->findCsvMatch($row, 'activated'));
         $this->item['employee_num'] = $this->findCsvMatch($row, 'employee_num');
         $this->item['department_id'] = $this->createOrFetchDepartment($this->findCsvMatch($row, 'department'));
         $this->item['manager_id'] = $this->fetchManager($this->findCsvMatch($row, 'manager_first_name'), $this->findCsvMatch($row, 'manager_last_name'));


### PR DESCRIPTION
This importer issue was occasioned because at the moment of read the value that comes from the CSV file for the 'Activated' column, it takes a value of 'Yes' or 'No' instead of '1' for true, or '0' for false. Giving the result that every imported User is inserted as Inactive in the DB, regardless of the value selected in the file.

Also, if the User was new, the importer doesn't encrypt the generated password, storing it in plain text, when the User tries to log in, the system encrypts the password textbox filled value, therefore fails because the strings doesn't match.