### PR TITLE
Added the Gate Facade to the API AssetsController 

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -1,6 +1,7 @@
 <?php
 namespace App\Http\Controllers\Api;
 
+use Illuminate\Support\Facades\Gate;
 use App\Helpers\Helper;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\AssetCheckoutRequest;


### PR DESCRIPTION
In develop the list of all assets failed to load because the facade to Gate is not used. Minor change that aliviates this. The error was reproducible in https://develop.snipeitapp.com/hardware.