### PR TITLE
Feedback for Kits; Fix checkins for accessories

### DIFF
--- a/app/Http/Controllers/Accessories/AccessoryCheckinController.php
+++ b/app/Http/Controllers/Accessories/AccessoryCheckinController.php
@@ -59,11 +59,16 @@ class AccessoryCheckinController extends Controller
 
         $this->authorize('checkin', $accessory);
 
+        $checkin_at = date('Y-m-d');
+        if($request->filled('checkin_at')){
+            $checkin_at = $request->input('checkin_at');
+        }
+
         // Was the accessory updated?
         if (DB::table('accessories_users')->where('id', '=', $accessory_user->id)->delete()) {
             $return_to = e($accessory_user->assigned_to);
 
-            event(new CheckoutableCheckedIn($accessory, User::find($return_to), Auth::user(), $request->input('note')));
+            event(new CheckoutableCheckedIn($accessory, User::find($return_to), Auth::user(), $request->input('note'), $checkin_at));
 
             return redirect()->route("accessories.show", $accessory->id)->with('success', trans('admin/accessories/message.checkin.success'));
         }

--- a/app/Http/Controllers/Kits/CheckoutKitController.php
+++ b/app/Http/Controllers/Kits/CheckoutKitController.php
@@ -9,6 +9,7 @@ use App\Models\PredefinedModel;
 use App\Models\User;
 use App\Services\PredefinedKitCheckoutService;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 
 /**
  * This controller handles all access kits management:
@@ -57,11 +58,14 @@ class CheckoutKitController extends Controller
         $kit = new PredefinedKit();
         $kit->id = $kit_id;
 
-        $errors = $this->kitService->checkout($request, $kit, $user);
-        if (count($errors) > 0) {
-            return redirect()->back()->with('error', 'Checkout error')->with('error_messages', $errors);  // TODO: trans
+        $checkout_result = $this->kitService->checkout($request, $kit, $user);
+        if (Arr::has($checkout_result, 'errors') && count($checkout_result['errors']) > 0 ) {
+            return redirect()->back()->with('error', 'Checkout error')->with('error_messages', $checkout_result['errors']);  // TODO: trans
         }
-        return redirect()->back()->with('success', 'Checkout was successfully');                                   // TODO: trans
+        return redirect()->back()->with('success', 'Checkout was successful')
+            ->with('assets', Arr::get($checkout_result, 'assets', null))
+            ->with('accessories', Arr::get($checkout_result, 'accessories', null))
+            ->with('consumables', Arr::get($checkout_result, 'consumables', null));                                   // TODO: trans
 
     }
 }

--- a/app/Services/PredefinedKitCheckoutService.php
+++ b/app/Services/PredefinedKitCheckoutService.php
@@ -29,7 +29,7 @@ class PredefinedKitCheckoutService
 
             // Check if the user exists
             if (is_null($user)) {
-                return [trans('admin/users/message.user_not_found')];
+                return ['errors' => trans('admin/users/message.user_not_found')];
             }
 
             $errors = [];
@@ -40,7 +40,7 @@ class PredefinedKitCheckoutService
             $accessories_to_add = $this->getAccessoriesToAdd($kit, $errors);
 
             if (count($errors) > 0) {
-                return $errors;
+                return ['errors' => $errors];
             }
 
             $checkout_at = date("Y-m-d H:i:s");
@@ -58,11 +58,12 @@ class PredefinedKitCheckoutService
             $note = e($request->get('note'));
 
             $errors = $this->saveToDb($user, $admin, $checkout_at, $expected_checkin, $errors, $assets_to_add, $license_seats_to_add, $consumables_to_add, $accessories_to_add, $note);
-            return $errors;
+
+            return ['errors' => $errors, 'assets' => $assets_to_add, 'accessories' => $accessories_to_add, 'consumables' => $consumables_to_add ];
         } catch (ModelNotFoundException $e) {
-            return [$e->getMessage()];
+            return ['errors' => [$e->getMessage()]];
         } catch (CheckoutNotAllowed $e) {
-            return [$e->getMessage()];
+            return ['errors' => [$e->getMessage()]];
         }
     }
 
@@ -134,7 +135,7 @@ class PredefinedKitCheckoutService
         $accessories = $kit->accessories()->with('users')->get();
         foreach ($accessories as $accessory) {
             if ($accessory->numRemaining() < $accessory->pivot->quantity) {
-                $errors[] = trans('admin/kits/general.none_accessory', ['consumable'=> $accessory->name, 'qty' => $accessory->pivot->quantity]);
+                $errors[] = trans('admin/kits/general.none_accessory', ['accessory'=> $accessory->name, 'qty' => $accessory->pivot->quantity]);
             }
         }
         return $accessories;

--- a/resources/views/accessories/checkin.blade.php
+++ b/resources/views/accessories/checkin.blade.php
@@ -30,9 +30,7 @@
                         </div><!-- /.box-header -->
                     @endif
 
-                    <div class="box-body">
-
-                        <form class="form-horizontal" method="post" action="" autocomplete="off">
+                            <div class="box-body">
                             <!-- CSRF Token -->
                             <input type="hidden" name="_token" value="{{ csrf_token() }}" />
 
@@ -54,12 +52,28 @@
                                             {!! $errors->first('note', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
                                         </div>
                                     </div>
+                            <!-- Checkout/Checkin Date -->
+                            <div class="form-group{{ $errors->has('checkin_at') ? ' has-error' : '' }}">
+                                {{ Form::label('checkin_at', trans('admin/hardware/form.checkin_date'), array('class' => 'col-md-3 control-label')) }}
+                                <div class="col-md-8">
+                                    <div class="input-group col-md-5 required">
+                                        <div class="input-group date" data-provide="datepicker" data-date-format="yyyy-mm-dd" data-date-end-date="0d" data-autoclose="true">
+                                            <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="checkin_at" id="checkin_at" value="{{ Input::old('checkin_at', date('Y-m-d')) }}">
+                                            <span class="input-group-addon"><i class="fa fa-calendar"></i></span>
+                                        </div>
+                                        {!! $errors->first('checkin_at', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
+                                    </div>
+                                </div>
+                            </div>
+
                               </div>
                         <div class="box-footer">
                             <a class="btn btn-link" href="{{ URL::previous() }}">{{ trans('button.cancel') }}</a>
                             <button type="submit" class="btn btn-success pull-right"><i class="fa fa-check icon-white"></i>
                                 {{ trans('general.checkin') }}</button>
                         </div>
+
+
                 </div> <!-- .box.box-default -->
             </form>
         </div> <!-- .col-md-9-->

--- a/resources/views/notifications.blade.php
+++ b/resources/views/notifications.blade.php
@@ -34,6 +34,58 @@
 </div>
 @endif
 
+
+@if ($assets = Session::get('assets'))
+    @foreach ($assets as $asset)
+        <div class="col-md-12">
+            <div class="alert alert-info fade in">
+                <button type="button" class="close" data-dismiss="alert">&times;</button>
+                <i class="fa fa-info-circle faa-pulse animated"></i>
+                <strong>Asset Information: </strong>
+                <ul>
+                    @isset ($asset->model->name)
+                        <li><b>Model Name: </b> {{ $asset->model->name }}</li>
+                    @endisset
+                    @isset ($asset->name)
+                        <li><b>Asset Name: </b> {{ $asset->model->name }}</li>
+                    @endisset
+                    <li><b>Asset Tag:</b> {{ $asset->asset_tag }}</li>
+                </ul>
+
+            </div>
+        </div>
+    @endforeach
+@endif
+
+
+@if ($consumables = Session::get('consumables'))
+    @foreach ($consumables as $consumable)
+        <div class="col-md-12">
+            <div class="alert alert-info fade in">
+                <button type="button" class="close" data-dismiss="alert">&times;</button>
+                <i class="fa fa-info-circle faa-pulse animated"></i>
+                <strong>Consumable Information: </strong>
+                <ul><li><b>Name:</b> {{ $consumable->name }}</li></ul>
+            </div>
+        </div>
+    @endforeach
+@endif
+
+
+@if ($accessories = Session::get('accessories'))
+    @foreach ($accessories as $accessory)
+        <div class="col-md-12">
+            <div class="alert alert-info fade in">
+                <button type="button" class="close" data-dismiss="alert">&times;</button>
+                <i class="fa fa-info-circle faa-pulse animated"></i>
+                <strong>Accessory Information: </strong>
+                <ul><li><b>Name:</b> {{ $accessory->name }}</li></ul>
+            </div>
+        </div>
+    @endforeach
+@endif
+
+
 @if ($message = Session::get('error'))
 <div class="col-md-12">
     <div class="alert alert alert-danger fade in">
@@ -44,6 +96,7 @@
     </div>
 </div>
 @endif
+
 
 @if ($messages = Session::get('error_messages'))
 @foreach ($messages as $message)        
@@ -58,6 +111,7 @@
 @endforeach
 @endif
 
+
 @if ($message = Session::get('warning'))
 <div class="col-md-12">
     <div class="alert alert-warning fade in">
@@ -68,6 +122,7 @@
     </div>
 </div>
 @endif
+
 
 @if ($message = Session::get('info'))
 <div class="col-md-12">


### PR DESCRIPTION
Check-ins for accessories were technically still working but throwing big nasty errors in development mode. Fixed by adding the checkin_at field from asset check-ins.

When a kit was checked out, there was no feedback about which asset from a model should be given to the person.  Added feedback for the check-in that lists those details.

Also fixed the 'Checkout was successfully' success message, which didn't make grammatical sense.

Aaaand there was a rogue opening form tag in the accessories check-in template that I got rid of.