### PR TITLE
Renamed User test for consistency

### DIFF
--- a/tests/Feature/Users/Api/CreateUserTest.php
+++ b/tests/Feature/Users/Api/CreateUserTest.php
@@ -8,7 +8,7 @@ use App\Models\User;
 use Illuminate\Testing\Fluent\AssertableJson;
 use Tests\TestCase;
 
-class StoreUsersTest extends TestCase
+class CreateUserTest extends TestCase
 {
     public function testRequiresPermission()
     {


### PR DESCRIPTION
This just changes the name of the `StoreUserTest` to `CreateUserTest` so it's the same between the UI and API.