### PR TITLE
Fixes #17051 - Nulling Custom Fields In Bulk Asset Updates

### DIFF
--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -201,7 +201,6 @@ class BulkAssetsController extends Controller
      */
     public function update(Request $request) : RedirectResponse
     {
-        //dd($request->all());
         $this->authorize('update', Asset::class);
         $has_errors = 0;
         $error_array = array();
@@ -296,7 +295,6 @@ class BulkAssetsController extends Controller
                         $this->conditionallyAddItem($custom_field_column); 
                    }
                 foreach ($custom_fields_to_null as $key => $custom_field_to_null) {
-                    //dd($key);
                     $this->conditionallyAddItem($key);
                 }
 

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -214,15 +214,16 @@ class BulkAssetsController extends Controller
         }
 
        $custom_field_columns = CustomField::all()->pluck('db_column')->toArray();
-        // find input attirubtes that start with 'null_'
-        $temp_custom_fields_to_null = array_filter($request->all(), function ($key) {
+
+        // find custom field input attributes that start with 'null_'
+        $null_custom_fields_inputs = array_filter($request->all(), function ($key) {
             // filter out all keys that start with 'null_'
             return (strpos($key, 'null_') === 0);
         }, ARRAY_FILTER_USE_KEY);;
-        // remove 'null_' from the keys
+        // remove 'null' from the keys
         $custom_fields_to_null = [];
-        foreach ($temp_custom_fields_to_null as $key => $value) {
-            $custom_fields_to_null[str_replace('null_', '', $key)] = $value;
+        foreach ($null_custom_fields_inputs as $key => $value) {
+            $custom_fields_to_null[str_replace('null', '', $key)] = $value;
         }
 
 
@@ -267,7 +268,7 @@ class BulkAssetsController extends Controller
             || ($request->filled('null_next_audit_date'))
             || ($request->filled('null_asset_eol_date'))
             || ($request->anyFilled($custom_field_columns))
-            || ($request->anyFilled(array_keys($custom_fields_to_null)))
+            || ($request->anyFilled(array_keys($null_custom_fields_inputs)))
 
         ) {
             // Let's loop through those assets and build an update array
@@ -295,7 +296,7 @@ class BulkAssetsController extends Controller
                         $this->conditionallyAddItem($custom_field_column); 
                    }
                 foreach ($custom_fields_to_null as $key => $custom_field_to_null) {
-
+                    //dd($key);
                     $this->conditionallyAddItem($key);
                 }
 
@@ -450,6 +451,15 @@ class BulkAssetsController extends Controller
                 // Does the model have a fieldset?
                 if ($asset->model->fieldset) {
                     foreach ($asset->model->fieldset->fields as $field) {
+
+                        // null custom fields
+                        if ($custom_fields_to_null) {
+                            foreach ($custom_fields_to_null as $key => $custom_field_to_null) {
+                                if ($field->db_column == $key) {
+                                    $this->update_array[$field->db_column] = null;
+                                }
+                            }
+                        }
 
                         if ((array_key_exists($field->db_column, $this->update_array)) && ($field->field_encrypted == '1')) {
                             if (Gate::allows('admin')) {

--- a/resources/views/models/custom_fields_form_bulk_edit.blade.php
+++ b/resources/views/models/custom_fields_form_bulk_edit.blade.php
@@ -30,6 +30,12 @@
                       :selected="old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id)))"
                       class="format form-control"
                   />
+                  <div class="col-md-5">
+                      <label class="form-control">
+                          <input type="checkbox" name="null_asset_eol_date" value="1">
+                          {{ trans_choice('general.set_to_null', count($assets),['selection_count' => count($assets)]) }}
+                      </label>
+                  </div>
 
               @elseif ($field->element=='textarea')
                 @if($field->is_unique)
@@ -37,7 +43,7 @@
                 @endif
                 @if(!$field->is_unique) 
                     <textarea class="col-md-6 form-control" id="{{ $field->db_column_name() }}" name="{{ $field->db_column_name() }}">{{ old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id))) }}</textarea>
-                @endif 
+                    @endif
               @elseif ($field->element=='checkbox')
                     <!-- Checkboxes -->
                   @foreach ($field->formatFieldValuesAsArray() as $key => $value)
@@ -45,7 +51,6 @@
                           <input type="checkbox" value="{{ $value }}" name="{{ $field->db_column_name() }}[]" {{  isset($item) ? (in_array($value, array_map('trim', explode(',', $item->{$field->db_column_name()}))) ? ' checked="checked"' : '') : (old($field->db_column_name()) != '' ? ' checked="checked"' : (in_array($key, array_map('trim', explode(',', $field->defaultValue($model->id)))) ? ' checked="checked"' : '')) }}>
                           {{ $value }}
                       </label>
-
                   @endforeach
             @elseif ($field->element=='radio')
             @foreach ($field->formatFieldValuesAsArray() as $value)
@@ -115,8 +120,14 @@
         </div>
         @endif
 
-
+        <div class="col-md-5">
+            <label class="form-control">
+                <input type="checkbox" name="{{ 'null_'.$field->db_column_name() }}" value="1">
+                {{ trans_choice('general.set_to_null', count($assets),['selection_count' => count($assets)]) }}
+            </label>
+        </div>
     </div>
-  @endforeach
+
+    @endforeach
 @endif
  @endforeach 

--- a/resources/views/models/custom_fields_form_bulk_edit.blade.php
+++ b/resources/views/models/custom_fields_form_bulk_edit.blade.php
@@ -122,7 +122,7 @@
 
         <div class="col-md-5">
             <label class="form-control">
-                <input type="checkbox" name="{{ 'null_'.$field->db_column_name() }}" value="1">
+                <input type="checkbox" name="{{ 'null'.$field->db_column_name() }}" value="1">
                 {{ trans_choice('general.set_to_null', count($assets),['selection_count' => count($assets)]) }}
             </label>
         </div>

--- a/tests/Feature/Assets/Ui/BulkEditAssetsTest.php
+++ b/tests/Feature/Assets/Ui/BulkEditAssetsTest.php
@@ -197,6 +197,47 @@ class BulkEditAssetsTest extends TestCase
         });
     }
 
+    public function testBulkEditAssetsNullsCustomFieldsIfSelected()
+    {
+        $this->markIncompleteIfMySQL('Custom Fields tests do not work on MySQL');
+
+        CustomField::factory()->ram()->create();
+        CustomField::factory()->cpu()->create();
+        CustomField::factory()->phone()->create();
+
+        // when getting the custom field directly from the factory the field has not been fully created yet
+        // so we have to do a query afterwards to get the actual model :shrug:
+
+        $ram = CustomField::where('name', 'RAM')->first();
+        $cpu = CustomField::where('name', 'CPU')->first();
+        $phone = CustomField::where('name', 'Phone Number')->first();
+
+        $assets = Asset::factory()->count(10)->hasMultipleCustomFields([$ram, $cpu])->create([
+            $ram->db_column => 8,
+            $cpu->db_column => '2.1',
+        ]);
+
+        $id_array = $assets->pluck('id')->toArray();
+
+        $this->actingAs(User::factory()->editAssets()->create())->post(route('hardware/bulksave'), [
+            'ids'                    => $id_array,
+            $ram->db_column          => 16,
+            $cpu->db_column          => '4.1',
+            'null'.$phone->db_column => '8304997586',
+        ])->assertStatus(302);
+
+        $this->actingAs(User::factory()->editAssets()->create())->post(route('hardware/bulksave'), [
+            'ids'                  => $id_array,
+            null.$phone->db_column => 1,
+        ]);
+
+        Asset::findMany($id_array)->each(function (Asset $asset) use ($ram, $cpu, $phone) {
+            $this->assertEquals(16, $asset->{$ram->db_column});
+            $this->assertEquals('4.1', $asset->{$cpu->db_column});
+            $this->assertEquals(null, $asset->{$phone->db_column});
+        });
+    }
+
     public function testBulkEditAssetsAcceptsAndUpdatesEncryptedCustomFields()
     {
         $this->markIncompleteIfMySQL('Custom Fields tests do not work on MySQL');


### PR DESCRIPTION
Pretty much what's on the tin, adds a checkbox to custom fields to allow nulling them like the rest of the fields when doing a bulk edit. 

Fixes #[17051](https://github.com/grokability/snipe-it/issues/17051)