### PR TITLE
Adds #5554 locale for acceptance notifications and checkin/out emails

### DIFF
--- a/app/Http/Controllers/Account/AcceptanceController.php
+++ b/app/Http/Controllers/Account/AcceptanceController.php
@@ -256,7 +256,7 @@ class AcceptanceController extends Controller
                 }
             }
             try {
-                $acceptance->notify((new AcceptanceAssetAcceptedToUserNotification($data))->locale(Setting::getSettings()->locale));
+                $acceptance->notify((new AcceptanceAssetAcceptedNotification($data))->locale(Setting::getSettings()->locale));
             } catch (\Exception $e) {
                 Log::warning($e);
             }

--- a/app/Http/Controllers/Account/AcceptanceController.php
+++ b/app/Http/Controllers/Account/AcceptanceController.php
@@ -248,15 +248,15 @@ class AcceptanceController extends Controller
 
                 // Add the attachment for the signing user into the $data array
                 $data['file'] = $pdf_filename;
-
+                $locale = $assigned_user->locale;
                 try {
-                    $assigned_user->notify(new AcceptanceAssetAcceptedToUserNotification($data));
+                    $assigned_user->notify((new AcceptanceAssetAcceptedToUserNotification($data))->locale($locale));
                 } catch (\Exception $e) {
                     Log::warning($e);
                 }
             }
             try {
-                $acceptance->notify(new AcceptanceAssetAcceptedNotification($data));
+                $acceptance->notify((new AcceptanceAssetAcceptedToUserNotification($data))->locale(Setting::getSettings()->locale));
             } catch (\Exception $e) {
                 Log::warning($e);
             }

--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -96,7 +96,8 @@ class CheckoutableListener
 
             if (!empty($to)) {
                 try {
-                    Mail::to(array_flatten($to))->cc(array_flatten($cc))->send($mailable);
+                    Mail::to(array_flatten($to))->send($mailable->locale($notifiable->locale));
+                    Mail::to(array_flatten($cc))->send($mailable->locale(Setting::getSettings()->locale));
                     Log::info('Checkout Mail sent to checkout target');
                 } catch (ClientException $e) {
                     Log::debug("Exception caught during checkout email: " . $e->getMessage());
@@ -180,7 +181,8 @@ class CheckoutableListener
 
             try {
                 if (!empty($to)) {
-                    Mail::to(array_flatten($to))->cc(array_flatten($cc))->send($mailable);
+                    Mail::to(array_flatten($to))->send($mailable->locale($notifiable->locale));
+                    Mail::to(array_flatten($cc))->send($mailable->locale(Setting::getSettings()->locale));
                     Log::info('Checkin Mail sent to CC addresses');
                 }
             } catch (ClientException $e) {

--- a/tests/Feature/Checkouts/Ui/BulkAssetCheckoutTest.php
+++ b/tests/Feature/Checkouts/Ui/BulkAssetCheckoutTest.php
@@ -58,7 +58,7 @@ class BulkAssetCheckoutTest extends TestCase
             $this->assertHasTheseActionLogs($asset, ['create', 'checkout']); //Note: '$this' gets auto-bound in closures, so this does work.
         });
 
-        Mail::assertSent(CheckoutAssetMail::class, 2);
+        Mail::assertSent(CheckoutAssetMail::class, 4);
         Mail::assertSent(CheckoutAssetMail::class, function (CheckoutAssetMail $mail) {
             return $mail->hasTo('someone@example.com');
         });

--- a/tests/Feature/Notifications/Email/EmailNotificationsToAdminAlertEmailUponCheckinTest.php
+++ b/tests/Feature/Notifications/Email/EmailNotificationsToAdminAlertEmailUponCheckinTest.php
@@ -51,8 +51,12 @@ class EmailNotificationsToAdminAlertEmailUponCheckinTest extends TestCase
 
         $this->fireCheckInEvent($this->asset, $this->user);
 
+        Mail::assertSentCount(2);
         Mail::assertSent(CheckinAssetMail::class, function ($mail) {
-            return $mail->hasTo($this->user->email) && $mail->hasCc('cc@example.com');
+            return $mail->hasTo($this->user->email);
+        });
+        Mail::assertSent(CheckinAssetMail::class, function ($mail) {
+            return $mail->hasTo('cc@example.com');
         });
     }
 

--- a/tests/Feature/Notifications/Email/EmailNotificationsToAdminAlertEmailUponCheckoutTest.php
+++ b/tests/Feature/Notifications/Email/EmailNotificationsToAdminAlertEmailUponCheckoutTest.php
@@ -48,7 +48,7 @@ class EmailNotificationsToAdminAlertEmailUponCheckoutTest extends TestCase
         $this->fireCheckoutEvent();
 
         Mail::assertSent(CheckoutAssetMail::class, function (CheckoutAssetMail $mail) {
-            return $mail->hasCc('cc@example.com');
+            return $mail->hasTo('cc@example.com');
         });
     }
 


### PR DESCRIPTION
This uses the locale of the `$assigned_user` for acceptance emails and checkin/out
The system's locale is used for alert emails and cc emails.

This fires the `Mail::to()` twice in the checkoutable listener. This is the best way I could think of to handle the different locales for this process.

Fixes: #5554 