### PR TITLE
Label bugs in general settings

### DIFF
--- a/resources/views/settings/general.blade.php
+++ b/resources/views/settings/general.blade.php
@@ -47,7 +47,7 @@
                             {{ Form::label('full_multiple_companies_support', trans('admin/settings/general.full_multiple_companies_support_text')) }}
                         </div>
                         <div class="col-md-9">
-                            {{ Form::checkbox('full_multiple_companies_support', '1', Input::old('full_multiple_companies_support', $setting->full_multiple_companies_support),array('class' => 'minimal')) }}
+                            {{ Form::checkbox('c', '1', Input::old('full_multiple_companies_support', $setting->full_multiple_companies_support),array('class' => 'minimal')) }}
                             {{ trans('admin/settings/general.full_multiple_companies_support_text') }}
                             {!! $errors->first('full_multiple_companies_support', '<span class="alert-msg">:message</span>') !!}
                             <p class="help-block">
@@ -61,7 +61,7 @@
                     <!-- Require signature for acceptance -->
                     <div class="form-group {{ $errors->has('require_accept_signature') ? 'error' : '' }}">
                         <div class="col-md-3">
-                            {{ Form::label('full_multiple_companies_support',
+                            {{ Form::label('require_accept_signature',
                                            trans('admin/settings/general.require_accept_signature')) }}
                         </div>
                         <div class="col-md-9">

--- a/resources/views/settings/general.blade.php
+++ b/resources/views/settings/general.blade.php
@@ -179,7 +179,7 @@
                     <!-- Default EULA -->
                    <div class="form-group {{ $errors->has('default_eula_text') ? 'error' : '' }}">
                        <div class="col-md-3">
-                           {{ Form::label('per_page', trans('admin/settings/general.default_eula_text')) }}
+                           {{ Form::label('default_eula_text', trans('admin/settings/general.default_eula_text')) }}
                        </div>
                        <div class="col-md-9">
                            {{ Form::textarea('default_eula_text', Input::old('default_eula_text', $setting->default_eula_text), array('class' => 'form-control','placeholder' => 'Add your default EULA text')) }}

--- a/resources/views/settings/general.blade.php
+++ b/resources/views/settings/general.blade.php
@@ -47,7 +47,7 @@
                             {{ Form::label('full_multiple_companies_support', trans('admin/settings/general.full_multiple_companies_support_text')) }}
                         </div>
                         <div class="col-md-9">
-                            {{ Form::checkbox('c', '1', Input::old('full_multiple_companies_support', $setting->full_multiple_companies_support),array('class' => 'minimal')) }}
+                            {{ Form::checkbox('full_multiple_companies_support', '1', Input::old('full_multiple_companies_support', $setting->full_multiple_companies_support),array('class' => 'minimal')) }}
                             {{ trans('admin/settings/general.full_multiple_companies_support_text') }}
                             {!! $errors->first('full_multiple_companies_support', '<span class="alert-msg">:message</span>') !!}
                             <p class="help-block">


### PR DESCRIPTION
The checkbox label in general settings for require_accept_signature was set to full_multiple_companies_support instead so when you click the label for require accept signature it would check the wrong box.