### PR TITLE
Fixes #9365 #9800 Added a validation to use the same name in categories with different types [sc-17487]

### DIFF
--- a/app/Http/Traits/TwoColumnUniqueUndeletedTrait.php
+++ b/app/Http/Traits/TwoColumnUniqueUndeletedTrait.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Traits;
+
+trait TwoColumnUniqueUndeletedTrait
+{
+    /**
+     * Prepare a unique_ids rule, adding a model identifier if required.
+     *
+     * @param  array  $parameters
+     * @param  string $field
+     * @return string
+     */
+    protected function prepareTwoColumnUniqueUndeletedRule($parameters, $field)
+    {
+        $column = $parameters[0];
+        $value = $this->{$parameters[0]};
+
+        if ($this->exists) {
+            return 'two_column_unique_undeleted:'.$this->table.','.$this->getKey().','.$column.','.$value;
+        }
+
+        return 'two_column_unique_undeleted:'.$this->table.',0,'.$column.','.$value;
+    }
+}

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -2,7 +2,7 @@
 
 namespace App\Models;
 
-use App\Http\Traits\UniqueUndeletedTrait;
+use App\Http\Traits\TwoColumnUniqueUndeletedTrait;
 use App\Models\Traits\Searchable;
 use App\Presenters\Presentable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -38,7 +38,7 @@ class Category extends SnipeModel
      */
     public $rules = [
         'user_id' => 'numeric|nullable',
-        'name'   => 'required|min:1|max:255|unique_undeleted',
+        'name'   => 'required|min:1|max:255|two_column_unique_undeleted:category_type',
         'require_acceptance'   => 'boolean',
         'use_default_eula'   => 'boolean',
         'category_type'   => 'required|in:asset,accessory,consumable,component,license',
@@ -53,7 +53,8 @@ class Category extends SnipeModel
      */
     protected $injectUniqueIdentifier = true;
     use ValidatingTrait;
-    use UniqueUndeletedTrait;
+    use TwoColumnUniqueUndeletedTrait;
+
 
     /**
      * The attributes that are mass assignable.

--- a/app/Providers/ValidationServiceProvider.php
+++ b/app/Providers/ValidationServiceProvider.php
@@ -54,6 +54,20 @@ class ValidationServiceProvider extends ServiceProvider
             }
         });
 
+        // Unique if undeleted for two columns
+            // Same as unique_undeleted but taking the combination of two columns as unique constrain.
+            Validator::extend('two_column_unique_undeleted', function ($attribute, $value, $parameters, $validator) {
+                if (count($parameters)) {
+                    $count = DB::table($parameters[0])
+                             ->select('id')->where($attribute, '=', $value)
+                             ->whereNull('deleted_at')
+                             ->where('id', '!=', $parameters[1])
+                             ->where($parameters[2], $parameters[3])->count();
+
+                    return $count < 1;
+                }
+            });
+
         // Prevent circular references
         //
         // Example usage in Location model where parent_id references another Location:


### PR DESCRIPTION
# Description
A feature was required to allow categories with the same name if the type is different between them. So, for example I can have:

| name |type |
| ------------- | ------------- |
| Keyboards| Asset |
| Keyboards| Component |
| Keyboards| Accessory |

But can't have records of categories repeated. So I create a new validator to support this use case and added it to the model. I like this approach because the new validator takes the other column to check as parameter, making possible to use the same validator if other model requires a similar constraint.

Fixes #9365 #9800

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
