### PR TITLE
Fixed #13382 Add help text to localization view to avoid confusion

### DIFF
--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -268,6 +268,7 @@ return [
     'submit'				=> 'Submit',
     'target'                => 'Target',
     'time_and_date_display' => 'Time and Date Display',
+    'time_and_date_display_help_text' => 'The date is only a representative example to show how a date would look in every format and doesn\'t reflect the actual system date',
     'total_assets'			=> 'total assets',
     'total_licenses'		=> 'total licenses',
     'total_accessories'		=> 'total accessories',

--- a/resources/views/settings/localization.blade.php
+++ b/resources/views/settings/localization.blade.php
@@ -61,7 +61,7 @@
                                 {!! Form::date_display_format('date_display_format', Request::old('date_display_format', $setting->date_display_format), 'select2') !!}
 
                                 {!! Form::time_display_format('time_display_format', Request::old('time_display_format', $setting->time_display_format), 'select2') !!}
-
+                                <p class="help-block">{{ trans('general.time_and_date_display_help_text') }}</p>
                                 {!! $errors->first('time_display_format', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                             </div>
                         </div>


### PR DESCRIPTION
# Description
Just gonna put the screenshot on how it looks, and I think the commit and the screenshot are sufficient explanation, not a big change.

![image](https://github.com/snipe/snipe-it/assets/653557/e9b9e000-0da9-4373-8688-fdb3d205f3d2)

Fixes #13382 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 11


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
