### PR TITLE
Fix #6763. Import Stuck Processing - Error - Can only flip STRING and INTEGER values!

### DIFF
--- a/app/Http/Requests/ItemImportRequest.php
+++ b/app/Http/Requests/ItemImportRequest.php
@@ -42,7 +42,18 @@ class ItemImportRequest extends FormRequest
         $import->field_map  = request('column-mappings');
         $import->save();
         $fieldMappings=[];
+
         if ($import->field_map) {
+            foreach ($import->field_map as $field => $fieldValue) {
+                $errorMessage = null;
+
+                if(is_null($fieldValue)){
+                    $errorMessage = "ERROR. The Import Field for: " . $field . ", shouldn't be empty";
+                    $this->errorCallback($import, $field, $errorMessage);
+                    
+                    return $this->errors;
+                }
+            }
             // We submit as csv field: column, but the importer is happier if we flip it here.
             $fieldMappings = array_change_key_case(array_flip($import->field_map), CASE_LOWER);
                         // dd($fieldMappings);

--- a/app/Http/Requests/ItemImportRequest.php
+++ b/app/Http/Requests/ItemImportRequest.php
@@ -48,7 +48,7 @@ class ItemImportRequest extends FormRequest
                 $errorMessage = null;
 
                 if(is_null($fieldValue)){
-                    $errorMessage = "ERROR. The Import Field for: " . $field . ", shouldn't be empty";
+                    $errorMessage = "The Import Field for: " . $field . ", shouldn't be empty";
                     $this->errorCallback($import, $field, $errorMessage);
                     
                     return $this->errors;

--- a/app/Http/Requests/ItemImportRequest.php
+++ b/app/Http/Requests/ItemImportRequest.php
@@ -48,7 +48,7 @@ class ItemImportRequest extends FormRequest
                 $errorMessage = null;
 
                 if(is_null($fieldValue)){
-                    $errorMessage = "The Import Field for: " . $field . ", shouldn't be empty";
+                    $errorMessage = trans('validation.import_field_empty');
                     $this->errorCallback($import, $field, $errorMessage);
                     
                     return $this->errors;

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -90,7 +90,7 @@ return array(
     'uploaded'             => 'The :attribute failed to upload.',
     'url'                  => 'The :attribute format is invalid.',
     "unique_undeleted"     => "The :attribute must be unique.",
-
+    "import_field_empty"   => "The value of the Import Field shouldn't be empty",
     /*
     |--------------------------------------------------------------------------
     | Custom Validation Language Lines

--- a/resources/lang/es-CO/validation.php
+++ b/resources/lang/es-CO/validation.php
@@ -89,6 +89,7 @@ return array(
     'uploaded'             => 'El atributo: no se pudo cargar.',
     'url'                  => ':attribute formato incorrecto.',
     "unique_undeleted"     => "El :atrribute debe ser único.",
+    "import_field_empty"   => "El valor del Import Field no puede estar vacío.",
 
     /*
     |--------------------------------------------------------------------------

--- a/resources/lang/es-ES/validation.php
+++ b/resources/lang/es-ES/validation.php
@@ -89,6 +89,7 @@ return array(
     'uploaded'             => 'El atributo: no se pudo cargar.',
     'url'                  => ':attribute formato incorrecto.',
     "unique_undeleted"     => "El :atrribute debe ser único.",
+    "import_field_empty"   => "El valor del Import Field no puede estar vacío.",
 
     /*
     |--------------------------------------------------------------------------

--- a/resources/lang/es-MX/validation.php
+++ b/resources/lang/es-MX/validation.php
@@ -89,6 +89,7 @@ return array(
     'uploaded'             => 'El atributo: no se pudo cargar.',
     'url'                  => ':attribute formato incorrecto.',
     "unique_undeleted"     => "El :atrribute debe ser único.",
+    "import_field_empty"   => "El valor del Import Field no puede estar vacío.",
 
     /*
     |--------------------------------------------------------------------------

--- a/resources/lang/es-VE/validation.php
+++ b/resources/lang/es-VE/validation.php
@@ -89,6 +89,7 @@ return array(
     'uploaded'             => 'El :attribute fallo al cargar.',
     'url'                  => 'El formato :attribute es inválido.',
     "unique_undeleted"     => "El :atrribute debe ser único.",
+    "import_field_empty"   => "El valor del Import Field no puede estar vacío.",
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Not really a fix in the sense that this is not an error in the software, but every Header in the CSV file has to have an Import Field assigned, if some of the Import Fields aren't stetted, then the system fails silently generating the Flip STRING and INTEGER values error.

So I just added a validation for this cases so the user knows what to do if the import fails.