### PR TITLE
Exclude web.config from Apache

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -36,3 +36,7 @@
 
 </IfModule>
 Options -Indexes
+
+<Files "web.config">
+    Deny from all
+</Files>


### PR DESCRIPTION
# Description

When deploying Snipe IT with Apache. the web.config file, which is for IIS servers is exposed and caught by vulnerability scanners like Nessus.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

http://localhost/web.config now returns 403 instead of file contents

# Checklist:

- [X] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [X] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
