### PR TITLE
Adds #8799 Prevention of checkout of expired or terminated licenses

### DIFF
--- a/app/Http/Controllers/Licenses/LicensesController.php
+++ b/app/Http/Controllers/Licenses/LicensesController.php
@@ -256,6 +256,9 @@ class LicensesController extends Controller
         else {
             $checkedout_seats_count = ($total_seats_count - $available_seats_count);
         }
+        if($license->isInactive()){
+            session()->flash('warning', (trans('admin/licenses/message.checkout.license_is_inactive')));
+        }
 
         $this->authorize('view', $license);
         return view('licenses.view', compact('license'))

--- a/app/Http/Transformers/LicenseSeatsTransformer.php
+++ b/app/Http/Transformers/LicenseSeatsTransformer.php
@@ -51,7 +51,7 @@ class LicenseSeatsTransformer
             'reassignable' => (bool) $seat->license->reassignable,
             'notes' => e($seat->notes),
             'user_can_checkout' => (($seat->assigned_to == '') && ($seat->asset_id == '')),
-            'disabled' => $seat->unreassignable_seat,
+            'disabled' => $seat->unreassignable_seat || $seat->license->isInactive(),
         ];
 
         $permissions_array['available_actions'] = [

--- a/app/Http/Transformers/LicensesTransformer.php
+++ b/app/Http/Transformers/LicensesTransformer.php
@@ -58,7 +58,7 @@ class LicensesTransformer
         ];
 
         $permissions_array['available_actions'] = [
-            'checkout' => Gate::allows('checkout', $license),
+            'checkout' => Gate::allows('checkout', License::class),
             'checkin' => Gate::allows('checkin', License::class),
             'clone' => Gate::allows('create', License::class),
             'update' => Gate::allows('update', License::class),

--- a/app/Http/Transformers/LicensesTransformer.php
+++ b/app/Http/Transformers/LicensesTransformer.php
@@ -54,11 +54,11 @@ class LicensesTransformer
             'updated_at' => Helper::getFormattedDateObject($license->updated_at, 'datetime'),
             'deleted_at' => Helper::getFormattedDateObject($license->deleted_at, 'datetime'),
             'user_can_checkout' => (bool) ($license->free_seats_count > 0),
-
+            'disabled' => $license->isInactive(),
         ];
 
         $permissions_array['available_actions'] = [
-            'checkout' => Gate::allows('checkout', License::class),
+            'checkout' => Gate::allows('checkout', $license),
             'checkin' => Gate::allows('checkin', License::class),
             'clone' => Gate::allows('create', License::class),
             'update' => Gate::allows('update', License::class),

--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -296,6 +296,18 @@ class License extends Depreciable
         }
         $this->attributes['termination_date'] = $value;
     }
+
+    public function isInactive(): bool
+{
+    $day = now()->startOfDay();
+
+    $expired = $this->expiration_date && $this->asDateTime($this->expiration_date)->startofDay()->lessThanOrEqualTo($day);
+
+    $terminated = $this->termination_date && $this->asDateTime($this->termination_date)->startofDay()->lessThanOrEqualTo($day);
+
+
+    return $expired || $terminated;
+}
     /**
      * Sets free_seat_count attribute
      *

--- a/app/Presenters/LicensePresenter.php
+++ b/app/Presenters/LicensePresenter.php
@@ -202,7 +202,7 @@ class LicensePresenter extends Presenter
             'switchable' => false,
             'title' => trans('general.checkin').'/'.trans('general.checkout'),
             'visible' => true,
-            'formatter' => 'licenseSeatInOutFormatter',
+            'formatter' => 'licenseInOutFormatter',
             'printIgnore' => true,
         ];
 

--- a/app/Presenters/LicensePresenter.php
+++ b/app/Presenters/LicensePresenter.php
@@ -202,7 +202,7 @@ class LicensePresenter extends Presenter
             'switchable' => false,
             'title' => trans('general.checkin').'/'.trans('general.checkout'),
             'visible' => true,
-            'formatter' => 'licensesInOutFormatter',
+            'formatter' => 'licenseSeatInOutFormatter',
             'printIgnore' => true,
         ];
 

--- a/resources/lang/en-US/admin/licenses/message.php
+++ b/resources/lang/en-US/admin/licenses/message.php
@@ -46,6 +46,7 @@ return array(
         'not_enough_seats' => 'Not enough license seats available for checkout',
         'mismatch' => 'The license seat provided does not match the license',
         'unavailable' => 'This seat is not available for checkout.',
+        'license_is_inactive' => 'This license is expired or terminated.',
     ),
 
     'checkin' => array(

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -556,21 +556,30 @@
         }
     }
 
-
+    function licenseInOutFormatter(value, row) {
+        if(row.disabled || row.user_can_checkout === false) {
+            return '<a href="{{ config('app.url') }}/licenses/' + row.id + '/checkin" class="btn btn-sm bg-maroon disabled" data-tooltip="true" title="{{ trans('general.checkin_tooltip') }}">{{ trans('general.checkout') }}</a>';
+        } else
+            // The user is allowed to check the license seat out and it's available
+        if ((row.available_actions.checkout === true) && (row.user_can_checkout === true)) {
+            return '<a href="{{ config('app.url') }}/licenses/' + row.id + '/checkout/'+row.id+'" class="btn btn-sm bg-maroon" data-tooltip="true" title="{{ trans('general.checkout_tooltip') }}">{{ trans('general.checkout') }}</a>';
+        }
+    }
     // We need a special formatter for license seats, since they don't work exactly the same
     // Checkouts need the license ID, checkins need the specific seat ID
 
     function licenseSeatInOutFormatter(value, row) {
+        if (row.disabled && (row.assigned_user || row.assigned_asset)) {
+            return '<a href="{{ config('app.url') }}/licenses/' + row.id + '/checkin" class="btn btn-sm bg-purple" data-tooltip="true" title="{{ trans('general.checkin_tooltip') }}">{{ trans('general.checkin') }}</a>';
+        }
         if(row.disabled) {
             return '<a href="{{ config('app.url') }}/licenses/' + row.id + '/checkin" class="btn btn-sm bg-maroon disabled" data-tooltip="true" title="{{ trans('general.checkin_tooltip') }}">{{ trans('general.checkout') }}</a>';
-        } else
+        }
         // The user is allowed to check the license seat out and it's available
-        if ((row.available_actions.checkout === true) && (row.user_can_checkout === true) && ((!row.asset_id) && (!row.assigned_to))) {
+        if ((row.available_actions.checkout === true) && (row.user_can_checkout === true) && ((!row.assigned_asset) && (!row.assigned_user))) {
             return '<a href="{{ config('app.url') }}/licenses/' + row.license_id + '/checkout/'+row.id+'" class="btn btn-sm bg-maroon" data-tooltip="true" title="{{ trans('general.checkout_tooltip') }}">{{ trans('general.checkout') }}</a>';
         }
-        else {
-                return '<a href="{{ config('app.url') }}/licenses/' + row.id + '/checkin" class="btn btn-sm bg-purple" data-tooltip="true" title="{{ trans('general.checkin_tooltip') }}">{{ trans('general.checkin') }}</a>';
-            }
+
     }
 
     function genericCheckinCheckoutFormatter(destination) {


### PR DESCRIPTION
This adds a formatter for the checkin/out buttons on the license index page, because it works slightly different than the licenses seats formatter would. but both now check for expiration and termination dates and disable the checkout button if those dates have passed.
Licenses Index:
<img width="1157" height="791" alt="image" src="https://github.com/user-attachments/assets/7f6741b3-683c-4553-ba2f-b1166cb14c6e" />

When viewing the license a warning appears explaining/reminding the user that the license is no longer usable.
<img width="1191" height="791" alt="image" src="https://github.com/user-attachments/assets/d1f85cea-403c-4b6a-bb00-11b2fb7546d0" />

Still allows checkins but disables checkouts.

#8799