### PR TITLE
Check that the asset exists before trying to get properties

### DIFF
--- a/app/Http/Transformers/AssetMaintenancesTransformer.php
+++ b/app/Http/Transformers/AssetMaintenancesTransformer.php
@@ -45,7 +45,7 @@ class AssetMaintenancesTransformer
                 'name'=> e($assetmaintenance->asset->location->name),
 
             ] : null,
-            'rtd_location' => ($assetmaintenance->asset->defaultLoc) ? [
+            'rtd_location' => (($assetmaintenance->asset) && ($assetmaintenance->asset->defaultLoc)) ? [
                 'id' => (int) $assetmaintenance->asset->defaultLoc->id,
                 'name'=> e($assetmaintenance->asset->defaultLoc->name),
             ] : null,


### PR DESCRIPTION
This checks to make sure the asset exists before trying to get the defaultLoc on it. (This wouldn't really happen much in the wild I don't think, but can get triggered when the demo is resetting.)