### PR TITLE
Fix of typo in an HTML tag

### DIFF
--- a/resources/views/account/requestable-assets.blade.php
+++ b/resources/views/account/requestable-assets.blade.php
@@ -78,7 +78,7 @@
                         <div class="col-md-12">
 
                             @if ($models->count() > 0)
-                            <h2>{{ trans('general.requestable_models') }}</h4>
+                            <h2>{{ trans('general.requestable_models') }}</h2>
                                 <table
                                         name="requested-assets"
                                         data-toolbar="#toolbar"


### PR DESCRIPTION
# Description

Fixed Typo in an HTML tag that was starting with h2 tag and ending with h4 tag.
changed the ending tag to h2.
         

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:
* PHP version:  PHP 8.0.28
* MySQL version: 10.4.28-MariaDB
* Webserver version: Apache/2.4.56
* OS version: Windows 11


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
