### PR TITLE
Removed debugging dump() in test

### DIFF
--- a/tests/Feature/Assets/Api/StoreAssetTest.php
+++ b/tests/Feature/Assets/Api/StoreAssetTest.php
@@ -782,7 +782,6 @@ class StoreAssetTest extends TestCase
                 'status_id'                   => $status->id,
                 'asset_tag'                   => '1234',
             ])
-            ->dump()
             ->assertStatusMessageIs('error')
             ->assertJsonPath('messages.'.$alphaField->db_column_name(), [trans('validation.alpha', ['attribute' => $cleaned_name])])
             ->assertOk()


### PR DESCRIPTION
This PR removes a debugging `dump()` call that was left in a test.