### PR TITLE
Fixed #16205 - Add an index to deleted_at for those with many deleted action_logs

### DIFF
--- a/database/migrations/2025_06_04_101736_add_deleted_at_index_to_action_logs.php
+++ b/database/migrations/2025_06_04_101736_add_deleted_at_index_to_action_logs.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('action_logs', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('action_logs', function (Blueprint $table) {
+            $table->dropIndex('deleted_at');
+        });
+    }
+};


### PR DESCRIPTION
This seems pretty safe, and it seemed to help at least one user.