### PR TITLE
Fixed #17117 - use translation for “site default”

### DIFF
--- a/resources/views/blade/input/skin.blade.php
+++ b/resources/views/blade/input/skin.blade.php
@@ -25,7 +25,7 @@
     ];
 
     if ($includeBlankOption) {
-        $formats = ['' => 'Site Default'] + $formats;
+        $formats = ['' => trans('general.skins.site_default')] + $formats;
     }
 @endphp
 


### PR DESCRIPTION
This fixes the skin blade to use the translation for "Site default"