### PR TITLE
Empty Option Tag Comment

### DIFF
--- a/resources/views/reports/custom.blade.php
+++ b/resources/views/reports/custom.blade.php
@@ -643,7 +643,7 @@
                     class="form-control select2"
                     data-placeholder="{{ trans('admin/reports/general.select_a_template') }}"
                 >
-                    <option></option>
+                    <option></option> {{-- This seems empty, but this makes the dropdown select work :| --}}
                     @foreach($report_templates as $savedTemplate)
                         <option
                             value="{{ $savedTemplate->id }}"


### PR DESCRIPTION
This is legit just to remind me for later that while the option tag is empty, the dropdown selecting down't work without it.

I have no idea why, but that's just how it works atm.

I want to have this referenced for when we add onto saved reports