### PR TITLE
Throttle password reset requests to 5 every 60 seconds

### DIFF
--- a/app/Http/Controllers/Auth/ForgotPasswordController.php
+++ b/app/Http/Controllers/Auth/ForgotPasswordController.php
@@ -29,7 +29,7 @@ class ForgotPasswordController extends Controller
     public function __construct()
     {
         $this->middleware('guest');
-        $this->middleware('throttle:5,60', ['except' => 'showLinkRequestForm']);
+        $this->middleware('throttle:1,1', ['except' => 'showLinkRequestForm']);
     }
 
     /**
@@ -72,7 +72,7 @@ class ForgotPasswordController extends Controller
          * Once we have attempted to send the link, we will examine the response
          * then see the message we need to show to the user. Finally, we'll send out a proper response.
          */
-
+        
         $response = null;
 
         try {

--- a/app/Http/Controllers/Auth/ForgotPasswordController.php
+++ b/app/Http/Controllers/Auth/ForgotPasswordController.php
@@ -29,6 +29,7 @@ class ForgotPasswordController extends Controller
     public function __construct()
     {
         $this->middleware('guest');
+        $this->middleware('throttle:5,60', ['except' => 'showLinkRequestForm']);
     }
 
     /**


### PR DESCRIPTION
This adds password reset form throttling. (5 attempts in 60 seconds). I wish there was a more elegant way to handle this, it currently just shows a generic 429 error page. Something using the error bag in the future would be a little nicer.

https://www.huntr.dev/bounties/59bedd63-2e4d-44e3-b831-abb7085e282d/