### PR TITLE
Fix #6561: added offset for the pagination to work in Accessories checkedout table

### DIFF
--- a/app/Http/Controllers/Api/AccessoriesController.php
+++ b/app/Http/Controllers/Api/AccessoriesController.php
@@ -141,18 +141,27 @@ class AccessoriesController extends Controller
             return ['total' => 0, 'rows' => []];
         }
 
+        $offset = request('offset', 0);
+        $limit = request('limit', 50);
+
         $accessory->lastCheckoutArray = $accessory->lastCheckout->toArray();
         $accessory_users = $accessory->users;
-        
+        $total = $accessory_users->count();
+
+        if($total < $offset){
+            $offset = 0;
+        }
+
+        $accessory_users = $accessory->users()->skip($offset)->take($limit)->get();
+
         if ($request->filled('search')) {
             $accessory_users = $accessory->users()
                                 ->where('first_name', 'like', '%'.$request->input('search').'%')
                                 ->orWhere('last_name', 'like', '%'.$request->input('search').'%')
                                 ->get();
+            $total = $accessory_users->count();
         }
-
-        $total = $accessory_users->count();
-    
+        
         return (new AccessoriesTransformer)->transformCheckedoutAccessory($accessory, $accessory_users, $total);
     }
 

--- a/app/Http/Controllers/Api/LicensesController.php
+++ b/app/Http/Controllers/Api/LicensesController.php
@@ -231,10 +231,6 @@ class LicensesController extends Controller
             $offset = request('offset', 0);
             $limit = request('limit', 50);
 
-            if($seats->count() < $offset){
-                $offset = 0;
-            }
-
             $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
             $total = $seats->count();
 


### PR DESCRIPTION
The offset wasn't present, so the Controller always show the same checkedout accessories and pagination appears not to work.

Also, delete some redundant lines in LicensesController I'm not sure how this escaped to my sight at the time I checked that code.