### PR TITLE
Use x-icon blade component, nicer small-screen form size for datepicker on assets checkout

### DIFF
--- a/resources/views/accessories/checkin.blade.php
+++ b/resources/views/accessories/checkin.blade.php
@@ -63,7 +63,9 @@
                                     <div class="input-group col-md-5 required" style="padding-left: 0px;">
                                         <div class="input-group date" data-date-clear-btn="true" data-provide="datepicker" data-date-format="yyyy-mm-dd" data-date-end-date="0d" data-autoclose="true">
                                             <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="checkin_at" id="checkin_at" value="{{ old('checkin_at', date('Y-m-d')) }}">
-                                            <span class="input-group-addon"><i class="fas fa-calendar"></i></span>
+                                            <span class="input-group-addon">
+                                                <x-icon type="calendar" />
+                                            </span>
                                         </div>
                                         {!! $errors->first('checkin_at', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}
                                     </div>

--- a/resources/views/hardware/checkin.blade.php
+++ b/resources/views/hardware/checkin.blade.php
@@ -118,20 +118,21 @@
 
                                         <!-- Checkout/Checkin Date -->
                                         <div class="form-group{{ $errors->has('checkin_at') ? ' has-error' : '' }}">
-                                            <label for="checkin_at" class="col-sm-3 control-label">
+                                            <label for="checkin_at" class="col-sm-3 col-xs-12 col-sm-12 control-label">
                                                 {{ trans('admin/hardware/form.checkin_date') }}
                                             </label>
 
-                                            <div class="col-md-8">
-                                                <div class="input-group col-md-5 required">
+                                            <div class="col-md-8 col-xs-12 col-sm-12">
+                                                <div class="input-group col-xl-5 col-lg-5 col-md-7 col-sm-9 col-xs-12 required">
                                                     <div class="input-group date" data-provide="datepicker"
                                                          data-date-format="yyyy-mm-dd" data-autoclose="true">
                                                         <input type="text" class="form-control"
                                                                placeholder="{{ trans('general.select_date') }}"
                                                                name="checkin_at" id="checkin_at"
                                                                value="{{ old('checkin_at', date('Y-m-d')) }}">
-                                                        <span class="input-group-addon"><i class="fas fa-calendar"
-                                                                                           aria-hidden="true"></i></span>
+                                                        <span class="input-group-addon">
+                                                            <x-icon type="calendar" />
+                                                        </span>
                                                     </div>
                                                     {!! $errors->first('checkin_at', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                                                 </div>


### PR DESCRIPTION
This just adjusts the date picker form field size on the assets checkout and switches to using the icon blade component for the input group.