### PR TITLE
Added a condition to create the variable $user

### DIFF
--- a/app/Http/Controllers/AssetCheckinController.php
+++ b/app/Http/Controllers/AssetCheckinController.php
@@ -54,7 +54,11 @@ class AssetCheckinController extends Controller
 
         if ($asset->assignedType() == Asset::USER) {
             $user = $asset->assignedTo;
+        } else {
+            $user = null;
         }
+
+
         if (is_null($target = $asset->assignedTo)) {
             return redirect()->route('hardware.index')->with('error', trans('admin/hardware/message.checkin.already_checked_in'));
         }


### PR DESCRIPTION
If an Asset is checked out to some entity different to 'user' (location, or another asset), the variable $user is never created, so when the method tries to check if $user exists, it fails because we don't have that variable created, hence the 'Undefined variable' error. Just added a little else for this. If the asset is not checked out to an user, then the variable $user is defined as null.