### PR TITLE
docker: Fix upgrades

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -47,5 +47,9 @@ then
   cp -ax /var/www/html/vendor/laravel/passport/database/migrations/* /var/www/html/database/migrations/
 fi
 
+php artisan migrate --force
+php artisan config:clear
+php artisan config:cache
+
 . /etc/apache2/envvars
 exec apache2 -DNO_DETACH < /dev/null

--- a/docker/entrypoint_alpine.sh
+++ b/docker/entrypoint_alpine.sh
@@ -44,5 +44,10 @@ if [ ! -f "/var/www/html/database/migrations/*create_oauth*" ]
 then
   cp -a /var/www/html/vendor/laravel/passport/database/migrations/* /var/www/html/database/migrations/
 fi
+
+php artisan migrate --force
+php artisan config:clear
+php artisan config:cache
+
 export APACHE_LOG_DIR=/var/log/apache2
 exec httpd -DNO_DETACH < /dev/null


### PR DESCRIPTION
Until now, the Docker image was not performing actions that are necessary for an upgrade completion. That is considered an anti-pattern.

See https://snipe-it.readme.io/docs/upgrading for more information.