### PR TITLE
Develop: Allow empty ldap filter in settings 

### DIFF
--- a/app/Services/LdapAd.php
+++ b/app/Services/LdapAd.php
@@ -322,7 +322,7 @@ class LdapAd extends LdapAdConfiguration
     private function getFilter(): ?string
     {
         $filter = $this->ldapSettings['ldap_filter'];
-        if ('' === $filter) {
+        if (!$filter) {
             return null;
         }
         // Add surrounding parentheses as needed


### PR DESCRIPTION
`if ($filter === '') `

doesn't match so it tries to substring on an empty string which fails.