### PR TITLE
tests: allow to fail on PHP 7.3 and use the latest PHP 7.1 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,13 @@ services:
 php:
   - 5.6
   - 7.0
-  - 7.2 
-  - 7.1.4
+  - 7.1
+  - 7.2
   - 7.3
+
+  matrix:
+  allow_failures:
+  - php: 7.3
 
 # execute any number of scripts before the test run, custom env's are available as variables
 before_script:


### PR DESCRIPTION
This should get the CI green again.
Shall we also add `master` in the PHP test matrix (php-latest)?