### PR TITLE
Add Safety Around Bulk Status Update

### DIFF
--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -358,7 +358,11 @@ class BulkAssetsController extends Controller
                  * to someone/something.
                  */
                 if ($request->filled('status_id')) {
-                    $updated_status = Statuslabel::find($request->input('status_id'));
+                    try {
+                        $updated_status = Statuslabel::findOrFail($request->input('status_id'));
+                    } catch (ModelNotFoundException $e) {
+                        return redirect($bulk_back_url)->with('error', trans('admin/statuslabels/message.does_not_exist'));
+                    }
 
                     // We cannot assign a non-deployable status type if the asset is already assigned.
                     // This could probably be added to a form request.
@@ -366,7 +370,7 @@ class BulkAssetsController extends Controller
                     // Otherwise we need to make sure the status type is still a deployable one.
                     if (
                         ($asset->assigned_to == '')
-                        || ($updated_status->deployable == '1') && ($asset->assetstatus->deployable == '1')
+                        || ($updated_status->deployable == '1') && ($asset->assetstatus?->deployable == '1')
                     ) {
                         $this->update_array['status_id'] = $updated_status->id;
                     }


### PR DESCRIPTION
One of those "this should never happen but..."

Error was `Attempt to read property 'deployable' on null` - I wasn't able to recreate, but now there's a null safe on `$asset->assetstatus` so that'll evaluate to null rendering the condition false, and changed the `Statuslabel::find` to `findOrFail` so that can be caught and redirected if a bad `label_id` ends up in the request somehow. 