### PR TITLE
support apache REDIRECT_* for remote user login

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -154,6 +154,9 @@ class LoginController extends Controller
     {
         $header_name = Setting::getSettings()->login_remote_user_header_name ?: 'REMOTE_USER';
         $remote_user = $request->server($header_name);
+        if (!isset($remote_user)) {
+          $remote_user = $request->server('REDIRECT_'.$header_name);
+        }
         if (Setting::getSettings()->login_remote_user_enabled == '1' && isset($remote_user) && ! empty($remote_user)) {
             Log::debug("Authenticating via HTTP header $header_name.");
 


### PR DESCRIPTION
# Description

On a mod_rewrite redirect Apache will prepend server environment variables with "REDIRECT_". This has caused numerous woes [example](https://stackoverflow.com/questions/3050444/when-setting-environment-variables-in-apache-rewriterule-directives-what-causes). After fighting with Apache config for too long I decided to patch Snipe rather than figure out what the hell Apache is doing.

Symfony does this for the HTTP_AUTHORIZATON variable.
https://github.com/symfony/http-foundation/blob/9f34f02e8a5fdc7a56bafe011cea1ce97300e54c/ServerBag.php#L58-L62

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I've performed manual testing on my own install of Snipe. There doesn't seem to be any tests specifically for REMOTE_USER in `tests/`.


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
