### PR TITLE
next_audit_date error on saving asset

### DIFF
--- a/app/Observers/AssetObserver.php
+++ b/app/Observers/AssetObserver.php
@@ -17,12 +17,15 @@ class AssetObserver
      */
     public function updating(Asset $asset)
     {
-
+        $attributes = $asset->getAttributes();
+        $attributesOriginal = $asset->getAttributes();
+        
         // If the asset isn't being checked out or audited, log the update.
         // (Those other actions already create log entries.)
-        if (($asset->getAttributes()['assigned_to'] == $asset->getOriginal()['assigned_to'])
-            && ($asset->getAttributes()['next_audit_date'] == $asset->getOriginal()['next_audit_date'])
-            && ($asset->getAttributes()['last_checkout'] == $asset->getOriginal()['last_checkout'])) {
+          if (($attributes['assigned_to'] == $attributesOriginal['assigned_to'])
+            && ((isset( $attributes['next_audit_date']) ? $attributes['next_audit_date'] : null) == (isset($attributesOriginal['next_audit_date']) ? $attributesOriginal['next_audit_date']: null))
+            && ($attributes['last_checkout']   == $attributesOriginal['last_checkout'])) {
+              
             $changed = [];
 
             foreach ($asset->getOriginal() as $key => $value) {


### PR DESCRIPTION
Solved error 500 when saving new Asset and no next_audit_date  is defined

# Description

this should patch the issue

https://github.com/snipe/snipe-it/issues/10860

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Creating a few items
This shouldn't break anything, however I don't know if that item should always be present in the array
