### PR TITLE
Fixes asset components must return relationship instance

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -386,7 +386,7 @@ class Asset extends Depreciable
      */
     public function components()
     {
-
+        return $this->belongsToMany('\App\Models\Component', 'components_assets', 'asset_id', 'component_id')->withPivot('id', 'assigned_qty', 'created_at')->withTrashed();
     }
 
 


### PR DESCRIPTION
# Description
For some reason the method `Asset.php@components()` in the asset model was empty in develop which makes not possible to look at any asset detail, so I put the same relationship that's on master right now. I'm not sure if this change was on purpose, but in the develop demo is reproducible, so I fixed it here.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
