### PR TITLE
Docker: harden updating of `php.ini` in entrypoint

### DIFF
--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -100,13 +100,13 @@ chown -R docker:root /var/www/html/storage/framework/cache
 # Fix php settings
 if [ -v "PHP_UPLOAD_LIMIT" ]
 then
-  PHP_INI_FILE=$(find /etc/php/*/apache2/php.ini)
-  if [ -e $PHP_INI_FILE ]
-  then
-    echo "Changing upload limit to ${PHP_UPLOAD_LIMIT}M in ${PHP_INI_FILE}"
-    sed -i "s/^upload_max_filesize.*/upload_max_filesize = ${PHP_UPLOAD_LIMIT}M/" $PHP_INI_FILE
-    sed -i "s/^post_max_size.*/post_max_size = ${PHP_UPLOAD_LIMIT}M/" $PHP_INI_FILE
-  fi
+    find /etc/php -type f -name php.ini | while IFS= read -r ini; do
+        echo "Changing upload limit to ${PHP_UPLOAD_LIMIT}M in $ini"
+        sed -i \
+            -e "s/^;\? *upload_max_filesize *=.*/upload_max_filesize = ${PHP_UPLOAD_LIMIT}M/" \
+            -e "s/^;\? *post_max_size *=.*/post_max_size = ${PHP_UPLOAD_LIMIT}M/" \
+            "$ini"
+    done
 fi
 
 # If the Oauth DB files are not present copy the vendor files over to the db migrations

--- a/docker/startup_alpine.sh
+++ b/docker/startup_alpine.sh
@@ -84,9 +84,13 @@ chown -R apache:root /var/www/html/storage/framework/cache
 # Fix php settings
 if [ ! -z "${PHP_UPLOAD_LIMIT}" ]
 then
-    echo "Changing upload limit to ${PHP_UPLOAD_LIMIT}"
-    sed -i "s/^upload_max_filesize.*/upload_max_filesize = ${PHP_UPLOAD_LIMIT}M/" /etc/php*/php.ini
-    sed -i "s/^post_max_size.*/post_max_size = ${PHP_UPLOAD_LIMIT}M/" /etc/php*/php.ini
+    find /etc -type f -name php.ini | while IFS= read -r ini; do
+        echo "Changing upload limit to ${PHP_UPLOAD_LIMIT}M in $ini"
+        sed -i \
+            -e "s/^;\? *upload_max_filesize *=.*/upload_max_filesize = ${PHP_UPLOAD_LIMIT}M/" \
+            -e "s/^;\? *post_max_size *=.*/post_max_size = ${PHP_UPLOAD_LIMIT}M/" \
+            "$ini"
+    done
 fi
 
 # If the Oauth DB files are not present copy the vendor files over to the db migrations


### PR DESCRIPTION
The Docker entrypoint scripts set values for the `upload_max_filesize` and `post_max_size` directives in `php.ini` based on the value of the `PHP_UPLOAD_LIMIT` environment variable, subject to the following restrictions:

* Exactly one file matches `/etc/php/*/apache2/php.ini` (on Ubuntu) or `/etc/php*/php.ini` (on Alpine) - if, for example, more than one PHP package is installed in the base image, `PHP_UPLOAD_LIMIT` will not be honoured.
* The `php.ini` file already sets a non-default value for the `upload_max_filesize` or `post_max_size` directives - this is currently the case for the configurations inherited from upstream, but is not guaranteed. If the default values are relied upon, `PHP_UPLOAD_LIMIT` will silently not be honoured (although the script output will claim that it is).

Iterate over the lines outputted by `file(1)` so `PHP_UPLOAD_LIMIT` is honoured in all available `php.ini` files, and set `upload_max_filesize` and `post_max_size` regardless of whether they already have a value set.