### PR TITLE
Import locations from CSV via command line

### DIFF
--- a/app/Console/Commands/ImportLocations.php
+++ b/app/Console/Commands/ImportLocations.php
@@ -78,7 +78,7 @@ class ImportLocations extends Command
         }
 
         foreach ($results as $index => $row) {
-            
+
             $location = Location::firstOrNew(array('name' => trim($row['Name'])));
             $location->name = trim($row['Name']);
             $location->currency = trim($row['Currency']);
@@ -87,6 +87,8 @@ class ImportLocations extends Command
             $location->city = trim($row['City']);
             $location->state = trim($row['State']);
             $location->zip = trim($row['Zip']);
+            $location->country = trim($row['Country']);
+            $location->ldap_ou = trim($row['OU']);
 
             $this->info('Checking location: '.$location->name);
 

--- a/app/Console/Commands/ImportLocations.php
+++ b/app/Console/Commands/ImportLocations.php
@@ -39,8 +39,7 @@ class ImportLocations extends Command
      */
     public function handle()
     {
-        // Import parent location names first if they don't exist
-        // 2019-05-13-021051-locationscsv
+
 
         if (!ini_get("auto_detect_line_endings")) {
             ini_set("auto_detect_line_endings", '1');
@@ -48,26 +47,28 @@ class ImportLocations extends Command
 
         $filename = $this->argument('filename');
         $csv = Reader::createFromPath(storage_path('private_uploads/imports/').$filename, 'r');
-
         $this->info('Attempting to process: '.storage_path('private_uploads/imports/').$filename);
         $csv->setOffset(1); //because we don't want to insert the header
         $results = $csv->fetchAssoc();
 
+        // Import parent location names first if they don't exist
         foreach ($results as $parent_index => $parent_row) {
 
             $parent_name = trim($parent_row['Parent Name']);
             // First create any parents if they don't exist
 
             if ($parent_name!='') {
+
+                // Save parent location name
+                // This creates a sort of name-stub that we'll update later on in this script
                 $parent_location = Location::firstOrCreate(array('name' => $parent_name));
                 $this->info('Parent for '.$parent_row['Name'].' is '.$parent_name.'. Attempting to save '.$parent_name.'.');
 
-
-                // Save parent location name
+                // Check if the record was updated or created.
+                // This is mostly for clearer debugging.
                 if ($parent_location->exists) {
                         $this->info('- Parent location '.$parent_name.' already exists.');
                 } else {
-
                     $this->info('- Parent location '.$parent_name.' was created.');
                 }
 
@@ -77,8 +78,11 @@ class ImportLocations extends Command
 
         }
 
+        // Loop through ALL records and add/update them if there are additional fields
+        // besides name
         foreach ($results as $index => $row) {
 
+            // Set the location attributes to save
             $location = Location::firstOrNew(array('name' => trim($row['Name'])));
             $location->name = trim($row['Name']);
             $location->currency = trim($row['Currency']);
@@ -92,21 +96,26 @@ class ImportLocations extends Command
 
             $this->info('Checking location: '.$location->name);
 
-
+            // If a parent name nis provided, we created it earlier in the script,
+            // so let's grab that ID
             if ($parent_name) {
                 $parent = Location::where('name', '=', $parent_name)->first();
                 $location->parent_id = $parent->id;
                 $this->info('Parent ID: '.$parent->id);
             }
 
+            // Make sure the more advanced (non-name) fields pass validation
             if (($location->isValid()) && ($location->save())) {
 
+                // Check if the record was updated or created.
+                // This is mostly for clearer debugging.
                 if ($location->exists) {
                     $this->info('Location ' . $location->name . ' already exists. Updating...');
                 } else {
                     $this->info('- Location '.$location->name.' was created. ');
                 }
 
+            // If there's a validation error, display that
             } else {
                 $this->error('- Non-parent Location '.$location->name.' could not be created: '.$location->getErrors() );
             }

--- a/app/Console/Commands/ImportLocations.php
+++ b/app/Console/Commands/ImportLocations.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use League\Csv\Reader;
+use App\Models\Location;
+
+class ImportLocations extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'snipeit:import-locations {filename}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Import locations and their parents';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        // Import parent location names first if they don't exist
+        // 2019-05-13-021051-locationscsv
+
+        if (!ini_get("auto_detect_line_endings")) {
+            ini_set("auto_detect_line_endings", '1');
+        }
+
+        $filename = $this->argument('filename');
+        $csv = Reader::createFromPath(storage_path('private_uploads/imports/').$filename.'.csv', 'r');
+
+        $this->info('Attempting to process: '.storage_path('private_uploads/imports/').$filename.'.csv');
+        $keys = ['Name', 'Currency', 'Address 1', 'Address 2', 'City', 'State', 'Country', 'Zip', 'Parent Name', 'Manager'];
+
+        $csv->setOffset(1); //because we don't want to insert the header
+        $results = $csv->fetchAssoc($keys);
+
+        foreach ($results as $parent_index => $parent_row) {
+
+            $parent_name = trim($parent_row['Parent Name']);
+            // First create any parents if they don't exist
+            //$this->info(print_r($parent_row));
+            $parent_location = Location::firstOrNew(array('name' => trim($parent_name)));
+
+
+            if ($parent_name!='') {
+                $this->info('Parent for '.$parent_row['Name'].' is '.$parent_name.'. Attempting to save '.$parent_name.'.');
+
+                // Save parent location name
+                if ($parent_location->exists()) {
+                        $this->info('- Parent location '.$parent_name.' already exists: '.$parent_location);
+                } else {
+                    $parent_location->save();
+                    $this->info('- Parent location '.$parent_name.' was created.');
+                }
+
+            } else {
+                $this->info('- No parent location for '.$parent_row['Name'].' provided.');
+            }
+
+        }
+
+        foreach ($results as $index => $row) {
+
+            $this->info(print_r($row));
+            $location = Location::updateOrCreate(array('name' => trim($row['Name'])));
+            $location->name = trim($row['Name']);
+            $location->currency = trim($row['Currency']);
+            $location->address = trim($row['Address 1']);
+            $location->address2 = trim($row['Address 2']);
+            $location->city = trim($row['City']);
+            $location->state = trim($row['State']);
+            $location->zip = trim($row['Zip']);
+
+            //$this->info(print_r($location));
+
+            $this->info('Checking location: '.$location->name);
+
+            if ($parent_location->id) {
+                $location->parent_id = Location::find($parent_location->id);
+                $this->info('Parent ID: '.$parent_location->id);
+            }
+
+            if ($location->save()) {
+
+                if ($location->exists()) {
+                    $this->error('Location ' . $location->name . ' already exists. Updating...');
+                } else {
+                    $this->info('- Location '.$location->name.' was created. ');
+                }
+
+            } else {
+                $this->error('- Non-parent Location '.$location->name.' could not be created:');
+            }
+
+
+
+
+        }
+
+
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -33,6 +33,7 @@ class Kernel extends ConsoleKernel
         Commands\SyncAssetCounters::class,
         Commands\RestoreDeletedUsers::class,
         Commands\SendUpcomingAuditReport::class,
+        Commands\ImportLocations::class,
     ];
 
     /**


### PR DESCRIPTION
The signature for this is:

`snipeit:import-locations {filename}`

This importer will look in the `storage/private_uploads/imports` directory for your file, so you can just upload it using the Assets/Licenses/Etc importer, but call it directly from artisan. 

It will update existing fields based on the values in the CSV.

The column names can be in any order, but they MUST be exactly:

`Name`, `Currency`, `Address 1`, `Address 2`,  `City`, `State`, `Zip`, `Parent Name`, `Country`, `OU`

Additional included fields will not be imported. 

This walks through the CSV records and first creates a "stub" of the parent locations, creating a record for their name if there is no matching name already in the locations table. It then loops through the CSV rows again and adds/updates all of the location records, which will *also* update those newly created parent stubs with their address, etc information if it's provided in the CSV. 

### If you blank out any of the information in the CSV for an existing location, it will blank out that value in the database for that location. If you don't want that to happen, you should make sure your CSV has correct, complete data or omit the column. (Name is obviously still required, but it's the only required field.)

We'll be building in support for importing via the normal GUI updater at some point in the future, but this was a tool we needed, so we shipped this as is.