### PR TITLE
Added employee number to asset view

### DIFF
--- a/app/Helpers/IconHelper.php
+++ b/app/Helpers/IconHelper.php
@@ -64,14 +64,19 @@ class IconHelper
             case 'kits':
                 return 'fas fa-object-group';
             case 'assets':
+            case 'asset':
                 return 'fas fa-barcode';
             case 'accessories':
+            case 'accessory':
                 return 'far fa-keyboard';
             case 'components':
+            case 'component':
                 return 'far fa-hdd';
             case 'consumables':
+            case 'consumable':
                 return 'fas fa-tint';
             case 'licenses':
+            case 'license':
                 return 'far fa-save';
             case 'requestable':
                 return 'fas fa-laptop';
@@ -141,6 +146,8 @@ class IconHelper
                 return 'fas fa-lock';
             case 'locations':
                 return 'fas fa-map-marker-alt';
+            case 'location':
+                return 'fas fa-map-marker-alt';
             case 'superadmin':
                 return 'fas fa-crown';
             case 'print':
@@ -173,6 +180,8 @@ class IconHelper
                 return 'fas fa-crosshairs';
             case 'oauth':
                 return 'fas fa-user-secret';
+            case 'employee_num' :
+                return 'fa-regular fa-id-card';
 
         }
     }

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -277,26 +277,40 @@
                                     <div class="col-md-12" style="text-align: left">
                                         <h2>
                                             {{ trans('admin/hardware/form.checkedout_to') }}
+                                            <x-icon type="long-arrow-right" />
                                         </h2>
-                                        <p>
+
+                                        <ul class="list-unstyled" style="line-height: 25px; font-size: 14px">
+
                                             @if (($asset->checkedOutToUser()) && ($asset->assignedTo->present()->gravatar()))
-                                                <img src="{{ $asset->assignedTo->present()->gravatar() }}" class="user-image-inline hidden-print" alt="{{ $asset->assignedTo->present()->fullName() }}">
+                                                <li>
+                                                    <img src="{{ $asset->assignedTo->present()->gravatar() }}" class="user-image-inline hidden-print" alt="{{ $asset->assignedTo->present()->fullName() }}">
+                                                    {!! $asset->assignedTo->present()->nameUrl() !!}
+                                                </li>
+                                            @else
+                                                <li>
+                                                    <x-icon type="{{ $asset->assignedType() }}" class="fa-fw" />
+                                                    {!! $asset->assignedTo->present()->nameUrl() !!}
+                                                </li>
                                             @endif
-                                        </p>
-                                        {!! $asset->assignedTo->present()->glyph() . ' ' .$asset->assignedTo->present()->nameUrl() !!}
 
 
-                                        <ul class="list-unstyled" style="line-height: 25px;">
+                                            @if ((isset($asset->assignedTo->employee_num)) && ($asset->assignedTo->employee_num!=''))
+                                                <li>
+                                                    <x-icon type="employee_num" class="fa-fw"/>
+                                                    {{ $asset->assignedTo->employee_num }}
+                                                </li>
+                                            @endif
                                             @if ((isset($asset->assignedTo->email)) && ($asset->assignedTo->email!=''))
                                                 <li>
-                                                    <x-icon type="email" />
+                                                    <x-icon type="email" class="fa-fw" />
                                                     <a href="mailto:{{ $asset->assignedTo->email }}">{{ $asset->assignedTo->email }}</a>
                                                 </li>
                                             @endif
 
                                             @if ((isset($asset->assignedTo)) && ($asset->assignedTo->phone!=''))
                                                 <li>
-                                                    <x-icon type="phone" />
+                                                    <x-icon type="phone" class="fa-fw" />
                                                     <a href="tel:{{ $asset->assignedTo->phone }}">{{ $asset->assignedTo->phone }}</a>
                                                 </li>
                                             @endif
@@ -307,7 +321,7 @@
 
                                             @if (isset($asset->location))
                                                 <li>
-                                                    <x-icon type="locations" />
+                                                    <x-icon type="locations" class="fa-fw" />
                                                      {{ $asset->location->name }}</li>
                                                 <li>{{ $asset->location->address }}
                                                     @if ($asset->location->address2!='')
@@ -323,12 +337,12 @@
                                                 </li>
                                             @endif
                                             <li>
-                                                <x-icon type="calendar" />
+                                                <x-icon type="calendar" class="fa-fw" />
                                                 {{ trans('admin/hardware/form.checkout_date') }}: {{ Helper::getFormattedDateObject($asset->last_checkout, 'date', false) }}
                                             </li>
                                             @if (isset($asset->expected_checkin))
                                                 <li>
-                                                    <x-icon type="calendar" />
+                                                    <x-icon type="calendar" class="fa-fw" />
                                                     {{ trans('admin/hardware/form.expected_checkin') }}: {{ Helper::getFormattedDateObject($asset->expected_checkin, 'date', false) }}
                                                 </li>
                                             @endif
@@ -397,7 +411,7 @@
 
                                                 
                                                     <x-icon type="long-arrow-right" />
-                                                    {!!  $asset->assignedTo->present()->glyph()  !!}
+                                                    <x-icon type="{{ $asset->assignedType() }}" class="fa-fw" />
                                                     {!!  $asset->assignedTo->present()->nameUrl() !!}
                                                 @else
                                                     @if (($asset->assetstatus) && ($asset->assetstatus->deployable=='1'))


### PR DESCRIPTION
This went a little out of scope, but I think the changes are good. As we continue to build out the visual lexicon, I think these changes will matter. 

The initial change was just to add the employee ID to the asset "checked out to" section. 

In the future, I might make this a popout menu or user card to save space, but I'm okay with the solution I have here for now.

Note I did not include the glyph if it's checked out to user, since the `gravatar()` method already handles that.

<img width="591" alt="Screenshot 2024-08-31 at 1 39 28 PM" src="https://github.com/user-attachments/assets/b4c7c2ab-076d-430c-a901-72c148fa7b0c">

<img width="299" alt="Screenshot 2024-08-31 at 1 43 27 PM" src="https://github.com/user-attachments/assets/c10da492-dccf-4150-b604-2497f8682205">
