### PR TITLE
Smaller api response on asset api update

### DIFF
--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -40,7 +40,6 @@ class AssetsTransformer
             ] : null,
             'byod' => ($asset->byod ? true : false),
             'requestable' => ($asset->requestable ? true : false),
-
             'model_number' => (($asset->model) && ($asset->model->model_number)) ? e($asset->model->model_number) : null,
             'eol' => (($asset->asset_eol_date != '') && ($asset->purchase_date != '')) ? (int) Carbon::parse($asset->asset_eol_date)->diffInMonths($asset->purchase_date, true) . ' months' : null,
             'asset_eol_date' => ($asset->asset_eol_date != '') ? Helper::getFormattedDateObject($asset->asset_eol_date, 'date') : null,

--- a/app/Http/Transformers/UsersTransformer.php
+++ b/app/Http/Transformers/UsersTransformer.php
@@ -121,22 +121,24 @@ class UsersTransformer
      */
     public function transformUserCompact(User $user) : array
     {
-
-        $array = [
-            'id' => (int) $user->id,
-            'image' => e($user->present()->gravatar) ?? null,
-            'type' => 'user',
-            'name' => e($user->getFullNameAttribute()),
-            'first_name' => e($user->first_name),
-            'last_name' => e($user->last_name),
-            'username' => e($user->username),
-            'created_by' => $user->adminuser ? [
-                'id' => (int) $user->adminuser->id,
-                'name'=> e($user->adminuser->present()->fullName),
-            ]: null,
-            'created_at' => Helper::getFormattedDateObject($user->created_at, 'datetime'),
-            'deleted_at' => ($user->deleted_at) ? Helper::getFormattedDateObject($user->deleted_at, 'datetime') : null,
-        ];
+        $array = [];
+        if (Gate::allows('view', $user) && ($user->deleted_at == '')) {
+            $array = [
+                'id' => (int) $user->id,
+                'image' => e($user->present()->gravatar) ?? null,
+                'type' => 'user',
+                'name' => e($user->getFullNameAttribute()),
+                'first_name' => e($user->first_name),
+                'last_name' => e($user->last_name),
+                'username' => e($user->username),
+                'created_by' => $user->adminuser ? [
+                    'id' => (int) $user->adminuser->id,
+                    'name'=> e($user->adminuser->present()->fullName),
+                ]: null,
+                'created_at' => Helper::getFormattedDateObject($user->created_at, 'datetime'),
+                'deleted_at' => ($user->deleted_at) ? Helper::getFormattedDateObject($user->deleted_at, 'datetime') : null,
+            ];
+        }
 
         return $array;
     }

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -773,7 +773,7 @@ class Asset extends Depreciable
      */
     public function model()
     {
-        return $this->belongsTo(\App\Models\AssetModel::class, 'model_id')->select(['id', 'name', 'model_number', 'category_id', 'created_at', 'created_by'])->withTrashed();
+        return $this->belongsTo(\App\Models\AssetModel::class, 'model_id')->select(['id', 'name', 'model_number', 'manufacturer_id', 'category_id', 'created_at', 'created_by'])->withTrashed();
     }
 
     /**

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -747,7 +747,7 @@ class Asset extends Depreciable
      */
     public function adminuser()
     {
-        return $this->belongsTo(\App\Models\User::class, 'created_by');
+        return $this->belongsTo(\App\Models\User::class, 'created_by')->select(['id', 'first_name', 'last_name', 'username', 'created_at', 'created_by'])->withTrashed();
     }
 
 
@@ -773,7 +773,7 @@ class Asset extends Depreciable
      */
     public function model()
     {
-        return $this->belongsTo(\App\Models\AssetModel::class, 'model_id')->withTrashed();
+        return $this->belongsTo(\App\Models\AssetModel::class, 'model_id')->select(['id', 'name', 'model_number', 'category_id', 'created_at', 'created_by'])->withTrashed();
     }
 
     /**

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -955,7 +955,7 @@
                                                 </strong>
                                             </div>
                                             <div class="col-md-9">
-                                                @if ($asset->purchase_date)
+                                                @if (($asset->purchase_date) && $asset->depreciated_date()))
                                                     {{ Helper::getFormattedDateObject($asset->depreciated_date()->format('Y-m-d'), 'date', false) }}
                                                     -
                                                     {{ Carbon::parse($asset->depreciated_date())->diffForHumans(['parts' => 2]) }}


### PR DESCRIPTION
This change should let us deliver a smaller payload for the admin user and models associated with assets. We really *should* be using the standard transformer for that response, but it currently breaks Jamf2Snipe and Kandji2Snipe, so we'll have to update those integration scripts or do something clever with the User-Agent there to determine if we still need the flatter array or if we can return a normally shaped response. 

This change only selects what we need, so we're able to return a much smaller payload. 

One thing I haven't solved for is that - for example in the payload below - the `_snipeit_imei_1` doesn't actually apply to this particular asset (it's a laptop), but it still gets returned in the object payload since we're getting the whole object, not just the nicely shaped version we use everywhere else. 

I might need to revert the model tightening in the new one after looking at how Jamf2Snipe and Kandji2Snipe handle that hierarchy, but that's for a different PR I think. Need to dig into whether we can update those scripts to parse the (correct) hierarchical version instead of the flat version, or if we can sniff some stuff out to see which one we can use.  

### Old

```json
{
    "status": "success",
    "messages": "Asset updated successfully.",
    "payload": {
        "id": 25,
        "name": "Test 6",
        "asset_tag": "423110423",
        "model_id": 1,
        "serial": "648cb288-4462-3905-9ed5-9ee9a747f0a5",
        "purchase_date": "2024-09-12T23:00:00.000000Z",
        "asset_eol_date": "2027-09-13",
        "eol_explicit": true,
        "purchase_cost": "467.40",
        "order_number": "21027357",
        "assigned_to": 26,
        "notes": "Created by DB seeder",
        "image": null,
        "created_by": 1,
        "created_at": "2025-07-15T13:24:32.000000Z",
        "updated_at": "2025-07-16T12:02:59.000000Z",
        "physical": 1,
        "deleted_at": null,
        "status_id": 1,
        "archived": 0,
        "warranty_months": null,
        "depreciate": null,
        "supplier_id": 5,
        "requestable": 1,
        "rtd_location_id": 3,
        "accepted": null,
        "last_checkout": null,
        "last_checkin": null,
        "expected_checkin": null,
        "company_id": null,
        "assigned_type": "App\\Models\\User",
        "last_audit_date": null,
        "next_audit_date": null,
        "location_id": 3,
        "checkin_counter": 0,
        "checkout_counter": 0,
        "requests_counter": 0,
        "byod": 0,
        "_snipeit_imei_1": null,
        "_snipeit_phone_number_2": null,
        "_snipeit_ram_3": "test update",
        "_snipeit_cpu_4": null,
        "_snipeit_mac_address_5": null,
        "_snipeit_test_encrypted_6": null,
        "_snipeit_test_checkbox_7": null,
        "_snipeit_test_radio_8": null,
        "model": {
            "id": 1,
            "name": "Macbook Pro 13\"",
            "model_number": "6011453070422543",
            "min_amt": null,
            "manufacturer_id": null,
            "category_id": 1,
            "created_at": "2025-07-15T13:24:30.000000Z",
            "updated_at": "2025-07-15T13:24:30.000000Z",
            "depreciation_id": 1,
            "created_by": 1,
            "eol": 36,
            "image": "mbp.jpg",
            "deprecated_mac_address": 0,
            "deleted_at": null,
            "fieldset_id": 2,
            "notes": "Created by demo seeder",
            "requestable": 0,
            "fieldset": {
                "id": 2,
                "name": "Laptops and Desktops",
                "created_at": "2025-07-15T13:24:30.000000Z",
                "updated_at": "2025-07-15T13:24:30.000000Z",
                "created_by": null,
                "fields": [
                    {
                        "id": 3,
                        "name": "RAM",
                        "format": "ANY",
                        "element": "text",
                        "created_at": "2025-07-15T13:24:30.000000Z",
                        "updated_at": "2025-07-15T13:24:30.000000Z",
                        "created_by": null,
                        "field_values": null,
                        "field_encrypted": 0,
                        "db_column": "_snipeit_ram_3",
                        "help_text": "The amount of RAM this device has.",
                        "show_in_email": 0,
                        "show_in_requestable_list": false,
                        "is_unique": 0,
                        "display_in_user_view": 0,
                        "auto_add_to_fieldsets": 0,
                        "show_in_listview": 0,
                        "display_checkin": 0,
                        "display_checkout": 0,
                        "display_audit": 0,
                        "pivot": {
                            "custom_fieldset_id": 2,
                            "custom_field_id": 3,
                            "required": 0,
                            "order": 0
                        }
                    },
                    {
                        "id": 4,
                        "name": "CPU",
                        "format": "ANY",
                        "element": "text",
                        "created_at": "2025-07-15T13:24:30.000000Z",
                        "updated_at": "2025-07-15T13:24:30.000000Z",
                        "created_by": null,
                        "field_values": null,
                        "field_encrypted": 0,
                        "db_column": "_snipeit_cpu_4",
                        "help_text": "The speed of the processor on this device.",
                        "show_in_email": 0,
                        "show_in_requestable_list": true,
                        "is_unique": 0,
                        "display_in_user_view": 0,
                        "auto_add_to_fieldsets": 0,
                        "show_in_listview": 0,
                        "display_checkin": 0,
                        "display_checkout": 0,
                        "display_audit": 0,
                        "pivot": {
                            "custom_fieldset_id": 2,
                            "custom_field_id": 4,
                            "required": 0,
                            "order": 0
                        }
                    },
                    {
                        "id": 5,
                        "name": "MAC Address",
                        "format": "regex:/^([0-9a-fA-F]{2}[:-]){5}[0-9a-fA-F]{2}$/",
                        "element": "text",
                        "created_at": "2025-07-15T13:24:30.000000Z",
                        "updated_at": "2025-07-15T13:24:30.000000Z",
                        "created_by": null,
                        "field_values": null,
                        "field_encrypted": 0,
                        "db_column": "_snipeit_mac_address_5",
                        "help_text": null,
                        "show_in_email": 0,
                        "show_in_requestable_list": false,
                        "is_unique": 0,
                        "display_in_user_view": 0,
                        "auto_add_to_fieldsets": 0,
                        "show_in_listview": 0,
                        "display_checkin": 0,
                        "display_checkout": 0,
                        "display_audit": 0,
                        "pivot": {
                            "custom_fieldset_id": 2,
                            "custom_field_id": 5,
                            "required": 0,
                            "order": 0
                        }
                    },
                    {
                        "id": 6,
                        "name": "Test Encrypted",
                        "format": "ANY",
                        "element": "text",
                        "created_at": "2025-07-15T13:24:30.000000Z",
                        "updated_at": "2025-07-15T13:24:30.000000Z",
                        "created_by": null,
                        "field_values": null,
                        "field_encrypted": 1,
                        "db_column": "_snipeit_test_encrypted_6",
                        "help_text": "This is a sample encrypted field.",
                        "show_in_email": 0,
                        "show_in_requestable_list": false,
                        "is_unique": 0,
                        "display_in_user_view": 0,
                        "auto_add_to_fieldsets": 0,
                        "show_in_listview": 0,
                        "display_checkin": 0,
                        "display_checkout": 0,
                        "display_audit": 0,
                        "pivot": {
                            "custom_fieldset_id": 2,
                            "custom_field_id": 6,
                            "required": 0,
                            "order": 0
                        }
                    },
                    {
                        "id": 7,
                        "name": "Test Checkbox",
                        "format": "ANY",
                        "element": "checkbox",
                        "created_at": "2025-07-15T13:24:30.000000Z",
                        "updated_at": "2025-07-15T13:24:30.000000Z",
                        "created_by": null,
                        "field_values": "One\r\nTwo\r\nThree",
                        "field_encrypted": 0,
                        "db_column": "_snipeit_test_checkbox_7",
                        "help_text": "This is a sample checkbox.",
                        "show_in_email": 0,
                        "show_in_requestable_list": false,
                        "is_unique": 0,
                        "display_in_user_view": 0,
                        "auto_add_to_fieldsets": 0,
                        "show_in_listview": 0,
                        "display_checkin": 0,
                        "display_checkout": 0,
                        "display_audit": 0,
                        "pivot": {
                            "custom_fieldset_id": 2,
                            "custom_field_id": 7,
                            "required": 0,
                            "order": 0
                        }
                    },
                    {
                        "id": 8,
                        "name": "Test Radio",
                        "format": "ANY",
                        "element": "radio",
                        "created_at": "2025-07-15T13:24:30.000000Z",
                        "updated_at": "2025-07-15T13:24:30.000000Z",
                        "created_by": null,
                        "field_values": "One\r\nTwo\r\nThree",
                        "field_encrypted": 0,
                        "db_column": "_snipeit_test_radio_8",
                        "help_text": "This is a sample radio.",
                        "show_in_email": 0,
                        "show_in_requestable_list": false,
                        "is_unique": 0,
                        "display_in_user_view": 0,
                        "auto_add_to_fieldsets": 0,
                        "show_in_listview": 0,
                        "display_checkin": 0,
                        "display_checkout": 0,
                        "display_audit": 0,
                        "pivot": {
                            "custom_fieldset_id": 2,
                            "custom_field_id": 8,
                            "required": 0,
                            "order": 0
                        }
                    }
                ]
            }
        },
        "adminuser": {
            "id": 1,
            "email": "slind@example.net",
            "activated": 1,
            "created_by": 1,
            "activated_at": null,
            "last_login": "2025-07-16 11:15:36",
            "first_name": "Admin",
            "last_name": "User",
            "created_at": "2025-07-15T13:24:30.000000Z",
            "updated_at": "2025-07-16T10:15:36.000000Z",
            "deleted_at": null,
            "website": null,
            "country": "Bulgaria",
            "gravatar": null,
            "location_id": null,
            "phone": "774-212-5080",
            "jobtitle": "Food Servers",
            "manager_id": null,
            "employee_num": "30168",
            "avatar": "1.jpg",
            "username": "admin",
            "notes": "Created by DB seeder",
            "company_id": 3,
            "ldap_import": 0,
            "locale": "en-US",
            "show_in_list": 1,
            "two_factor_enrolled": 0,
            "two_factor_optin": 0,
            "department_id": 6,
            "address": "283 Johann Roads\nGoldnermouth, WA 32914",
            "city": "Port Lucioview",
            "state": "VA",
            "zip": "64752-2863",
            "skin": null,
            "remote": 0,
            "start_date": null,
            "end_date": null,
            "scim_externalid": null,
            "autoassign_licenses": 1,
            "vip": 0,
            "enable_sounds": 0,
            "enable_confetti": 0
        }
    }
}
```

### New

```json
{
    "status": "success",
    "messages": "Asset updated successfully.",
    "payload": {
        "id": 25,
        "name": "Test 6",
        "asset_tag": "423110423",
        "model_id": 1,
        "serial": "648cb288-4462-3905-9ed5-9ee9a747f0a5",
        "purchase_date": "2024-09-12T23:00:00.000000Z",
        "asset_eol_date": "2027-09-13",
        "eol_explicit": true,
        "purchase_cost": "467.40",
        "order_number": "21027357",
        "assigned_to": 26,
        "notes": "Created by DB seeder",
        "image": null,
        "created_by": 1,
        "created_at": "2025-07-15T13:24:32.000000Z",
        "updated_at": "2025-07-16T12:02:59.000000Z",
        "physical": 1,
        "deleted_at": null,
        "status_id": 1,
        "archived": 0,
        "warranty_months": null,
        "depreciate": null,
        "supplier_id": 5,
        "requestable": 1,
        "rtd_location_id": 3,
        "accepted": null,
        "last_checkout": null,
        "last_checkin": null,
        "expected_checkin": null,
        "company_id": null,
        "assigned_type": "App\\Models\\User",
        "last_audit_date": null,
        "next_audit_date": null,
        "location_id": 3,
        "checkin_counter": 0,
        "checkout_counter": 0,
        "requests_counter": 0,
        "byod": 0,
        "_snipeit_imei_1": null,
        "_snipeit_phone_number_2": null,
        "_snipeit_ram_3": "test update",
        "_snipeit_cpu_4": null,
        "_snipeit_mac_address_5": null,
        "_snipeit_test_encrypted_6": null,
        "_snipeit_test_checkbox_7": null,
        "_snipeit_test_radio_8": null,
        "model": {
            "id": 1,
            "name": "Macbook Pro 13\"",
            "model_number": "6011453070422543",
            "category_id": 1,
            "created_at": "2025-07-15T13:24:30.000000Z",
            "created_by": 1,
            "fieldset": null
        },
        "adminuser": {
            "id": 1,
            "first_name": "Admin",
            "last_name": "User",
            "username": "admin",
            "created_at": "2025-07-15T13:24:30.000000Z",
            "created_by": 1
        }
    }
}
```