### PR TITLE
Fixed potentially incorrect qty in component checkout email

### DIFF
--- a/app/Http/Controllers/Components/ComponentCheckoutController.php
+++ b/app/Http/Controllers/Components/ComponentCheckoutController.php
@@ -102,13 +102,15 @@ class ComponentCheckoutController extends Controller
             return redirect()->route('components.checkout.show', $componentId)->with('error', trans('general.error_user_company'));
         }
 
+        $component->checkout_qty = $request->input('assigned_qty');
+
         // Update the component data
         $component->asset_id = $request->input('asset_id');
         $component->assets()->attach($component->id, [
             'component_id' => $component->id,
             'created_by' => auth()->user()->id,
             'created_at' => date('Y-m-d H:i:s'),
-            'assigned_qty' => $request->input('assigned_qty'),
+            'assigned_qty' => $component->checkout_qty,
             'asset_id' => $request->input('asset_id'),
             'note' => $request->input('note'),
         ]);

--- a/app/Mail/CheckoutComponentMail.php
+++ b/app/Mail/CheckoutComponentMail.php
@@ -26,7 +26,7 @@ class CheckoutComponentMail extends Mailable
         $this->note = $note;
         $this->target = $checkedOutTo;
         $this->acceptance = $acceptance;
-        $this->qty = $component->assets->first()?->pivot?->assigned_qty;
+        $this->qty = $component->checkout_qty;
 
         $this->settings = Setting::getSettings();
     }


### PR DESCRIPTION
While working on #17826 I noticed that the `qty` in the component checkout email referenced the _first_ checkout to that asset. Meaning if a component was checked out to an asset with a `qty` of 2 and the action was repeated but using a `qty` of 1 the second time, the email would still say 2:

https://github.com/user-attachments/assets/24eaaf8f-086d-4874-bf7b-574f2cb92b2c

