### PR TITLE
Fixed #15371: docker-compose files updated.

### DIFF
--- a/.env.dev.docker
+++ b/.env.dev.docker
@@ -1,6 +1,8 @@
 # --------------------------------------------
 # REQUIRED: DB SETUP
 # --------------------------------------------
+# https://mariadb.com/kb/en/mariadb-server-docker-official-image-environment-variables/
+
 MYSQL_DATABASE=snipeit
 MYSQL_USER=snipeit
 MYSQL_PASSWORD=changeme1234

--- a/dev.docker-compose.yml
+++ b/dev.docker-compose.yml
@@ -1,3 +1,5 @@
+# Compose file to spin up a local Snipe-IT for development.
+
 version: '3'
 
 services:
@@ -7,44 +9,38 @@ services:
       dockerfile: Dockerfile.alpine
     container_name: snipeit
     ports:
-    - "8000:80"
-    volumes:
-    - ./storage/logs:/var/www/html/storage/logs
+      - "8000:80"
     depends_on:
-    - mariadb
-    - redis
+      redis:
+      mariadb:
+        condition: service_healthy
+        restart: true
     env_file:
-    - .env.docker
-    networks:
-    - snipeit-backend
+      - .env.dev.docker
 
   mariadb:
-    image: mariadb:10.6.4-focal
+    image: mariadb:11.5.2
     volumes:
-    - db:/var/lib/mysql
+      - db:/var/lib/mysql
     env_file:
-    - .env.docker
-    networks:
-    - snipeit-backend
+      - .env.dev.docker
     ports:
       - "3306:3306"
+    healthcheck:
+      # https://mariadb.com/kb/en/using-healthcheck-sh/#compose-file-example
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 2s
+      retries: 5
 
   redis:
-    image: redis:6.2.5-buster
-    networks:
-    - snipeit-backend
+    image: redis:7.4.0
 
   mailhog:
     image: mailhog/mailhog:v1.0.1
     ports:
-    # - 1025:1025
-    - "8025:8025"
-    networks:
-    - snipeit-backend
-
+      # - 1025:1025
+      - "8025:8025"
 
 volumes:
   db: {}
-
-networks:
-  snipeit-backend: {}

--- a/dev.docker-compose.yml
+++ b/dev.docker-compose.yml
@@ -12,6 +12,8 @@ services:
       - "8000:80"
     depends_on:
       redis:
+        # The default needs to be stated.
+        condition: service_started
       mariadb:
         condition: service_healthy
         restart: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,13 @@
+# Compose file for production.
+
 volumes:
   db_data:
   storage:
 
 services:
   app:
-    image: snipe/snipe-it:${APP_VERSION:-v6.4.1}
-    restart: always
+    image: snipe/snipe-it:${APP_VERSION:-v7.0.11}
+    restart: unless-stopped
     volumes:
       - storage:/var/lib/snipeit
     ports:
@@ -18,8 +20,8 @@ services:
       - .env
 
   db:
-    image: mariadb:10.6.4-focal
-    restart: always
+    image: mariadb:11.5.2
+    restart: unless-stopped
     volumes:
       - db_data:/var/lib/mysql
     environment:
@@ -28,7 +30,8 @@ services:
       MYSQL_PASSWORD: ${DB_PASSWORD}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
     healthcheck:
-      test: mysqladmin ping -h 127.0.0.1 -u $$MYSQL_USER --password=$$MYSQL_PASSWORD
+      # https://mariadb.com/kb/en/using-healthcheck-sh/#compose-file-example
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
       interval: 5s
       timeout: 1s
       retries: 5


### PR DESCRIPTION
# Description

Fixes #15371

Some reworking to `dev.docker-compose.yml`. Mostly the issue was using a wrong `.env` file.
Besides that, this removes obsolete stuff, uses the official maridb healthcheck and bumps container versions.

I made the corresponding changes to `docker-compose.yml` too, and changed the restart policies to more reasonable `unless-stopped`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```commandline
$ podman-compose -f dev.docker-compose.yml up
$ docker-compose -f dev.docker-compose.yml up
```
Both work.


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
