### PR TITLE
Adds support for label sheets Avery L4736 & L6009

### DIFF
--- a/app/Models/Labels/Sheets/Avery/L6009.php
+++ b/app/Models/Labels/Sheets/Avery/L6009.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Models\Labels\Sheets\Avery;
+
+use App\Helpers\Helper;
+use App\Models\Labels\RectangleSheet;
+
+abstract class L6009 extends RectangleSheet
+{
+
+    private const PAPER_FORMAT      = 'A4';
+    private const PAPER_ORIENTATION = 'P';
+
+    /* Data in pt from Word Template */
+	private const COLUMN1_X =  31.70;
+	private const COLUMN2_X = 167.92;
+	private const ROW1_Y    =  53.00;
+	private const ROW2_Y    = 112.8;
+	private const LABEL_W   = 122.24;	
+	private const LABEL_H   =  66.5; 
+
+    private float $pageWidth;
+    private float $pageHeight;
+    private float $pageMarginLeft;
+    private float $pageMarginTop;
+
+    private float $columnSpacing;
+    private float $rowSpacing;
+
+    private float $labelWidth;
+    private float $labelHeight;
+
+    public function __construct()
+    {
+        $paperSize = static::fromFormat(self::PAPER_FORMAT, self::PAPER_ORIENTATION, $this->getUnit(), 0);
+        $this->pageWidth = $paperSize->width;
+        $this->pageHeight = $paperSize->height;
+
+        $this->pageMarginLeft = Helper::convertUnit(self::COLUMN1_X, 'pt', $this->getUnit());
+        $this->pageMarginTop = Helper::convertUnit(self::ROW1_Y, 'pt', $this->getUnit());
+
+        $columnSpacingPt = self::COLUMN2_X - self::COLUMN1_X - self::LABEL_W;
+        $columnSpacingPt = self::COLUMN2_X - self::LABEL_W + 7.15;
+        $this->columnSpacing = Helper::convertUnit($columnSpacingPt, 'pt', $this->getUnit());
+        $rowSpacingPt = self::ROW2_Y - self::ROW1_Y - self::LABEL_H;
+        $rowSpacingPt = self::ROW2_Y - self::LABEL_H;
+        $this->rowSpacing = Helper::convertUnit($rowSpacingPt, 'pt', $this->getUnit());
+
+        $this->labelWidth = Helper::convertUnit(self::LABEL_W, 'pt', $this->getUnit());
+        $this->labelHeight = Helper::convertUnit(self::LABEL_H, 'pt', $this->getUnit());
+    }
+
+    public function getPageWidth()
+    {
+        return $this->pageWidth;
+    }
+    public function getPageHeight()
+    {
+        return $this->pageHeight;
+    }
+
+    public function getPageMarginTop()
+    {
+        return $this->pageMarginTop;
+    }
+    public function getPageMarginBottom()
+    {
+        return $this->pageMarginTop;
+    }
+    public function getPageMarginLeft()
+    {
+        return $this->pageMarginLeft;
+    }
+    public function getPageMarginRight()
+    {
+        return $this->pageMarginLeft;
+    }
+
+    public function getColumns()
+    {
+        return 4;
+    }
+    public function getRows()
+    {
+        return 12;
+    }
+
+    public function getLabelColumnSpacing()
+    {
+        return $this->columnSpacing;
+    }
+    public function getLabelRowSpacing()
+    {
+        return $this->rowSpacing;
+    }
+
+    public function getLabelWidth()
+    {
+        return $this->labelWidth;
+    }
+    public function getLabelHeight()
+    {
+        return $this->labelHeight;
+    }
+
+    public function getLabelBorder()
+    {
+        return 0;
+    }
+}
+
+?>

--- a/app/Models/Labels/Sheets/Avery/L6009.php
+++ b/app/Models/Labels/Sheets/Avery/L6009.php
@@ -40,10 +40,8 @@ abstract class L6009 extends RectangleSheet
         $this->pageMarginTop = Helper::convertUnit(self::ROW1_Y, 'pt', $this->getUnit());
 
         $columnSpacingPt = self::COLUMN2_X - self::COLUMN1_X - self::LABEL_W;
-        $columnSpacingPt = self::COLUMN2_X - self::LABEL_W + 7.15;
         $this->columnSpacing = Helper::convertUnit($columnSpacingPt, 'pt', $this->getUnit());
         $rowSpacingPt = self::ROW2_Y - self::ROW1_Y - self::LABEL_H;
-        $rowSpacingPt = self::ROW2_Y - self::LABEL_H;
         $this->rowSpacing = Helper::convertUnit($rowSpacingPt, 'pt', $this->getUnit());
 
         $this->labelWidth = Helper::convertUnit(self::LABEL_W, 'pt', $this->getUnit());

--- a/app/Models/Labels/Sheets/Avery/L6009_A.php
+++ b/app/Models/Labels/Sheets/Avery/L6009_A.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace App\Models\Labels\Sheets\Avery;
+
+
+class L6009_A extends L6009
+{
+    private const BARCODE_MARGIN =   1.80;
+    private const TAG_SIZE       =   4.80;
+    private const TITLE_SIZE     =   3.00;
+    private const TITLE_MARGIN   =   1.80;
+    private const LABEL_SIZE     =   2.8;
+    private const LABEL_MARGIN   = - 0.45;
+    private const FIELD_SIZE     =   3.80;
+    private const FIELD_MARGIN   =   0.20;
+
+    public function getUnit()
+    {
+        return 'mm';
+    }
+
+    public function getLabelMarginTop()
+    {
+        return 0.06;
+    }
+    public function getLabelMarginBottom()
+    {
+        return 0.06;
+    }
+    public function getLabelMarginLeft()
+    {
+        return 0.06;
+    }
+    public function getLabelMarginRight()
+    {
+        return 0.06;
+    }
+
+    public function getSupportAssetTag()
+    {
+        return true;
+    }
+    public function getSupport1DBarcode()
+    {
+        return false;
+    }
+    public function getSupport2DBarcode()
+    {
+        return true;
+    }
+    public function getSupportFields()
+    {
+        return 4;
+    }
+    public function getSupportLogo()
+    {
+        return false;
+    }
+    public function getSupportTitle()
+    {
+        return true;
+    }
+
+    public function preparePDF($pdf)
+    {
+    }
+
+    public function write($pdf, $record)
+    {
+        $pa = $this->getLabelPrintableArea();
+
+        $currentX = $pa->x1;
+        $currentY = $pa->y1;
+        $usableWidth = $pa->w;
+        $usableHeight = $pa->h;
+
+        if ($record->has('title')) {
+            static::writeText(
+                $pdf, $record->get('title'),
+                $pa->x1, $pa->y1,
+                'freesans', '', self::TITLE_SIZE, 'C',
+                $pa->w, self::TITLE_SIZE, true, 0
+            );
+
+        }
+            $currentY += self::TITLE_SIZE + self::TITLE_MARGIN;
+            $usableHeight -= self::TITLE_SIZE + self::TITLE_MARGIN;
+        $barcodeSize = $usableHeight;
+        if ($record->has('barcode2d')) {
+            static::write2DBarcode(
+                $pdf, $record->get('barcode2d')->content, $record->get('barcode2d')->type,
+                $currentX, $currentY,
+                $barcodeSize, $barcodeSize
+            );
+            $currentX += $barcodeSize + self::BARCODE_MARGIN;
+            $usableWidth -= $barcodeSize + self::BARCODE_MARGIN;
+        }
+
+        foreach ($record->get('fields') as $field) {
+            static::writeText(
+                $pdf, $field['label'],
+                $currentX, $currentY,
+                'freesans', '', self::LABEL_SIZE, 'L',
+                $usableWidth, self::LABEL_SIZE, true, 0
+            );
+            $currentY += self::LABEL_SIZE + self::LABEL_MARGIN;
+
+            static::writeText(
+                $pdf, $field['value'],
+                $currentX, $currentY,
+                'freemono', 'B', self::FIELD_SIZE, 'L',
+                $usableWidth, self::FIELD_SIZE, true, 0, 0.01
+            );
+            $currentY += self::FIELD_SIZE + self::FIELD_MARGIN;
+        }
+
+    }
+}
+
+
+?>


### PR DESCRIPTION
Added support for 4x12 avery label sheets.

Tested on printer:
Hewlett-Packard HP LaserJet MFP M426dw

<img width="858" height="1163" alt="image" src="https://github.com/user-attachments/assets/35c0b810-2462-4ab9-974d-560807451ead" />
