### PR TITLE
Manage EOL date by checkbox of eol_explicit

### DIFF
--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -136,6 +136,7 @@ class AssetsController extends Controller
             $asset->purchase_cost           = request('purchase_cost');
             $asset->purchase_date           = request('purchase_date', null);
             $asset->asset_eol_date          = request('asset_eol_date', null);
+			$asset->eol_explicit          	= request('eol_explicit', 0);
             $asset->assigned_to             = request('assigned_to', null);
             $asset->supplier_id             = request('supplier_id', null);
             $asset->requestable             = request('requestable', 0);
@@ -179,6 +180,26 @@ class AssetsController extends Controller
                     }
                 }
             }
+
+			// Update EOL date
+			// Validation for this field is on the base eol_explicit, purchase_date and model_eol fields
+			if ($request->filled('eol_explicit')) {
+				if ($request->filled('asset_eol_date')) {
+					$asset->asset_eol_date = $request->input('asset_eol_date', null);
+				} elseif ($request->filled('purchase_date') && ($asset->model->eol > 0)) {
+					$asset->eol_explicit = false;
+					$asset->asset_eol_date = Carbon::parse($asset->purchase_date)->addMonths($asset->model->eol)->format('Y-m-d');
+				} else {
+					$asset->eol_explicit = false;
+					$asset->asset_eol_date = null;
+				}
+			} else {
+				if ($request->filled('purchase_date') && ($asset->model->eol > 0)) {
+					$asset->asset_eol_date = Carbon::parse($asset->purchase_date)->addMonths($asset->model->eol)->format('Y-m-d');
+				} else {
+					$asset->asset_eol_date = null;
+				}
+			}
 
             // Validate the asset before saving
             if ($asset->isValid() && $asset->save()) {
@@ -305,31 +326,12 @@ class AssetsController extends Controller
         $asset->warranty_months = $request->input('warranty_months', null);
         $asset->purchase_cost = $request->input('purchase_cost', null);
         $asset->purchase_date = $request->input('purchase_date', null); 
-        if ($request->filled('purchase_date') && !$request->filled('asset_eol_date') && ($asset->model->eol > 0)) {
-            $asset->purchase_date = $request->input('purchase_date', null); 
-            $asset->asset_eol_date = Carbon::parse($request->input('purchase_date'))->addMonths($asset->model->eol)->format('Y-m-d');
-            $asset->eol_explicit = false;
-        } elseif ($request->filled('asset_eol_date')) {
-           $asset->asset_eol_date = $request->input('asset_eol_date', null);
-           $months = Carbon::parse($asset->asset_eol_date)->diffInMonths($asset->purchase_date);
-           if($asset->model->eol) {
-               if($months != $asset->model->eol > 0) {
-                   $asset->eol_explicit = true;
-               } else {
-                   $asset->eol_explicit = false;
-               }
-           } else {
-               $asset->eol_explicit = true;
-           }
-        } elseif (!$request->filled('asset_eol_date') && (($asset->model->eol) == 0)) {
-           $asset->asset_eol_date = null;
-		   $asset->eol_explicit = false;
-        }
         $asset->supplier_id = $request->input('supplier_id', null);
         $asset->expected_checkin = $request->input('expected_checkin', null);
 
         // If the box isn't checked, it's not in the request at all.
         $asset->requestable = $request->filled('requestable');
+		$asset->eol_explicit = $request->filled('eol_explicit');
         $asset->rtd_location_id = $request->input('rtd_location_id', null);
         $asset->byod = $request->input('byod', 0);
 
@@ -391,7 +393,26 @@ class AssetsController extends Controller
             }
         }
 
-
+		// Update EOL date
+		// Validation for this field is on the base eol_explicit, purchase_date and model_eol fields
+		if ($request->filled('eol_explicit')) {
+			if ($request->filled('asset_eol_date')) {
+				$asset->asset_eol_date = $request->input('asset_eol_date', null);
+			} elseif ($request->filled('purchase_date') && ($asset->model->eol > 0)) {
+				$asset->eol_explicit = false;
+				$asset->asset_eol_date = Carbon::parse($asset->purchase_date)->addMonths($asset->model->eol)->format('Y-m-d');
+			} else {
+				$asset->eol_explicit = false;
+				$asset->asset_eol_date = null;
+			}
+		} else {
+			if ($request->filled('purchase_date') && ($asset->model->eol > 0)) {
+				$asset->asset_eol_date = Carbon::parse($asset->purchase_date)->addMonths($asset->model->eol)->format('Y-m-d');
+			} else {
+				$asset->asset_eol_date = null;
+			}
+		}
+		
         if ($asset->save()) {
             return redirect()->route('hardware.show', $assetId)
                 ->with('success', trans('admin/hardware/message.update.success'));

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -11,6 +11,7 @@ use App\Models\AssetModel;
 use App\Models\Statuslabel;
 use App\Models\Setting;
 use App\View\Label;
+use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -261,11 +262,31 @@ class BulkAssetsController extends Controller
                         $this->conditionallyAddItem($custom_field_column); 
                    }
 
+                if (!($asset->eol_explicit)) {
+					if ($request->filled('model_id')) {
+						$model = AssetModel::find($request->input('model_id'));
+						if ($model->eol > 0) {
+							if ($request->filled('purchase_date')) {
+								$this->update_array['asset_eol_date'] = Carbon::parse($request->input('purchase_date'))->addMonths($model->eol)->format('Y-m-d');
+							} else {
+								$this->update_array['asset_eol_date'] = Carbon::parse($asset->purchase_date)->addMonths($model->eol)->format('Y-m-d');
+							}
+						} else {
+							$this->update_array['asset_eol_date'] = null;
+						}
+					} elseif (($request->filled('purchase_date')) && ($asset->model->eol > 0)) {
+						$this->update_array['asset_eol_date'] = Carbon::parse($request->input('purchase_date'))->addMonths($asset->model->eol)->format('Y-m-d');
+					}
+				}
+
                 /**
                  * Blank out fields that were requested to be blanked out via checkbox
                  */
                 if ($request->input('null_purchase_date')=='1') {
                     $this->update_array['purchase_date'] = null;
+                    if (!($asset->eol_explicit)) {
+						$this->update_array['asset_eol_date'] = null;
+					}
                 }
 
                 if ($request->input('null_expected_checkin_date')=='1') {

--- a/app/Observers/AssetObserver.php
+++ b/app/Observers/AssetObserver.php
@@ -156,7 +156,7 @@ class AssetObserver
      * use saveQuietly() in the migration which skips this observer.
      *
      * @see https://github.com/snipe/snipe-it/issues/13723#issuecomment-1761315938
-     */
+
     public function saving(Asset $asset)
     {
         // determine if calculated eol and then calculate it - this should only happen on a new asset
@@ -181,4 +181,5 @@ class AssetObserver
        }
 
     }
+    */
 }

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -109,6 +109,7 @@ return [
     'download_all'		    => 'Download All',
     'editprofile'  			=> 'Edit Your Profile',
     'eol'					=> 'EOL',
+    'eol_date_help'			=> 'This option allow to set manually EOL date. If checkbox is not enabled, EOL date is calculated by asset model EOL rate.',
     'email_domain'			=> 'Email Domain',
     'email_format'			=> 'Email Format',
     'employee_number'       => 'Employee Number',

--- a/resources/views/hardware/edit.blade.php
+++ b/resources/views/hardware/edit.blade.php
@@ -167,6 +167,23 @@
     });
     @endif
 
+	// If the "eol_explicit" check box is checked, show then the ability to set eol_date
+	$(document).ready(function() {
+		$("#eol_explicit_active").change(function() {
+			if ((this.checked)) {
+				$("#eol_date_row").show();
+			} else {
+				$("#eol_date_row").hide();
+			}
+		});
+	
+		if({{ $item->eol_explicit ? 'true' : 'false' }}) {
+			$("#eol_date_row").show();
+		} else {
+			$("#eol_date_row").hide();
+		};
+	});
+
     var transformed_oldvals={};
 
     function fetchCustomFields() {

--- a/resources/views/partials/forms/edit/eol_date.blade.php
+++ b/resources/views/partials/forms/edit/eol_date.blade.php
@@ -1,11 +1,15 @@
 <!-- EOL Date -->
 <div class="form-group {{ $errors->has('asset_eol_date') ? ' has-error' : '' }}">
     <label for="asset_eol_date" class="col-md-3 control-label">{{ trans('admin/hardware/form.eol_date') }}</label>
-    <div class="input-group col-md-4">
+    <div class="col-md-1 control-label">
+        <input type="checkbox" value="1" name="eol_explicit" id="eol_explicit_active" {{ old('eol_explicit', $item->eol_explicit) == '1' ? ' checked="checked"' : '' }}>
+    </div>
+    <div class="input-group col-md-4" id="eol_date_row">
         <div class="input-group date" data-provide="datepicker" data-date-clear-btn="true" data-date-format="yyyy-mm-dd"  data-autoclose="true">
-            <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="asset_eol_date" id="asset_eol_date" readonly value="{{  old('asset_eol_date', optional($item->asset_eol_date)->format('Y-m-d') ?? $item->asset_eol_date ?? '')  }}"  style="background-color:inherit" />
+            <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="asset_eol_date" id="asset_eol_date" readonly value="{{  old('asset_eol_date', optional($item->asset_eol_date)->format('Y-m-d') ?? $item->asset_eol_date ?? '') }}"  style="background-color:inherit" /> 
             <span class="input-group-addon"><i class="fas fa-calendar" aria-hidden="true"></i></span>
         </div>
         {!! $errors->first('asset_eol_date', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
+    <p class="col-md-7 col-md-offset-3 help-block">{{ trans('general.eol_date_help') }}</p>
 </div>


### PR DESCRIPTION
# Description
[ It's re-created PR #13806 as I made mistake and updated my branch by master, sorry for confusion ]
This improvement allow setup EOL date manually by user on damand by set eol_explicit checkbox.

**BEFORE:**
![image](https://github.com/snipe/snipe-it/assets/82208283/4c9221ce-78a8-4c53-9575-f30634e53eba)

**AFTER:**
If checkbox is not checked then EOL date is hiden and calculation of date is on the base Model EOL rate
![image](https://github.com/snipe/snipe-it/assets/82208283/e0140b06-b105-474a-950c-5cc9e551888a)

If checkbox is checked then EOL date is showed and user can input EOL Date manually.
Status of checkbox is saved as eol_explicit value
![image](https://github.com/snipe/snipe-it/assets/82208283/468f9e12-5860-4052-b899-845b24e1d8d0)


In this way is much easier to manage EOL date and explicit marker status instead of build complex rules  :)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 8.1
* MySQL version 10.6.5-MariaDB
* Webserver version IIS
* Web browser: MS Edge, Chrome


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
