### PR TITLE
Valo/checkin date in history of asset

### DIFF
--- a/app/Events/CheckoutableCheckedIn.php
+++ b/app/Events/CheckoutableCheckedIn.php
@@ -14,17 +14,19 @@ class CheckoutableCheckedIn
     public $checkedOutTo;
     public $checkedInBy;
     public $note;
+    public $action_date; // Date setted in the hardware.checkin view at the checkin_at input, for the action log
 
     /**
      * Create a new event instance.
      *
      * @return void
      */
-    public function __construct($checkoutable, $checkedOutTo, User $checkedInBy, $note)
+    public function __construct($checkoutable, $checkedOutTo, User $checkedInBy, $note, $action_date)
     {
         $this->checkoutable = $checkoutable;
         $this->checkedOutTo = $checkedOutTo;
         $this->checkedInBy  = $checkedInBy;
         $this->note         = $note;
+        $this->action_date  = $action_date;
     }
 }

--- a/app/Http/Controllers/Assets/AssetCheckinController.php
+++ b/app/Http/Controllers/Assets/AssetCheckinController.php
@@ -82,10 +82,15 @@ class AssetCheckinController extends Controller
             $asset->location_id =  e($request->get('location_id'));
         }
 
+        $checkin_at = date('Y-m-d');
+        if($request->filled('checkin_at')){
+            $checkin_at = $request->input('checkin_at');
+        }
+
         // Was the asset updated?
         if ($asset->save()) {
         
-            event(new CheckoutableCheckedIn($asset, $target, Auth::user(), $request->input('note'), $request->input('checkin_at')));
+            event(new CheckoutableCheckedIn($asset, $target, Auth::user(), $request->input('note'), $checkin_at));
 
             if ($backto=='user') {
                 return redirect()->route("users.show", $user->id)->with('success', trans('admin/hardware/message.checkin.success'));

--- a/app/Http/Controllers/Assets/AssetCheckinController.php
+++ b/app/Http/Controllers/Assets/AssetCheckinController.php
@@ -85,7 +85,7 @@ class AssetCheckinController extends Controller
         // Was the asset updated?
         if ($asset->save()) {
         
-            event(new CheckoutableCheckedIn($asset, $target, Auth::user(), $request->input('note')));
+            event(new CheckoutableCheckedIn($asset, $target, Auth::user(), $request->input('note'), $request->input('checkin_at')));
 
             if ($backto=='user') {
                 return redirect()->route("users.show", $user->id)->with('success', trans('admin/hardware/message.checkin.success'));

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -65,7 +65,7 @@ class ActionlogsTransformer
             'note'          => ($actionlog->note) ? e($actionlog->note): null,
             'signature_file'   => ($actionlog->signature_filename) ? route('log.signature.view', ['filename' => $actionlog->signature_filename ]) : null,
             'log_meta'          => ($actionlog->log_meta) ? json_decode($actionlog->log_meta): null,
-
+            'action_date'   => ($actionlog->action_date) ? Helper::getFormattedDateObject($actionlog->action_date, 'date'): null,
 
         ];
 

--- a/app/Listeners/LogListener.php
+++ b/app/Listeners/LogListener.php
@@ -27,11 +27,11 @@ class LogListener
 {
 
     public function onCheckoutableCheckedIn(CheckoutableCheckedIn $event) {
-        $event->checkoutable->logCheckin($event->checkedOutTo, $event->note);
+        $event->checkoutable->logCheckin($event->checkedOutTo, $event->note, $event->action_date);
     }
 
     public function onCheckoutableCheckedOut(CheckoutableCheckedOut $event) {
-        $event->checkoutable->logCheckout($event->note, $event->checkedOutTo);
+        $event->checkoutable->logCheckout($event->note, $event->checkedOutTo, $event->checkoutable->last_checkout);
     }    
 
     public function onCheckoutAccepted(CheckoutAccepted $event) {

--- a/app/Models/Loggable.php
+++ b/app/Models/Loggable.php
@@ -29,7 +29,7 @@ trait Loggable
      * @since [v3.4]
      * @return \App\Models\Actionlog
      */
-    public function logCheckout($note, $target /* What are we checking out to? */)
+    public function logCheckout($note, $target, $action_date)
     {
         $log = new Actionlog;
         $log = $this->determineLogItemType($log);
@@ -53,6 +53,7 @@ trait Loggable
         }
 
         $log->note = $note;
+        $log->action_date = $action_date;
         $log->logaction('checkout');
 
         return $log;
@@ -79,7 +80,7 @@ trait Loggable
      * @since [v3.4]
      * @return \App\Models\Actionlog
      */
-    public function logCheckin($target, $note)
+    public function logCheckin($target, $note, $action_date)
     {
         $log = new Actionlog;
         $log->target_type = get_class($target);
@@ -95,7 +96,6 @@ trait Loggable
 
             if (static::class == Asset::class) {
                 if ($asset = Asset::find($log->item_id)) {
-                    \Log::debug('Increment the checkin count for asset: '.$log->item_id);
                     $asset->increment('checkin_counter', 1);
                 }
             }
@@ -105,6 +105,7 @@ trait Loggable
 
         $log->location_id = null;
         $log->note = $note;
+        $log->action_date = $action_date;
         $log->user_id = Auth::user()->id;
         $log->logaction('checkin from');
 

--- a/database/migrations/2019_02_12_182750_add_actiondate_to_actionlog.php
+++ b/database/migrations/2019_02_12_182750_add_actiondate_to_actionlog.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddActionDateToActionlog extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('action_logs', function (Blueprint $table) {
+            $table->date('action_date')->nullable()->default(null);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('action_logs', function (Blueprint $table) {
+            $table->dropColumn('action_date');
+        });
+    }
+}

--- a/database/migrations/2019_02_12_182750_add_actiondate_to_actionlog.php
+++ b/database/migrations/2019_02_12_182750_add_actiondate_to_actionlog.php
@@ -16,6 +16,12 @@ class AddActionDateToActionlog extends Migration
         Schema::table('action_logs', function (Blueprint $table) {
             $table->date('action_date')->nullable()->default(null);
         });
+
+        $results = DB::table('action_logs')->select('created_at', 'id')->where('action_type', 'checkout')->orWhere('action_type', 'checkin from')->get();
+
+        foreach($results as $result){
+            $update = DB::update('update '.DB::getTablePrefix().'action_logs set action_date=? where id=?', [$result->created_at, $result->id]);
+        }
     }
 
     /**

--- a/resources/views/hardware/checkin.blade.php
+++ b/resources/views/hardware/checkin.blade.php
@@ -82,7 +82,7 @@
               {{ Form::label('checkin_at', trans('admin/hardware/form.checkin_date'), array('class' => 'col-md-3 control-label')) }}
               <div class="col-md-8">
               <div class="input-group col-md-5 required">
-                <div class="input-group date" data-provide="datepicker" data-date-format="yyyy-mm-dd"  data-autoclose="true">
+                <div class="input-group date" data-provide="datepicker" data-date-format="yyyy-mm-dd" data-date-end-date="0d" data-autoclose="true">
                   <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="checkin_at" id="checkin_at" value="{{ Input::old('checkin_at', date('Y-m-d')) }}">
                   <span class="input-group-addon"><i class="fa fa-calendar"></i></span>
                 </div>

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -750,12 +750,12 @@
                 <thead>
                 <tr>
                   <th data-field="icon" data-visible="true" style="width: 40px;" class="hidden-xs" data-formatter="iconFormatter"></th>
-                  <th class="col-sm-2" data-visible="true" data-field="created_at" data-formatter="dateDisplayFormatter">{{ trans('general.date') }}</th>
+                  <th class="col-sm-2" data-visible="false" data-field="created_at" data-formatter="dateDisplayFormatter">{{ trans('general.date') }}</th>
                   <th class="col-sm-1" data-visible="true" data-field="admin" data-formatter="usersLinkObjFormatter">{{ trans('general.admin') }}</th>
                   <th class="col-sm-2" data-visible="true" data-field="item" data-formatter="polymorphicItemFormatter">{{ trans('general.item') }}</th>
                   <th class="col-sm-1" data-visible="true" data-field="action_type">{{ trans('general.action') }}</th>
                   <th class="col-sm-2" data-visible="true" data-field="target" data-formatter="polymorphicItemFormatter">{{ trans('general.target') }}</th>
-                  <th class="col-sm-2" data-visible="true" data-field="action_date" data-formatter="dateDisplayFormatter">Action Date</th>
+                  <th class="col-sm-2" data-visible="true" data-field="action_date" data-formatter="dateDisplayFormatter">{{ trans('general.date') }}</th>
                   <th class="col-sm-2" data-field="note">{{ trans('general.notes') }}</th>
                   @if  ($snipeSettings->require_accept_signature=='1')
                     <th class="col-md-3" data-field="signature_file" data-visible="false"  data-formatter="imageFormatter">{{ trans('general.signature') }}</th>

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -752,9 +752,10 @@
                   <th data-field="icon" data-visible="true" style="width: 40px;" class="hidden-xs" data-formatter="iconFormatter"></th>
                   <th class="col-sm-2" data-visible="true" data-field="created_at" data-formatter="dateDisplayFormatter">{{ trans('general.date') }}</th>
                   <th class="col-sm-1" data-visible="true" data-field="admin" data-formatter="usersLinkObjFormatter">{{ trans('general.admin') }}</th>
-                  <th class="col-sm-1" data-visible="true" data-field="action_type">{{ trans('general.action') }}</th>
                   <th class="col-sm-2" data-visible="true" data-field="item" data-formatter="polymorphicItemFormatter">{{ trans('general.item') }}</th>
+                  <th class="col-sm-1" data-visible="true" data-field="action_type">{{ trans('general.action') }}</th>
                   <th class="col-sm-2" data-visible="true" data-field="target" data-formatter="polymorphicItemFormatter">{{ trans('general.target') }}</th>
+                  <th class="col-sm-2" data-visible="true" data-field="action_date" data-formatter="dateDisplayFormatter">Action Date</th>
                   <th class="col-sm-2" data-field="note">{{ trans('general.notes') }}</th>
                   @if  ($snipeSettings->require_accept_signature=='1')
                     <th class="col-md-3" data-field="signature_file" data-visible="false"  data-formatter="imageFormatter">{{ trans('general.signature') }}</th>


### PR DESCRIPTION
In reference to #5105. This was a tough one (for me, at least). The asset model doesn't have a property with the date of the last checkin, and I think that is fine. But we needed that info for the action log, so I added some logic in the AssetCheckinController to get the date from one input in the checkin view that was not used, or if that input was not filled to take the date atomatically. Then I aggregate that date to the CheckoutableCheckedIn event in order to pass it to the Loggable model to finally store it in the action log. Similar method was used with the checkout date, but the asset has one property called last_checkout, so I used that for the action log.

I also added a migration to aggregate a column called action_date to the Log Action table, in which the data previously processed is stored. And finally, add the column 'Action Date' in the History tab of the assets view. I think is kind of important to discuss if I can use this 'Action Date' as is, directly on the <th> tag of the table, or maybe I need to add this phrase in the language files. But right now I needed this to work.