### PR TITLE
Fixed #17642 - location data displaying incorrectly in checkout email intro line

### DIFF
--- a/app/Mail/CheckoutAssetMail.php
+++ b/app/Mail/CheckoutAssetMail.php
@@ -13,7 +13,6 @@ use Illuminate\Mail\Mailables\Address;
 use Illuminate\Mail\Mailables\Attachment;
 use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
-use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Queue\SerializesModels;
 
 class CheckoutAssetMail extends Mailable
@@ -100,7 +99,7 @@ class CheckoutAssetMail extends Mailable
                 'admin'         => $this->admin,
                 'status'        => $this->item->assetstatus?->name,
                 'note'          => $this->note,
-                'target'        => $this->target,
+                'target'        => $this->target->name ?? $this->admin->present()->fullName(),
                 'fields'        => $fields,
                 'eula'          => $eula,
                 'req_accept'    => $req_accept,
@@ -125,7 +124,7 @@ class CheckoutAssetMail extends Mailable
     private function getSubject(): string
     {
         if ($this->firstTimeSending) {
-            return trans('mail.Asset_Checkout_Notification');
+            return trans('mail.Asset_Checkout_Notification').' - '.$this->item->asset_tag;
         }
 
         return trans('mail.unaccepted_asset_reminder');


### PR DESCRIPTION
This fixes the intro line when an asset has been checked out to a location.

### Before
<img width="821" height="560" alt="Screenshot 2025-08-19 at 8 42 11 AM" src="https://github.com/user-attachments/assets/ed849e74-70ad-4cf2-be53-266bda9a4551" />

### After
<img width="853" height="563" alt="Screenshot 2025-08-19 at 8 42 21 AM" src="https://github.com/user-attachments/assets/f1c15735-2e7a-48fb-a296-d738393c6432" />


Fixes #17642