### PR TITLE
Fixed #6634: Asset Import History fixes and optimizations

### DIFF
--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -517,7 +517,7 @@ class AssetsController extends Controller
      */
     public function getImportHistory()
     {
-        $this->authorize('checkout', Asset::class);
+        $this->authorize('admin');
         return view('hardware/history');
     }
 

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -537,9 +537,11 @@ class AssetsController extends Controller
         }
 
         $csv = Reader::createFromPath(Input::file('user_import_csv'));
-        $csv->setNewline("\r\n");
-        //get the first row, usually the CSV header
+
         $csv->setHeaderOffset(0);
+
+        $header = $csv->getHeader();
+
         $results = $csv->getRecords();
         $item = array();
         $status = array();
@@ -563,6 +565,7 @@ class AssetsController extends Controller
                 $item[$asset_tag][$batch_counter]['email'] = Helper::array_smart_fetch($row, "email");
 
                 if ($asset = Asset::where('asset_tag', '=', $asset_tag)->first()) {
+                    //we've found our asset, now lets look for a user
                     $item[$asset_tag][$batch_counter]['asset_id'] = $asset->id;
 
                     $base_username = User::generateFormattedNameFromFullName($item[$asset_tag][$batch_counter]['name'], Setting::getSettings()->username_format);
@@ -612,6 +615,7 @@ class AssetsController extends Controller
                             'action_type'   => 'checkout',
                         ));
 
+                        //
                         $asset->assigned_to = $user->id;
 
                         if ($asset->save()) {

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -558,12 +558,11 @@ class AssetsController extends Controller
         $status['error'] = array();
         $status['success'] = array();
         $base_username = null;
-        $cachetime = 1;
+        $cachetime = Carbon::now()->addSeconds(120);
 
         foreach ($results as $batch_counter => $record) {
 
             $asset_tag = $record['Asset Tag'];
-            $username = $record['Full Name'];
 
             try {
                 $checkoutdate = Carbon::parse($record['Checkout Date'])->format('Y-m-d H:i:s');

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -560,7 +560,7 @@ class AssetsController extends Controller
         $base_username = null;
         $cachetime = Carbon::now()->addSeconds(120);
 
-        foreach ($results as $batch_counter => $record) {
+        foreach ($results as $record) {
 
             $asset_tag = $record['Asset Tag'];
 
@@ -573,7 +573,7 @@ class AssetsController extends Controller
                 continue;
             }
 
-            if ($asset = Cache::remember('asset:' . $asset_tag, $cachetime, function () use( &$asset_tag) {
+            if($asset = Cache::remember('asset:' . $asset_tag, $cachetime, function () use( &$asset_tag) {
                 $tocache = Asset::where('asset_tag', '=', $asset_tag)->value('id');
                 return is_null($tocache) ? false : $tocache;}))
             {
@@ -582,7 +582,7 @@ class AssetsController extends Controller
 
                     $base_username = User::generateFormattedNameFromFullName($record['Full Name'], Setting::getSettings()->username_format);
 
-                    if (!$user = Cache::remember('user:' . $base_username['username'], $cachetime, function () use( &$base_username) {
+                    if(!$user = Cache::remember('user:' . $base_username['username'], $cachetime, function () use( &$base_username) {
                         $tocache = User::where('username', '=', $base_username['username'])->value('id');
                         return is_null($tocache) ? false : $tocache;}))
                     {

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -598,7 +598,8 @@ class AssetsController extends Controller
                         'item_type' => Asset::class,
                         'user_id' => Auth::user()->id,
                         'note' => 'Historical record added by '.Auth::user()->present()->fullName(),
-                        'target_id' => null,
+                        'target_id' => $user->id,
+                        'target_type' => User::class,
                         'created_at' => $checkindate,
                         'action_type' => 'checkin'
                     ));

--- a/resources/views/hardware/history.blade.php
+++ b/resources/views/hardware/history.blade.php
@@ -49,171 +49,111 @@
             <div class="box box-default">
                 <div class="box-body">
                     <div class="col-md-12">
-                    <form class="form-horizontal" role="form" method="post" enctype="multipart/form-data" action="">
-                        <!-- CSRF Token -->
-                        <input type="hidden" name="_token" value="{{ csrf_token() }}" />
+                        <form class="form-horizontal" role="form" method="post" enctype="multipart/form-data" action="">
+                            <!-- CSRF Token -->
+                            <input type="hidden" name="_token" value="{{ csrf_token() }}" />
 
-                        @if (Session::get('message'))
-                            <p class="alert-danger">
-                                You have an error in your CSV file:<br />
-                                {{ Session::get('message') }}
+                            @if (Session::get('message'))
+                                <p class="alert-danger">
+                                    You have an error in your CSV file:<br />
+                                    {{ Session::get('message') }}
+                                </p>
+                            @endif
+
+                            <p>
+                               Upload a CSV that contains asset history. The assets and users MUST already exist in the system, or they will be skipped. Matching assets for history import happens against the asset tag.  We will try to find a matching user based on the user's full name you provide, based on the username format you configured in the Admin &gt; General Settings.
                             </p>
-                        @endif
 
-                        <p>
-                           Upload a CSV that contains asset history. The assets and users MUST already exist in the system, or they will be skipped. Matching assets for history import happens against the asset tag. We will try to find a matching user based on the user's name you provide, and the criteria you select below. If you do not select any criteria below, it will simply try to match on the username format you configured in the Admin &gt; General Settings.
-                        </p>
+                            <p>Fields included in the CSV must match the headers: <strong>Asset Tag, Checkout Date, Checkin Date, User Name, User E-mail (optional)</strong>. Any additional fields will be ignored. </p>
 
-                        <p>Fields included in the CSV must match the headers: <strong>Date, Tag, Name</strong>. Any additional fields will be ignored. </p>
+                            <p><strong>History should be ordered by checkout date in ascending order.</strong></p>
 
-                        <p><strong>Date</strong> should be the checkout date. <strong>Tag</strong> should be the asset tag. <strong>Name</strong> should be the user's name (firstname lastname).</p>
-
-                        <p><strong>History should be ordered by date in ascending order.</strong></p>
-
-                        <div class="form-group">
-                            <label for="first_name" class="col-sm-3 control-label">{{ trans('admin/users/general.usercsv') }}</label>
-                            <div class="col-sm-9">
-                                <input type="file" name="user_import_csv" id="user_import_csv"{{ (config('app.lock_passwords')===true) ? ' disabled' : '' }}>
+                            <div class="form-group">
+                                <label for="first_name" class="col-sm-3 control-label">{{ trans('admin/users/general.usercsv') }}</label>
+                                <div class="col-sm-9">
+                                    <input type="file" name="user_import_csv" id="user_import_csv"{{ (config('app.lock_passwords')===true) ? ' disabled' : '' }}>
+                                </div>
                             </div>
-                        </div>
 
 
+                            <!-- Form Actions -->
+                            <div class="box-footer text-right">
+                                @if (config('app.lock_passwords')===true)
+                                    <div class="col-md-12">
+                                        <div class="callout callout-info">
+                                            {{ trans('general.feature_disabled') }}
+                                        </div>
+                                    </div>
 
-
-                <!-- Match firstname.lastname -->
-                <div class="form-group">
-                    <div class="col-sm-2">
-                    </div>
-                    <div class="col-sm-10">
-                        {{ Form::checkbox('match_firstnamelastname', '1', Input::old('match_firstnamelastname')) }} Try to match users by firstname.lastname (jane.smith) format
-                    </div>
-                </div>
-
-                <!-- Match flastname -->
-                <div class="form-group">
-                    <div class="col-sm-2">
-                    </div>
-                    <div class="col-sm-10">
-                        {{ Form::checkbox('match_flastname', '1', Input::old('match_flastname')) }} Try to match users by first initial last name (jsmith) format
-                    </div>
-                </div>
-
-                <!-- Match firstname -->
-                <div class="form-group">
-                    <div class="col-sm-2">
-                    </div>
-                    <div class="col-sm-10">
-                        {{ Form::checkbox('match_firstname', '1', Input::old('match_firstname')) }} Try to match users by first name (jane) format
-                    </div>
-                </div>
-
-                <!-- Match email -->
-                <div class="form-group">
-                    <div class="col-sm-2">
-                    </div>
-                    <div class="col-sm-10">
-                        {{ Form::checkbox('match_email', '1', Input::old('match_email')) }} Try to match users by email as username
-                    </div>
-                </div>
-
-
-               </div>
-
-
-
-        </div>
-
-    <!-- Form Actions -->
-    <div class="box-footer text-right">
-        @if (config('app.lock_passwords')===true)
-            <div class="col-md-12">
-                <div class="callout callout-info">
-                    {{ trans('general.feature_disabled') }}
-                </div>
-            </div>
-
-        @else
-            <button type="submit" class="btn btn-default">{{ trans('button.submit') }}</button>
-         @endif
-    </div>
-
-</form>
-
- </div>
-
-            @if (isset($status))
-
-
-                @if (count($status['error']) > 0)
-                <div class="row">
-                    <div class="col-md-12">
-                        <div class="box box-default">
-                            <div class="box-header with-border">
-                                <h3 class="box-title"> {{ count($status['error']) }} Error Messages </h3>
+                                @else
+                                    <button type="submit" class="btn btn-default">{{ trans('button.submit') }}</button>
+                                 @endif
                             </div>
-                            <div class="box-body">
-                                <div style="height : 400px; overflow : auto;">
-                                    <table class="table">
-                                        @for ($x = 0; $x < count($status['error']); $x++)
-                                            @foreach($status['error'][$x] as $object_type => $message)
-                                            <tr class="danger">
-                                                <td><strong>{{ ucwords($object_type)  }} {{ key($message)  }}:</strong></td>
-                                                <td>{{ $message[key($message)]['msg']  }}</td>
-                                            </tr>
-                                            @endforeach
-                                        @endfor
-                                    </table>
-                               </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
 
-                @endif
+                        </form>
 
-                @if (count($status['success']) > 0)
+
+                    @if (isset($status))
+
+
+                        @if (count($status['error']) > 0)
                         <div class="row">
                             <div class="col-md-12">
                                 <div class="box box-default">
                                     <div class="box-header with-border">
-                                        <h3 class="box-title"> {{ count($status['success']) }} Success Messages </h3>
+                                        <h3 class="box-title"> {{ count($status['error']) }} Error Messages </h3>
                                     </div>
                                     <div class="box-body">
                                         <div style="height : 400px; overflow : auto;">
                                             <table class="table">
-                                                @for ($x = 0; $x < count($status['success']); $x++)
-                                                    @foreach($status['success'][$x] as $object_type => $message)
-                                                        <tr class="success">
-                                                            <td><strong>{{ ucwords($object_type)  }} {{ key($message)  }}:</strong></td>
-                                                            <td>{{ $message[key($message)]['msg']  }}</td>
-                                                        </tr>
+                                                @for ($x = 0; $x < count($status['error']); $x++)
+                                                    @foreach($status['error'][$x] as $object_type => $message)
+                                                    <tr class="danger">
+                                                        <td><strong>{{ ucwords($object_type)  }} {{ key($message)  }}:</strong></td>
+                                                        <td>{{ $message[key($message)]['msg']  }}</td>
+                                                    </tr>
                                                     @endforeach
                                                 @endfor
                                             </table>
-                                        </div>
+                                       </div>
                                     </div>
                                 </div>
                             </div>
                         </div>
-                @endif
-            @endif
 
-        </div></div></div>
-<script nonce="{{ csrf_token() }}">
-$(document).ready(function(){
+                        @endif
 
-    $('#generate-password').pGenerator({
-        'bind': 'click',
-        'passwordElement': '#password',
-        'displayElement': '#password-display',
-        'passwordLength': 10,
-        'uppercase': true,
-        'lowercase': true,
-        'numbers':   true,
-        'specialChars': false,
+                        @if (count($status['success']) > 0)
+                                <div class="row">
+                                    <div class="col-md-12">
+                                        <div class="box box-default">
+                                            <div class="box-header with-border">
+                                                <h3 class="box-title"> {{ count($status['success']) }} Success Messages </h3>
+                                            </div>
+                                            <div class="box-body">
+                                                <div style="height : 400px; overflow : auto;">
+                                                    <table class="table">
+                                                        @for ($x = 0; $x < count($status['success']); $x++)
+                                                            @foreach($status['success'][$x] as $object_type => $message)
+                                                                <tr class="success">
+                                                                    <td><strong>{{ ucwords($object_type)  }} {{ key($message)  }}:</strong></td>
+                                                                    <td>{{ $message[key($message)]['msg']  }}</td>
+                                                                </tr>
+                                                            @endforeach
+                                                        @endfor
+                                                    </table>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                        @endif
+                    @endif
 
-    });
-});
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
 
-</script>
-@stop
+            @stop

--- a/resources/views/hardware/history.blade.php
+++ b/resources/views/hardware/history.blade.php
@@ -61,12 +61,15 @@
                             @endif
 
                             <p>
-                               Upload a CSV that contains asset history. The assets and users MUST already exist in the system, or they will be skipped. Matching assets for history import happens against the asset tag.  We will try to find a matching user based on the user's full name you provide, based on the username format you configured in the Admin &gt; General Settings.
+                                Use this tool to import asset history you may have in CSV format. This information likely will be extracted from your previous asset management system.
+                            </p>
+                            <p>
+                                <i>Asset history</i> is defined as a checkout and subsequent checkin that has happened in the past. The assets and users MUST already exist in SNIPE, or they will be skipped. Matching assets for history import happens against the asset tag.  We will try to find a matching user based on the user's full name you provide, based on the username format you configured in the Admin &gt; General Settings.
                             </p>
 
-                            <p>Fields included in the CSV must match the headers: <strong>Asset Tag, Checkout Date, Checkin Date, User Name, User E-mail (optional)</strong>. Any additional fields will be ignored. </p>
-
-                            <p><strong>History should be ordered by checkout date in ascending order.</strong></p>
+                            <p>
+                                Fields included in the CSV must match <i>exactly</i> these header values: <strong>Asset Tag, Checkout Date, Checkin Date, Full Name</strong>. Any additional fields will be ignored.
+                            </p>
 
                             <div class="form-group">
                                 <label for="first_name" class="col-sm-3 control-label">{{ trans('admin/users/general.usercsv') }}</label>

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -442,6 +442,8 @@
                             {{ trans('general.asset_maintenances') }}
                           </a>
                       </li>
+                    @endcan
+                    @can('admin')
                       <li>
                           <a href="{{ url('hardware/history') }}">
                             {{ trans('general.import-history') }}


### PR DESCRIPTION
I took a quick stab at fixing asset history imports.

Assumptions made:
-Asset history is coming from a previous management system.
-It isn't historical unless it has both a checkout and a checkin (sysadmin can fudge a checkin date if they don't have this information in previous system)
-The history importer no longer assigns assets (this can be done using the regular importer)

Optimizations made:
-Removed second iteration of asset import list, including all business attempting to 'magically' create past checkin dates
-Removed creation of, potentially giant, $items array
-Removed username matching schemes and only use that which is configured in settings
-CSV is sorted using league/csv statement filters (in post) on username to reduce db or cache calls
-Asset and User query results (both hits and misses) are cached (for 1 minute) to avoid duplicate queries
-Some better controls around date conversions included