### PR TITLE
Fixes/integrity constraint

### DIFF
--- a/database/migrations/2019_02_21_224703_make_fields_nullable_for_integrity.php
+++ b/database/migrations/2019_02_21_224703_make_fields_nullable_for_integrity.php
@@ -13,6 +13,8 @@ class MakeFieldsNullableForIntegrity extends Migration
      */
     public function up()
     {
+
+
         Schema::table('locations', function (Blueprint $table) {
             $table->string('city')->nullable()->default(null)->change();
             $table->string('state')->nullable()->default(null)->change();
@@ -20,10 +22,6 @@ class MakeFieldsNullableForIntegrity extends Migration
             $table->integer('user_id')->nullable()->default(null)->change();
             $table->string('address')->nullable()->default(null)->change();
             $table->string('address2')->nullable()->default(null)->change();
-        });
-
-        Schema::table('assets', function (Blueprint $table) {
-            $table->string('city')->nullable()->default(null)->change();
         });
 
         Schema::table('users', function (Blueprint $table) {
@@ -46,7 +44,7 @@ class MakeFieldsNullableForIntegrity extends Migration
 
         Schema::table('licenses', function (Blueprint $table) {
             $table->integer('user_id')->nullable()->default(null)->change();
-            $table->tinyInteger('maintained')->nullable()->default(null)->change();
+            $table->boolean('maintained')->nullable()->default(null)->change();
         });
 
         Schema::table('depreciations', function (Blueprint $table) {

--- a/database/migrations/2019_02_21_224703_make_fields_nullable_for_integrity.php
+++ b/database/migrations/2019_02_21_224703_make_fields_nullable_for_integrity.php
@@ -1,0 +1,66 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class MakeFieldsNullableForIntegrity extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('locations', function (Blueprint $table) {
+            $table->string('city')->nullable()->default(null)->change();
+            $table->string('state')->nullable()->default(null)->change();
+            $table->string('country')->nullable()->default(null)->change();
+            $table->integer('user_id')->nullable()->default(null)->change();
+            $table->string('address')->nullable()->default(null)->change();
+            $table->string('address2')->nullable()->default(null)->change();
+        });
+
+        Schema::table('assets', function (Blueprint $table) {
+            $table->string('city')->nullable()->default(null)->change();
+        });
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('last_name')->nullable()->default(null)->change();
+        });
+
+        Schema::table('suppliers', function (Blueprint $table) {
+            $table->integer('user_id')->nullable()->default(null)->change();
+        });
+
+        Schema::table('status_labels', function (Blueprint $table) {
+            $table->integer('user_id')->nullable()->default(null)->change();
+        });
+
+        Schema::table('models', function (Blueprint $table) {
+            $table->integer('user_id')->nullable()->default(null)->change();
+            $table->integer('manufacturer_id')->nullable()->default(null)->change();
+            $table->integer('category_id')->nullable()->default(null)->change();
+        });
+
+        Schema::table('licenses', function (Blueprint $table) {
+            $table->integer('user_id')->nullable()->default(null)->change();
+            $table->tinyInteger('maintained')->nullable()->default(null)->change();
+        });
+
+        Schema::table('depreciations', function (Blueprint $table) {
+            $table->integer('user_id')->nullable()->default(null)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}


### PR DESCRIPTION
This should fix an issue involving DB-nullable fields introduced in 90cddb7aeeca6ca3c471ca75ab8d5fd08ba47858 where we’re passing null instead of an empty string (necessary to nullify values via the API). I'm not sure why they weren't created as nullable by default in the first place, but this should make them all nullable. 

Reviewers, please make sure I didn't fuck up any of the field types (changing strings to integers, etc). My local tests are working, but never hurts to have extra eyes.