### PR TITLE
Fixed #11351 - add link on asset view to order number

### DIFF
--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -531,7 +531,7 @@
                                                 </strong>
                                             </div>
                                             <div class="col-md-6">
-                                                #{{ $asset->order_number }}
+                                                <a href="{{ route('hardware.index', ['order_number' => $asset->order_number]) }}">#{{ $asset->order_number }}</a>
                                             </div>
                                         </div>
                                     @endif


### PR DESCRIPTION
Fixed #11351 - adds a link to the hardware listing with order_number filter.