### PR TITLE
Fixes #6821 - fixed 2 fa active for users list

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -52,6 +52,7 @@ class UsersController extends Controller
             'users.phone',
             'users.state',
             'users.two_factor_enrolled',
+            'users.two_factor_optin',
             'users.updated_at',
             'users.username',
             'users.zip',

--- a/app/Http/Transformers/UsersTransformer.php
+++ b/app/Http/Transformers/UsersTransformer.php
@@ -53,6 +53,8 @@ class UsersTransformer
                 'permissions' => $user->decodePermissions(),
                 'activated' => ($user->activated =='1') ? true : false,
                 'two_factor_activated' => ($user->two_factor_active()) ? true : false,
+                'two_factor_enrolled' => ($user->two_factor_active_and_enrolled()) ? true : false,
+
                 'assets_count' => (int) $user->assets_count,
                 'licenses_count' => (int) $user->licenses_count,
                 'accessories_count' => (int) $user->accessories_count,

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -389,7 +389,11 @@ class User extends SnipeModel implements AuthenticatableContract, CanResetPasswo
     }
 
     /**
-     * Check whether two-factor authorization is required and the user has activated it
+     * Check whether two-factor authorization is requiredfor this user
+     *
+     * 0 = 2FA disabled
+     * 1 = 2FA optional
+     * 2 = 2FA universally required
      *
      * @author [A. Gianotto] [<snipe@snipe.net>]
      * @since [v4.0]
@@ -398,10 +402,45 @@ class User extends SnipeModel implements AuthenticatableContract, CanResetPasswo
      */
     public function two_factor_active () {
 
-        if (Setting::getSettings()->two_factor_enabled !='0') {
-            if (($this->two_factor_optin =='1') && ($this->two_factor_enrolled)) {
-                return true;
-            }
+        // If the 2FA is optional and the user has opted in and is enrolled
+        if ((Setting::getSettings()->two_factor_enabled =='1') && ($this->two_factor_optin =='1'))
+        {
+            return true;
+        }
+        // If the 2FA is required and the user has enrolled
+        elseif (Setting::getSettings()->two_factor_enabled =='2')
+        {
+            return true;
+        }
+
+        return false;
+
+    }
+
+    /**
+     * Check whether two-factor authorization is required and the user has activated it
+     * and enrolled a device
+     *
+     * 0 = 2FA disabled
+     * 1 = 2FA optional
+     * 2 = 2FA universally required
+     *
+     * @author [A. Gianotto] [<snipe@snipe.net>]
+     * @since [v4.6.14]
+     *
+     * @return bool
+     */
+    public function two_factor_active_and_enrolled () {
+
+        // If the 2FA is optional and the user has opted in and is enrolled
+        if ((Setting::getSettings()->two_factor_enabled =='1') && ($this->two_factor_optin =='1') && ($this->two_factor_enrolled =='1'))
+        {
+            return true;
+        }
+        // If the 2FA is required and the user has enrolled
+        elseif ((Setting::getSettings()->two_factor_enabled =='2') && ($this->two_factor_enrolled))
+        {
+            return true;
         }
         return false;
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -402,12 +402,12 @@ class User extends SnipeModel implements AuthenticatableContract, CanResetPasswo
      */
     public function two_factor_active () {
 
-        // If the 2FA is optional and the user has opted in and is enrolled
+        // If the 2FA is optional and the user has opted in
         if ((Setting::getSettings()->two_factor_enabled =='1') && ($this->two_factor_optin =='1'))
         {
             return true;
         }
-        // If the 2FA is required and the user has enrolled
+        // If the 2FA is required for everyone so is implicitly active
         elseif (Setting::getSettings()->two_factor_enabled =='2')
         {
             return true;
@@ -437,7 +437,7 @@ class User extends SnipeModel implements AuthenticatableContract, CanResetPasswo
         {
             return true;
         }
-        // If the 2FA is required and the user has enrolled
+        // If the 2FA is required for everyone and the user has enrolled
         elseif ((Setting::getSettings()->two_factor_enabled =='2') && ($this->two_factor_enrolled))
         {
             return true;

--- a/app/Presenters/UserPresenter.php
+++ b/app/Presenters/UserPresenter.php
@@ -226,14 +226,14 @@ class UserPresenter extends Presenter
             [
                 "field" => "two_factor_enrolled",
                 "searchable" => false,
-                "sortable" => false,
+                "sortable" => true,
                 "switchable" => true,
                 "title" => trans('admin/users/general.two_factor_enrolled'),
                 "visible" => false,
                 'formatter' => 'trueFalseFormatter'
             ],
             [
-                "field" => "two_factor_active",
+                "field" => "two_factor_activated",
                 "searchable" => false,
                 "sortable" => false,
                 "switchable" => true,
@@ -246,7 +246,7 @@ class UserPresenter extends Presenter
                 "searchable" => false,
                 "sortable" => true,
                 "switchable" => true,
-                "title" => trans('general.activated'),
+                "title" => trans('general.login_enabled'),
                 "visible" => true,
                 'formatter' => 'trueFalseFormatter'
             ],

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -221,4 +221,5 @@
     'zip'  					=> 'Zip',
     'noimage'					=> 'No image uploaded or image not found.',
     'token_expired'             => 'Your form session has expired. Please try again.',
+    'login_enabled'             => 'Login Enabled',
     ];

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -232,6 +232,18 @@
                       <td>{{ ($user->activated=='1') ? trans('general.yes') : trans('general.no') }}</td>
                     </tr>
 
+                    @if ($user->activated=='1')
+                      <tr>
+                        <td>{{ trans('admin/users/general.two_factor_active') }}</td>
+                        <td>{{ ($user->two_factor_active()) ? trans('general.yes') : trans('general.no') }}</td>
+                      </tr>
+                      <tr>
+                        <td>{{ trans('admin/users/general.two_factor_enrolled') }}</td>
+                        <td>{{ ($user->two_factor_active_and_enrolled()) ? trans('general.yes') : trans('general.no') }}</td>
+                      </tr>
+                     @endif
+
+
                 </table>
               </div>
             </div> <!--/col-md-8-->

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -127,22 +127,22 @@
                 <table class="table table-striped">
                   @if (!is_null($user->company))
                     <tr>
-                        <td>{{ trans('general.company') }}</td>
+                        <td class="text-nowrap">{{ trans('general.company') }}</td>
                         <td>{{ $user->company->name }}</td>
                     </tr>
                   @endif
 
                   <tr>
-                    <td>{{ trans('admin/users/table.name') }}</td>
+                    <td class="text-nowrap">{{ trans('admin/users/table.name') }}</td>
                     <td>{{ $user->present()->fullName() }}</td>
                   </tr>
                   <tr>
-                    <td>{{ trans('admin/users/table.username') }}</td>
+                    <td class="text-nowrap">{{ trans('admin/users/table.username') }}</td>
                     <td>{{ $user->username }}</td>
                   </tr>
 
                     <tr>
-                      <td>{{ trans('general.groups') }}</td>
+                      <td class="text-nowrap">{{ trans('general.groups') }}</td>
                       <td>
                         @if ($user->groups->count() > 0)
                             @foreach ($user->groups as $group)
@@ -164,21 +164,21 @@
 
                   @if ($user->jobtitle)
                   <tr>
-                    <td>{{ trans('admin/users/table.job') }}</td>
+                    <td class="text-nowrap">{{ trans('admin/users/table.job') }}</td>
                     <td>{{ $user->jobtitle }}</td>
                   </tr>
                   @endif
 
                   @if ($user->employee_num)
                   <tr>
-                    <td>{{ trans('admin/users/table.employee_num') }}</td>
+                    <td class="text-nowrap">{{ trans('admin/users/table.employee_num') }}</td>
                     <td>{{ $user->employee_num }}</td>
                   </tr>
                   @endif
 
                   @if ($user->manager)
                   <tr>
-                    <td>{{ trans('admin/users/table.manager') }}</td>
+                    <td class="text-nowrap">{{ trans('admin/users/table.manager') }}</td>
                     <td>
                       <a href="{{ route('users.show', $user->manager->id) }}">{{ $user->manager->getFullNameAttribute() }}</a>
 
@@ -188,21 +188,21 @@
 
                   @if ($user->email)
                   <tr>
-                    <td>{{ trans('admin/users/table.email') }}</td>
+                    <td class="text-nowrap">{{ trans('admin/users/table.email') }}</td>
                     <td><a href="mailto:{{ $user->email }}">{{ $user->email }}</a></td>
                   </tr>
                   @endif
 
                   @if ($user->phone)
                   <tr>
-                    <td>{{ trans('admin/users/table.phone') }}</td>
+                    <td class="text-nowrap">{{ trans('admin/users/table.phone') }}</td>
                     <td><a href="tel:{{ $user->phone }}">{{ $user->phone }}</a></td>
                   </tr>
                   @endif
 
                   @if ($user->userloc)
                   <tr>
-                    <td>{{ trans('admin/users/table.location') }}</td>
+                    <td class="text-nowrap">{{ trans('admin/users/table.location') }}</td>
                     <td>{{ link_to_route('locations.show', $user->userloc->name, [$user->userloc->id]) }}</td>
 
 
@@ -210,14 +210,14 @@
                   @endif
                     @if ($user->last_login)
                       <tr>
-                        <td>{{ trans('general.last_login') }}</td>
+                        <td class="text-nowrap">{{ trans('general.last_login') }}</td>
                         <td>{{ \App\Helpers\Helper::getFormattedDateObject($user->last_login, 'datetime', false) }}</td>
                       </tr>
                     @endif
 
                     @if (!is_null($user->department))
                       <tr>
-                        <td>{{ trans('general.department') }}</td>
+                        <td class="text-nowrap">{{ trans('general.department') }}</td>
                         <td><a href="{{ route('departments.show', $user->department) }}">{{ $user->department->name }}</a></td>
                       </tr>
                     @endif
@@ -228,19 +228,41 @@
                   </tr>
                   @endif
                     <tr>
-                      <td>{{ trans('general.login_enabled') }}</td>
+                      <td class="text-nowrap">{{ trans('general.login_enabled') }}</td>
                       <td>{{ ($user->activated=='1') ? trans('general.yes') : trans('general.no') }}</td>
                     </tr>
 
                     @if ($user->activated=='1')
                       <tr>
-                        <td>{{ trans('admin/users/general.two_factor_active') }}</td>
+                        <td class="text-nowrap">{{ trans('admin/users/general.two_factor_active') }}</td>
                         <td>{{ ($user->two_factor_active()) ? trans('general.yes') : trans('general.no') }}</td>
                       </tr>
                       <tr>
-                        <td>{{ trans('admin/users/general.two_factor_enrolled') }}</td>
-                        <td>{{ ($user->two_factor_active_and_enrolled()) ? trans('general.yes') : trans('general.no') }}</td>
+                        <td class="text-nowrap">{{ trans('admin/users/general.two_factor_enrolled') }}</td>
+                        <td class="two_factor_resetrow">
+                          <div class="row">
+                          <div class="col-md-1" id="two_factor_reset_toggle">
+                            {{ ($user->two_factor_active_and_enrolled()) ? trans('general.yes') : trans('general.no') }}
+                          </div>
+
+                          @if ((Auth::user()->isSuperUser()) && ($snipeSettings->two_factor_enabled!='0'))
+                            <div class="col-md-11">
+                            <a class="btn btn-default btn-sm pull-left" id="two_factor_reset" style="margin-right: 10px;"> {{ trans('admin/settings/general.two_factor_reset') }}</a>
+                            <span id="two_factor_reseticon">
+                            </span>
+                            <span id="two_factor_resetresult">
+                            </span>
+                            <span id="two_factor_resetstatus">
+                            </span>
+
+                                <br><br><p class="help-block">{{ trans('admin/settings/general.two_factor_reset_help') }}</p>
+                            </div>
+                          </div>
+                       @endif
+
+                        </td>
                       </tr>
+
                      @endif
 
 
@@ -559,6 +581,40 @@
   @include ('partials.bootstrap-table', ['simple_view' => true])
 <script nonce="{{ csrf_token() }}">
 $(function () {
+
+  $("#two_factor_reset").click(function(){
+    $("#two_factor_resetrow").removeClass('success');
+    $("#two_factor_resetrow").removeClass('danger');
+    $("#two_factor_resetstatus").html('');
+    $("#two_factor_reseticon").html('<i class="fa fa-spinner spin"></i>');
+    $.ajax({
+      url: '{{ route('api.users.two_factor_reset', ['id'=> $user->id]) }}',
+      type: 'POST',
+      data: {},
+      headers: {
+        "X-Requested-With": 'XMLHttpRequest',
+        "X-CSRF-TOKEN": $('meta[name="csrf-token"]').attr('content')
+      },
+      dataType: 'json',
+
+      success: function (data) {
+        $("#two_factor_reset_toggle").html('').html('{{ trans('general.no') }}');
+        $("#two_factor_reseticon").html('');
+        $("#two_factor_resetstatus").html('<i class="fa fa-check text-success"></i>' + data.message);
+
+      },
+
+      error: function (data) {
+        $("#two_factor_reseticon").html('');
+        $("#two_factor_reseticon").html('<i class="fa fa-exclamation-triangle text-danger"></i>');
+        $('#two_factor_resetstatus').text(data.message);
+      }
+
+
+    });
+  });
+
+
     //binds to onchange event of your input field
     var uploadedFileSize = 0;
     $('#fileupload').bind('change', function() {

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -227,6 +227,11 @@
                     <td>{{ $user->created_at->format('F j, Y h:iA') }}</td>
                   </tr>
                   @endif
+                    <tr>
+                      <td>{{ trans('general.login_enabled') }}</td>
+                      <td>{{ ($user->activated=='1') ? trans('general.yes') : trans('general.no') }}</td>
+                    </tr>
+
                 </table>
               </div>
             </div> <!--/col-md-8-->


### PR DESCRIPTION
This PR fixes #6821. The active column wasn't exactly incorrect, but it was a confusing UI if you enforce 2FA globally, since it was only checking for the `two_factor_optin` field to be set to 1, but we bypass that check if `settings.enable_two_factor` is equal to `2` (globally enforced, no opt-out).

This should now check the 2FA settings in the settings table/cache first to see whether it's applied globally, and overrides the individual user settings in the user's list and API if it is. 

Additionally, I've added the 2FA info to the user's detail page, and a "reset enrollment device" button that only appears for superadmins, that will let super admins reset the device enrollment in the case of a lost or stolen 2FA device:

<img width="628" alt="View_User_Farts_User____Snipe-IT_Demo" src="https://user-images.githubusercontent.com/197404/54325194-2a762780-45be-11e9-956c-26eb619a5ea9.png">

<img width="627" alt="View_User_Farts_User____Snipe-IT_Demo-2" src="https://user-images.githubusercontent.com/197404/54325192-29dd9100-45be-11e9-94f7-6c1f5ac8202e.png">

(Previously, you'd have had to go to the edit screen for this reset button.)

And finally, I changed the language of the "Activated" option in the user list to "Login Enabled", since that's really what it means, and using an ambiguous term like "activated" wasn't particularly helpful. 

<img width="628" alt="Current_Users____Snipe-IT_Demo" src="https://user-images.githubusercontent.com/197404/54325281-a7090600-45be-11e9-8432-89294332126f.png">

### Acceptance Testing / QA:

- Disable 2FA for everyone, device enrolled and 2FA active should be false
- 2FA set to optional, enable it on a user
     - User not opted in should show false (X) for 2FA active and 2FA enrolled
     - User opted in but not enrolled should show true (checkmark) for 2FA active and false (X) for 2FA enrolled     
    - User opted in and enrolled should show true (checkmark) for 2FA active and true (checkmark) for 2FA enrolled
- 2FA set to enforced for everyone, all users should show true (checkmark) as 2FA active, should show true or false depending on whether the user's device is enrolled
- A user whose device is currently enrolled should become un-enrolled when the "Reset Two-Factor Secret" button is clicked. Next time logging in as that user, you should be prompted to enroll a device (similar to the behavior when the user first logged in with 2FA enabled)


### Potential To-Dos:
- Use DI to pull the settings out of the User methods to make testing easier.