### PR TITLE
Fixes #6204 - added email alerts and web/API access to assets due for audits

### DIFF
--- a/app/Console/Commands/SendUpcomingAuditReport.php
+++ b/app/Console/Commands/SendUpcomingAuditReport.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Asset;
+use App\Models\License;
+use App\Models\Setting;
+use App\Notifications\ExpiringAssetsNotification;
+use App\Models\Recipients;
+use DB;
+use Illuminate\Console\Command;
+use App\Notifications\SendUpcomingAuditNotification;
+use Carbon\Carbon;
+
+class SendUpcomingAuditReport extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'snipeit:upcoming-audits';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Send email/slack notifications for upcoming asset audits.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $settings = Setting::getSettings();
+
+        // Threshold sets the very latest date the next audit could be: $settings->audit_warning_days from today
+        $threshold = Carbon::now()->addDays($settings->audit_warning_days);
+
+
+
+        if (($settings->alert_email != '') && ($settings->audit_warning_days) && ($settings->alerts_enabled == 1)) {
+
+            // Send a rollup to the admin, if settings dictate
+            $recipients = collect(explode(',', $settings->alert_email))->map(function ($item, $key) {
+                return new \App\Models\Recipients\AlertRecipient($item);
+            });
+
+            // Assets due for auditing
+            $assets = Asset::whereDate('next_audit_date', '<=', $threshold)
+                ->orderBy('last_audit_date', 'asc')->get();
+
+            if ($assets->count() > 0) {
+
+                $this->info(trans_choice('mail.upcoming-audits', $assets->count(),
+                    ['count' => $assets->count(), 'threshold' => $threshold]));
+                \Notification::send($recipients, new SendUpcomingAuditNotification($assets, $threshold));
+                $this->info('Audit report sent to '.$settings->alert_email);
+            } else {
+                $this->info('No assets to be audited. No report sent.');
+            }
+
+
+
+        } elseif ($settings->alert_email=='') {
+            $this->error('Could not send email. No alert email configured in settings');
+        } elseif (!$settings->audit_warning_days) {
+            $this->error('No audit warning days set in Admin Notifications. No mail will be sent.');
+        } elseif ($settings->alerts_enabled!=1) {
+            $this->info('Alerts are disabled in the settings. No mail will be sent');
+        } else {
+            $this->error('Something went wrong. :( ');
+            $this->error('Admin Notifications Email Setting: '.$settings->alert_email);
+            $this->error('Admin Audit Warning Setting: '.$settings->audit_warning_days);
+            $this->error('Admin Alerts Emnabled: '.$settings->alerts_enabled);
+        }
+
+
+    }
+}

--- a/app/Console/Commands/SendUpcomingAuditReport.php
+++ b/app/Console/Commands/SendUpcomingAuditReport.php
@@ -58,7 +58,7 @@ class SendUpcomingAuditReport extends Command
             // Assets due for auditing
 
             $assets = Asset::whereNotNull('next_audit_date')
-                    ->dueForAudit($settings)
+                    ->DueOrOverdueForAudit($settings)
                     ->orderBy('last_audit_date', 'asc')->get();
 
             if ($assets->count() > 0) {

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -49,6 +49,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('snipeit:expected-checkin')->daily();
         $schedule->command('snipeit:backup')->weekly();
         $schedule->command('backup:clean')->daily();
+        $schedule->command('snipeit:upcoming-audits')->daily();
     }
 
     protected function commands()

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Console;
 
+use App\Console\Commands\RestoreDeletedUsers;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
@@ -31,6 +32,7 @@ class Kernel extends ConsoleKernel
         Commands\RegenerateAssetTags::class,
         Commands\SyncAssetCounters::class,
         Commands\RestoreDeletedUsers::class,
+        Commands\SendUpcomingAuditReport::class,
     ];
 
     /**

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -52,7 +52,7 @@ class AssetsController extends Controller
      * @since [v4.0]
      * @return JsonResponse
      */
-    public function index(Request $request)
+    public function index(Request $request, $audit = null)
     {
 
         $this->authorize('index', Asset::class);
@@ -147,6 +147,21 @@ class AssetsController extends Controller
         $offset = (($assets) && (request('offset') > $assets->count())) ? 0 : request('offset', 0);
         $limit = $request->input('limit', 50);
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
+
+        // This is used by the audit reporting routes
+        if (Gate::allows('audit', Asset::class)) {
+
+            switch ($audit) {
+                case 'due':
+                    $assets->DueForAudit($settings);
+                    break;
+                case 'overdue':
+                    $assets->overdueForAudit($settings);
+                    break;
+            }
+        }
+
+
 
         // This is used by the sidenav, mostly
 

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -153,7 +153,7 @@ class AssetsController extends Controller
 
             switch ($audit) {
                 case 'due':
-                    $assets->DueForAudit($settings);
+                    $assets->DueOrOverdueForAudit($settings);
                     break;
                 case 'overdue':
                     $assets->overdueForAudit($settings);

--- a/app/Http/Controllers/AssetsController.php
+++ b/app/Http/Controllers/AssetsController.php
@@ -744,6 +744,18 @@ class AssetsController extends Controller
         return view('hardware/audit')->with('asset', $asset)->with('next_audit_date', $dt)->with('locations_list');
     }
 
+    public function dueForAudit()
+    {
+        $this->authorize('audit', Asset::class);
+        return view('hardware/audit-due');
+    }
+
+    public function overdueForAudit()
+    {
+        $this->authorize('audit', Asset::class);
+        return view('hardware/audit-overdue');
+    }
+
 
     public function auditStore(AssetFileRequest $request, $id)
     {

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -813,7 +813,7 @@ class Asset extends Depreciable
      * now = May 4, 2019
      *
      * @author A. Gianotto <snipe@snipe.net>
-     * @since v4.5.17
+     * @since v4.6.16
      * @param Setting $settings
      *
      * @return \Illuminate\Database\Query\Builder          Modified query builder
@@ -836,7 +836,7 @@ class Asset extends Depreciable
      * for an upcoming API call for retrieving a report on overdue assets.
      *
      * @author A. Gianotto <snipe@snipe.net>
-     * @since v4.5.17
+     * @since v4.6.16
      * @param Setting $settings
      *
      * @return \Illuminate\Database\Query\Builder          Modified query builder
@@ -858,7 +858,7 @@ class Asset extends Depreciable
      * for an upcoming API call for retrieving a report on assets that will need to be audited.
      *
      * @author A. Gianotto <snipe@snipe.net>
-     * @since v4.5.17
+     * @since v4.6.16
      * @param Setting $settings
      *
      * @return \Illuminate\Database\Query\Builder          Modified query builder

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -842,7 +842,7 @@ class Asset extends Depreciable
      * @return \Illuminate\Database\Query\Builder          Modified query builder
      */
 
-    public function scopeOverdueForAudit($query, $settings)
+    public function scopeOverdueForAudit($query)
     {
         return $query->whereNotNull('assets.next_audit_date')
             ->where('assets.next_audit_date', '<', Carbon::now())

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -796,6 +796,60 @@ class Asset extends Depreciable
         });
     }
 
+    /**
+     * Query builder scope for Assets that are due for auditing, based on the assets.next_audit_date
+     * and settings.audit_warning_days.
+     *
+     * This is/will be used in the artisan command snipeit:upcoming-audits and also
+     * for an upcoming API call for retrieving a report on assets that will need to be audited.
+     *
+     * Due for audit soon:
+     * next_audit_date greater than or equal to now (must be in the future)
+     * and (next_audit_date - threshold days) <= now ()
+     *
+     * Example:
+     * next_audit_date = May 4, 2025
+     * threshold for alerts = 30 days
+     * now = May 4, 2019
+     *
+     * @author A. Gianotto <snipe@snipe.net>
+     * @since v4.5.17
+     * @param Setting $settings
+     *
+     * @return \Illuminate\Database\Query\Builder          Modified query builder
+     */
+
+    public function scopeDueForAudit($query, $settings)
+    {
+        return $query->whereNotNull('assets.next_audit_date')
+            ->where('assets.next_audit_date', '>=', Carbon::now())
+            ->whereRaw("DATE_SUB(assets.next_audit_date, INTERVAL $settings->audit_warning_days DAY) <= '".Carbon::now()."'")
+            ->where('assets.archived', '=', 0)
+            ->NotArchived();
+    }
+
+    /**
+     * Query builder scope for Assets that are OVERDUE for auditing, based on the assets.next_audit_date
+     * and settings.audit_warning_days. It checks to see if assets.next audit_date is before now
+     *
+     * This is/will be used in the artisan command snipeit:upcoming-audits and also
+     * for an upcoming API call for retrieving a report on overdue assets.
+     *
+     * @author A. Gianotto <snipe@snipe.net>
+     * @since v4.5.17
+     * @param Setting $settings
+     *
+     * @return \Illuminate\Database\Query\Builder          Modified query builder
+     */
+
+    public function scopeOverdueForAudit($query, $settings)
+    {
+        return $query->whereNotNull('assets.next_audit_date')
+            ->where('assets.next_audit_date', '<', Carbon::now())
+            ->where('assets.archived', '=', 0)
+            ->NotArchived();
+    }
+
   /**
    * Query builder scope for Archived assets
    *

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -850,6 +850,29 @@ class Asset extends Depreciable
             ->NotArchived();
     }
 
+    /**
+     * Query builder scope for Assets that are due for auditing OR overdue, based on the assets.next_audit_date
+     * and settings.audit_warning_days.
+     *
+     * This is/will be used in the artisan command snipeit:upcoming-audits and also
+     * for an upcoming API call for retrieving a report on assets that will need to be audited.
+     *
+     * @author A. Gianotto <snipe@snipe.net>
+     * @since v4.5.17
+     * @param Setting $settings
+     *
+     * @return \Illuminate\Database\Query\Builder          Modified query builder
+     */
+
+    public function scopeDueOrOverdueForAudit($query, $settings)
+    {
+        return $query->whereNotNull('assets.next_audit_date')
+            ->whereRaw("DATE_SUB(assets.next_audit_date, INTERVAL $settings->audit_warning_days DAY) <= '".Carbon::now()."'")
+            ->where('assets.archived', '=', 0)
+            ->NotArchived();
+    }
+
+
   /**
    * Query builder scope for Archived assets
    *

--- a/app/Notifications/SendUpcomingAuditNotification.php
+++ b/app/Notifications/SendUpcomingAuditNotification.php
@@ -20,6 +20,7 @@ class SendUpcomingAuditNotification extends Notification
     public function __construct($params, $threshold)
     {
         $this->assets = $params;
+        $this->threshold = $threshold;
     }
 
     /**
@@ -44,8 +45,9 @@ class SendUpcomingAuditNotification extends Notification
         $message = (new MailMessage)->markdown('notifications.markdown.upcoming-audits',
             [
                 'assets'  => $this->assets,
+                'threshold'  => $this->threshold,
             ])
-            ->subject(trans_choice('mail.upcoming-audits', $this->assets->count(), ['count' => $this->assets->count()]));
+            ->subject(trans_choice('mail.upcoming-audits', $this->assets->count(), ['count' => $this->assets->count(), 'threshold' => $this->threshold]));
 
         return $message;
     }

--- a/app/Notifications/SendUpcomingAuditNotification.php
+++ b/app/Notifications/SendUpcomingAuditNotification.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Setting;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+
+class SendUpcomingAuditNotification extends Notification
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @return void
+     */
+    public function __construct($params, $threshold)
+    {
+        $this->assets = $params;
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return $notifyBy = ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        $message = (new MailMessage)->markdown('notifications.markdown.upcoming-audits',
+            [
+                'assets'  => $this->assets,
+            ])
+            ->subject(trans_choice('mail.upcoming-audits', $this->assets->count(), ['count' => $this->assets->count()]));
+
+        return $message;
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function toArray($notifiable)
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Presenters/AssetAuditPresenter.php
+++ b/app/Presenters/AssetAuditPresenter.php
@@ -1,0 +1,273 @@
+<?php
+namespace App\Presenters;
+
+use App\Models\CustomField;
+use DateTime;
+
+/**
+ * Class AssetPresenter
+ * @package App\Presenters
+ */
+class AssetAuditPresenter extends Presenter
+{
+
+    /**
+     * Json Column Layout for bootstrap table
+     * @return string
+     */
+    public static function dataTableLayout()
+    {
+        $layout = [
+             [
+                "field" => "id",
+                "searchable" => false,
+                "sortable" => true,
+                "switchable" => true,
+                "title" => trans('general.id'),
+                "visible" => false
+            ], [
+                "field" => "company",
+                "searchable" => true,
+                "sortable" => true,
+                "switchable" => true,
+                "title" => trans('general.company'),
+                "visible" => false,
+                "formatter" => 'assetCompanyObjFilterFormatter'
+            ], [
+                "field" => "name",
+                "searchable" => true,
+                "sortable" => true,
+                "title" => trans('admin/hardware/form.name'),
+                "visible" => true,
+                "formatter" => "hardwareLinkFormatter"
+            ], [
+                "field" => "image",
+                "searchable" => false,
+                "sortable" => true,
+                "switchable" => true,
+                "title" => trans('admin/hardware/table.image'),
+                "visible" => false,
+                "formatter" => "imageFormatter"
+            ], [
+                "field" => "asset_tag",
+                "searchable" => true,
+                "sortable" => true,
+                "title" => trans('admin/hardware/table.asset_tag'),
+                "visible" => true,
+                "formatter" => "hardwareLinkFormatter"
+            ], [
+                "field" => "serial",
+                "searchable" => true,
+                "sortable" => true,
+                "title" => trans('admin/hardware/form.serial'),
+                "visible" => true,
+                "formatter" => "hardwareLinkFormatter"
+            ],  [
+                "field" => "model",
+                "searchable" => true,
+                "sortable" => true,
+                "title" => trans('admin/hardware/form.model'),
+                "visible" => true,
+                "formatter" => "modelsLinkObjFormatter"
+            ], [
+                "field" => "model_number",
+                "searchable" => true,
+                "sortable" => true,
+                "title" => trans('admin/models/table.modelnumber'),
+                "visible" => false
+            ], [
+                "field" => "category",
+                "searchable" => true,
+                "sortable" => true,
+                "title" => trans('general.category'),
+                "visible" => false,
+                "formatter" => "categoriesLinkObjFormatter"
+            ], [
+                "field" => "status_label",
+                "searchable" => true,
+                "sortable" => true,
+                "title" => trans('admin/hardware/table.status'),
+                "visible" => true,
+                "formatter" => "statuslabelsLinkObjFormatter"
+            ], [
+                "field" => "assigned_to",
+                "searchable" => true,
+                "sortable" => true,
+                "title" => trans('admin/hardware/form.checkedout_to'),
+                "visible" => true,
+                "formatter" => "polymorphicItemFormatter"
+            ], [
+                "field" => "location",
+                "searchable" => true,
+                "sortable" => true,
+                "title" => trans('admin/hardware/table.location'),
+                "visible" => true,
+                "formatter" => "deployedLocationFormatter"
+            ], [
+                "field" => "rtd_location",
+                "searchable" => true,
+                "sortable" => true,
+                "title" => trans('admin/hardware/form.default_location'),
+                "visible" => false,
+                "formatter" => "deployedLocationFormatter"
+            ], [
+                "field" => "manufacturer",
+                "searchable" => true,
+                "sortable" => true,
+                "title" => trans('general.manufacturer'),
+                "visible" => false,
+                "formatter" => "manufacturersLinkObjFormatter"
+            ], [
+                "field" => "purchase_date",
+                "searchable" => true,
+                "sortable" => true,
+                "visible" => false,
+                "title" => trans('general.purchase_date'),
+                "formatter" => "dateDisplayFormatter"
+            ], [
+                "field" => "purchase_cost",
+                "searchable" => true,
+                "sortable" => true,
+                "visible" => false,
+                "title" => trans('general.purchase_cost'),
+                "footerFormatter" => 'sumFormatter',
+            ], [
+                "field" => "order_number",
+                "searchable" => true,
+                "sortable" => true,
+                "visible" => false,
+                "title" => trans('general.order_number'),
+                'formatter' => "orderNumberObjFilterFormatter"
+            ], [
+                "field" => "eol",
+                "searchable" => false,
+                "sortable" => false,
+                "visible" => false,
+                "title" => trans('general.eol'),
+                "formatter" => "dateDisplayFormatter"
+            ], [
+                "field" => "warranty_months",
+                "searchable" => true,
+                "sortable" => true,
+                "visible" => false,
+                "title" => trans('admin/hardware/form.warranty')
+            ],[
+                "field" => "warranty_expires",
+                "searchable" => false,
+                "sortable" => false,
+                "visible" => false,
+                "title" => trans('admin/hardware/form.warranty_expires'),
+                "formatter" => "dateDisplayFormatter"
+            ],[
+                "field" => "notes",
+                "searchable" => true,
+                "sortable" => true,
+                "visible" => false,
+                "title" => trans('general.notes'),
+
+            ], [
+                "field" => "checkout_counter",
+                "searchable" => false,
+                "sortable" => true,
+                "visible" => false,
+                "title" => trans('general.checkouts_count')
+
+            ],[
+                "field" => "checkin_counter",
+                "searchable" => false,
+                "sortable" => true,
+                "visible" => false,
+                "title" => trans('general.checkins_count')
+
+            ], [
+                "field" => "requests_counter",
+                "searchable" => false,
+                "sortable" => true,
+                "visible" => false,
+                "title" => trans('general.user_requests_count')
+
+            ], [
+                "field" => "created_at",
+                "searchable" => false,
+                "sortable" => true,
+                "visible" => false,
+                "title" => trans('general.created_at'),
+                "formatter" => "dateDisplayFormatter"
+            ], [
+                "field" => "updated_at",
+                "searchable" => false,
+                "sortable" => true,
+                "visible" => false,
+                "title" => trans('general.updated_at'),
+                "formatter" => "dateDisplayFormatter"
+            ], [
+                "field" => "last_checkout",
+                "searchable" => false,
+                "sortable" => true,
+                "visible" => false,
+                "title" => trans('admin/hardware/table.checkout_date'),
+                "formatter" => "dateDisplayFormatter"
+            ], [
+                "field" => "expected_checkin",
+                "searchable" => false,
+                "sortable" => true,
+                "visible" => false,
+                "title" => trans('admin/hardware/form.expected_checkin'),
+                "formatter" => "dateDisplayFormatter"
+            ], [
+                "field" => "last_audit_date",
+                "searchable" => false,
+                "sortable" => true,
+                "visible" => true,
+                "title" => trans('general.last_audit'),
+                "formatter" => "dateDisplayFormatter"
+            ], [
+                "field" => "next_audit_date",
+                "searchable" => false,
+                "sortable" => true,
+                "visible" => true,
+                "title" => trans('general.next_audit_date'),
+                "formatter" => "dateDisplayFormatter"
+            ],
+        ];
+
+        // This looks complicated, but we have to confirm that the custom fields exist in custom fieldsets
+        // *and* those fieldsets are associated with models, otherwise we'll trigger
+        // javascript errors on the bootstrap tables side of things, since we're asking for properties
+        // on fields that will never be passed through the REST API since they're not associated with
+        // models. We only pass the fieldsets that pertain to each asset (via their model) so that we
+        // don't junk up the REST API with tons of custom fields that don't apply
+
+        $fields =  CustomField::whereHas('fieldset', function ($query) {
+            $query->whereHas('models');
+        })->get();
+
+        foreach ($fields as $field) {
+            $layout[] = [
+                "field" => 'custom_fields.'.$field->convertUnicodeDbSlug(),
+                "searchable" => true,
+                "sortable" => true,
+                "visible" => false,
+                "switchable" => true,
+                "title" => ($field->field_encrypted=='1') ?'<i class="fa fa-lock"></i> '.e($field->name) : e($field->name),
+                "formatter" => "customFieldsFormatter"
+            ];
+
+        }
+
+
+        $layout[] = [
+            "field" => "actions",
+            "searchable" => false,
+            "sortable" => false,
+            "switchable" => false,
+            "title" => trans('table.actions'),
+            "formatter" => "hardwareAuditFormatter",
+        ];
+
+        return json_encode($layout);
+    }
+
+
+
+}

--- a/config/version.php
+++ b/config/version.php
@@ -1,10 +1,10 @@
 <?php
 return array (
-  'app_version' => 'v4.6.15',
-  'full_app_version' => 'v4.6.15 - build 4011-gd1e9fbfa2',
-  'build_version' => '4011',
+  'app_version' => 'v4.6.16',
+  'full_app_version' => 'v4.6.16 - build 4018-gce16eae50',
+  'build_version' => '4018',
   'prerelease_version' => '',
-  'hash_version' => 'gd1e9fbfa2',
-  'full_hash' => 'v4.6.15-2-gd1e9fbfa2',
-  'branch' => 'master',
+  'hash_version' => 'gce16eae50',
+  'full_hash' => 'v4.6.16-6-gce16eae50',
+  'branch' => 'features/6204_email_audit-alerts',
 );

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -219,7 +219,9 @@
     'years'					=> 'years',
     'yes' 					=> 'Yes',
     'zip'  					=> 'Zip',
-    'noimage'					=> 'No image uploaded or image not found.',
-    'token_expired'             => 'Your form session has expired. Please try again.',
-    'login_enabled'             => 'Login Enabled',
+    'noimage'				=> 'No image uploaded or image not found.',
+    'token_expired'         => 'Your form session has expired. Please try again.',
+    'login_enabled'         => 'Login Enabled',
+    'audit_due'             => 'Due for Audit',
+    'audit_overdue'         => 'Overdue for Audit',
     ];

--- a/resources/lang/en/mail.php
+++ b/resources/lang/en/mail.php
@@ -64,9 +64,11 @@ return array(
     'license_expiring_alert' => 'There is :count license expiring in the next :threshold days.|There are :count licenses expiring in the next :threshold days.',
     'to_reset' => 'To reset your :web password, complete this form:',
     'type' => 'Type',
+    'upcoming-audits' => 'There is :count asset that is coming up for audit within :threshold days.|There are :count assets that are coming up for audit within :threshold days.',
     'user' => 'User',
     'username' => 'Username',
     'welcome' => 'Welcome :name',
     'welcome_to' => 'Welcome to :web!',
     'your_credentials' => 'Your Snipe-IT credentials',
+
 );

--- a/resources/views/hardware/audit-due.blade.php
+++ b/resources/views/hardware/audit-due.blade.php
@@ -1,0 +1,73 @@
+@extends('layouts/default')
+
+@section('title0')
+
+    @if ((Input::get('company_id')) && ($company))
+        {{ $company->name }}
+    @endif
+
+    {{ trans('general.assets') }}
+
+@stop
+
+{{-- Page title --}}
+@section('title')
+    @yield('title0')  @parent
+@stop
+
+@section('header_right')
+    <a href="{{ route('hardware.create') }}" class="btn btn-primary pull-right"></i> {{ trans('general.create') }}</a>
+@stop
+
+{{-- Page content --}}
+@section('content')
+
+    <div class="row">
+        <div class="col-md-12">
+            <div class="box">
+                <div class="box-body">
+                    {{ Form::open([
+                      'method' => 'POST',
+                      'route' => ['hardware/bulkedit'],
+                      'class' => 'form-inline',
+                       'id' => 'bulkForm']) }}
+                    <div class="row">
+                        <div class="col-md-12">
+
+                            <table
+                                    data-click-to-select="true"
+                                    data-columns="{{ \App\Presenters\AssetAuditPresenter::dataTableLayout() }}"
+                                    data-cookie-id-table="assetsAuditListingTable"
+                                    data-pagination="true"
+                                    data-id-table="assetsAuditListingTable"
+                                    data-search="true"
+                                    data-side-pagination="server"
+                                    data-show-columns="true"
+                                    data-show-export="true"
+                                    data-show-footer="true"
+                                    data-show-refresh="true"
+                                    data-sort-order="asc"
+                                    data-sort-name="name"
+                                    data-toolbar="#toolbar"
+                                    id="assetsAuditListingTable"
+                                    class="table table-striped snipe-table"
+                                    data-url="{{ route('api.asset.to-audit', ['audit' => 'due']) }}"
+                                    data-export-options='{
+                "fileName": "export-assets-due-audit-{{ date('Y-m-d') }}",
+                "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
+                }'>
+                            </table>
+
+                        </div><!-- /.col -->
+                    </div><!-- /.row -->
+                    {{ Form::close() }}
+                </div><!-- ./box-body -->
+            </div><!-- /.box -->
+        </div>
+    </div>
+@stop
+
+@section('moar_scripts')
+    @include('partials.bootstrap-table')
+
+@stop

--- a/resources/views/hardware/audit-due.blade.php
+++ b/resources/views/hardware/audit-due.blade.php
@@ -6,7 +6,7 @@
         {{ $company->name }}
     @endif
 
-    {{ trans('general.assets') }}
+    {{ trans('general.audit_due') }}
 
 @stop
 
@@ -15,9 +15,6 @@
     @yield('title0')  @parent
 @stop
 
-@section('header_right')
-    <a href="{{ route('hardware.create') }}" class="btn btn-primary pull-right"></i> {{ trans('general.create') }}</a>
-@stop
 
 {{-- Page content --}}
 @section('content')

--- a/resources/views/hardware/audit-overdue.blade.php
+++ b/resources/views/hardware/audit-overdue.blade.php
@@ -6,7 +6,7 @@
         {{ $company->name }}
     @endif
 
-    {{ trans('general.assets') }}
+    {{ trans('general.audit_overdue') }}
 
 @stop
 
@@ -15,9 +15,6 @@
     @yield('title0')  @parent
 @stop
 
-@section('header_right')
-    <a href="{{ route('hardware.create') }}" class="btn btn-primary pull-right"></i> {{ trans('general.create') }}</a>
-@stop
 
 {{-- Page content --}}
 @section('content')

--- a/resources/views/hardware/audit-overdue.blade.php
+++ b/resources/views/hardware/audit-overdue.blade.php
@@ -1,0 +1,73 @@
+@extends('layouts/default')
+
+@section('title0')
+
+    @if ((Input::get('company_id')) && ($company))
+        {{ $company->name }}
+    @endif
+
+    {{ trans('general.assets') }}
+
+@stop
+
+{{-- Page title --}}
+@section('title')
+    @yield('title0')  @parent
+@stop
+
+@section('header_right')
+    <a href="{{ route('hardware.create') }}" class="btn btn-primary pull-right"></i> {{ trans('general.create') }}</a>
+@stop
+
+{{-- Page content --}}
+@section('content')
+
+    <div class="row">
+        <div class="col-md-12">
+            <div class="box">
+                <div class="box-body">
+                    {{ Form::open([
+                      'method' => 'POST',
+                      'route' => ['hardware/bulkedit'],
+                      'class' => 'form-inline',
+                       'id' => 'bulkForm']) }}
+                    <div class="row">
+                        <div class="col-md-12">
+
+                            <table
+                                    data-click-to-select="true"
+                                    data-columns="{{ \App\Presenters\AssetAuditPresenter::dataTableLayout() }}"
+                                    data-cookie-id-table="assetsOverdueAuditListingTable"
+                                    data-pagination="true"
+                                    data-id-table="assetsOverdueAuditListingTable"
+                                    data-search="true"
+                                    data-side-pagination="server"
+                                    data-show-columns="true"
+                                    data-show-export="true"
+                                    data-show-footer="true"
+                                    data-show-refresh="true"
+                                    data-sort-order="asc"
+                                    data-sort-name="name"
+                                    data-toolbar="#toolbar"
+                                    id="assetsAuditListingTable"
+                                    class="table table-striped snipe-table"
+                                    data-url="{{ route('api.asset.to-audit', ['audit' => 'overdue']) }}"
+                                    data-export-options='{
+                "fileName": "export-assets-due-audit-{{ date('Y-m-d') }}",
+                "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
+                }'>
+                            </table>
+
+                        </div><!-- /.col -->
+                    </div><!-- /.row -->
+                    {{ Form::close() }}
+                </div><!-- ./box-body -->
+            </div><!-- /.box -->
+        </div>
+    </div>
+@stop
+
+@section('moar_scripts')
+    @include('partials.bootstrap-table')
+
+@stop

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -441,26 +441,26 @@
                     </li>
 
                     @can('audit', \App\Models\Asset::class)
-                        <li>
+                        <li{!! (Request::is('hardware/audit/due') ? ' class="active"' : '') !!}>
                             <a href="{{ route('assets.audit.due') }}">
-                                <i class="fa fa-clock-o text-yellow"></i> Due for Audit
+                                <i class="fa fa-clock-o text-yellow"></i> {{ trans('general.audit_due') }}
                             </a>
                         </li>
-                        <li>
+                        <li{!! (Request::is('hardware/audit/overdue') ? ' class="active"' : '') !!}>
                             <a href="{{ route('assets.audit.overdue') }}">
-                                <i class="fa fa-warning text-red"></i> Overdue for Audit
+                                <i class="fa fa-warning text-red"></i> {{ trans('general.audit_overdue') }}
                             </a>
                         </li>
                     @endcan
 
                   <li class="divider">&nbsp;</li>
                     @can('checkout', \App\Models\Asset::class)
-                    <li{!! (Request::is('hardware/bulkcheckout') ? ' class="active>"' : '') !!}>
+                    <li{!! (Request::is('hardware/bulkcheckout') ? ' class="active"' : '') !!}>
                         <a href="{{ route('hardware/bulkcheckout') }}">
                             {{ trans('general.bulk_checkout') }}
                         </a>
                     </li>
-                    <li{!! (Request::is('hardware/requested') ? ' class="active>"' : '') !!}>
+                    <li{!! (Request::is('hardware/requested') ? ' class="active"' : '') !!}>
                         <a href="{{ route('assets.requested') }}">
                             {{ trans('general.requested') }}</a>
                     </li>

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -440,6 +440,19 @@
                         </a>
                     </li>
 
+                    @can('audit', \App\Models\Asset::class)
+                        <li>
+                            <a href="{{ route('assets.audit.due') }}">
+                                <i class="fa fa-clock-o text-yellow"></i> Due for Audit
+                            </a>
+                        </li>
+                        <li>
+                            <a href="{{ route('assets.audit.overdue') }}">
+                                <i class="fa fa-warning text-red"></i> Overdue for Audit
+                            </a>
+                        </li>
+                    @endcan
+
                   <li class="divider">&nbsp;</li>
                     @can('checkout', \App\Models\Asset::class)
                     <li{!! (Request::is('hardware/bulkcheckout') ? ' class="active>"' : '') !!}>

--- a/resources/views/notifications/markdown/upcoming-audits.blade.php
+++ b/resources/views/notifications/markdown/upcoming-audits.blade.php
@@ -1,6 +1,6 @@
 @component('mail::message')
 
-### {{ trans_choice('mail.upcoming-audits', $assets->count(), ['count' => $assets->count()]) }}
+### {{ trans_choice('mail.upcoming-audits', $assets->count(), ['count' => $assets->count(), 'threshold' => $threshold]) }}
 
 @component('mail::table')
 | |{{ trans('mail.name') }}|{{ trans('general.last_audit') }}|{{ trans('general.next_audit_date') }}|{{ trans('mail.Days') }}|{{ trans('mail.supplier') }} | {{ trans('mail.assigned_to') }}

--- a/resources/views/notifications/markdown/upcoming-audits.blade.php
+++ b/resources/views/notifications/markdown/upcoming-audits.blade.php
@@ -9,7 +9,7 @@
 @php
 $next_audit_date = \App\Helpers\Helper::getFormattedDateObject($asset->next_audit_date, 'date', false);
 $last_audit_date = \App\Helpers\Helper::getFormattedDateObject($asset->last_audit_date, 'date', false);
-$diff = Carbon::parse($last_audit_date)->diffInDays(Carbon::now());
+$diff = Carbon::parse($next_audit_date)->diffInDays(Carbon::now());
 $icon = ($diff <= 7) ? '🚨' : (($diff <= 14) ? '⚠️' : ' ');
 @endphp
 |{{ $icon }}| [{{ $asset->present()->name }}]({{ route('hardware.show', $asset->id) }}) | {{ $last_audit_date }}| {{ $next_audit_date }} | {{ $diff }}  | {{ ($asset->supplier ? e($asset->supplier->name) : '') }}|{{ ($asset->assignedTo ? $asset->assignedTo->present()->name() : '') }}

--- a/resources/views/notifications/markdown/upcoming-audits.blade.php
+++ b/resources/views/notifications/markdown/upcoming-audits.blade.php
@@ -9,7 +9,7 @@
 @php
 $next_audit_date = \App\Helpers\Helper::getFormattedDateObject($asset->next_audit_date, 'date', false);
 $last_audit_date = \App\Helpers\Helper::getFormattedDateObject($asset->last_audit_date, 'date', false);
-$diff = Carbon::parse($next_audit_date)->diffInDays(Carbon::now());
+$diff = Carbon::parse(Carbon::now())->diffInDays($next_audit_date, false);
 $icon = ($diff <= 7) ? '🚨' : (($diff <= 14) ? '⚠️' : ' ');
 @endphp
 |{{ $icon }}| [{{ $asset->present()->name }}]({{ route('hardware.show', $asset->id) }}) | {{ $last_audit_date }}| {{ $next_audit_date }} | {{ $diff }}  | {{ ($asset->supplier ? e($asset->supplier->name) : '') }}|{{ ($asset->assignedTo ? $asset->assignedTo->present()->name() : '') }}

--- a/resources/views/notifications/markdown/upcoming-audits.blade.php
+++ b/resources/views/notifications/markdown/upcoming-audits.blade.php
@@ -1,0 +1,20 @@
+@component('mail::message')
+
+### {{ trans_choice('mail.upcoming-audits', $assets->count(), ['count' => $assets->count()]) }}
+
+@component('mail::table')
+| |{{ trans('mail.name') }}|{{ trans('general.last_audit') }}|{{ trans('general.next_audit_date') }}|{{ trans('mail.Days') }}|{{ trans('mail.supplier') }} | {{ trans('mail.assigned_to') }}
+| |:------------- |:-------------|:---------|:---------|:---------|:---------|
+@foreach ($assets as $asset)
+@php
+$next_audit_date = \App\Helpers\Helper::getFormattedDateObject($asset->next_audit_date, 'date', false);
+$last_audit_date = \App\Helpers\Helper::getFormattedDateObject($asset->last_audit_date, 'date', false);
+$diff = Carbon::parse($last_audit_date)->diffInDays(Carbon::now());
+$icon = ($diff <= 7) ? '🚨' : (($diff <= 14) ? '⚠️' : ' ');
+@endphp
+|{{ $icon }}| [{{ $asset->present()->name }}]({{ route('hardware.show', $asset->id) }}) | {{ $last_audit_date }}| {{ $next_audit_date }} | {{ $diff }}  | {{ ($asset->supplier ? e($asset->supplier->name) : '') }}|{{ ($asset->assignedTo ? $asset->assignedTo->present()->name() : '') }}
+@endforeach
+@endcomponent
+
+
+@endcomponent

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -167,6 +167,11 @@
         };
     }
 
+    function hardwareAuditFormatter(value, row) {
+        return '<a href="{{ url('/') }}/hardware/audit/' + row.id + '/" class="btn btn-sm bg-yellow" data-tooltip="true" title="Audit this item">{{ trans('general.audit') }}</a>';
+    }
+
+
     // Make the edit/delete buttons
     function genericActionsFormatter(destination) {
         return function (value,row) {

--- a/routes/api.php
+++ b/routes/api.php
@@ -321,12 +321,16 @@ Route::group(['prefix' => 'v1','namespace' => 'Api'], function () {
             'uses' => 'AssetsController@selectlist'
         ]);
 
+        Route::get('audit/{audit}', [
+            'as' => 'api.asset.to-audit',
+            'uses' => 'AssetsController@index'
+        ]);
+
 
         Route::post('audit', [
             'as' => 'api.asset.audit',
             'uses' => 'AssetsController@audit'
         ]);
-
 
         Route::post('{asset_id}/checkout',
             [

--- a/routes/web/hardware.php
+++ b/routes/web/hardware.php
@@ -29,6 +29,16 @@ Route::group(
             'uses' => 'AssetsController@scan'
         ]);
 
+        Route::get('audit/due', [
+            'as' => 'assets.audit.due',
+            'uses' => 'AssetsController@dueForAudit'
+        ]);
+
+        Route::get('audit/overdue', [
+            'as' => 'assets.audit.overdue',
+            'uses' => 'AssetsController@overdueForAudit'
+        ]);
+
         Route::get('audit/{id}', [
             'as' => 'asset.audit.create',
             'uses' => 'AssetsController@audit'


### PR DESCRIPTION
This introduces a few new features:

### Upcoming Audit Email Alerts via Artisan command

<img width="1150" alt="Screen Shot 2019-05-05 at 7 41 52 PM" src="https://user-images.githubusercontent.com/197404/57201970-ec6a0400-6f6d-11e9-8768-ac79a7d92837.png">

If you're already using the built-in scheduler, this will be included automatically. To run it manually, you would use `php artisan snipeit:upcoming-audits`.

<img width="1102" alt="Screen Shot 2019-05-05 at 7 42 44 PM" src="https://user-images.githubusercontent.com/197404/57201980-fbe94d00-6f6d-11e9-99f6-2cb8c1fe787c.png">

This should resolved #6204.

### Upcoming/Overdue Audit Web UI View

This adds two new sidenav items into the Assets menu that bring you to a report of assets that are due soon (using whatever your audit threshold is set to in Admin Settings > Notifications) and what is overdue.

<img width="417" alt="Screen Shot 2019-05-05 at 7 39 18 PM" src="https://user-images.githubusercontent.com/197404/57202012-5da9b700-6f6e-11e9-89fa-4a28f3c47e60.png">

<img width="1434" alt="Screen Shot 2019-05-05 at 7 39 09 PM" src="https://user-images.githubusercontent.com/197404/57202010-5682a900-6f6e-11e9-8e5d-68a05ac66f04.png">

### Upcoming/Overdue Audit API Endpoints 

Two new `GET` endpoints have been added, `/api/v1/hardware/audit/due` and `/api/v1/hardware/audit/overdue`.

These actually use the main `index` Asset API controller, because there would have been a lot of copypasta otherwise, and that method is already a workhorse. 

### To-Do:

- [ ] Finish tests 
- [x] Correct the number of days displaying in the email (possibly fixed by finishing the tests)
