### PR TITLE
Fixed #17798 - added `require_serial` to model importer

### DIFF
--- a/app/Importer/AssetModelImporter.php
+++ b/app/Importer/AssetModelImporter.php
@@ -66,6 +66,7 @@ class AssetModelImporter extends ItemImporter
         $this->item['fieldset'] = trim($this->findCsvMatch($row, 'fieldset'));
         $this->item['depreciation'] = trim($this->findCsvMatch($row, 'depreciation'));
         $this->item['requestable'] = trim(($this->fetchHumanBoolean($this->findCsvMatch($row, 'requestable'))) == 1) ? 1 : 0;
+        $this->item['require_serial'] = trim(($this->fetchHumanBoolean($this->findCsvMatch($row, 'require_serial'))) == 1) ? 1 : 0;
 
         if (!empty($this->item['category'])) {
             if ($category = $this->createOrFetchCategory($this->item['category'])) {

--- a/app/Livewire/Importer.php
+++ b/app/Livewire/Importer.php
@@ -412,6 +412,7 @@ class Importer extends Component
             'model_number' => trans('general.model_no'),
             'notes' => trans('general.item_notes', ['item' => trans('admin/hardware/form.model')]),
             'requestable' => trans('admin/models/general.requestable'),
+            'require_serial' => trans('admin/hardware/general.require_serial'),
 
         ];
 
@@ -534,6 +535,10 @@ class Importer extends Component
                     'serial no',
                     'product key',
                     'key',
+                ],
+            'require_serial' =>
+                [
+                    'serial required',
                 ],
             'model_number' =>
                 [


### PR DESCRIPTION
This just adds the `require_serial` field to the asset model importer.