### PR TITLE
Fixed #12027: Add memcached php extensions to docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ php7.4-mbstring \
 php7.4-zip \
 php7.4-bcmath \
 php7.4-redis \
+php-memcached \
 patch \
 curl \
 wget  \

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -28,6 +28,7 @@ RUN  apk add --no-cache \
         php7-xmlreader \
         php7-sodium \
         php7-redis \
+        php7-pecl-memcached \
         curl \
         wget \
         vim \


### PR DESCRIPTION
# Description

Adds the missing php extensions to Ubuntu and Alpine docker images.

Fixes #12027 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Built new images with my changes included, and tried them with the official Memcached docker images. 
The reported errors disappeared and all appears to work.


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
