### PR TITLE
Fixes bulk edit message counts more users than the actual selected users number

### DIFF
--- a/app/Http/Controllers/Users/BulkUsersController.php
+++ b/app/Http/Controllers/Users/BulkUsersController.php
@@ -33,7 +33,8 @@ class BulkUsersController extends Controller
         // Make sure there were users selected
         if (($request->filled('ids')) && (count($request->input('ids')) > 0)) {
             // Get the list of affected users
-            $users = User::whereIn('id', array_keys(request('ids')))
+            $user_raw_array = request('ids');
+            $users = User::whereIn('id', $user_raw_array)
                 ->with('groups', 'assets', 'licenses', 'accessories')->get();
 
             if ($request->input('bulk_actions') == 'edit') {


### PR DESCRIPTION
# Description
When selecting more than one user to bulk edit their data, the number of affected users in the next screen is wrongly represented presenting a higher number than the actual selected users. For some reason,  the bootstrap table (I think) sends the ids two times when selecting the users but as we were using `array_keys(request('ids')` when getting the users some indexes where added, I only put the values of the ids in an array before passing to the function that gets the users, and as the query uses a `whereIn` it only  passed the correct users.

Fixes internal freshdesk 23910

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
