### PR TITLE
Fixes Bug: Asset Advance Search with Standard and Custom filters 

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -1420,35 +1420,35 @@ class Asset extends Depreciable
                         });
                     });
                 }
-            }
+            
 
-            /**
-             * THIS CLUNKY BIT IS VERY IMPORTANT
-             *
-             * Although inelegant, this section matters a lot when querying against fields that do not
-             * exist on the asset table. There's probably a better way to do this moving forward, for
-             * example using the Schema:: methods to determine whether or not a column actually exists,
-             * or even just using the $searchableRelations variable earlier in this file.
-             *
-             * In short, this set of statements tells the query builder to ONLY query against an
-             * actual field that's being passed if it doesn't meet known relational fields. This
-             * allows us to query custom fields directly in the assetsv table
-             * (regardless of their name) and *skip* any fields that we already know can only be
-             * searched through relational searches that we do earlier in this method.
-             *
-             * For example, we do not store "location" as a field on the assets table, we store
-             * that relationship through location_id on the assets table, therefore querying
-             * assets.location would fail, as that field doesn't exist -- plus we're already searching
-             * against those relationships earlier in this method.
-             *
-             * - snipe 
-             *
-             */
-            if (($fieldname != 'category') && ($fieldname != 'model_number') && ($fieldname != 'rtd_location') && ($fieldname != 'location') && ($fieldname != 'supplier')
-                && ($fieldname != 'status_label') && ($fieldname != 'model') && ($fieldname != 'company') && ($fieldname != 'manufacturer')) {
-                $query->orWhere('assets.'.$fieldname, 'LIKE', '%'.$search_val.'%');
+                /**
+                 * THIS CLUNKY BIT IS VERY IMPORTANT
+                 *
+                 * Although inelegant, this section matters a lot when querying against fields that do not
+                 * exist on the asset table. There's probably a better way to do this moving forward, for
+                 * example using the Schema:: methods to determine whether or not a column actually exists,
+                 * or even just using the $searchableRelations variable earlier in this file.
+                 *
+                 * In short, this set of statements tells the query builder to ONLY query against an
+                 * actual field that's being passed if it doesn't meet known relational fields. This
+                 * allows us to query custom fields directly in the assetsv table
+                 * (regardless of their name) and *skip* any fields that we already know can only be
+                 * searched through relational searches that we do earlier in this method.
+                 *
+                 * For example, we do not store "location" as a field on the assets table, we store
+                 * that relationship through location_id on the assets table, therefore querying
+                 * assets.location would fail, as that field doesn't exist -- plus we're already searching
+                 * against those relationships earlier in this method.
+                 *
+                 * - snipe 
+                 *
+                 */
+                if (($fieldname != 'category') && ($fieldname != 'model_number') && ($fieldname != 'rtd_location') && ($fieldname != 'location') && ($fieldname != 'supplier')
+                    && ($fieldname != 'status_label') && ($fieldname != 'model') && ($fieldname != 'company') && ($fieldname != 'manufacturer')) {
+                    $query->where('assets.'.$fieldname, 'LIKE', '%'.$search_val.'%');
+                }
             }
-
 
 
 


### PR DESCRIPTION
# Description

Corrects and issue when using advanced search in assets. 

Entering custom field, search, then add standard field in addition to the custom field
  - Shows results of only standard field in search
  - Does not include custom field in query

Entering standard field, search, then add custom field in addition to the standard field
  - Shows results of only custom field in search
  - Does include custom field in query with an OR statement

I included the custom fields in the for loop on line 1316 of asset.php and changed `orWhere` to `where`

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

See description for steps used to replicated. Replicated this issue on the demo, as well as my local version

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version: 7.4.3
* MySQL version: Ver 8.0.27-0ubuntu0.20.04.1 for Linux on x86_64 ((Ubuntu))
* Webserver version: Apache/2.4.41 (Ubuntu)
* OS version: Chrome 94.0.4606.81


# Checklist:

- [X] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [X ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
