### PR TITLE
Fix #6726. Bulk edit assets from within the Assets tab

### DIFF
--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -664,9 +664,9 @@
 
                 <table
                         data-columns="{{ \App\Presenters\AssetPresenter::dataTableLayout() }}"
-                        data-cookie-id-table="assetsTable"
+                        data-cookie-id-table="assetsListingTable"
                         data-pagination="true"
-                        data-id-table="assetsTable"
+                        data-id-table="assetsListingTable"
                         data-search="true"
                         data-side-pagination="server"
                         data-show-columns="true"

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -537,7 +537,7 @@
 
     $(function () {
         $('#bulkEdit').click(function () {
-            var selectedIds = $('.snipe-table').bootstrapTable('getSelections');
+            var selectedIds = $('#assetsListingTable').bootstrapTable('getSelections');
             $.each(selectedIds, function(key,value) {
                 $( "#bulkForm" ).append($('<input type="hidden" name="ids[' + value.id + ']" value="' + value.id + '">' ));
             });


### PR DESCRIPTION
Ok, in the previous PR you told me that we need to pass the IDs as in the normal Asset view, so I checked. The method was the same, so when I look at the why this thing doesn't work it really puzzles my mind as it looks identical. 

But running some commands in the DevTools I get to discover that inside the asset tab we don't see the other tables (history, maintenances, etc) and those have the same class 'snipe-table' that is called in the bootstrap-table.blade.php file, so the method $('#assetsListingTable').bootstrapTable('getSelections') gets overrided in every declared table. 

Anyway, to fix it I change the selector from $('.snipe-table') to $('#assetsListingTable') and now everything really should be fine.