### PR TITLE
Fix [sc-25008] - correct and improve legacy language warnings

### DIFF
--- a/app/Http/Middleware/CheckLocale.php
+++ b/app/Http/Middleware/CheckLocale.php
@@ -8,6 +8,12 @@ use \App\Helpers\Helper;
 
 class CheckLocale
 {
+    private function warn_legacy_locale($language, $source)
+    {
+        if ($language != Helper::mapLegacyLocale($language)) {
+            \Log::warning("$source $language and should be updated to be ".Helper::mapLegacyLocale($language));
+        }
+    }
     /**
      * Handle the locale for the user, default to settings otherwise.
      *
@@ -22,24 +28,23 @@ class CheckLocale
 
         // Default app settings from config
         $language = config('app.locale');
+        $this->warn_legacy_locale($language, "APP_LOCALE in .env is set to");
 
         if ($settings = Setting::getSettings()) {
 
             // User's preference
             if (($request->user()) && ($request->user()->locale)) {
                 $language = $request->user()->locale;
+                $this->warn_legacy_locale($language, "username ".$request->user()->username." (".$request->user()->id.") has a language");
 
             // App setting preference
             } elseif ($settings->locale != '') {
                 $language = $settings->locale;
+                $this->warn_legacy_locale($language, "App Settings is set to");
             }
 
         }
-
-        if (config('app.locale') != Helper::mapLegacyLocale($language)) {
-           \Log::warning('Your current APP_LOCALE in your .env is set to "'.config('app.locale').'" and should be updated to be "'.Helper::mapLegacyLocale($language).'" in '.base_path().'/.env. Translations may display unexpectedly until this is updated.');
-        }
-
+        
         \App::setLocale(Helper::mapLegacyLocale($language));
         return $next($request);
     }


### PR DESCRIPTION
The legacy language warning was misfiring when a user's language didn't match the APP_LOCALE from .env.

Additionally, we weren't properly warning when the legacy-language came from Settings or from the user themselves. Both of which should be impossible but still probably not a bad idea to warn on it, anyways

# Testing

First, I stashed my changes and prove that the bug exists the way I said - 
I will set my user to have a language of 'en-US' and set the `APP_LOCALE` to 'pt-PT'. I got this message:

> Your current APP_LOCALE in your .env is set to "pt-PT" and should be updated to be "en-US" in /Users/uberbrady/Documents/grokability/snipe-it/.env. Translations may display unexpectedly until this is updated.  

Then, I reapplied my change and reloaded the dashboard. That message then went away.

Next, I changed the `APP_LOCALE` to be 'en', and my user's locale to be 'es'. I got this:

> APP_LOCALE in .env is set to en and should be updated to be en-US  
> username admin (1) has a language es and should be updated to be en-US  

(Note, we didn't have an es->es-MX fallback in-place, so this behavior is expected)

Finally, I blanked out my user's locale setting, and reloaded the dashboard. The messages I got were:

> APP_LOCALE in .env is set to en and should be updated to be en-US  
> App Settings is set to pt and should be updated to be en-US  

(Note, we never had a 'pt' language so it didn't select pt-PT as the fallback)