### PR TITLE
fix Paginator and unecessary recursion 

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -25,12 +25,12 @@ class LdapSync extends Command
      *
      * @var string
      */
-    protected $signature = 'snipeit:ldap-sync 
-                {--location= : A location name } 
-                {--location_id= : A location id} 
-                {--base_dn= : A diffrent base DN to use } 
-                {--summary : Print summary } 
-                {--json_summary : Print summary in json format } 
+    protected $signature = 'snipeit:ldap-sync
+                {--location= : A location name }
+                {--location_id= : A location id}
+                {--base_dn= : A diffrent base DN to use }
+                {--summary : Print summary }
+                {--json_summary : Print summary in json format }
                 {--dryrun : Run the sync process but don\'t update the database}';
 
     /**
@@ -142,7 +142,7 @@ class LdapSync extends Command
      * @return string
      */
     private function getSummary(): string
-    {        
+    {
         if ($this->option('summary') && !$this->dryrun) {
             $this->summary->each(function ($item) {
                 if ('ERROR' === $item['status']) {
@@ -218,33 +218,29 @@ class LdapSync extends Command
      *
      * @param int $page The page to get the result set
      */
-    private function processLdapUsers(int $page=0): void
-    {
-        try {
-            $ldapUsers = $this->ldap->getLdapUsers($page);
-        } catch (Exception $e) {
-            $this->outputError($e);
-            exit($e->getMessage());
-        }
+     private function processLdapUsers(): void
+     {
+         try {
+             $ldapUsers = $this->ldap->getLdapUsers();
+         } catch (Exception $e) {
+             $this->outputError($e);
+             exit($e->getMessage());
+         }
 
-        if (0 == $ldapUsers->count()) {
-            $msg = 'ERROR: No users found!';
-            Log::error($msg);
-            if ($this->dryrun) {
-                $this->error($msg);
-            }
-            exit($msg);
-        }
+         if (0 == count($ldapUsers)) {
+             $msg = 'ERROR: No users found!';
+             Log::error($msg);
+             if ($this->dryrun) {
+                 $this->error($msg);
+             }
+             exit($msg);
+         }
 
-        // Process each individual users
-        foreach ($ldapUsers as $user) {
-            $this->updateCreateUser($user);
-        }
-
-        if ($ldapUsers->getCurrentPage() < $ldapUsers->getPages()) {
-            $this->processLdapUsers($ldapUsers->getCurrentPage() + 1);
-        }
-    }
+         // Process each individual users
+         foreach ($ldapUsers as $user) {
+             $this->updateCreateUser($user);
+         }
+     }
 
     /**
      * Get the mapped locations if a base_dn is provided.

--- a/app/Services/LdapAd.php
+++ b/app/Services/LdapAd.php
@@ -430,11 +430,9 @@ class LdapAd extends LdapAdConfiguration
      *
      * @since 5.0.0
      *
-     * @param int $page The paged results to get
-     *
      * @return \Adldap\Query\Paginator
      */
-    public function getLdapUsers(int $page=0): Paginator
+    public function getLdapUsers(): Paginator
     {
         $search = $this->ldap->search()->users()->in($this->getBaseDn());
 
@@ -444,6 +442,6 @@ class LdapAd extends LdapAdConfiguration
         }
 
         return $search->select($this->getSelectedFields())
-            ->paginate(self::PAGE_SIZE, $page);
+            ->paginate(self::PAGE_SIZE);
     }
 }


### PR DESCRIPTION
This fixes an intensive request SEARCH on the LDAP side. The previous implementation was doing twice the amount of requests which were necessary. 

The logs from OpenLDAP when using the new code are here (`653` objects of type `inetOrgPerson` are stored in the LDAP in question):

```
5d025307 conn=1626 fd=12 ACCEPT from IP=172.17.0.5:33014 (IP=0.0.0.0:389)
5d025307 conn=1626 op=0 BIND dn="cn=admin,dc=example,dc=org" method=128
5d025307 conn=1626 op=0 BIND dn="cn=admin,dc=example,dc=org" mech=SIMPLE ssf=0
5d025307 conn=1626 op=0 RESULT tag=97 err=0 text=
5d025307 conn=1626 op=1 SRCH base="ou=users,ou=accounts,dc=example,dc=org" scope=2 deref=0 filter="(objectClass=groupOfUniqueNames)"
5d025307 conn=1626 op=1 SRCH attr=*
5d025307 conn=1626 op=1 SEARCH RESULT tag=101 err=0 nentries=0 text=
5d025307 conn=1626 op=2 SRCH base="ou=users,ou=accounts,dc=example,dc=org" scope=2 deref=0 filter="(&(objectClass=inetOrgPerson)(objectClass=inetOrgPerson)(objectClass=person))"
5d025307 conn=1626 op=2 SRCH attr=uid givenname sn mail 1.1 1.1 memberof useraccountcontrol title telephonenumber objectclass objectclass
5d025307 conn=1626 op=2 SEARCH RESULT tag=101 err=0 nentries=500 text=
5d025307 conn=1626 op=3 SRCH base="ou=users,ou=accounts,dc=example,dc=org" scope=2 deref=0 filter="(&(objectClass=inetOrgPerson)(objectClass=inetOrgPerson)(objectClass=person))"
5d025307 conn=1626 op=3 SRCH attr=uid givenname sn mail 1.1 1.1 memberof useraccountcontrol title telephonenumber objectclass objectclass
5d025307 conn=1626 op=3 SEARCH RESULT tag=101 err=0 nentries=153 text=
5d02530a conn=1626 op=4 UNBIND
5d02530a conn=1626 fd=12 closed
```