### PR TITLE
Fixed #6791: Fix ability to create assets

### DIFF
--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -151,15 +151,14 @@ class AssetsController extends Controller
                 $asset->location_id = $request->input('rtd_location_id', null);
             }
 
-        // Create the image (if one was chosen.)
-        if ($request->hasFile('image')) {
-            $image = $request->input('image');
-
-
             $asset->asset_tag = $asset_tags[$a];
-            $asset = $request->handleImages($asset);
-        }
 
+            // Create the image (if one was chosen.)
+            if ($request->hasFile('image')) {
+                $image = $request->input('image');
+
+                $asset = $request->handleImages($asset);
+            }
 
             // Update custom fields in the database.
             // Validation for these fields is handled through the AssetRequest form request


### PR DESCRIPTION
Assets can't be created as asset tags aren't being assigned to assets unless they have an image.

This moves the asset tag assignment out of the `if` block