### PR TITLE
Adds #10107 previous selection to next checkout

### DIFF
--- a/app/Http/Controllers/Assets/AssetCheckoutController.php
+++ b/app/Http/Controllers/Assets/AssetCheckoutController.php
@@ -31,7 +31,6 @@ class AssetCheckoutController extends Controller
     {
 
         $this->authorize('checkout', $asset);
-
         if (!$asset->model) {
             return redirect()->route('hardware.show', $asset)
                 ->with('error', trans('admin/hardware/general.model_invalid_fix'));
@@ -120,7 +119,8 @@ class AssetCheckoutController extends Controller
                 }
             }
 
-            session()->put(['redirect_option' => $request->get('redirect_option'), 'checkout_to_type' => $request->get('checkout_to_type')]);
+            session()->put(['redirect_option' => $request->get('redirect_option'),
+                            'checkout_to_type' => $request->get('checkout_to_type')]);
 
             if ($asset->checkOut($target, $admin, $checkout_at, $expected_checkin, $request->get('note'), $request->get('name'))) {
                 return Helper::getRedirectOption($request, $asset->id, 'Assets')

--- a/resources/views/partials/forms/checkout-selector.blade.php
+++ b/resources/views/partials/forms/checkout-selector.blade.php
@@ -1,20 +1,23 @@
+@php
+    $selected = old('checkout_to_type', session('checkout_to_type', 'user')); // default 'user'
+@endphp
 <div class="form-group" id="assignto_selector"{!!  (isset($style)) ? ' style="'.e($style).'"' : ''  !!}>
     <label for="checkout_to_type" class="col-md-3 control-label">{{ trans('admin/hardware/form.checkout_to') }}</label>
     <div class="col-md-8">
         <div class="btn-group" data-toggle="buttons">
             @if ((isset($user_select)) && ($user_select!='false'))
-            <label class="btn btn-default active">
-                <input name="checkout_to_type" value="user" aria-label="checkout_to_type" type="radio" checked="checked"><x-icon type="user" /> {{ trans('general.user') }}
+            <label class="btn btn-default {{ $selected === 'user' ? 'active' : '' }}">
+                <input name="checkout_to_type" value="user" aria-label="checkout_to_type" type="radio" @checked($selected === 'user')><x-icon type="user" /> {{ trans('general.user') }}
             </label>
             @endif
             @if ((isset($asset_select)) && ($asset_select!='false'))
-            <label class="btn btn-default">
-                <input name="checkout_to_type" value="asset" aria-label="checkout_to_type" type="radio"><i class="fas fa-barcode" aria-hidden="true"></i> {{ trans('general.asset') }}
+            <label class="btn btn-default {{ $selected === 'asset' ? 'active' : '' }}">
+                <input name="checkout_to_type" value="asset" aria-label="checkout_to_type" type="radio" @checked($selected === 'asset')><i class="fas fa-barcode" aria-hidden="true"></i> {{ trans('general.asset') }}
             </label>
             @endif
             @if ((isset($location_select)) && ($location_select!='false'))
-            <label class="btn btn-default">
-                <input name="checkout_to_type" value="location" aria-label="checkout_to_type" class="active" type="radio"><i class="fas fa-map-marker-alt" aria-hidden="true"></i> {{ trans('general.location') }}
+            <label class="btn btn-default {{ $selected === 'location' ? 'active' : '' }}">
+                <input name="checkout_to_type" value="location" aria-label="checkout_to_type" class="active" type="radio" @checked($selected === 'location')><i class="fas fa-map-marker-alt" aria-hidden="true"></i> {{ trans('general.location') }}
             </label>
             @endif
 


### PR DESCRIPTION
When you checkout to a User/Asset/Location your choice is remembered for the next checkout across Assets, Licenses, Accessories. Defaults to `user` if no previous choice is saved.