### PR TITLE
Improve the design and performance of the nested location selectlist

### DIFF
--- a/app/Http/Controllers/Api/LocationsController.php
+++ b/app/Http/Controllers/Api/LocationsController.php
@@ -234,10 +234,13 @@ class LocationsController extends Controller
 
         $locations_with_children = [];
         foreach ($locations as $location) {
-            $locations_with_children[$location->parent_id] = true;
+            if(!array_key_exists($location->parent_id, $locations_with_children)) {
+                $locations_with_children[$location->parent_id] = []
+            }
+            $locations_with_children[$location->parent_id][] = $location;
         }
 
-        $location_options = Location::indenter($locations, $locations_with_children);
+        $location_options = Location::indenter($locations_with_children);
 
         $locations_formatted = new Collection($location_options);
         $paginated_results =  new LengthAwarePaginator($locations_formatted->forPage($page, 50), $locations_formatted->count(), 50, $page, []);

--- a/app/Http/Controllers/Api/LocationsController.php
+++ b/app/Http/Controllers/Api/LocationsController.php
@@ -234,7 +234,7 @@ class LocationsController extends Controller
         $locations_with_children = [];
         foreach ($locations as $location) {
             if(!array_key_exists($location->parent_id, $locations_with_children)) {
-                $locations_with_children[$location->parent_id] = []
+                $locations_with_children[$location->parent_id] = [];
             }
             $locations_with_children[$location->parent_id][] = $location;
         }

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -156,7 +156,7 @@ class Location extends SnipeModel
             return [];
         }
 
-        foreach ($locations[$parent_id] as $location) {
+        foreach ($locations_with_children[$parent_id] as $location) {
             //$count++;
             //append this parent node first,
             $location->use_text = $prefix.' '.$location->name;

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -148,24 +148,26 @@ class Location extends SnipeModel
      * @return Illuminate\Database\Query\Builder          Modified query builder
      */
 
-    public static function indenter($locations, $locations_with_children, $parent_id = null, $prefix = '') {
+    public static function indenter($locations_with_children, $parent_id = null, $prefix = '') {
         $results = Array();
-        static $count = 0;
+        //static $count = 0;
+        
+        if (!array_key_exists($parent_id, $locations_with_children)) {
+            return [];
+        }
 
-        foreach ($locations as $location) {
-            $count++;
-            if($location->parent_id == $parent_id) {
-                //append this parent node first,
-                $location->use_text = $prefix.' '.$location->name;
-                $location->use_image = ($location->image) ? url('/').'/uploads/locations/'.$location->image : null;
-                $results[] = $location;
-                //now append the children. (if we have any)
-                if (array_key_exists($location->id, $locations_with_children)) {
-                    $results = array_merge($results,Location::indenter($locations,$locations_with_children, $location->id,$prefix.'--'));
-                }
+        foreach ($locations[$parent_id] as $location) {
+            //$count++;
+            //append this parent node first,
+            $location->use_text = $prefix.' '.$location->name;
+            $location->use_image = ($location->image) ? url('/').'/uploads/locations/'.$location->image : null;
+            $results[] = $location;
+            //now append the children. (if we have any)
+            if (array_key_exists($location->id, $locations_with_children)) {
+                $results = array_merge($results, Location::indenter($locations_with_children, $location->id,$prefix.'--'));
             }
         }
-        \Log::debug($count);
+        //\Log::debug($count);
         return $results;
     }
 

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -150,15 +150,12 @@ class Location extends SnipeModel
 
     public static function indenter($locations_with_children, $parent_id = null, $prefix = '') {
         $results = Array();
-        //static $count = 0;
         
         if (!array_key_exists($parent_id, $locations_with_children)) {
             return [];
         }
 
         foreach ($locations_with_children[$parent_id] as $location) {
-            //$count++;
-            //append this parent node first,
             $location->use_text = $prefix.' '.$location->name;
             $location->use_image = ($location->image) ? url('/').'/uploads/locations/'.$location->image : null;
             $results[] = $location;
@@ -167,7 +164,6 @@ class Location extends SnipeModel
                 $results = array_merge($results, Location::indenter($locations_with_children, $location->id,$prefix.'--'));
             }
         }
-        //\Log::debug($count);
         return $results;
     }
 


### PR DESCRIPTION
This uses a array-hash lookup instead of iterating the entire contents of the array. It ends up traversing the entire array only once, then afterwards just uses the hash to only iterate the parts of the result set that are necessary. This should hopefully improve performance which can be a little sluggish on multi-thousand deeply-nested location sets.