### PR TITLE
Ensure boolean returned from method with boolean return type

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -963,6 +963,7 @@ class Asset extends Depreciable
             return $this->model->category->require_acceptance;
         }
 
+        return false;
     }
 
 


### PR DESCRIPTION
This PR ensures a boolean is returned from the `requireAcceptance` method on the `Asset` model to avoid potentially returning null.