### PR TITLE
Add #7393 - calculate next_audit_date on asset creation

### DIFF
--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -146,6 +146,10 @@ class AssetsController extends Controller
             $asset->requestable             = request('requestable', 0);
             $asset->rtd_location_id         = request('rtd_location_id', null);
 
+            if (!empty($settings->audit_interval)) {
+                $asset->next_audit_date         = Carbon::now()->addMonths($settings->audit_interval)->toDateString();
+            }
+
             if ($asset->assigned_to=='') {
                 $asset->location_id = $request->input('rtd_location_id', null);
             }


### PR DESCRIPTION
For #7393 (and potentially #6713 too?) - on asset creation, set the next_audit_date using audit_interval if that value is set. If not, leave next_audit_date as null to maintain existing behavior.