### PR TITLE
Add models IDE helper to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ phpmd\.xml
 /public/storage
 _ide_helper.php
 .phpstorm.meta.php
+_ide_helper_models.php


### PR DESCRIPTION
This is an extension to a previous PR (#6805) - and now adds model helper to `.gitignore`

