### PR TITLE
Fix for the issue when the user tries to query assets due for audit without appropiate configuration [ch9625] 

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -1068,8 +1068,14 @@ class Asset extends Depreciable
 
     public function scopeDueOrOverdueForAudit($query, $settings)
     {
+        if(is_null($settings->audit_warning_days)){
+            $days_left = 0;
+        } else {
+            $days_left = $settings->audit_warning_days;
+        }
+
         return $query->whereNotNull('assets.next_audit_date')
-            ->whereRaw("DATE_SUB(assets.next_audit_date, INTERVAL $settings->audit_warning_days DAY) <= '".Carbon::now()."'")
+            ->whereRaw("DATE_SUB(assets.next_audit_date, INTERVAL $days_left DAY) <= '".Carbon::now()."'")
             ->where('assets.archived', '=', 0)
             ->NotArchived();
     }

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -1069,13 +1069,13 @@ class Asset extends Depreciable
     public function scopeDueOrOverdueForAudit($query, $settings)
     {
         if(is_null($settings->audit_warning_days)){
-            $days_left = 0;
+            $interval = 0;
         } else {
-            $days_left = $settings->audit_warning_days;
+            $interval = $settings->audit_warning_days;
         }
 
         return $query->whereNotNull('assets.next_audit_date')
-            ->whereRaw("DATE_SUB(assets.next_audit_date, INTERVAL $days_left DAY) <= '".Carbon::now()."'")
+            ->whereRaw("DATE_SUB(assets.next_audit_date, INTERVAL $interval DAY) <= '".Carbon::now()."'")
             ->where('assets.archived', '=', 0)
             ->NotArchived();
     }

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -1068,12 +1068,8 @@ class Asset extends Depreciable
 
     public function scopeDueOrOverdueForAudit($query, $settings)
     {
-        if(is_null($settings->audit_warning_days)){
-            $interval = 0;
-        } else {
-            $interval = $settings->audit_warning_days;
-        }
-
+        $interval = 0 + $settings->audit_warning_days;
+    
         return $query->whereNotNull('assets.next_audit_date')
             ->whereRaw("DATE_SUB(assets.next_audit_date, INTERVAL $interval DAY) <= '".Carbon::now()."'")
             ->where('assets.archived', '=', 0)

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -1068,7 +1068,7 @@ class Asset extends Depreciable
 
     public function scopeDueOrOverdueForAudit($query, $settings)
     {
-        $interval = 0 + $settings->audit_warning_days;
+        $interval = $settings->audit_warning_days ?? 0;
     
         return $query->whereNotNull('assets.next_audit_date')
             ->whereRaw("DATE_SUB(assets.next_audit_date, INTERVAL $interval DAY) <= '".Carbon::now()."'")

--- a/routes/web/hardware.php
+++ b/routes/web/hardware.php
@@ -31,12 +31,12 @@ Route::group(
 
         Route::get('audit/due', [
             'as' => 'assets.audit.due',
-            'uses' => 'AssetsController@dueForAudit'
+            'uses' => 'Assets\AssetsController@dueForAudit'
         ]);
 
         Route::get('audit/overdue', [
             'as' => 'assets.audit.overdue',
-            'uses' => 'AssetsController@overdueForAudit'
+            'uses' => 'Assets\AssetsController@overdueForAudit'
         ]);
 
         Route::get('audit/{id}', [


### PR DESCRIPTION
First added the proper routes because I think they're pointing to the old structure of the system (i.e. AssetControllers VS Asset/AssetsController).

Then when the audit_warning_days property from $settings is not setted, the system queries for all the assets due to audit that same day. Which I think it's the sane behaviour to observe. As always, if this assumption is incorrect I'm open to change it.