### PR TITLE
Added `ico`, `image/x-icon`, `image/vnd.microsoft.icon` to favicon validation

### DIFF
--- a/app/Http/Requests/ImageUploadRequest.php
+++ b/app/Http/Requests/ImageUploadRequest.php
@@ -36,6 +36,7 @@ class ImageUploadRequest extends Request
             return [
                 'image' => 'mimes:png,gif,jpg,jpeg,svg,bmp,svg+xml,webp,avif',
                 'avatar' => 'mimes:png,gif,jpg,jpeg,svg,bmp,svg+xml,webp,avif',
+                'favicon' => 'mimes:png,gif,jpg,jpeg,svg,bmp,svg+xml,webp,image/x-icon,image/vnd.microsoft.icon,ico',
             ];
     }
 
@@ -103,9 +104,9 @@ class ImageUploadRequest extends Request
                 \Log::info('File name will be: '.$file_name);
                 \Log::debug('File extension is: '.$ext);
 
-                if (($image->getMimeType() == 'image/avif') || ($image->getMimeType() == 'image/webp')) {
-                    // If the file is a webp or avif, we need to just move it since webp support
-                    // needs to be compiled into gd for resizing to be available
+                if (($image->getMimeType() == 'image/vnd.microsoft.icon') || ($image->getMimeType() == 'image/x-icon') || ($image->getMimeType() == 'image/avif') || ($image->getMimeType() == 'image/webp')) {
+                    // If the file is an icon, webp or avif, we need to just move it since gd doesn't support resizing
+                    // icons or avif, and webp support and needs to be compiled into gd for resizing to be available
                     Storage::disk('public')->put($path.'/'.$file_name, file_get_contents($image));
 
                 } elseif($image->getMimeType() == 'image/svg+xml') {


### PR DESCRIPTION
We were not checking for the icon formats for the `favicon` validation which resulted in the following error:

<img width="1074" alt="Screenshot 2024-04-22 at 1 56 39 PM" src="https://github.com/snipe/snipe-it/assets/197404/d454ebf1-9e31-43e6-9747-125e85bad95b">

We also have to prevent it from attempting to resize, since gd cannot resize icons.