### PR TITLE
[FIX and improvements] EOL rate and EOL date

### DIFF
--- a/app/Http/Controllers/AssetModelsController.php
+++ b/app/Http/Controllers/AssetModelsController.php
@@ -179,9 +179,14 @@ class AssetModelsController extends Controller
        
         if ($model->save()) {
             if ($model->wasChanged('eol')) {
-                    $newEol = $model->eol; 
-                    $model->assets()->whereNotNull('purchase_date')->where('eol_explicit', false)
-                        ->update(['asset_eol_date' => DB::raw('DATE_ADD(purchase_date, INTERVAL ' . $newEol . ' MONTH)')]);
+                    if ($model->eol > 0) {
+                        $newEol = $model->eol; 
+                        $model->assets()->whereNotNull('purchase_date')->where('eol_explicit', false)
+                            ->update(['asset_eol_date' => DB::raw('DATE_ADD(purchase_date, INTERVAL ' . $newEol . ' MONTH)')]);
+                        } elseif ($model->eol == 0) {
+    						$model->assets()->whereNotNull('purchase_date')->where('eol_explicit', false)
+    							->update(['asset_eol_date' => DB::raw('null')]);
+					}
                 }
             return redirect()->route('models.index')->with('success', trans('admin/models/message.update.success'));
         }

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -137,7 +137,7 @@ class AssetsController extends Controller
             $asset->warranty_months         = request('warranty_months', null);
             $asset->purchase_cost           = request('purchase_cost');
             $asset->purchase_date           = request('purchase_date', null);
-            $asset->asset_eol_date          = request('asset_eol_date', $asset->present()->eol_date());
+            $asset->asset_eol_date          = request('asset_eol_date', null);
             $asset->assigned_to             = request('assigned_to', null);
             $asset->supplier_id             = request('supplier_id', null);
             $asset->requestable             = request('requestable', 0);
@@ -309,14 +309,15 @@ class AssetsController extends Controller
         $asset->warranty_months = $request->input('warranty_months', null);
         $asset->purchase_cost = $request->input('purchase_cost', null);
         $asset->purchase_date = $request->input('purchase_date', null); 
-        if ($request->filled('purchase_date') && !$request->filled('asset_eol_date') && $asset->model->eol) {
+        if ($request->filled('purchase_date') && !$request->filled('asset_eol_date') && ($asset->model->eol > 0)) {
             $asset->purchase_date = $request->input('purchase_date', null); 
             $asset->asset_eol_date = Carbon::parse($request->input('purchase_date'))->addMonths($asset->model->eol)->format('Y-m-d');
+            $asset->eol_explicit = false;
         } elseif ($request->filled('asset_eol_date')) {
            $asset->asset_eol_date = $request->input('asset_eol_date', null);
            $months = Carbon::parse($asset->asset_eol_date)->diffInMonths($asset->purchase_date);
            if($asset->model->eol) {
-               if($months != $asset->model->eol) {
+               if($months != $asset->model->eol > 0) {
                    $asset->eol_explicit = true;
                } else {
                    $asset->eol_explicit = false;
@@ -324,6 +325,9 @@ class AssetsController extends Controller
            } else {
                $asset->eol_explicit = true;
            }
+        } elseif (!$request->filled('asset_eol_date') && (($asset->model->eol) == 0)) {
+           $asset->asset_eol_date = null;
+		   $asset->eol_explicit = false;
         }
         $asset->supplier_id = $request->input('supplier_id', null);
         $asset->expected_checkin = $request->input('expected_checkin', null);

--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -7,6 +7,7 @@ use App\Models\Asset;
 use App\Models\Setting;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Database\Eloquent\Collection;
+use Carbon\Carbon;
 
 
 class AssetsTransformer
@@ -38,7 +39,7 @@ class AssetsTransformer
             'byod' => ($asset->byod ? true : false),
 
             'model_number' => (($asset->model) && ($asset->model->model_number)) ? e($asset->model->model_number) : null,
-            'eol' => (($asset->model) && ($asset->model->eol != '')) ? $asset->model->eol : null,
+            'eol' => (($asset->asset_eol_date != '') && ($asset->purchase_date != '')) ? Carbon::parse($asset->asset_eol_date)->diffInMonths($asset->purchase_date).' months' : null,
             'asset_eol_date' => ($asset->asset_eol_date != '') ? Helper::getFormattedDateObject($asset->asset_eol_date, 'date') : null,
             'status_label' => ($asset->assetstatus) ? [
                 'id' => (int) $asset->assetstatus->id,

--- a/app/Observers/AssetObserver.php
+++ b/app/Observers/AssetObserver.php
@@ -137,14 +137,14 @@ class AssetObserver
     public function saving(Asset $asset)
     {
         // determine if calculated eol and then calculate it - this should only happen on a new asset
-        if (is_null($asset->asset_eol_date) && !is_null($asset->purchase_date) && !is_null($asset->model->eol)){
+        if (is_null($asset->asset_eol_date) && !is_null($asset->purchase_date) && ($asset->model->eol > 0)){
             $asset->asset_eol_date = $asset->purchase_date->addMonths($asset->model->eol)->format('Y-m-d');
             $asset->eol_explicit = false; 
         } 
 
        // determine if explicit and set eol_explicit to true
        if (!is_null($asset->asset_eol_date) && !is_null($asset->purchase_date)) {
-            if($asset->model->eol) {
+            if($asset->model->eol > 0) {
                 $months = Carbon::parse($asset->asset_eol_date)->diffInMonths($asset->purchase_date); 
                 if($months != $asset->model->eol) {
                     $asset->eol_explicit = true;
@@ -153,7 +153,7 @@ class AssetObserver
        } elseif (!is_null($asset->asset_eol_date) && is_null($asset->purchase_date)) {
            $asset->eol_explicit = true;
        }
-       if ((!is_null($asset->asset_eol_date)) && (!is_null($asset->purchase_date)) && (is_null($asset->model->eol))) {
+       if ((!is_null($asset->asset_eol_date)) && (!is_null($asset->purchase_date)) && (is_null($asset->model->eol) || ($asset->model->eol == 0))) {
            $asset->eol_explicit = true;
        }
 

--- a/app/Presenters/AssetModelPresenter.php
+++ b/app/Presenters/AssetModelPresenter.php
@@ -104,7 +104,7 @@ class AssetModelPresenter extends Presenter
                 'searchable' => false,
                 'sortable' => true,
                 'switchable' => true,
-                'title' => trans('general.eol'),
+                'title' => trans('admin/hardware/form.eol_rate'),
                 'visible' => true,
             ],
             [

--- a/app/Presenters/AssetPresenter.php
+++ b/app/Presenters/AssetPresenter.php
@@ -173,7 +173,7 @@ class AssetPresenter extends Presenter
                 'searchable' => false,
                 'sortable' => true,
                 'visible' => false,
-                'title' => trans('general.eol'),
+                'title' => trans('admin/hardware/form.eol_rate'),
             ],
             [
                 'field' => 'asset_eol_date',

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -631,7 +631,7 @@
                                         </div>
                                     @endif
 
-                                    @if (($asset->model) && ($asset->model->eol))
+                                    @if (($asset->asset_eol_date) && ($asset->purchase_date))
                                         <div class="row">
                                             <div class="col-md-2">
                                                 <strong>
@@ -639,7 +639,7 @@
                                                 </strong>
                                             </div>
                                             <div class="col-md-6">
-                                                {{ $asset->model->eol }}
+                                                {{ Carbon::parse($asset->asset_eol_date)->diffInMonths($asset->purchase_date) }}
                                                 {{ trans('admin/hardware/form.months') }}
 
                                             </div>
@@ -650,6 +650,9 @@
                                             <div class="col-md-2">
                                                 <strong>
                                                     {{ trans('admin/hardware/form.eol_date') }}
+                                                    @if ($asset->purchase_date)
+														{!! $asset->asset_eol_date < date("Y-m-d") ? '<i class="fas fa-exclamation-triangle text-orange" aria-hidden="true"></i>' : '' !!}
+                                                    @endif
                                                 </strong>
                                             </div>
                                             <div class="col-md-6">

--- a/resources/views/partials/forms/edit/eol_date.blade.php
+++ b/resources/views/partials/forms/edit/eol_date.blade.php
@@ -1,9 +1,9 @@
-<!-- Purchase Date -->
+<!-- EOL Date -->
 <div class="form-group {{ $errors->has('asset_eol_date') ? ' has-error' : '' }}">
     <label for="asset_eol_date" class="col-md-3 control-label">{{ trans('admin/hardware/form.eol_date') }}</label>
     <div class="input-group col-md-4">
         <div class="input-group date" data-provide="datepicker" data-date-clear-btn="true" data-date-format="yyyy-mm-dd"  data-autoclose="true">
-            <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="asset_eol_date" id="asset_eol_date" readonly value="{{  old('asset_eol_date', optional($item->asset_eol_date)->format('Y-m-d') ?? $item->present()->eol_date() ?? '')  }}"  style="background-color:inherit">
+            <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="asset_eol_date" id="asset_eol_date" readonly value="{{  old('asset_eol_date', optional($item->asset_eol_date)->format('Y-m-d') ?? $item->asset_eol_date ?? '')  }}"  style="background-color:inherit" />
             <span class="input-group-addon"><i class="fas fa-calendar" aria-hidden="true"></i></span>
         </div>
         {!! $errors->first('asset_eol_date', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}


### PR DESCRIPTION
# Description

Some improvements :
- display EOL rate for assets (real rate as diff between pruchase date and eol date),
- display market in asset details if EOL date is expired,
- display EOL rate as months
- upated name of column from 'EOL' to 'EOL rate'

Some fixes:
- during update check model EOL rate if is >0 or =0, set correct status explicit marker,
- during edit asset read real eol date from database instead calculate on base model eol,
- keep consistance during update model EOL rate 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:
* PHP version: 8.1
* MySQL version 10.6.5-MariaDB
* Webserver version IIS
* Web browser: MS Edge, Chrome


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
