### PR TITLE
[Feature] add API endpoint to request user asset print

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -18,6 +18,7 @@ use App\Models\Accessory;
 use App\Models\Company;
 use App\Models\Consumable;
 use App\Models\License;
+use App\Models\Setting;
 use App\Models\User;
 use App\Notifications\CurrentInventory;
 use App\Notifications\WelcomeNotification;
@@ -660,6 +661,49 @@ class UsersController extends Controller
 
         return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/users/message.user_not_found', compact('id'))));
 
+    }
+
+    /**
+     * Print inventory
+     *
+     * @since [v8.3.2]
+     * @author Aladin Alaily
+     */
+    public function printInventory($id)
+    {
+        $this->authorize('view', User::class);
+
+        $user = User::where('id', $id)
+            ->with([
+                'assets.log' => fn($query) => $query->withTrashed()->where('target_type', User::class)->where('target_id', $id)->where('action_type', 'accepted'),
+                'assets.assignedAssets.log' => fn($query) => $query->withTrashed()->where('target_type', User::class)->where('target_id', $id)->where('action_type', 'accepted'),
+                'assets.assignedAssets.defaultLoc',
+                'assets.assignedAssets.location',
+                'assets.assignedAssets.model.category',
+                'assets.defaultLoc',
+                'assets.location',
+                'assets.model.category',
+                'accessories.log' => fn($query) => $query->withTrashed()->where('target_type', User::class)->where('target_id', $id)->where('action_type', 'accepted'),
+                'accessories.category',
+                'accessories.manufacturer',
+                'consumables.log' => fn($query) => $query->withTrashed()->where('target_type', User::class)->where('target_id', $id)->where('action_type', 'accepted'),
+                'consumables.category',
+                'consumables.manufacturer',
+                'licenses.category',
+            ])
+            ->withTrashed()
+            ->first();
+
+        if ($user) {
+            $this->authorize('view', $user);
+
+            return response()->json(Helper::formatStandardApiResponse('success',view('users.print')
+                ->with('users', [$user])
+                ->with('settings', Setting::getSettings())
+                ->render(), null));
+        }
+
+        return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/users/message.user_not_found', compact('id'))));
     }
 
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -1103,6 +1103,14 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'api-throttle:api']], fu
                 ]
             )->name('api.users.email_assets');
 
+            Route::get('{userId}/print',
+                [
+                    Api\UsersController::class,
+                    'printInventory'
+                ]
+            )->name('api.users.print');
+
+
             Route::get('{user}/accessories',
             [
                 Api\UsersController::class, 


### PR DESCRIPTION
This is a small feature addition to the API. 

This change copies the inventory print function from the regular user to the API.
It would be available under `https://{{host}}/api/v1/users/{{userId}}/print`

Is there any way to update the API docs? I could not find a way to contribute.

Our goal is to generate these reports automatically as part of an automated process.