### PR TITLE
Adds reqestable as model bulk edit field

### DIFF
--- a/app/Http/Controllers/BulkAssetModelsController.php
+++ b/app/Http/Controllers/BulkAssetModelsController.php
@@ -80,6 +80,11 @@ class BulkAssetModelsController extends Controller
             $update_array['depreciation_id'] = $request->input('depreciation_id');
         }
 
+        if ($request->filled('requestable') != '') {
+            $update_array['requestable'] = $request->input('requestable');
+        }
+
+
         if (count($update_array) > 0) {
             AssetModel::whereIn('id', $models_raw_array)->update($update_array);
 

--- a/app/Presenters/AssetModelPresenter.php
+++ b/app/Presenters/AssetModelPresenter.php
@@ -107,6 +107,14 @@ class AssetModelPresenter extends Presenter
                 'formatter' => 'fieldsetsLinkObjFormatter',
             ],
             [
+                'field' => 'requestable',
+                'searchable' => false,
+                'sortable' => true,
+                'visible' => false,
+                'title' => trans('admin/hardware/general.requestable'),
+                'formatter' => 'trueFalseFormatter',
+            ],
+            [
                 'field' => 'notes',
                 'searchable' => true,
                 'sortable' => true,

--- a/resources/views/models/bulk-edit.blade.php
+++ b/resources/views/models/bulk-edit.blade.php
@@ -72,13 +72,30 @@
                                 </div>
                             </div>
 
+                            <!-- requestable -->
+                                <div class="form-group {{ $errors->has('requestable') ? 'has-error' : '' }}">
+                                <div class="col-md-7 col-md-offset-3">
+                            
+
+                                    <div class="checkbox">
+                                        <label for="requestable">
+                                            {{ Form::radio('requestable', '', true, ['aria-label'=>'requestable']) }} Do not change  requestable status<br>
+                                            {{ Form::radio('requestable', '1', old('requestable'), ['aria-label'=>'requestable']) }}  {{  trans('admin/hardware/general.requestable')}} <br>
+                                            {{ Form::radio('requestable', '0', old('requestable'), ['aria-label'=>'requestable']) }}  Not requestable
+    
+                                        </label>
+                                    </div>
+
+                                </div>
+                                </div>
+
                             @foreach ($models as $model)
                                 <input type="hidden" name="ids[{{ $model->id }}]" value="{{ $model->id }}">
                             @endforeach
                         </div>
                     </div> <!--/.box-body-->
 
-                    <div class="box-footer text-right">
+                    <div class="text-right box-footer">
                         <button type="submit" class="btn btn-success"><i class="fas fa-check icon-white" aria-hidden="true"></i> {{ trans('general.save') }}</button>
                     </div>
                 </div> <!--/.box.box-default-->

--- a/resources/views/users/bulk-edit.blade.php
+++ b/resources/views/users/bulk-edit.blade.php
@@ -73,7 +73,7 @@
                                 <div class="checkbox">
                                     <label for="activated">
                                         {{ Form::radio('activated', '', true, ['aria-label'=>'activated']) }} Do not change activation status <br>
-                                        {{ Form::radio('activated', '1', old('activated'), ['aria-label'=>'activated']) }}  User is activated<br>
+                                        {{ Form::radio('activated', '1', old('activated'), ['aria-label'=>'activated']) }}  {{  trans('general.login_enabled')}} <br>
                                         {{ Form::radio('activated', '0', old('activated'), ['aria-label'=>'activated']) }}  User is de-activated
 
                                     </label>
@@ -113,7 +113,7 @@
                         @endforeach
                     </div> <!--/.box-body-->
 
-                    <div class="box-footer text-right">
+                    <div class="text-right box-footer">
                         <button type="submit" class="btn btn-success"><i class="fas fa-check icon-white" aria-hidden="true"></i> {{ trans('general.save') }}</button>
                     </div>
                 </div> <!--/.box.box-default-->


### PR DESCRIPTION
This adds the ability to set a requestable status on models from the bulk edit screen. (It also sneaks in slightly better language for "activated" vs "User is able to login" on bulk user edit page.)

<img width="923" alt="Screen Shot 2021-10-28 at 3 18 04 PM" src="https://user-images.githubusercontent.com/197404/139344025-c8e5f5e0-4288-4bf9-82e2-54bdd03e0cb4.png">
