### PR TITLE
Return flat JSON instead of transformed data

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -765,9 +765,13 @@ class AssetsController extends Controller
             }
 
             if ($problems_updating_encrypted_custom_fields) {
-                return response()->json(Helper::formatStandardApiResponse('success', (new AssetsTransformer)->transformAsset($asset), trans('admin/hardware/message.update.encrypted_warning')));
+                return response()->json(Helper::formatStandardApiResponse('success', $asset, trans('admin/hardware/message.update.encrypted_warning')));
+                // Below is the *correct* return since it uses the transformer, but we have to use the old, flat return for now until we can update Jamf2Snipe and Kanji2Snipe
+                // return response()->json(Helper::formatStandardApiResponse('success', (new AssetsTransformer)->transformAsset($asset), trans('admin/hardware/message.update.encrypted_warning')));
             } else {
-                return response()->json(Helper::formatStandardApiResponse('success', (new AssetsTransformer)->transformAsset($asset), trans('admin/hardware/message.update.success')));
+                return response()->json(Helper::formatStandardApiResponse('success', $asset, trans('admin/hardware/message.update.success')));
+                // Below is the *correct* return since it uses the transformer, but we have to use the old, flat return for now until we can update Jamf2Snipe and Kanji2Snipe
+                /// return response()->json(Helper::formatStandardApiResponse('success', (new AssetsTransformer)->transformAsset($asset), trans('admin/hardware/message.update.success')));
             }
         }
         return response()->json(Helper::formatStandardApiResponse('error', null, $asset->getErrors()), 200);


### PR DESCRIPTION
In a previous PR, we updated the `update()` method of the API assets controller to use the standard asset payload return. This unfortunately broke some integrations with Kandji2Snipe and Jamf2Snipe, as those are expecting the old (incorrect) flat object shape. 

This is a temporary fix, as I think the API object return shape should conform with the way we return it everywhere else, but this should at least get people who use Kandji2Snipe and Jamf2Snipe back up and running.

Big thanks to @uberbrady, @ctsamuraix, @ParadoxGuitarist, and @mcarras8 for working through the issue with us. 

The longer term plan will be to correct those scripts to use the "right" API object return shape, and/or allow you to opt into using the new one if for some reason you can't update your own integrations. 

This should fix https://github.com/grokability/jamf2snipe/issues/134