### PR TITLE
Use icheckbox formatting on BOM and archived checkboxes

### DIFF
--- a/resources/views/reports/custom.blade.php
+++ b/resources/views/reports/custom.blade.php
@@ -341,11 +341,13 @@
 
             <div class="col-md-9 col-md-offset-3">
             <label>
-              {{ Form::checkbox('exclude_archived', '1') }}
+              {{ Form::checkbox('exclude_archived', '1', old('exclude_archived'), ['class' => 'minimal']) }}
               {{ trans('general.exclude_archived') }}
             </label>
+            </div>
+            <div class="col-md-9 col-md-offset-3">
               <label>
-                {{ Form::checkbox('use_bom', '1') }}
+                {{ Form::checkbox('use_bom', '1', old('use_bom'), ['class' => 'minimal']) }}
                 {{ trans('general.bom_remark') }}
               </label>
             </div>


### PR DESCRIPTION
This just applies the icheckbox formatting to the BOM and Exclude archived asset checkboxes in the custom asset report. 