### PR TITLE
Adds a check for assigned target not being null when creating an asset

### DIFF
--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -190,10 +190,10 @@ class AssetsController extends Controller
             if ($asset->isValid() && $asset->save()) {
                 if (request('assigned_user')) {
                     $target = User::find(request('assigned_user'));
-                    $location = $target->location_id ?? $target->rtd_location_id;
+                    $location = $target?->location_id;
                 } elseif (request('assigned_asset')) {
                     $target = Asset::find(request('assigned_asset'));
-                    $location = $target->location_id ?? $target->rtd_location_id;
+                    $location = $target?->location_id;
                 } elseif (request('assigned_location')) {
                     $target = Location::find(request('assigned_location'));
                     $location = $target->id;

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -190,7 +190,7 @@ class AssetsController extends Controller
             if ($asset->isValid() && $asset->save()) {
                 $target = null;
                 $location = null;
-                request()->merge(['assigned_asset' => -1]);
+
                 if ($userId = request('assigned_user')) {
                     $target = User::find($userId);
 

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -190,10 +190,10 @@ class AssetsController extends Controller
             if ($asset->isValid() && $asset->save()) {
                 if (request('assigned_user')) {
                     $target = User::find(request('assigned_user'));
-                    $location = $target->location_id;
+                    $location = $target->location_id ?? $target->rtd_location_id;
                 } elseif (request('assigned_asset')) {
                     $target = Asset::find(request('assigned_asset'));
-                    $location = $target->location_id;
+                    $location = $target->location_id ?? $target->rtd_location_id;
                 } elseif (request('assigned_location')) {
                     $target = Location::find(request('assigned_location'));
                     $location = $target->id;

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -188,14 +188,31 @@ class AssetsController extends Controller
 
             // Validate the asset before saving
             if ($asset->isValid() && $asset->save()) {
-                if (request('assigned_user')) {
-                    $target = User::find(request('assigned_user'));
-                    $location = $target?->location_id;
-                } elseif (request('assigned_asset')) {
-                    $target = Asset::find(request('assigned_asset'));
-                    $location = $target?->location_id;
-                } elseif (request('assigned_location')) {
-                    $target = Location::find(request('assigned_location'));
+                $target = null;
+                $location = null;
+
+                if ($userId = request('assigned_user')) {
+                    $target = User::find($userId);
+
+                    if (!$target) {
+                        return redirect()->back()->with('error', trans('admin/hardware/message.create.target_not_found.user'));
+                    }
+                    $location = $target->location_id;
+
+                } elseif ($assetId = request('assigned_asset')) {
+                    $target = Asset::find($assetId);
+
+                    if (!$target) {
+                        return redirect()->back()->with('error', trans('admin/hardware/message.create.target_not_found.asset'));
+                    }
+                    $location = $target->location_id;
+
+                } elseif ($locationId = request('assigned_location')) {
+                    $target = Location::find($locationId);
+
+                    if (!$target) {
+                        return redirect()->back()->with('error', trans('admin/hardware/message.create.target_not_found.location'));
+                    }
                     $location = $target->id;
                 }
 

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -190,12 +190,12 @@ class AssetsController extends Controller
             if ($asset->isValid() && $asset->save()) {
                 $target = null;
                 $location = null;
-
+                request()->merge(['assigned_asset' => -1]);
                 if ($userId = request('assigned_user')) {
                     $target = User::find($userId);
 
                     if (!$target) {
-                        return redirect()->back()->with('error', trans('admin/hardware/message.create.target_not_found.user'));
+                        return redirect()->back()->withInput()->with('error', trans('admin/hardware/message.create.target_not_found.user'));
                     }
                     $location = $target->location_id;
 
@@ -203,7 +203,7 @@ class AssetsController extends Controller
                     $target = Asset::find($assetId);
 
                     if (!$target) {
-                        return redirect()->back()->with('error', trans('admin/hardware/message.create.target_not_found.asset'));
+                        return redirect()->back()->withInput()->with('error', trans('admin/hardware/message.create.target_not_found.asset'));
                     }
                     $location = $target->location_id;
 
@@ -211,7 +211,7 @@ class AssetsController extends Controller
                     $target = Location::find($locationId);
 
                     if (!$target) {
-                        return redirect()->back()->with('error', trans('admin/hardware/message.create.target_not_found.location'));
+                        return redirect()->back()->withInput()->with('error', trans('admin/hardware/message.create.target_not_found.location'));
                     }
                     $location = $target->id;
                 }

--- a/resources/lang/en-US/admin/hardware/message.php
+++ b/resources/lang/en-US/admin/hardware/message.php
@@ -19,6 +19,11 @@ return [
         'success_linked' => 'Asset with tag :tag was created successfully. <strong><a href=":link" style="color: white;">Click here to view</a></strong>.',
         'multi_success_linked' => 'Asset with tag :links was created successfully.|:count assets were created succesfully. :links.',
         'partial_failure' => 'An asset was unable to be created. Reason: :failures|:count assets were unable to be created. Reasons: :failures',
+        'target_not_found' => [
+            'user' => 'The assigned user could not be found.',
+            'asset' => 'The assigned asset could not be found.',
+            'location' => 'The assigned location could not be found.',
+        ],
     ],
 
     'update' => [


### PR DESCRIPTION
This adds a `$target` check when assigning during creating an asset. It will now redirect back 
Returns a message of `The assigned user could not be found.`
<img width="1088" alt="image" src="https://github.com/user-attachments/assets/cf13df45-0153-41c3-b076-197fdb597645" />
also a similar error message for assigned asset and locations
