### PR TITLE
Add logic around menu options

### DIFF
--- a/resources/views/partials/asset-bulk-actions.blade.php
+++ b/resources/views/partials/asset-bulk-actions.blade.php
@@ -17,21 +17,28 @@
         </span>
     </label>
     <select name="bulk_actions" class="form-control select2" aria-label="bulk_actions" style="min-width: 350px;">
-        @if((isset($status)) && ($status == 'Deleted'))
+        @if ((isset($status)) && ($status == 'Deleted'))
             @can('delete', \App\Models\Asset::class)
                 <option value="restore">{{trans('button.restore')}}</option>
             @endcan
         @else
+
             @can('update', \App\Models\Asset::class)
                 <option value="edit">{{ trans('button.edit') }}</option>
                 <option value="maintenance">{{ trans('button.add_maintenance') }}</option>
             @endcan
-            @can('checkout', \App\Models\Asset::class)
-                <option value="checkout">{{ trans('general.bulk_checkout') }}</option>
-            @endcan
-            @can('delete', \App\Models\Asset::class)
-                <option value="delete">{{ trans('button.delete') }}</option>
-            @endcan
+
+            @if((isset($status)) && (($status != 'Deployed') && ($status != 'Archived') && ($status != 'Deleted')))
+                @can('checkout', \App\Models\Asset::class)
+                    <option value="checkout">{{ trans('general.bulk_checkout') }}</option>
+                @endcan
+            @endif
+
+            @if ((isset($status) && ($status != 'Deleted')))
+                @can('delete', \App\Models\Asset::class)
+                    <option value="delete">{{ trans('button.delete') }}</option>
+                @endcan
+            @endif
             <option value="labels" {{$snipeSettings->shortcuts_enabled == 1 ? "accesskey=l" : ''}}>{{ trans_choice('button.generate_labels', 2) }}</option>
         @endif
     </select>


### PR DESCRIPTION
This PR just makes the bulk dropdown options make a little more sense if we're looking at a specific view. For example, we wouldn't want to show you a checkout option for archived or deleted assets. 