### PR TITLE
Limit API request results per page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ APP_KEY=ChangeMe
 APP_URL=null
 APP_TIMEZONE='UTC'
 APP_LOCALE=en
+MAX_RESULTS=500
 
 # --------------------------------------------
 # REQUIRED: DATABASE SETTINGS

--- a/app/Http/Controllers/Api/AccessoriesController.php
+++ b/app/Http/Controllers/Api/AccessoriesController.php
@@ -50,7 +50,11 @@ class AccessoriesController extends Controller
         }
 
         $offset = (($accessories) && (request('offset') > $accessories->count())) ? 0 : request('offset', 0);
-        $limit = $request->input('limit', 50);
+
+        // Check to make sure the limit is not higher than the max allowed
+        (config('app.max_results') < $request->input('limit')) ? $limit = $request->input('limit') : $limit = config('app.max_results');
+
+
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $sort = in_array($request->input('sort'), $allowed_columns) ? $request->input('sort') : 'created_at';
 

--- a/app/Http/Controllers/Api/AssetModelsController.php
+++ b/app/Http/Controllers/Api/AssetModelsController.php
@@ -61,7 +61,10 @@ class AssetModelsController extends Controller
         }
 
         $offset = (($assetmodels) && (request('offset') > $assetmodels->count())) ? 0 : request('offset', 0);
-        $limit = $request->input('limit', 50);
+
+        // Check to make sure the limit is not higher than the max allowed
+        (config('app.max_results') < $request->input('limit')) ? $limit = $request->input('limit') : $limit = config('app.max_results');
+
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $sort = in_array($request->input('sort'), $allowed_columns) ? $request->input('sort') : 'models.created_at';
 

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -145,7 +145,10 @@ class AssetsController extends Controller
         $request->filled('order_number') ? $assets = $assets->where('assets.order_number', '=', e($request->get('order_number'))) : '';
 
         $offset = (($assets) && (request('offset') > $assets->count())) ? 0 : request('offset', 0);
-        $limit = $request->input('limit', 50);
+
+        // Check to make sure the limit is not higher than the max allowed
+        (config('app.max_results') < $request->input('limit')) ? $limit = $request->input('limit') : $limit = config('app.max_results');
+
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
 
         // This is used by the audit reporting routes

--- a/app/Http/Controllers/Api/CategoriesController.php
+++ b/app/Http/Controllers/Api/CategoriesController.php
@@ -31,7 +31,10 @@ class CategoriesController extends Controller
         }
 
         $offset = (($categories) && (request('offset') > $categories->count())) ? 0 : request('offset', 0);
-        $limit = $request->input('limit', 50);
+
+        // Check to make sure the limit is not higher than the max allowed
+        (config('app.max_results') < $request->input('limit')) ? $limit = $request->input('limit') : $limit = config('app.max_results');
+
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $sort = in_array($request->input('sort'), $allowed_columns) ? $request->input('sort') : 'assets_count';
         $categories->orderBy($sort, $order);

--- a/app/Http/Controllers/Api/CompaniesController.php
+++ b/app/Http/Controllers/Api/CompaniesController.php
@@ -42,7 +42,10 @@ class CompaniesController extends Controller
         }
 
         $offset = (($companies) && (request('offset') > $companies->count())) ? 0 : request('offset', 0);
-        $limit = $request->input('limit', 50);
+
+        // Check to make sure the limit is not higher than the max allowed
+        (config('app.max_results') < $request->input('limit')) ? $limit = $request->input('limit') : $limit = config('app.max_results');
+        
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $sort = in_array($request->input('sort'), $allowed_columns) ? $request->input('sort') : 'created_at';
         $companies->orderBy($sort, $order);

--- a/app/Http/Controllers/Api/ComponentsController.php
+++ b/app/Http/Controllers/Api/ComponentsController.php
@@ -44,7 +44,9 @@ class ComponentsController extends Controller
         }
 
         $offset = (($components) && (request('offset') > $components->count())) ? 0 : request('offset', 0);
-        $limit = request('limit', 50);
+
+        // Check to make sure the limit is not higher than the max allowed
+        (config('app.max_results') < $request->input('limit')) ? $limit = $request->input('limit') : $limit = config('app.max_results');
 
         $allowed_columns = ['id','name','min_amt','order_number','serial','purchase_date','purchase_cost','company','category','qty','location','image'];
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';

--- a/app/Http/Controllers/Api/ConsumablesController.php
+++ b/app/Http/Controllers/Api/ConsumablesController.php
@@ -45,7 +45,10 @@ class ConsumablesController extends Controller
 
 
         $offset = (($consumables) && (request('offset') > $consumables->count())) ? 0 : request('offset', 0);
-        $limit = request('limit', 50);
+
+        // Check to make sure the limit is not higher than the max allowed
+        (config('app.max_results') < $request->input('limit')) ? $limit = $request->input('limit') : $limit = config('app.max_results');
+
         $allowed_columns = ['id','name','order_number','min_amt','purchase_date','purchase_cost','company','category','model_number', 'item_no', 'manufacturer','location','qty','image'];
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $sort = in_array($request->input('sort'), $allowed_columns) ? $request->input('sort') : 'created_at';

--- a/app/Http/Controllers/Api/DepartmentsController.php
+++ b/app/Http/Controllers/Api/DepartmentsController.php
@@ -40,7 +40,10 @@ class DepartmentsController extends Controller
         }
 
         $offset = (($departments) && (request('offset') > $departments->count())) ? 0 : request('offset', 0);
-        $limit = $request->input('limit', 50);
+
+        // Check to make sure the limit is not higher than the max allowed
+        (config('app.max_results') < $request->input('limit')) ? $limit = $request->input('limit') : $limit = config('app.max_results');
+
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $sort = in_array($request->input('sort'), $allowed_columns) ? $request->input('sort') : 'created_at';
 

--- a/app/Http/Controllers/Api/DepreciationsController.php
+++ b/app/Http/Controllers/Api/DepreciationsController.php
@@ -29,7 +29,10 @@ class DepreciationsController extends Controller
         }
 
         $offset = (($depreciations) && (request('offset') > $depreciations->count())) ? 0 : request('offset', 0);
-        $limit = $request->input('limit', 50);
+
+        // Check to make sure the limit is not higher than the max allowed
+        (config('app.max_results') < $request->input('limit')) ? $limit = $request->input('limit') : $limit = config('app.max_results');
+
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $sort = in_array($request->input('sort'), $allowed_columns) ? $request->input('sort') : 'created_at';
         $depreciations->orderBy($sort, $order);

--- a/app/Http/Controllers/Api/GroupsController.php
+++ b/app/Http/Controllers/Api/GroupsController.php
@@ -29,7 +29,10 @@ class GroupsController extends Controller
         }
 
         $offset = (($groups) && (request('offset') > $groups->count())) ? 0 : request('offset', 0);
-        $limit = $request->input('limit', 50);
+
+        // Check to make sure the limit is not higher than the max allowed
+        (config('app.max_results') < $request->input('limit')) ? $limit = $request->input('limit') : $limit = config('app.max_results');
+
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $sort = in_array($request->input('sort'), $allowed_columns) ? $request->input('sort') : 'created_at';
         $groups->orderBy($sort, $order);

--- a/app/Http/Controllers/Api/LicensesController.php
+++ b/app/Http/Controllers/Api/LicensesController.php
@@ -83,7 +83,10 @@ class LicensesController extends Controller
 
 
         $offset = (($licenses) && (request('offset') > $licenses->count())) ? 0 : request('offset', 0);
-        $limit = request('limit', 50);
+
+        // Check to make sure the limit is not higher than the max allowed
+        (config('app.max_results') < $request->input('limit')) ? $limit = $request->input('limit') : $limit = config('app.max_results');
+
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
 
 

--- a/app/Http/Controllers/Api/LocationsController.php
+++ b/app/Http/Controllers/Api/LocationsController.php
@@ -52,7 +52,10 @@ class LocationsController extends Controller
 
 
         $offset = (($locations) && (request('offset') > $locations->count())) ? 0 : request('offset', 0);
-        $limit = $request->input('limit', 50);
+
+        // Check to make sure the limit is not higher than the max allowed
+        (config('app.max_results') < $request->input('limit')) ? $limit = $request->input('limit') : $limit = config('app.max_results');
+
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $sort = in_array($request->input('sort'), $allowed_columns) ? $request->input('sort') : 'created_at';
 

--- a/app/Http/Controllers/Api/ManufacturersController.php
+++ b/app/Http/Controllers/Api/ManufacturersController.php
@@ -40,7 +40,10 @@ class ManufacturersController extends Controller
 
 
         $offset = (($manufacturers) && (request('offset') > $manufacturers->count())) ? 0 : request('offset', 0);
-        $limit = $request->input('limit', 50);
+
+        // Check to make sure the limit is not higher than the max allowed
+        (config('app.max_results') < $request->input('limit')) ? $limit = $request->input('limit') : $limit = config('app.max_results');
+
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $sort = in_array($request->input('sort'), $allowed_columns) ? $request->input('sort') : 'created_at';
         $manufacturers->orderBy($sort, $order);

--- a/app/Http/Controllers/Api/StatuslabelsController.php
+++ b/app/Http/Controllers/Api/StatuslabelsController.php
@@ -31,7 +31,10 @@ class StatuslabelsController extends Controller
         }
 
         $offset = (($statuslabels) && (request('offset') > $statuslabels->count())) ? 0 : request('offset', 0);
-        $limit = $request->input('limit', 50);
+
+        // Check to make sure the limit is not higher than the max allowed
+        (config('app.max_results') < $request->input('limit')) ? $limit = $request->input('limit') : $limit = config('app.max_results');
+
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $sort = in_array($request->input('sort'), $allowed_columns) ? $request->input('sort') : 'created_at';
         $statuslabels->orderBy($sort, $order);

--- a/app/Http/Controllers/Api/SuppliersController.php
+++ b/app/Http/Controllers/Api/SuppliersController.php
@@ -34,7 +34,10 @@ class SuppliersController extends Controller
         }
 
         $offset = (($suppliers) && (request('offset') > $suppliers->count())) ? 0 : request('offset', 0);
-        $limit = $request->input('limit', 50);
+
+        // Check to make sure the limit is not higher than the max allowed
+        (config('app.max_results') < $request->input('limit')) ? $limit = $request->input('limit') : $limit = config('app.max_results');
+
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $sort = in_array($request->input('sort'), $allowed_columns) ? $request->input('sort') : 'created_at';
         $suppliers->orderBy($sort, $order);

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -88,7 +88,10 @@ class UsersController extends Controller
 
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $offset = (($users) && (request('offset') > $users->count())) ? 0 : request('offset', 0);
-        $limit = request('limit',  20);
+
+        // Check to make sure the limit is not higher than the max allowed
+        (config('app.max_results') < $request->input('limit')) ? $limit = $request->input('limit') : $limit = config('app.max_results');
+
 
         switch ($request->input('sort')) {
             case 'manager':

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -32,7 +32,15 @@ class ActionlogsTransformer
             $meta_array = json_decode($actionlog->log_meta);
             foreach ($meta_array as $key => $value) {
                 foreach ($value as $meta_key => $meta_value) {
-                    $clean_meta[$key][$meta_key] = e($meta_value);
+
+                    if (is_array($meta_value)) {
+                        foreach ($meta_value as $meta_value_key => $meta_value_value) {
+                            $clean_meta[$key][$meta_value_key] = e($meta_value_value);
+                        }
+                    } else {
+                        $clean_meta[$key][$meta_key] = e($meta_value);
+                    }
+
                 }
             }
         }

--- a/config/app.php
+++ b/config/app.php
@@ -38,6 +38,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Result Limit
+    |--------------------------------------------------------------------------
+    |
+    | This value determines the max number of results to return, even if a higher limit
+    | is passed in the API request. This is done to prevent server timeouts when
+    | custom scripts are requesting 100k assets at a time.
+    |
+    */
+
+    'max_results' => env('MAX_RESULTS', 500),
+
+    /*
+    |--------------------------------------------------------------------------
     | Application Debug Mode
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
This should prevent server timeouts when API requests are asking for 100k, etc assets at one time. 