### PR TITLE
Fixed #17822 - n+1 in top menu check

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -811,12 +811,11 @@ class Helper
             }
         }
 
-        foreach ($asset_models as $asset_model){
 
-            $asset = new Asset();
-            $total_owned = $asset->where('model_id', '=', $asset_model->id)->count();
-            $avail = $asset->where('model_id', '=', $asset_model->id)->whereNull('assigned_to')->count();
+        $total_owned = Asset::whereIn('model_id', $asset_models->pluck('id'))->count();
+        $avail = Asset::whereIn('model_id', $asset_models->pluck('id'))->whereNull('assigned_to')->count();
 
+        foreach ($asset_models as $asset_model) {
             if ($avail < ($asset_model->min_amt) + $alert_threshold) {
                 if ($avail > 0) {
                     $percent = number_format((($avail / $total_owned) * 100), 0);

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -817,7 +817,7 @@ class Helper
         foreach ($asset_models as $asset_model) {
 
             $total_owned = $asset_model->assets->count();
-            $avail =  $asset_model->assets->whereNull('assigned_to')->count();
+            $avail =  $asset_model->assets->whereNull('assets.assigned_to')->count();
 
             if ($avail < ($asset_model->min_amt) + $alert_threshold) {
                 if ($avail > 0) {

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -748,7 +748,7 @@ class Helper
         $consumables = Consumable::withCount('consumableAssignments as consumable_assignments_count')->whereNotNull('min_amt')->get();
         $accessories = Accessory::withCount('checkouts as checkouts_count')->whereNotNull('min_amt')->get();
         $components = Component::whereNotNull('min_amt')->get();
-        $asset_models = AssetModel::where('min_amt', '>', 0)->get();
+        $asset_models = AssetModel::where('min_amt', '>', 0)->with('assets')->get();
         $licenses = License::where('min_amt', '>', 0)->get();
 
         $items_array = [];
@@ -812,10 +812,13 @@ class Helper
         }
 
 
-        $total_owned = Asset::whereIn('model_id', $asset_models->pluck('id'))->count();
-        $avail = Asset::whereIn('model_id', $asset_models->pluck('id'))->whereNull('assigned_to')->count();
+
 
         foreach ($asset_models as $asset_model) {
+
+            $total_owned = $asset_model->assets->count();
+            $avail =  $asset_model->assets->whereNull('assigned_to')->count();
+
             if ($avail < ($asset_model->min_amt) + $alert_threshold) {
                 if ($avail > 0) {
                     $percent = number_format((($avail / $total_owned) * 100), 0);


### PR DESCRIPTION
This fixes #17822, which would do individual queries based on the number of models you had as it's trying to do the inventory check to alert you if you have models that are at or below min inventory. In my tests, this cut the number of queries down by about half.