### PR TITLE
Rewords Purchase cost to Unit Cost for Accessories, Components, Consumables

### DIFF
--- a/app/Presenters/AccessoryPresenter.php
+++ b/app/Presenters/AccessoryPresenter.php
@@ -120,7 +120,7 @@ class AccessoryPresenter extends Presenter
                 'field' => 'purchase_cost',
                 'searchable' => true,
                 'sortable' => true,
-                'title' => trans('general.purchase_cost'),
+                'title' => trans('general.unit_cost'),
                 'footerFormatter' => 'sumFormatterQuantity',
                 'class' => 'text-right text-padding-number-cell',
             ], [

--- a/app/Presenters/ComponentPresenter.php
+++ b/app/Presenters/ComponentPresenter.php
@@ -126,7 +126,7 @@ class ComponentPresenter extends Presenter
                 'field' => 'purchase_cost',
                 'searchable' => true,
                 'sortable' => true,
-                'title' => trans('general.purchase_cost'),
+                'title' => trans('general.unit_cost'),
                 'visible' => true,
                 'footerFormatter' => 'sumFormatterQuantity',
                 'class' => 'text-right',

--- a/app/Presenters/ConsumablePresenter.php
+++ b/app/Presenters/ConsumablePresenter.php
@@ -126,7 +126,7 @@ class ConsumablePresenter extends Presenter
                 'field' => 'purchase_cost',
                 'searchable' => true,
                 'sortable' => true,
-                'title' => trans('general.purchase_cost'),
+                'title' => trans('general.unit_cost'),
                 'visible' => true,
                 'footerFormatter' => 'sumFormatterQuantity',
                 'class' => 'text-right text-padding-number-cell',

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -313,6 +313,7 @@ return [
     'undeployable'			=> 'Un-deployable',
     'unknown_admin'			=> 'Unknown Admin',
     'unknown_user'          => 'Unknown User',
+    'unit_cost'				=> 'Unit Cost',
     'username'              => 'Username',
     'update'                => 'Update',
     'updating_item' => 'Updating :item',

--- a/resources/views/accessories/edit.blade.php
+++ b/resources/views/accessories/edit.blade.php
@@ -24,7 +24,7 @@
 @include ('partials.forms.edit.model_number')
 @include ('partials.forms.edit.order_number')
 @include ('partials.forms.edit.datepicker', ['translated_name' => trans('general.purchase_date'),'fieldname' => 'purchase_date'])
-@include ('partials.forms.edit.purchase_cost', ['currency_type' => $item->location->currency ?? null])
+@include ('partials.forms.edit.purchase_cost', ['currency_type' => $item->location->currency ?? null, 'unit_cost' => trans('general.unit_cost')])
 @include ('partials.forms.edit.quantity')
 @include ('partials.forms.edit.minimum_quantity')
 @include ('partials.forms.edit.notes')

--- a/resources/views/accessories/view.blade.php
+++ b/resources/views/accessories/view.blade.php
@@ -236,7 +236,7 @@
               <div class="row">
                   <div class="col-md-3" style="padding-bottom: 10px;">
                       <strong>
-                          {{ trans('general.purchase_cost') }}
+                          {{ trans('general.unit_cost') }}
                       </strong>
                   </div>
                   <div class="col-md-9" style="word-wrap: break-word;">

--- a/resources/views/components/edit.blade.php
+++ b/resources/views/components/edit.blade.php
@@ -28,7 +28,7 @@
 @include ('partials.forms.edit.supplier-select', ['translated_name' => trans('general.supplier'), 'fieldname' => 'supplier_id'])
 @include ('partials.forms.edit.order_number')
 @include ('partials.forms.edit.datepicker', ['translated_name' => trans('general.purchase_date'),'fieldname' => 'purchase_date'])
-@include ('partials.forms.edit.purchase_cost')
+@include ('partials.forms.edit.purchase_cost', ['unit_cost' => trans('general.unit_cost')])
 @include ('partials.forms.edit.notes')
 @include ('partials.forms.edit.image-upload', ['image_path' => app('components_upload_path')])
 

--- a/resources/views/components/view.blade.php
+++ b/resources/views/components/view.blade.php
@@ -201,7 +201,7 @@
     @endif
 
     @if ($component->purchase_cost)
-    <div class="col-md-12" style="padding-bottom: 5px;"><strong>{{ trans('admin/components/general.cost') }}:</strong>
+    <div class="col-md-12" style="padding-bottom: 5px;"><strong>{{ trans('general.unit_cost') }}:</strong>
     {{ $snipeSettings->default_currency }}
 
     {{ Helper::formatCurrencyOutput($component->purchase_cost) }} </div>

--- a/resources/views/consumables/edit.blade.php
+++ b/resources/views/consumables/edit.blade.php
@@ -24,7 +24,7 @@
 @include ('partials.forms.edit.item_number')
 @include ('partials.forms.edit.order_number')
 @include ('partials.forms.edit.datepicker', ['translated_name' => trans('general.purchase_date'),'fieldname' => 'purchase_date'])
-@include ('partials.forms.edit.purchase_cost')
+@include ('partials.forms.edit.purchase_cost', [ 'unit_cost' => trans('general.unit_cost')])
 @include ('partials.forms.edit.quantity')
 @include ('partials.forms.edit.minimum_quantity')
 @include ('partials.forms.edit.notes')

--- a/resources/views/consumables/view.blade.php
+++ b/resources/views/consumables/view.blade.php
@@ -272,7 +272,7 @@
                   @if ($consumable->purchase_cost)
                     <div class="row">
                       <div class="col-md-3">
-                        {{ trans('general.purchase_cost') }}
+                        {{ trans('general.unit_cost') }}
                       </div>
                       <div class="col-md-9">
                         {{ $snipeSettings->default_currency }}

--- a/resources/views/partials/forms/edit/purchase_cost.blade.php
+++ b/resources/views/partials/forms/edit/purchase_cost.blade.php
@@ -1,6 +1,6 @@
 <!-- Purchase Cost -->
 <div class="form-group {{ $errors->has('purchase_cost') ? ' has-error' : '' }}">
-    <label for="purchase_cost" class="col-md-3 control-label">{{ trans('general.purchase_cost') }}</label>
+    <label for="purchase_cost" class="col-md-3 control-label">{{ $unit_cost ?? trans('general.purchase_cost') }}</label>
     <div class="col-md-9">
         <div class="input-group col-md-5" style="padding-left: 0px;">
             <input class="form-control" type="number" name="purchase_cost" min="0.00" max="99999999999999999.000" step="0.001" aria-label="purchase_cost" id="purchase_cost" value="{{ old('purchase_cost', $item->purchase_cost) }}" maxlength="25" />

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -927,7 +927,7 @@
                     <th>{{ trans('general.name') }}</th>
                     <th>{{ trans('general.date') }}</th>
                     <th data-fieldname="note">{{ trans('general.notes') }}</th>
-                    <th data-footer-formatter="sumFormatter" data-fieldname="purchase_cost">{{ trans('general.purchase_cost') }}</th>
+                    <th data-footer-formatter="sumFormatter" data-fieldname="purchase_cost">{{ trans('general.unit_cost') }}</th>
                     <th class="hidden-print">{{ trans('general.action') }}</th>
                 </tr>
               </thead>
@@ -971,7 +971,7 @@
               <thead>
                 <tr>
                   <th class="col-md-3">{{ trans('general.name') }}</th>
-                  <th class="col-md-2" data-footer-formatter="sumFormatter" data-fieldname="purchase_cost">{{ trans('general.purchase_cost') }}</th>
+                  <th class="col-md-2" data-footer-formatter="sumFormatter" data-fieldname="purchase_cost">{{ trans('general.unit_cost') }}</th>
                   <th class="col-md-2">{{ trans('general.date') }}</th>
                     <th class="col-md-5">{{ trans('general.notes') }}</th>
                 </tr>


### PR DESCRIPTION
This changes the purchase cost translations to unit cost for Accessories, Components, and Consumables. This should create less confusion and more accurately represent the values shown.
Users:
<img width="1085" height="265" alt="image" src="https://github.com/user-attachments/assets/8072bdbb-81e6-4764-8854-a5e001e1db4e" />
<img width="1085" height="265" alt="image" src="https://github.com/user-attachments/assets/09b2a3b9-dcd9-4475-98f0-13d5c3178f1a" />
Consumables:
<img width="492" height="461" alt="image" src="https://github.com/user-attachments/assets/de7b9cb7-5b7d-4288-a630-8b30078a808c" />
<img width="1085" height="461" alt="image" src="https://github.com/user-attachments/assets/393bc69f-5726-498d-a350-58c18ef9602f" />
<img width="868" height="638" alt="image" src="https://github.com/user-attachments/assets/5f71bba4-374e-43e5-b115-4be37406b2a0" />

Accessories:
<img width="688" height="712" alt="image" src="https://github.com/user-attachments/assets/5323b075-2146-4869-91b6-cdc7be884c89" />
<img width="1080" height="396" alt="image" src="https://github.com/user-attachments/assets/34319a3c-e617-43c8-804a-37eee443d6e2" />
<img width="868" height="638" alt="image" src="https://github.com/user-attachments/assets/acaf53d9-6443-41be-9aac-148d3552f1df" />

Components:
<img width="1080" height="490" alt="image" src="https://github.com/user-attachments/assets/eda6b7d6-2572-43f3-939b-fd9d268a9f0f" />
<img width="1080" height="490" alt="image" src="https://github.com/user-attachments/assets/d7fee7a4-6c01-4876-ad1e-362bb0180cbe" />
<img width="868" height="638" alt="image" src="https://github.com/user-attachments/assets/e197c781-2413-4a2b-9311-2393be085e03" />
