### PR TITLE
Fixed #16217: database config, added option to skip ssl on the database dump

### DIFF
--- a/.env.dev.docker
+++ b/.env.dev.docker
@@ -35,6 +35,7 @@ DB_USERNAME=snipeit
 DB_PASSWORD=changeme1234
 DB_PREFIX=null
 DB_DUMP_PATH='/usr/bin'
+DB_DUMP_SKIP_SSL=true
 DB_CHARSET=utf8mb4
 DB_COLLATION=utf8mb4_unicode_ci
 

--- a/.env.docker
+++ b/.env.docker
@@ -35,6 +35,7 @@ DB_PASSWORD=changeme1234
 MYSQL_ROOT_PASSWORD=changeme1234
 DB_PREFIX=null
 DB_DUMP_PATH='/usr/bin'
+DB_DUMP_SKIP_SSL=true
 DB_CHARSET=utf8mb4
 DB_COLLATION=utf8mb4_unicode_ci
 

--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,7 @@ DB_USERNAME=null
 DB_PASSWORD=null
 DB_PREFIX=null
 DB_DUMP_PATH='/usr/bin'
+DB_DUMP_SKIP_SSL=false
 DB_CHARSET=utf8mb4
 DB_COLLATION=utf8mb4_unicode_ci
 DB_SANITIZE_BY_DEFAULT=false

--- a/config/database.php
+++ b/config/database.php
@@ -81,6 +81,7 @@ return [
             'unix_socket' => env('DB_SOCKET', ''),
             'dump' => [
                 'dump_binary_path' => env('DB_DUMP_PATH', '/usr/local/bin'),  // only the path, so without 'mysqldump'
+                'skip_ssl' => env('DB_DUMP_SKIP_SSL', false),  // turn off SSL if not available
                 'use_single_transaction' => false,
                 'timeout' => 60 * 5, // 5 minute timeout
                 //'exclude_tables' => ['table1', 'table2'],


### PR DESCRIPTION
This PR adds the option `mysql.dump.skip_ssl` to the database config file `config/database.php`.

I was having the same issue as #16217. Manual backups and cron backups were failing with the error `TLS/SSL error: SSL is required`

![423266145-ae4db4ac-027d-440e-92de-74d0c4c8f8a1](https://github.com/user-attachments/assets/1d270f53-035b-4627-8875-627dec0d04bf)

Doing some digging on the `spatie/laravel-backup` repo, I found there is an option to skip SSL - [laravel-backup / docs / installation-and-setup.md](https://github.com/spatie/laravel-backup/blob/main/docs/installation-and-setup.md#skipssl-in-mysqlmariadb-database-connection)
