### PR TITLE
Better messaging when an asset fails validation on quick scan

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -1146,7 +1146,7 @@ class AssetsController extends Controller
 
             // Validate the rest of the data before we turn off the event dispatcher
             if ($asset->isInvalid()) {
-                return response()->json(Helper::formatStandardApiResponse('error', null,  $asset->getErrors()));
+                return response()->json(Helper::formatStandardApiResponse('error', ['asset_tag' => $asset->asset_tag],  $asset->getErrors()));
             }
 
 

--- a/resources/views/hardware/quickscan.blade.php
+++ b/resources/views/hardware/quickscan.blade.php
@@ -140,6 +140,7 @@
 
             var form = $("#audit-form").get(0);
             var formData = $('#audit-form').serializeArray();
+            var asset_tag = $('#asset_tag').val();
 
             $.ajax({
                 url: "{{ route('api.asset.audit.legacy') }}",
@@ -151,6 +152,7 @@
                 dataType : 'json',
                 data : formData,
                 success : function (data) {
+
                     if (data.status == 'success') {
                         $('#audited tbody').prepend("<tr class='success'><td>" + data.payload.asset_tag + "</td><td>" + data.messages + "</td><td><i class='fas fa-check text-success' style='font-size:18px;'></i></td></tr>");
 
@@ -161,12 +163,12 @@
 
                         incrementOnSuccess();
                     } else {
-                        handleAuditFail(data);
+                        handleAuditFail(data, asset_tag);
                     }
                     $('input#asset_tag').val('');
                 },
                 error: function (data) {
-                    handleAuditFail(data);
+                    handleAuditFail(data, asset_tag);
                 },
                 complete: function() {
                     $('#audit-loader').hide();
@@ -177,22 +179,29 @@
             return false;
         });
 
-        function handleAuditFail (data) {
+        function handleAuditFail (data, asset_tag) {
             @if ($user->enable_sounds)
             var audio = new Audio('{{ config('app.url') }}/sounds/error.mp3');
             audio.play()
             @endif
-            if (data.asset_tag) {
-                var asset_tag = data.asset_tag;
-            } else {
-                var asset_tag = '';
+
+
+            if ((!asset_tag) && (data.payload)  && (data.payload.asset_tag)) {
+                asset_tag = data.payload.asset_tag;
             }
-            if (data.messages) {
-                var messages = data.messages;
-            } else {
-                var messages = '';
+
+            asset_tag = jQuery('<span>' + asset_tag + '</span>').text();
+
+            let messages = "";
+
+            // Loop through the error messages
+            if ((data.messages)  && (data.messages)) {
+                for (let x in data.messages) {
+                    messages += data.messages[x];
+                }
             }
-            $('#audited tbody').prepend("<tr class='danger'><td>" + data.payload.asset_tag + "</td><td>" + messages + "</td><td><i class='fas fa-times text-danger' style='font-size:18px;'></i></td></tr>");
+
+            $('#audited tbody').prepend("<tr class='danger'><td>" + asset_tag + "</td><td>" + messages + "</td><td><i class='fas fa-times text-danger' style='font-size:18px;'></i></td></tr>");
         }
 
         function incrementOnSuccess() {


### PR DESCRIPTION
This gives better validation feedback when an asset being audited fails validation further up via route model binding.

<img width="2386" alt="Screenshot 2025-05-26 at 1 15 08 PM" src="https://github.com/user-attachments/assets/812532e3-9bc9-42a7-bb28-232e1439aaff" />
