### PR TITLE
Fix #10482 for develop - Downgrade bootstrap-table to fix remembered-columns feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2942,9 +2942,9 @@
             "integrity": "sha1-EQPWvADPv6jPyaJZmrUYxVZD2j8="
         },
         "bootstrap-table": {
-            "version": "1.19.1",
-            "resolved": "https://registry.npmjs.org/bootstrap-table/-/bootstrap-table-1.19.1.tgz",
-            "integrity": "sha512-WvV+l1AI/C+zThaKmfHmi/IuayVNB0qdFyEhFx1jyZhO0oLtNJNANkCR3rvJf6Dkh72dsLElxpE/bzK9seEQLA=="
+            "version": "1.18.3",
+            "resolved": "https://registry.npmjs.org/bootstrap-table/-/bootstrap-table-1.18.3.tgz",
+            "integrity": "sha512-/eFLkldDlNFi37qC/d9THfRVxMUGD34E8fQBFtXJLDHLBOVKWDTq7BV+udoP7k3FfCEyhM1jWQnQ0rMQdBv//w=="
         },
         "brace-expansion": {
             "version": "1.1.11",
@@ -4255,7 +4255,7 @@
         "deep-equal": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-            "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+            "integrity": "sha1-tcmMlCzv+vfLBR4k4UNKJaLmB2o=",
             "requires": {
                 "is-arguments": "^1.0.4",
                 "is-date-object": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "bootstrap-colorpicker": "^2.5.3",
         "bootstrap-datepicker": "^1.9.0",
         "bootstrap-less": "^3.3.8",
-        "bootstrap-table": "^1.19.1",
+        "bootstrap-table": "1.18.x",
         "chart.js": "^2.9.4",
         "css-loader": "^3.6.0",
         "ekko-lightbox": "^5.1.1",


### PR DESCRIPTION
The same as #10927 - downgrade bootstrap-tables so the 'remembered columns' feature works again.