### PR TITLE
Added ability to do full name search in user dropdown selectlist - fixes ch463

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -148,8 +148,7 @@ class UsersController extends Controller
         $users = Company::scopeCompanyables($users);
 
         if ($request->has('search')) {
-            $users = $users->where('first_name', 'LIKE', '%'.$request->get('search').'%')
-                ->orWhere('last_name', 'LIKE', '%'.$request->get('search').'%')
+            $users = $users->SimpleNameSearch($request->get('search'))
                 ->orWhere('username', 'LIKE', '%'.$request->get('search').'%')
                 ->orWhere('employee_num', 'LIKE', '%'.$request->get('search').'%');
         }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -414,6 +414,25 @@ class User extends SnipeModel implements AuthenticatableContract, CanResetPasswo
     }
 
     /**
+     * Query builder scope to search user by name with spaces in it.
+     * We don't use the advancedTextSearch() scope because that searches
+     * all of the relations as well, which is more than what we need.
+     *
+     * @param  \Illuminate\Database\Query\Builder $query Query builder instance
+     * @param  array  $terms The search terms
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function scopeSimpleNameSearch($query,  $search) {
+
+           $query = $query->where('first_name', 'LIKE', '%'.$search.'%')
+               ->orWhere('last_name', 'LIKE', '%'.$search.'%')
+               ->orWhereRaw('CONCAT('.DB::getTablePrefix().'users.first_name," ",'.DB::getTablePrefix().'users.last_name) LIKE ?', ["%$search%", "%$search%"]);
+        return $query;
+    }
+
+
+
+    /**
      * Run additional, advanced searches.
      *
      * @param  Illuminate\Database\Eloquent\Builder $query


### PR DESCRIPTION
The problem in this case was the space between First and Last name, as soon as you hit the space button, you cannot find the name at all anymore. Searching by First OR Last name only, brings up the name in question, amongst a list of possible matches.

### Steps to reproduce:

- go to Locations > Create
- type in Last name only from manager drop down, observe that name you are looking for is displayed
- type in First Name only, from manager drop down menu, observe that name you are looking for is displayed
- type in First AND Last Name you are looking for, observe that as soon as you hit space between first and last name, it says "No results found"

This PR adds a query scope that allows first name, last name and full name searching to the select list.