### PR TITLE
Mail log for #17491 and some improvements on log errors

### DIFF
--- a/app/Http/Controllers/Account/AcceptanceController.php
+++ b/app/Http/Controllers/Account/AcceptanceController.php
@@ -347,6 +347,7 @@ class AcceptanceController extends Controller
 
             $acceptance->decline($sig_filename, $request->input('note'));
             $acceptance->notify(new AcceptanceAssetDeclinedNotification($data));
+            Log::debug('New event acceptance.');
             event(new CheckoutDeclined($acceptance));
             $return_msg = trans('admin/users/message.declined');
         }
@@ -356,13 +357,16 @@ class AcceptanceController extends Controller
                 $recipient = User::find($acceptance->alert_on_response_id);
 
                 if ($recipient) {
+                    Log::debug('Attempting to send email acceptance.');
                     Mail::to($recipient)->send(new CheckoutAcceptanceResponseMail(
                         $acceptance,
                         $recipient,
                         $request->input('asset_acceptance') === 'accepted',
                     ));
+                    Log::debug('Send email notification sucess on checkout acceptance response.');
                 }
             } catch (Exception $e) {
+                Log::error($e->getMessage());
                 Log::warning($e);
             }
         }

--- a/app/Http/Controllers/Api/SettingsController.php
+++ b/app/Http/Controllers/Api/SettingsController.php
@@ -150,11 +150,11 @@ class SettingsController extends Controller
         if (!config('app.lock_passwords')) {
             try {
                 Notification::send(Setting::first(), new MailTest());
-                Log::debug('Mail sending to '.config('mail.reply_to.address'));
+                Log::debug('Attempting to sending to '.config('mail.reply_to.address'));
                 return response()->json(['message' => 'Mail sent to '.config('mail.reply_to.address')], 200);
             } catch (\Exception $e) {
+                Log::error('Mail sent error using '.config('mail.reply_to.address') .': '. $e->getMessage());
                 Log::debug($e);
-                Log::error('Mail sent to '.config('mail.reply_to.address') . $e->getMessage());
                 return response()->json(['message' => $e->getMessage()], 500);
             }
         }

--- a/app/Http/Controllers/Api/SettingsController.php
+++ b/app/Http/Controllers/Api/SettingsController.php
@@ -150,8 +150,11 @@ class SettingsController extends Controller
         if (!config('app.lock_passwords')) {
             try {
                 Notification::send(Setting::first(), new MailTest());
+                Log::debug('Mail sending to '.config('mail.reply_to.address'));
                 return response()->json(['message' => 'Mail sent to '.config('mail.reply_to.address')], 200);
             } catch (\Exception $e) {
+                Log::debug($e);
+                Log::error('Mail sent to '.config('mail.reply_to.address') . $e->getMessage());
                 return response()->json(['message' => $e->getMessage()], 500);
             }
         }

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -1339,9 +1339,11 @@ class SettingsController extends Controller
                 'name'  => config('mail.from.name'),
                 'email' => config('mail.from.address'),
             ])->notify(new MailTest());
-
+            Log::debug('Attempting to send mail to '.config('mail.from.address'));
             return response()->json(Helper::formatStandardApiResponse('success', null, trans('mail_sent.mail_sent')));
         } catch (\Exception $e) {
+            Log::error('Mail sent from '.config('mail.from.address') .' with errors '. $e->getMessage());
+            Log::debug($e);
             return response()->json(Helper::formatStandardApiResponse('success', null, $e->getMessage()));
         }
     }


### PR DESCRIPTION
## Improve log error handling regarding notification sending for issue#17491

* Fix  problem where admins at test install cannot see the log of errors for UI test mail button, we can just see that this is the correct form cos other parts of the code manage the exception inside the catch using log interface class, we can just see that this is the correct form cos other parts of the code manage the exception inside the catch using log interface class
* when an error is generated when denying checkouts, there are not enough logs
to determine the problem from the email provider
* missing handling of log test mail config, there is none of logs cos there
is no log handling on test email, because all the results are just sent to
the http response and no log were written.

Partially addresses #17491