### PR TITLE
Extend #6229 to include superuser permission check

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -107,20 +107,12 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
     ];
 
     /**
-     * Check user permissions
+     * Internally check the user permission for the given section
      *
-     * Parses the user and group permission masks to see if the user
-     * is authorized to do the thing
-     *
-     * @author A. Gianotto <snipe@snipe.net>
-     * @since [v1.0]
      * @return boolean
      */
-    public function hasAccess($section)
+    protected function checkPermissionSection($section)
     {
-        if ($this->isSuperUser()) {
-            return true;
-        }
         $user_groups = $this->groups;
 
 
@@ -152,6 +144,24 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
     }
 
     /**
+     * Check user permissions
+     *
+     * Parses the user and group permission masks to see if the user
+     * is authorized to do the thing
+     *
+     * @author A. Gianotto <snipe@snipe.net>
+     * @since [v1.0]
+     * @return boolean
+     */
+    public function hasAccess($section)
+    {
+        if ($this->isSuperUser()) {
+            return true;
+        }
+        return $this->checkPermissionSection($section);
+    }
+
+    /**
      * Checks if the user is a SuperUser
      *
      * @author A. Gianotto <snipe@snipe.net>
@@ -160,23 +170,7 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
      */
     public function isSuperUser()
     {
-        if (!$user_permissions = json_decode($this->permissions, true)) {
-            return false;
-        }
-
-        foreach ($this->groups as $user_group) {
-            $group_permissions = json_decode($user_group->permissions, true);
-            $group_array = (array)$group_permissions;
-            if ((array_key_exists('superuser', $group_array)) && ($group_permissions['superuser']=='1')) {
-                return true;
-            }
-        }
-
-        if ((array_key_exists('superuser', $user_permissions)) && ($user_permissions['superuser']=='1')) {
-            return true;
-        }
-
-        return false;
+        return $this->checkPermissionSection('superuser');
     }
 
 


### PR DESCRIPTION
Fixes the null permission check for superuser permission. As
well as reducing duplicated code by moving the checks to a
separate function.

This change has a slight backwards compatibility break.
In the previous version a user could not be explicitly denied
the superuser permission through user-specific config. If
they were in a group with superuser they would always have
superuser. Now the user-specific configuration will take
precedence.