### PR TITLE
Added console rekey tool

### DIFF
--- a/app/Console/Commands/RotateAppKey.php
+++ b/app/Console/Commands/RotateAppKey.php
@@ -55,15 +55,15 @@ class RotateAppKey extends Command
             // Generate a new one
             Artisan::call('key:generate', ['--show' => true]);
             $new_app_key = Artisan::output();
-            // Clear the config cache
-            Artisan::call('config:cache');
 
-            //$new_app_key = substr($new_app_key, 7);
+            // Clear the config cache
+            Artisan::call('config:clear');
 
             $this->warn('Your app cipher is: '.$cipher);
             $this->warn('Your old APP_KEY is: '.$old_app_key);
             $this->warn('Your new APP_KEY is: '.$new_app_key);
 
+            // Write the new app key to the .env file
             $this->writeNewEnvironmentFileWith($new_app_key);
 
             // Manually create an old encrypter instance using the old app key
@@ -71,8 +71,6 @@ class RotateAppKey extends Command
             // using the newly generated app key
             $oldEncrypter = new Encrypter(base64_decode(substr($old_app_key, 7)), $cipher);
             $newEncrypter = new Encrypter(base64_decode(substr($new_app_key, 7)), $cipher);
-
-
 
             $fields = CustomField::where('field_encrypted', '1')->get();
 

--- a/app/Console/Commands/RotateAppKey.php
+++ b/app/Console/Commands/RotateAppKey.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Artisan;
+use App\Models\CustomField;
+use Illuminate\Support\Facades\Crypt;
+use App\Models\Asset;
+use App\Models\Setting;
+use \Illuminate\Encryption\Encrypter;
+use Illuminate\Foundation\Console\KeyGenerateCommand;
+
+class RotateAppKey extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'snipeit:rotate-key';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Command description';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        if ($this->confirm("\n****************************************************\nTHIS WILL MODIFY YOUR APP_KEY AND DE-CRYPT YOUR ENCRYPTED CUSTOM FIELDS AND \nRE-ENCRYPT THEM WITH A NEWLY GENERATED KEY. \n\nThere is NO undo. \n\nMake SURE you have a database backup and a backup of your .env generated BEFORE running this command. \n\nIf you do not save the newly generated APP_KEY to your .env in this process, \nyour encrypted data will no longer be decryptable. \n\nAre you SURE you wish to continue, and have confirmed you have a database backup and an .env backup? "))  {
+
+
+
+            // Get the existing app_key
+            $old_app_key = config('app.key');
+            $cipher = config('app.cipher');
+
+            // Generate a new one
+            Artisan::call('key:generate', ['--show' => true]);
+            $new_app_key = Artisan::output();
+            // Clear the config cache
+            Artisan::call('config:cache');
+
+            //$new_app_key = substr($new_app_key, 7);
+
+            $this->warn('Your app cipher is: '.$cipher);
+            $this->warn('Your old APP_KEY is: '.$old_app_key);
+            $this->warn('Your new APP_KEY is: '.$new_app_key);
+
+            $this->writeNewEnvironmentFileWith($new_app_key);
+
+            // Create a new encrypter instance so we can encrypt using the newly created key
+            //$oldEncrypter = new Encrypter(base64_decode(substr($old_app_key, 7)), $cipher);
+            $oldEncrypter = new Encrypter(base64_decode(substr($old_app_key, 7)), $cipher);
+            $newEncrypter = new Encrypter(base64_decode(substr($new_app_key, 7)), $cipher);
+
+
+
+            $fields = CustomField::where('field_encrypted', '1')->get();
+
+
+            foreach ($fields as $field) {
+                $assets = Asset::whereNotNull($field->db_column)->get();
+
+                foreach ($assets as $asset) {
+                    $asset->{$field->db_column} = $oldEncrypter->decrypt($asset->{$field->db_column});
+                    $this->line($field->db_column.' : '.$asset->{$field->db_column});
+
+                    $asset->{$field->db_column} = $newEncrypter->encrypt($asset->{$field->db_column});
+                    $this->line($field->db_column.' : '.$asset->{$field->db_column});
+                    $asset->save();
+
+                }
+
+            }
+
+
+
+        } else {
+            $this->info('This operation has been canceled. No changes have been made.');
+        }
+    }
+
+    /**
+     * Write a new environment file with the given key.
+     *
+     * @param  string  $key
+     * @return void
+     */
+    protected function writeNewEnvironmentFileWith($key)
+    {
+
+        file_put_contents($this->laravel->environmentFilePath(), preg_replace(
+            $this->keyReplacementPattern(),
+            'APP_KEY='.$key,
+            file_get_contents($this->laravel->environmentFilePath())
+        ));
+    }
+
+    /**
+     * Get a regex pattern that will match env APP_KEY with any random key.
+     *
+     * @return string
+     */
+    protected function keyReplacementPattern()
+    {
+        $escaped = preg_quote('='.$this->laravel['config']['app.key'], '/');
+        return "/^APP_KEY{$escaped}/m";
+    }
+
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -3,40 +3,13 @@
 namespace App\Console;
 
 use App\Console\Commands\ImportLocations;
+use App\Console\Commands\ReEncodeCustomFieldNames;
 use App\Console\Commands\RestoreDeletedUsers;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
 class Kernel extends ConsoleKernel
 {
-    /**
-     * The Artisan commands provided by your application.
-     *
-     * @var array
-     */
-    protected $commands = [
-        Commands\PaveIt::class,
-        Commands\CreateAdmin::class,
-        Commands\SendExpirationAlerts::class,
-        Commands\SendInventoryAlerts::class,
-        Commands\SendExpectedCheckinAlerts::class,
-        Commands\ObjectImportCommand::class,
-        Commands\Version::class,
-        Commands\SystemBackup::class,
-        Commands\DisableLDAP::class,
-        Commands\Purge::class,
-        Commands\LdapSync::class,
-        Commands\FixDoubleEscape::class,
-        Commands\RecryptFromMcrypt::class,
-        Commands\ResetDemoSettings::class,
-        Commands\SyncAssetLocations::class,
-        Commands\RegenerateAssetTags::class,
-        Commands\SyncAssetCounters::class,
-        Commands\RestoreDeletedUsers::class,
-        Commands\SendUpcomingAuditReport::class,
-        Commands\ImportLocations::class,
-        Commands\ReEncodeCustomFieldNames::class,
-    ];
 
     /**
      * Define the application's command schedule.


### PR DESCRIPTION
This PR should allow admins to use a command line tool to go through and quickly decrypt their custom fields, generate a new app_key, and then re-encrypt their encrypted custom fields. This would typically only be used if an APP_KEY was compromised (which is indicative of other problems, obviously), but this tool can be used once the compromised environment has been secured to quickly handle changing the app key without breaking encryption. 

Examples of where this would be used:

- Server environment is believed to be breached, where the attacker possibly gained access to the filesystem, including the .env file.

### Usage:

`php artisan snipeit:rotate-key`

<img width="1123" alt="Screen Shot 2019-08-06 at 9 34 26 PM" src="https://user-images.githubusercontent.com/197404/62595142-ff081800-b891-11e9-82d5-a9a985ce39c3.png">

### Notes:

If an attacker has exfiltrated both your APP_KEY *and* a dump of your data, they will still be able to decrypt your encrypted fields (because that's how encryption works). It is for this reason that we always strongly recommend securing your .env file (and not hosting Snipe-IT in a subdirectory, where a web server misconfiguration could potentially expose it to the internet.

<del>This is a WIP - still getting a `The MAC is invalid.` error when I test this more than once. Might be related to config caching (maybe).</del>



