### PR TITLE
[Docker] Don't cache composer deps, remove any .git repos that creep in

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,7 +110,7 @@ COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 
 # Get dependencies
 USER docker
-RUN composer install --no-dev --working-dir=/var/www/html
+RUN COMPOSER_CACHE_DIR=/dev/null composer install --no-dev --working-dir=/var/www/html && rm -rf /var/www/html/vendor/*/*/.git
 USER root
 
 ############### APPLICATION INSTALL/INIT #################


### PR DESCRIPTION
There is a failure mode in composer where if it has a connection trying to get
a dependency tarball from the github API, it will fall-back to
downloading the entire repo for the dependency and use that... and it
will cache it outside of vendor/, using a whopping 1.5G of space

that full 1.5G is _then_ copied into vendor/

```
98M     league
100M	tecnickcom
133M	laravel
323M	sebastian
681M	aws
```

for a total of a 1.8G vendor/ directory

vs the trimmed-down version with a 552M vendor/ directory

```
53M	league
30M	tecnickcom
31M	laravel
70M	sebastian
241M	aws
```

This is still a far cry from the proper 150M version when everything
works as it should, but it's still a vast improvement

```
3.2M    league
14M     laravel
30M     tecnickcom
260K	sebastian
52M     aws
```

Ideally this never happens, but it'd be great tp avoid the bloat if/when
it does..

To wit: Our ARM/Ubuntu Docker images are currently bloated because of this
issue due builds happening on an emulated ARM environment, and the resultant
performance penalties causing composer issues

All that to say, this change sets OMPOSER_CACHE_DIR to /dev/null to
avoid the caching, and then removes `vendor/*/*/.git` to remove that
needless bloat if it occurs. It's a no-op in general practice.