### PR TITLE
Fixes Exception when Checkin Licenses from Assets

### DIFF
--- a/app/Http/Controllers/Licenses/LicenseCheckinController.php
+++ b/app/Http/Controllers/Licenses/LicenseCheckinController.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Controller;
 use App\Models\License;
 use App\Models\LicenseSeat;
 use App\Models\User;
+use App\Models\Asset;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Input;
@@ -80,7 +81,12 @@ class LicenseCheckinController extends Controller
             // Ooops.. something went wrong
             return redirect()->back()->withInput()->withErrors($validator);
         }
-        $return_to = User::find($licenseSeat->assigned_to);
+
+        if($licenseSeat->assigned_to != null){
+            $return_to = User::find($licenseSeat->assigned_to);
+        } else {
+            $return_to = Asset::find($licenseSeat->asset_id);
+        }
 
         // Update the asset data
         $licenseSeat->assigned_to                   = null;
@@ -88,7 +94,6 @@ class LicenseCheckinController extends Controller
 
         // Was the asset updated?
         if ($licenseSeat->save()) {
-
             event(new CheckoutableCheckedIn($licenseSeat, $return_to, Auth::user(), $request->input('note')));
 
             if ($backTo=='user') {


### PR DESCRIPTION
# Description
If a License is assigned to an Asset, an exception occurs because we aren't returning correctly the `target` which had assigned that License. 

Fixes internal rollbar #14721

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx:1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
