### PR TITLE
Set default_label to 0 instead of null in Status Label API

### DIFF
--- a/app/Http/Controllers/Api/StatuslabelsController.php
+++ b/app/Http/Controllers/Api/StatuslabelsController.php
@@ -73,7 +73,7 @@ class StatuslabelsController extends Controller
         $statuslabel->archived          =  $statusType['archived'];
         $statuslabel->color             =  $request->input('color');
         $statuslabel->show_in_nav       =  $request->input('show_in_nav', 0);
-        $statuslabel->default_label     =  $request->input('default_label');
+        $statuslabel->default_label     =  $request->input('default_label', 0);
 
 
         if ($statuslabel->save()) {


### PR DESCRIPTION
This just sets 0 as the default value if no value is set when creating a status label via API, which mirrors the behavior in the GUI. Resolves internal rollbar495 