### PR TITLE
Fixes #16661: Empty signatures in print page

### DIFF
--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -147,8 +147,8 @@
                     <td>
                         {{ Helper::getFormattedDateObject($asset->last_checkout, 'datetime', false) }}</td>
                     <td>
-                        @if (($asset->assetlog->first()) && ($asset->assetlog->first()->accept_signature!=''))
-                            <img style="width:auto;height:100px;" src="{{ asset('/') }}display-sig/{{ $asset->assetlog->first()->accept_signature }}">
+                        @if (($asset->assetlog->firstWhere('action_type', 'accepted')) && ($asset->assetlog->firstWhere('action_type', 'accepted')->accept_signature!=''))
+                            <img style="width:auto;height:100px;" src="{{ asset('/') }}display-sig/{{ $asset->assetlog->firstWhere('action_type', 'accepted')->accept_signature }}">
                         @endif
                     </td>
                 </tr>
@@ -174,8 +174,8 @@
                             <td>
                                 {{ Helper::getFormattedDateObject($asset->last_checkout, 'datetime', false) }}</td>
                             <td>
-                                @if (($asset->assetlog->first()) && ($asset->assetlog->first()->accept_signature!=''))
-                                    <img style="width:auto;height:100px;" src="{{ asset('/') }}display-sig/{{ $asset->assetlog->first()->accept_signature }}">
+                                @if (($asset->assetlog->firstWhere('action_type', 'accepted')) && ($asset->assetlog->firstWhere('action_type', 'accepted')->accept_signature!=''))
+                                    <img style="width:auto;height:100px;" src="{{ asset('/') }}display-sig/{{ $asset->assetlog->firstWhere('action_type', 'accepted')->accept_signature }}">
                                 @endif
                             </td>
                         </tr>


### PR DESCRIPTION
Fixes #16661 

Assuming that whatever happens between the user accepting and signing for the asset and the print page being accessed isn't another user somehow signing for the same asset and it not being assigned to that second user.

Now hopefully targeting the right branch