### PR TITLE
Fixes #17302 - Tighter control on company

### DIFF
--- a/app/Http/Controllers/Api/CompaniesController.php
+++ b/app/Http/Controllers/Api/CompaniesController.php
@@ -43,7 +43,9 @@ class CompaniesController extends Controller
 
         $companies = Company::withCount(['assets as assets_count'  => function ($query) {
             $query->AssetsForShow();
-        }])->withCount('licenses as licenses_count', 'accessories as accessories_count', 'consumables as consumables_count', 'components as components_count', 'users as users_count');
+        }])
+            ->with('adminuser')
+            ->withCount('licenses as licenses_count', 'accessories as accessories_count', 'consumables as consumables_count', 'components as components_count', 'users as users_count');
 
 
         if ($request->filled('search')) {

--- a/app/Http/Controllers/Api/CompaniesController.php
+++ b/app/Http/Controllers/Api/CompaniesController.php
@@ -45,6 +45,8 @@ class CompaniesController extends Controller
             $query->AssetsForShow();
         }])->withCount('licenses as licenses_count', 'accessories as accessories_count', 'consumables as consumables_count', 'components as components_count', 'users as users_count');
 
+        $companies = Company::scopeCompanyables($companies, 'id', 'companies');
+
         if ($request->filled('search')) {
             $companies->TextSearch($request->input('search'));
         }
@@ -119,6 +121,8 @@ class CompaniesController extends Controller
     {
         $this->authorize('view', Company::class);
         $company = Company::findOrFail($id);
+        $this->authorize('view', $company);
+        $company = Company::scopeCompanyables($company, 'id', 'companies');
         return (new CompaniesTransformer)->transformCompany($company);
 
     }
@@ -136,6 +140,8 @@ class CompaniesController extends Controller
     {
         $this->authorize('update', Company::class);
         $company = Company::findOrFail($id);
+        $this->authorize('update', $company);
+        $company = Company::scopeCompanyables($company, 'id', 'companies');
         $company->fill($request->all());
         $company = $request->handleImages($company);
 
@@ -159,6 +165,7 @@ class CompaniesController extends Controller
     {
         $this->authorize('delete', Company::class);
         $company = Company::findOrFail($id);
+        $company = Company::scopeCompanyables($company, 'id', 'companies');
         $this->authorize('delete', $company);
 
         if (! $company->isDeletable()) {
@@ -187,6 +194,8 @@ class CompaniesController extends Controller
             'companies.email',
             'companies.image',
         ]);
+
+        $companies = Company::scopeCompanyables($companies, 'id', 'companies');
 
         if ($request->filled('search')) {
             $companies = $companies->where('companies.name', 'LIKE', '%'.$request->get('search').'%');

--- a/app/Http/Controllers/Api/CompaniesController.php
+++ b/app/Http/Controllers/Api/CompaniesController.php
@@ -45,7 +45,6 @@ class CompaniesController extends Controller
             $query->AssetsForShow();
         }])->withCount('licenses as licenses_count', 'accessories as accessories_count', 'consumables as consumables_count', 'components as components_count', 'users as users_count');
 
-        $companies = Company::scopeCompanyables($companies, 'id', 'companies');
 
         if ($request->filled('search')) {
             $companies->TextSearch($request->input('search'));
@@ -122,7 +121,6 @@ class CompaniesController extends Controller
         $this->authorize('view', Company::class);
         $company = Company::findOrFail($id);
         $this->authorize('view', $company);
-        $company = Company::scopeCompanyables($company, 'id', 'companies');
         return (new CompaniesTransformer)->transformCompany($company);
 
     }
@@ -141,7 +139,6 @@ class CompaniesController extends Controller
         $this->authorize('update', Company::class);
         $company = Company::findOrFail($id);
         $this->authorize('update', $company);
-        $company = Company::scopeCompanyables($company, 'id', 'companies');
         $company->fill($request->all());
         $company = $request->handleImages($company);
 
@@ -165,7 +162,6 @@ class CompaniesController extends Controller
     {
         $this->authorize('delete', Company::class);
         $company = Company::findOrFail($id);
-        $company = Company::scopeCompanyables($company, 'id', 'companies');
         $this->authorize('delete', $company);
 
         if (! $company->isDeletable()) {
@@ -195,7 +191,6 @@ class CompaniesController extends Controller
             'companies.image',
         ]);
 
-        $companies = Company::scopeCompanyables($companies, 'id', 'companies');
 
         if ($request->filled('search')) {
             $companies = $companies->where('companies.name', 'LIKE', '%'.$request->get('search').'%');

--- a/app/Http/Controllers/CompaniesController.php
+++ b/app/Http/Controllers/CompaniesController.php
@@ -83,8 +83,6 @@ final class CompaniesController extends Controller
     public function edit(Company $company) : View | RedirectResponse
     {
         $this->authorize('update', $company);
-        Company::isCurrentUserHasAccess($company);
-        // $company = Company::scopeCompanyables($company, 'id', 'companies');
         return view('companies/edit')->with('item', $company);
     }
 

--- a/app/Http/Controllers/CompaniesController.php
+++ b/app/Http/Controllers/CompaniesController.php
@@ -83,6 +83,8 @@ final class CompaniesController extends Controller
     public function edit(Company $company) : View | RedirectResponse
     {
         $this->authorize('update', $company);
+        Company::isCurrentUserHasAccess($company);
+        // $company = Company::scopeCompanyables($company, 'id', 'companies');
         return view('companies/edit')->with('item', $company);
     }
 
@@ -98,6 +100,7 @@ final class CompaniesController extends Controller
     {
 
         $this->authorize('update', $company);
+        $company = Company::scopeCompanyables($company, 'id', 'companies');
         $company->name = $request->input('name');
         $company->phone = $request->input('phone');
         $company->fax = $request->input('fax');
@@ -123,10 +126,13 @@ final class CompaniesController extends Controller
      */
     public function destroy($companyId) : RedirectResponse
     {
+
         if (is_null($company = Company::find($companyId))) {
             return redirect()->route('companies.index')
                 ->with('error', trans('admin/companies/message.not_found'));
         }
+
+        $company = Company::scopeCompanyables($company, 'id', 'companies');
 
         $this->authorize('delete', $company);
         if (! $company->isDeletable()) {

--- a/app/Http/Controllers/CompaniesController.php
+++ b/app/Http/Controllers/CompaniesController.php
@@ -100,7 +100,6 @@ final class CompaniesController extends Controller
     {
 
         $this->authorize('update', $company);
-        $company = Company::scopeCompanyables($company, 'id', 'companies');
         $company->name = $request->input('name');
         $company->phone = $request->input('phone');
         $company->fax = $request->input('fax');
@@ -132,7 +131,6 @@ final class CompaniesController extends Controller
                 ->with('error', trans('admin/companies/message.not_found'));
         }
 
-        $company = Company::scopeCompanyables($company, 'id', 'companies');
 
         $this->authorize('delete', $company);
         if (! $company->isDeletable()) {

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -18,6 +18,8 @@ use Illuminate\Support\Facades\Schema;
 final class Company extends SnipeModel
 {
     use HasFactory;
+    use CompanyableTrait;
+
 
     protected $table = 'companies';
 
@@ -146,10 +148,10 @@ final class Company extends SnipeModel
         if (!is_string($companyable)) {
             $company_table = $companyable->getModel()->getTable();
             try {
-                // This is primary for the gate:allows-check in location->isDeletable()
+                // This is primarily for the gate:allows-check in location->isDeletable()
                 // Locations don't have a company_id so without this it isn't possible to delete locations with FullMultipleCompanySupport enabled
                 // because this function is called by SnipePermissionsPolicy->before()
-                if (!$companyable instanceof Company && !Schema::hasColumn($company_table, 'company_id')) {
+                if (!Schema::hasColumn($company_table, 'company_id')) {
                     return true;
                 }
 
@@ -163,8 +165,18 @@ final class Company extends SnipeModel
             // Log::warning('Companyable is '.$companyable);
             $current_user_company_id = auth()->user()->company_id;
             $companyable_company_id = $companyable->company_id;
-            return $current_user_company_id == null || $current_user_company_id == $companyable_company_id || auth()->user()->isSuperUser();
+
+            // Set this to check companyable on company
+            if ($companyable instanceof Company) {
+                \Log::error('This is a company!');
+                $companyable_company_id = $companyable->id;
+                \Log::error('Companyable object ID: '.$companyable_company_id);
+                \Log::error('User company ID: '.$current_user_company_id);
+            }
+            return ($current_user_company_id == null) || ($current_user_company_id == $companyable_company_id) || auth()->user()->isSuperUser();
         }
+
+        return false;
 
     }
 

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -275,7 +275,7 @@ final class Company extends SnipeModel
      */
     public static function scopeCompanyables($query, $column = 'company_id', $table_name = null)
     {
-        // If not logged in and hitting this, assume we are on the command line and don't scope?'
+        // If not logged in and hitting this, assume we are on the command line and don't scope?
         if (! static::isFullMultipleCompanySupportEnabled() || (Auth::hasUser() && auth()->user()->isSuperUser()) || (! Auth::hasUser())) {
             return $query;
         } else {
@@ -292,11 +292,16 @@ final class Company extends SnipeModel
     private static function scopeCompanyablesDirectly($query, $column = 'company_id', $table_name = null)
     {
 
+        $company_id = null;
         // Get the company ID of the logged-in user, or set it to null if there is no company associated with the user
         if (Auth::hasUser()) {
             $company_id = auth()->user()->company_id;
-        } else {
-            $company_id = null;
+        }
+
+
+        // If we are scoping the companies table itself, look for the company.id
+        if ($query->getModel()->getTable() == 'companies') {
+            return $query->where('companies.id', '=', $company_id);
         }
 
 
@@ -308,6 +313,8 @@ final class Company extends SnipeModel
 
             return $query->where($table.$column, '=', $company_id);
         }
+
+
 
     }
 
@@ -336,7 +343,6 @@ final class Company extends SnipeModel
             return $query;
         } else {
             $f = function ($q) {
-                Log::debug('scopeCompanyablesDirectly firing ');
                 static::scopeCompanyablesDirectly($q);
             };
 

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -168,10 +168,7 @@ final class Company extends SnipeModel
 
             // Set this to check companyable on company
             if ($companyable instanceof Company) {
-                \Log::error('This is a company!');
                 $companyable_company_id = $companyable->id;
-                \Log::error('Companyable object ID: '.$companyable_company_id);
-                \Log::error('User company ID: '.$current_user_company_id);
             }
             return ($current_user_company_id == null) || ($current_user_company_id == $companyable_company_id) || auth()->user()->isSuperUser();
         }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -249,7 +249,7 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
 
 
     /**
-     * Checks if the can edit their own profile
+     * Checks if the user can edit their own profile
      *
      * @author A. Gianotto <snipe@snipe.net>
      * @since [v6.3.4]

--- a/app/Policies/CompanyPolicy.php
+++ b/app/Policies/CompanyPolicy.php
@@ -2,13 +2,11 @@
 
 namespace App\Policies;
 
-use App\Models\Setting;
-
 class CompanyPolicy extends SnipePermissionsPolicy
 {
     protected function columnName()
     {
         return 'companies';
     }
-    
+
 }

--- a/app/Policies/CompanyPolicy.php
+++ b/app/Policies/CompanyPolicy.php
@@ -10,12 +10,5 @@ class CompanyPolicy extends SnipePermissionsPolicy
     {
         return 'companies';
     }
-
-    public function canEditThisCompany($company_id = null) {
-        if ((Setting::getSettings()->scope_locations_fmcs) && ($this->company_id == $company_id)){
-            return true;
-        }
-
-        return false;
-    }
+    
 }

--- a/app/Policies/CompanyPolicy.php
+++ b/app/Policies/CompanyPolicy.php
@@ -2,10 +2,20 @@
 
 namespace App\Policies;
 
+use App\Models\Setting;
+
 class CompanyPolicy extends SnipePermissionsPolicy
 {
     protected function columnName()
     {
         return 'companies';
+    }
+
+    public function canEditThisCompany($company_id = null) {
+        if ((Setting::getSettings()->scope_locations_fmcs) && ($this->company_id == $company_id)){
+            return true;
+        }
+
+        return false;
     }
 }

--- a/app/Policies/SnipePermissionsPolicy.php
+++ b/app/Policies/SnipePermissionsPolicy.php
@@ -53,7 +53,7 @@ abstract class SnipePermissionsPolicy
         }
 
         /**
-         * If we got here by $this→authorize('something', $actualModel) then we can continue on Il but if we got here
+         * If we got here by $this→authorize('something', $actualModel) then we can continue on, but if we got here
          * via $this→authorize('something', Model::class) then calling Company:: isCurrentUserHasAccess($item) gets weird.
          * Bail out here by returning "nothing" and allow the relevant method lower in this class to be called and handle authorization.
          */

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -285,6 +285,11 @@ class UserFactory extends Factory
         return $this->appendPermission(['components.checkout' => '1']);
     }
 
+    public function viewCompanies()
+    {
+        return $this->appendPermission(['companies.view' => '1']);
+    }
+
     public function createCompanies()
     {
         return $this->appendPermission(['companies.create' => '1']);

--- a/tests/Feature/Categories/Api/IndexCategoriesTest.php
+++ b/tests/Feature/Categories/Api/IndexCategoriesTest.php
@@ -13,7 +13,7 @@ class IndexCategoriesTest extends TestCase
     public function testViewingCategoryIndexRequiresPermission()
     {
         $this->actingAsForApi(User::factory()->create())
-            ->getJson(route('api.departments.index'))
+            ->getJson(route('api.categories.index'))
             ->assertForbidden();
     }
 

--- a/tests/Feature/Companies/Api/IndexCompaniesTest.php
+++ b/tests/Feature/Companies/Api/IndexCompaniesTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Feature\Categories\Api;
+
+use App\Models\Company;
+use App\Models\User;
+use Illuminate\Testing\Fluent\AssertableJson;
+use Tests\TestCase;
+
+class IndexCompaniesTest extends TestCase
+{
+
+    public function testViewingCompanyIndexRequiresPermission()
+    {
+        $this->actingAsForApi(User::factory()->create())
+            ->getJson(route('api.companies.index'))
+            ->assertForbidden();
+    }
+
+    public function testCompanyIndexReturnsExpectedSearchResults()
+    {
+        Company::factory()->count(10)->create();
+        Company::factory()->create(['name' => 'My Test Company']);
+
+        $this->actingAsForApi(User::factory()->superuser()->create())
+            ->getJson(
+                route('api.companies.index', [
+                    'search' => 'My Test Company',
+                    'sort' => 'name',
+                    'order' => 'asc',
+                    'offset' => '0',
+                    'limit' => '20',
+                ]))
+            ->assertOk()
+            ->assertJsonStructure([
+                'total',
+                'rows',
+            ])
+            ->assertJson([
+                'total' => 1,
+            ]);
+
+    }
+
+    public function testAdheresToFullMultipleCompaniesSupportScoping()
+    {
+
+        $this->settings->enableMultipleFullCompanySupport();
+
+        [$companyA, $companyB] = Company::factory()->count(2)->create();
+
+        $superUser = $companyA->users()->save(User::factory()->superuser()->make());
+        $userInCompanyA = $companyA->users()->save(User::factory()->viewCompanies()->make());
+        $userInCompanyB = $companyB->users()->save(User::factory()->viewCompanies()->make());
+
+        $this->actingAsForApi($userInCompanyA)
+            ->getJson(route('api.companies.index'))
+            ->assertOk()
+            ->assertResponseContainsInRows($companyA)
+            ->assertResponseDoesNotContainInRows($companyB);
+
+        $this->actingAsForApi($userInCompanyB)
+            ->getJson(route('api.companies.index'))
+            ->assertOk()
+            ->assertResponseContainsInRows($companyB)
+            ->assertResponseDoesNotContainInRows($companyA);
+
+        $this->actingAsForApi($superUser)
+            ->getJson(route('api.companies.index'))
+            ->assertOk()
+            ->assertResponseContainsInRows($companyA)
+            ->assertResponseContainsInRows($companyB);
+    }
+
+
+}

--- a/tests/Feature/Companies/Api/UpdateCompaniesTest.php
+++ b/tests/Feature/Companies/Api/UpdateCompaniesTest.php
@@ -50,4 +50,52 @@ class UpdateCompaniesTest extends TestCase
         $this->assertEquals('A Changed Name', $company->name);
         $this->assertEquals('A Changed Note', $company->notes);
     }
+
+    public function testAdheresToFullMultipleCompaniesSupportScoping()
+    {
+
+        $this->settings->enableMultipleFullCompanySupport();
+
+        [$companyA, $companyB] = Company::factory()->count(2)->create();
+
+        $superUser = $companyA->users()->save(User::factory()->superuser()->make());
+        $userInCompanyA = $companyA->users()->save(User::factory()->editCompanies()->create());
+        $userInCompanyB = $companyB->users()->save(User::factory()->editCompanies()->create());
+
+        $this->actingAsForApi($userInCompanyA)
+            ->patchJson(route('api.companies.update', ['company' => $companyA->id]), [
+                'name' => 'A Changed Name',
+                'notes' => 'A Changed Note',
+            ])
+            ->assertStatus(200)
+            ->assertStatusMessageIs('success');
+
+        $this->actingAsForApi($userInCompanyB)
+            ->patchJson(route('api.companies.update', ['company' => $companyB]), [
+                'name' => 'Another Changed Name',
+                'notes' => 'Another Changed Note',
+            ])
+            ->assertStatus(200)
+            ->assertStatusMessageIs('success');
+
+        $this->actingAsForApi($userInCompanyA)
+            ->patchJson(route('api.companies.update', ['company' => $companyB->id]), [
+                'name' => 'Yet Another Changed Name',
+                'notes' => 'Yet Another Changed Note',
+            ])
+            ->assertJson([
+                'messages' =>  'Company not found'
+            ])
+            ->assertStatusMessageIs('error')
+            ->assertStatus(200);
+
+        $this->actingAsForApi($superUser)
+            ->patchJson(route('api.companies.update', ['company' => $companyB->id]), [
+                'name' => 'One Final Changed Name',
+                'notes' => 'One Final Changed Note',
+            ])
+            ->assertStatus(200)
+            ->assertStatusMessageIs('success');
+
+    }
 }


### PR DESCRIPTION
This fixes #17302 where non-admins could see the full company listing when FMCS is turned on. Added bonus, I found a spot where we were't eager loading the admin, and fixed that.

I'm in a bit of a quandary here though. I feel like if you have FMCS turned on, only superadmins should be able to administer companies at all, but that sort of implies it belongs in the `/admin` area. That said, moving it based on whether or not a setting is toggled seems like a terrible idea (and will make the docs much more confusing.)

I've tried to make the smallest change possible here while we discuss how this should work moving forward.