### PR TITLE
Fixes Bug: When parent asset is assigned to other location, children assets loca…

### DIFF
--- a/app/Http/Controllers/CheckInOutRequest.php
+++ b/app/Http/Controllers/CheckInOutRequest.php
@@ -39,6 +39,8 @@ trait CheckInOutRequest
         switch (request('checkout_to_type')) {
             case 'location':
                 $asset->location_id = $target->id;
+                Asset::where('assigned_type', 'App\Models\Asset')->where('assigned_to', $asset->id)
+                    ->update(['location_id' => $asset->location_id]);
                 break;
             case 'asset':
                 $asset->location_id = $target->rtd_location_id;


### PR DESCRIPTION
…tion are updated as well.

# Description

When a parent asset is reassigned to another location children assets would not go with it. Children assets location now automatically sync with parent asset's location when reassigned to one.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
