### PR TITLE
Fixes the sidebar margin top

### DIFF
--- a/resources/assets/less/overrides.less
+++ b/resources/assets/less/overrides.less
@@ -671,18 +671,18 @@ th.css-accessory > .th-inner::before
 }
 @media screen and (max-width: 511px){
   .sidebar-menu{
-    margin-top:64px;
+    margin-top:160px;
   }
 }
 @media screen and (max-width: 771px) and (min-width: 512px){
   .sidebar-menu {
-    margin-top:14px
+    margin-top:160px
   }
 }
 
 @media screen and (max-width: 1098px) and (min-width: 772px){
   .sidebar-menu {
-    margin-top:51px
+    margin-top:98px
   }
 }
 


### PR DESCRIPTION
# Description
Adjusts the sidbar menu's top margin so that it clears the nav header and all buttons are clickable for all media sizes.
<img width="1015" alt="image" src="https://user-images.githubusercontent.com/47435081/221931641-f0723f76-f7db-45e6-936c-eb5a5cee57fe.png">


Fixes #12571 

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
