### PR TITLE
Fixed #10222 - fixed permissions array to handle missing clone button

### DIFF
--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -116,22 +116,11 @@ class AssetsTransformer
         $permissions_array['available_actions'] = [
             'checkout' => Gate::allows('checkout', Asset::class),
             'checkin' => Gate::allows('checkin', Asset::class),
-            'clone' => false,
-            'restore' => false,
+            'clone' => Gate::allows('create', Asset::class),
+            'restore' => ($asset->deleted_at!='' && Gate::allows('create', Asset::class)) ? true : false,
             'update' => (bool) Gate::allows('update', Asset::class),
-            'delete' => ($asset->assigned_to=='' && Gate::allows('delete', Asset::class)),
+            'delete' => ($asset->deleted_at=='' && $asset->assigned_to =='' && Gate::allows('delete', Asset::class)),
         ];
-
-        if ($asset->deleted_at!='') {
-            $permissions_array['available_actions'] = [
-                'checkout' => true,
-                'checkin' => false,
-                'clone' => Gate::allows('create', Asset::class),
-                'restore' => Gate::allows('create', Asset::class),
-                'update' => false,
-                'delete' => false,
-            ];
-        }
 
 
 

--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -114,12 +114,12 @@ class AssetsTransformer
         }
 
         $permissions_array['available_actions'] = [
-            'checkout' => Gate::allows('checkout', Asset::class),
-            'checkin' => Gate::allows('checkin', Asset::class),
-            'clone' => Gate::allows('create', Asset::class),
-            'restore' => ($asset->deleted_at!='' && Gate::allows('create', Asset::class)) ? true : false,
-            'update' => (bool) Gate::allows('update', Asset::class),
-            'delete' => ($asset->deleted_at=='' && $asset->assigned_to =='' && Gate::allows('delete', Asset::class)),
+            'checkout'      => ($asset->deleted_at=='' && Gate::allows('checkout', Asset::class)) ? true : false,
+            'checkin'       => ($asset->deleted_at=='' && Gate::allows('checkin', Asset::class)) ? true : false,
+            'clone'         => Gate::allows('create', Asset::class) ? true : false,
+            'restore'       => ($asset->deleted_at!='' && Gate::allows('create', Asset::class)) ? true : false,
+            'update'        => ($asset->deleted_at=='' && Gate::allows('update', Asset::class)) ? true : false,
+            'delete'        => ($asset->deleted_at=='' && $asset->assigned_to =='' && Gate::allows('delete', Asset::class)) ? true : false,
         ];
 
 


### PR DESCRIPTION
This addresses the regression in 5.3.0 where the clone button was missing on the assets GUI mentioned in #10222.