### PR TITLE
Replace customfield_elements form macro take two

### DIFF
--- a/resources/lang/en-US/admin/custom_fields/general.php
+++ b/resources/lang/en-US/admin/custom_fields/general.php
@@ -60,5 +60,11 @@ return [
     'display_checkin' => 'Display in checkin forms',
     'display_checkout' => 'Display in checkout forms',
     'display_audit' => 'Display in audit forms',
-
+    'types' => [
+        'text' => 'Text Box',
+        'listbox' => 'List Box',
+        'textarea' => 'Textarea (multi-line)',
+        'checkbox' => 'Checkbox',
+        'radio' => 'Radio Buttons',
+    ],
 ];

--- a/resources/macros/macros.php
+++ b/resources/macros/macros.php
@@ -219,22 +219,3 @@ Form::macro('username_format', function ($name = 'username_format', $selected = 
 
     return $select;
 });
-
-Form::macro('customfield_elements', function ($name = 'customfield_elements', $selected = null, $class = null) {
-    $formats = [
-        'text' => 'Text Box',
-        'listbox' => 'List Box',
-        'textarea' => 'Textarea (multi-line) ',
-        'checkbox' => 'Checkbox',
-        'radio' => 'Radio Buttons',
-    ];
-
-    $select = '<select name="'.$name.'" class="'.$class.'" style="width: 100%" aria-label="'.$name.'">';
-    foreach ($formats as $format => $label) {
-        $select .= '<option value="'.$format.'"'.($selected == $format ? ' selected="selected" role="option" aria-selected="true"' : ' aria-selected="false"').'>'.$label.'</option> '."\n";
-    }
-
-    $select .= '</select>';
-
-    return $select;
-});

--- a/resources/views/custom_fields/fields/edit.blade.php
+++ b/resources/views/custom_fields/fields/edit.blade.php
@@ -64,11 +64,11 @@
                 class="field_element"
                 style="width: 100%;"
                 :options="[
-                    'text' => 'Text Box',
-                    'listbox' => 'List Box',
-                    'textarea' => 'Textarea (multi-line) ',
-                    'checkbox' => 'Checkbox',
-                    'radio' => 'Radio Buttons',
+                    'text' => trans('admin/custom_fields/general.types.text'),
+                    'listbox' => trans('admin/custom_fields/general.types.listbox'),
+                    'textarea' => trans('admin/custom_fields/general.types.textarea'),
+                    'checkbox' => trans('admin/custom_fields/general.types.checkbox'),
+                    'radio' => trans('admin/custom_fields/general.types.radio'),
                 ]"
             />
             {!! $errors->first('element', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}

--- a/resources/views/custom_fields/fields/edit.blade.php
+++ b/resources/views/custom_fields/fields/edit.blade.php
@@ -58,7 +58,19 @@
             </label>
             <div class="col-md-8 required">
 
-            {!! Form::customfield_elements('element', old('element', $field->element), 'field_element select2 form-control') !!}
+            <x-input.select
+                name="element"
+                :selected="old('element', $field->element)"
+                class="field_element"
+                style="width: 100%;"
+                :options="[
+                    'text' => 'Text Box',
+                    'listbox' => 'List Box',
+                    'textarea' => 'Textarea (multi-line) ',
+                    'checkbox' => 'Checkbox',
+                    'radio' => 'Radio Buttons',
+                ]"
+            />
             {!! $errors->first('element', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
 
             </div>


### PR DESCRIPTION
This PR removes the `customfield_elements` form macro and inlines it in the custom fields create/edit page.

![image](https://github.com/user-attachments/assets/22967ffc-7b38-4204-bf54-6c996d3f2ac9)

---

I also extracted translation strings for the options.

---

Replaces #17011