### PR TITLE
Fixed issue, asset-checkin saved without filling mandatory fields

### DIFF
--- a/app/Http/Requests/AssetCheckinRequest.php
+++ b/app/Http/Requests/AssetCheckinRequest.php
@@ -22,7 +22,8 @@ class AssetCheckinRequest extends Request
     public function rules()
     {
         return [
-
+            'status_id'             => 'exists:status_labels,id',
+            'checkin_at'             => 'required|date',
         ];
     }
 


### PR DESCRIPTION
# Description

Please go to any 'All Deployed' Asset menu. Choose any deployed asset. Click on 'Checkin' , On Checkin page, If we leave any mandatory field empty like 'Status' which has mandatory sign 'yellow' line, even then page is getting saved. ( it should show error to fill mandatory fields ). I have fixed this by adding the model validation for mandatory fields. ( Screen shot [attached](https://www.awesomescreenshot.com/image/30382044?key=e47d21dfcba1ee783917e49462e81000) )

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ * ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I have tested this manually. Please go to any 'All Deployed' asset menu. Choose any deployed asset. If we leave any mandatory field empty like 'Status' which has mandatory sign 'yellow' line, even then page was getting saved. After fixing the issue it is now showing error to fill mandatory fields.

**Test Configuration**:
* PHP version: 8.1
* MySQL version : 8.0
* Webserver version: Apache
* OS version : Ubuntu 20


# Checklist:

- [ # ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ # ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ # ] My code follows the style guidelines of this project
- [ # ] I have performed a self-review of my own code
- [ # ] I have commented my code, particularly in hard-to-understand areas
- [ # ] I have made corresponding changes to the documentation
- [ # ] My changes generate no new warnings
- [ # ] I have added tests that prove my fix is effective or that my feature works
- [ # ] New and existing unit tests pass locally with my changes
