### PR TITLE
Fixed: issue#13073 Deleted component showing in asset resolved

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -403,7 +403,7 @@ class Asset extends Depreciable
      */
     public function components()
     {
-        return $this->belongsToMany('\App\Models\Component', 'components_assets', 'asset_id', 'component_id')->withPivot('id', 'assigned_qty', 'created_at')->withTrashed();
+        return $this->belongsToMany('\App\Models\Component', 'components_assets', 'asset_id', 'component_id')->withPivot('id', 'assigned_qty', 'created_at');
     }
 
 


### PR DESCRIPTION
# Description

This PR includes a fix for the issue tracked under issue number #13073. The issue involved the component assigned to the asset stills show after it is being deleted from the components. This was problematic as it didn't show the appropriate information users to about attached (checkout) components

Fixes #13073

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A: Create a new Component, then assign it with an asset. Then delete the component and check is that specific component still shows in the asset component tab.
- [x] Test B: Create a new Component, then assign it with an asset. Check is that specific component still shows in the asset component tab.

**Test Configuration**:
* PHP version: 8.0
* MySQL version: 8.1.17
* Webserver version: Apache/2.4.56 (Debian)
* OS version: Mac OS


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas