### PR TITLE
Fixes #5054: LDAP users deactivated for none-ad

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -194,6 +194,11 @@ class LdapSync extends Command
                   $user->activated = ( in_array($results[$i]['useraccountcontrol'][0], $enabled_accounts) ) ? 1 : 0;
                 }
 
+                // If we're not using AD, and there isn't an activated flag set, activate all users
+                elseif (empty($ldap_result_active_flag)) {
+                  $user->activated = 1;
+                }
+
                 if ($item['ldap_location_override'] == true) {
                     $user->location_id = $item['location_id'];
                 } elseif ((isset($location)) && (!empty($location))) {


### PR DESCRIPTION
When using none-AD ldap, users are automatically deactivated every LDAP
sync.  This commit changes the behaviour so that if the active flag isn't set,
the users are enabled.

Fixed #5054, at least for 4.X