### PR TITLE
Fix #6810: API Get asset by tag, returns the id of a deleted asset instead of existing

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -288,7 +288,7 @@ class AssetsController extends Controller
      */
     public function showByTag($tag)
     {
-        if ($asset = Asset::with('assetstatus')->with('assignedTo')->withTrashed()->where('asset_tag',$tag)->first()) {
+        if ($asset = Asset::with('assetstatus')->with('assignedTo')->where('asset_tag',$tag)->first()) {
             $this->authorize('view', $asset);
             return (new AssetsTransformer)->transformAsset($asset);
         }


### PR DESCRIPTION
The eloquent relationship uses the 'withTrashed()' method, then returns first() encountered. Just erase the withTrashed(), so the soft deleted assets gets ignored.