### PR TITLE
Attempt to improve CSP

### DIFF
--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -87,14 +87,36 @@ class SecurityHeaders
             $csp_policy[] = "connect-src 'self'";
             $csp_policy[] = "object-src 'none'";
             $csp_policy[] = "font-src 'self' data:";
-            $csp_policy[] = "img-src 'self' data: ".config('app.url').' '.config('app.additional_csp_urls').' '.env('PUBLIC_AWS_URL').' https://secure.gravatar.com http://gravatar.com maps.google.com maps.gstatic.com *.googleapis.com';
-	          
+            $csp_policy[] = "img-src 'self' data: " . config('app.url') . ' ' . config('app.additional_csp_urls') . ' ' . env('PUBLIC_AWS_URL') . ' https://secure.gravatar.com http://gravatar.com maps.google.com maps.gstatic.com *.googleapis.com';
+
             if (config('filesystems.disks.public.driver') == 's3') {
-               $csp_policy[] = "img-src 'self' data:  ".config('filesystems.disks.public.url');
+                $csp_policy[] = "img-src 'self' data:  " . config('filesystems.disks.public.url');
             }
             $csp_policy = join(';', $csp_policy);
 
             $response->headers->set('Content-Security-Policy', $csp_policy);
+
+            $csp_policy = [];
+            $csp_policy[] = "default-src 'self'";
+            $csp_policy[] = "style-src 'self' 'unsafe-inline'";
+            $csp_policy[] = "script-src 'self' 'nonce-" . csrf_token() . "'";
+            $csp_policy[] = "connect-src 'self'";
+            $csp_policy[] = "object-src 'none'";
+            $csp_policy[] = "font-src 'self' data:";
+            $csp_policy[] = "img-src 'self' data: https://secure.gravatar.com https://gravatar.com https://maps.google.com https://maps.gstatic.com https://*.googleapis.com";
+            $csp_policy[] = "img-src 'self' data: " . config('app.url') . ' ' . config('app.additional_csp_urls') . ' ' . env('PUBLIC_AWS_URL');
+
+            if (config('filesystems.disks.public.driver') == 's3') {
+                $csp_policy[] = "img-src 'self' data:  " . config('filesystems.disks.public.url');
+            }
+
+            if (config('allow_iframing') == false) {
+                $csp_policy[] = "frame-ancestors 'none'";
+            }
+
+            $csp_policy = join(';', $csp_policy);
+
+            $response->headers->set('Content-Security-Policy-Report-Only', $csp_policy);
         }
 
         return $response;

--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -81,51 +81,60 @@ class SecurityHeaders
         // and it will break things.
 
         if ((config('app.debug') != 'true') && (config('app.enable_csp') == 'true')) {
-            $csp_policy[] = "default-src 'self'";
-            $csp_policy[] = "style-src 'self' 'unsafe-inline'";
-            $csp_policy[] = "script-src 'self' 'unsafe-inline' 'unsafe-eval'";
-            $csp_policy[] = "connect-src 'self'";
-            $csp_policy[] = "object-src 'none'";
-            $csp_policy[] = "font-src 'self' data:";
-            $csp_policy[] = "img-src 'self' data: " . config('app.url') . ' ' . config('app.additional_csp_urls') . ' ' . env('PUBLIC_AWS_URL') . ' https://secure.gravatar.com http://gravatar.com maps.google.com maps.gstatic.com *.googleapis.com';
+            $laxCspPolicy[] = "default-src 'self'";
+            $laxCspPolicy[] = "style-src 'self' 'unsafe-inline'";
+            $laxCspPolicy[] = "script-src 'self' 'unsafe-inline' 'unsafe-eval'";
+            $laxCspPolicy[] = "connect-src 'self'";
+            $laxCspPolicy[] = "object-src 'none'";
+            $laxCspPolicy[] = "font-src 'self' data:";
+            $laxCspPolicy[] = "img-src 'self' data: " . config('app.url') . ' ' . config('app.additional_csp_urls') . ' ' . env('PUBLIC_AWS_URL') . ' https://secure.gravatar.com http://gravatar.com maps.google.com maps.gstatic.com *.googleapis.com';
 
             if (config('filesystems.disks.public.driver') == 's3') {
-                $csp_policy[] = "img-src 'self' data:  " . config('filesystems.disks.public.url');
+                $laxCspPolicy[] = "img-src 'self' data:  " . config('filesystems.disks.public.url');
             }
-            $csp_policy = join(';', $csp_policy);
+            
+            $laxCspPolicy = join(';', $laxCspPolicy);
 
-            $response->headers->set('Content-Security-Policy', $csp_policy);
-
-            $csp_policy = [];
-            $csp_policy[] = "default-src 'self'";
-            $csp_policy[] = "style-src 'self' 'unsafe-inline'";
-            $csp_policy[] = "script-src 'self' 'nonce-" . csrf_token() . "'";
-            $csp_policy[] = "connect-src 'self'";
-            $csp_policy[] = "base-uri 'self'";
-            $csp_policy[] = "object-src 'none'";
-            $csp_policy[] = "font-src 'self' data:";
-            $csp_policy[] = "img-src 'self' data: ". config('app.url') . ' ' . config('app.additional_csp_urls') . ' ' . env('PUBLIC_AWS_URL') . ' https://secure.gravatar.com https://gravatar.com https://maps.google.com https://maps.gstatic.com https://*.googleapis.com';
+            $strictCspPolicy[] = "default-src 'self'";
+            $strictCspPolicy[] = "style-src 'self' 'unsafe-inline'";
+            $strictCspPolicy[] = "script-src 'self' 'nonce-" . csrf_token() . "'";
+            $strictCspPolicy[] = "connect-src 'self'";
+            $strictCspPolicy[] = "base-uri 'self'";
+            $strictCspPolicy[] = "object-src 'none'";
+            $strictCspPolicy[] = "font-src 'self' data:";
+            $strictCspPolicy[] = "img-src 'self' data: " . config('app.url') . ' ' . config('app.additional_csp_urls') . ' ' . env('PUBLIC_AWS_URL') . ' https://secure.gravatar.com https://gravatar.com https://maps.google.com https://maps.gstatic.com https://*.googleapis.com';
 
             if (config('filesystems.disks.public.driver') == 's3') {
-                $csp_policy[] = "img-src 'self' data:  " . config('filesystems.disks.public.url');
+                $strictCspPolicy[] = "img-src 'self' data:  " . config('filesystems.disks.public.url');
             }
 
             if (config('allow_iframing') == false) {
-                $csp_policy[] = "frame-ancestors 'none'";
+                $strictCspPolicy[] = "frame-ancestors 'none'";
             }
+
+            $cspReportOnlyPolicy = $strictCspPolicy;
+
+            $strictCspPolicy = join(';', $strictCspPolicy);
+
+            if (config('enable_strict_csp') == true) {
+                $response->headers->set('Content-Security-Policy', $strictCspPolicy);
+            } else {
+                $response->headers->set('Content-Security-Policy', $laxCspPolicy);
+            }
+
 
             if (!empty(config('csp_report_to'))) {
                 $cspReportToUri = config('csp_report_to');
 
-                $response->headers->set('Reporting-Endpoints', 'csp-endpoint="'.$cspReportToUri.'"');
+                $response->headers->set('Reporting-Endpoints', 'csp-endpoint="' . $cspReportToUri . '"');
 
-                $csp_policy[] = "report-to csp-endpoint";
-                $csp_policy[] = "report-uri ".$cspReportToUri;
+                $cspReportOnlyPolicy[] = "report-to csp-endpoint";
+                $cspReportOnlyPolicy[] = "report-uri " . $cspReportToUri;
             }
 
-            $csp_policy = join(';', $csp_policy);
+            $cspReportOnlyPolicy = join(';', $cspReportOnlyPolicy);
 
-            $response->headers->set('Content-Security-Policy-Report-Only', $csp_policy);
+            $response->headers->set('Content-Security-Policy-Report-Only', $cspReportOnlyPolicy);
         }
 
         return $response;

--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -81,6 +81,8 @@ class SecurityHeaders
         // and it will break things.
 
         if ((config('app.debug') != 'true') && (config('app.enable_csp') == 'true')) {
+            ## start lax CSP
+
             $laxCspPolicy[] = "default-src 'self'";
             $laxCspPolicy[] = "style-src 'self' 'unsafe-inline'";
             $laxCspPolicy[] = "script-src 'self' 'unsafe-inline' 'unsafe-eval'";
@@ -93,7 +95,9 @@ class SecurityHeaders
                 $laxCspPolicy[] = "img-src 'self' data:  " . config('filesystems.disks.public.url');
             }
 
-            $laxCspPolicy = join(';', $laxCspPolicy);
+            ## end lax CSP
+
+            ## start strict CSP
 
             $strictCspPolicy[] = "default-src 'self'";
             $strictCspPolicy[] = "style-src 'self' 'nonce-" . csrf_token() . "'";
@@ -113,8 +117,21 @@ class SecurityHeaders
                 $strictCspPolicy[] = "frame-ancestors 'none'";
             }
 
-            $cspReportOnlyPolicy = $strictCspPolicy;
+            ## end strict CSP
 
+            if (!empty(config('csp_report_to'))) {
+                $cspReportToUri = config('csp_report_to');
+
+                $response->headers->set('Reporting-Endpoints', 'csp-endpoint="' . $cspReportToUri . '"');
+
+                $cspReportTo[] = "report-to csp-endpoint";
+                $cspReportTo[] = "report-uri " . $cspReportToUri;
+
+                $laxCspPolicy = array_merge($laxCspPolicy, $cspReportTo);
+                $strictCspPolicy = array_merge($strictCspPolicy, $laxCspPolicy);
+            }
+
+            $laxCspPolicy = join(';', $laxCspPolicy);
             $strictCspPolicy = join(';', $strictCspPolicy);
 
             if (config('enable_strict_csp') == true) {
@@ -123,19 +140,7 @@ class SecurityHeaders
                 $response->headers->set('Content-Security-Policy', $laxCspPolicy);
             }
 
-
-            if (!empty(config('csp_report_to'))) {
-                $cspReportToUri = config('csp_report_to');
-
-                $response->headers->set('Reporting-Endpoints', 'csp-endpoint="' . $cspReportToUri . '"');
-
-                $cspReportOnlyPolicy[] = "report-to csp-endpoint";
-                $cspReportOnlyPolicy[] = "report-uri " . $cspReportToUri;
-            }
-
-            $cspReportOnlyPolicy = join(';', $cspReportOnlyPolicy);
-
-            $response->headers->set('Content-Security-Policy-Report-Only', $cspReportOnlyPolicy);
+            $response->headers->set('Content-Security-Policy-Report-Only', $strictCspPolicy);
         }
 
         return $response;

--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -114,6 +114,15 @@ class SecurityHeaders
                 $csp_policy[] = "frame-ancestors 'none'";
             }
 
+            if (!empty(config('csp_report_to'))) {
+                $csp_report_to_uri = config('csp_report_to');
+
+                $response->headers->set('Reporting-Endpoints', 'csp-endpoint="'.$csp_report_to_uri.'"');
+
+                $csp_policy[] = "report-to csp-endpoint";
+                $csp_policy[] = "report-uri ".$csp_report_to_uri;
+            }
+
             $csp_policy = join(';', $csp_policy);
 
             $response->headers->set('Content-Security-Policy-Report-Only', $csp_policy);

--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -130,7 +130,7 @@ class SecurityHeaders
                 $cspReportTo[] = "report-uri " . $cspReportToUri;
 
                 $laxCspPolicy = array_merge($laxCspPolicy, $cspReportTo);
-                $strictCspPolicy = array_merge($strictCspPolicy, $laxCspPolicy);
+                $strictCspPolicy = array_merge($strictCspPolicy, $cspReportTo);
             }
 
             $laxCspPolicy = join(';', $laxCspPolicy);

--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -115,12 +115,12 @@ class SecurityHeaders
             }
 
             if (!empty(config('csp_report_to'))) {
-                $csp_report_to_uri = config('csp_report_to');
+                $cspReportToUri = config('csp_report_to');
 
-                $response->headers->set('Reporting-Endpoints', 'csp-endpoint="'.$csp_report_to_uri.'"');
+                $response->headers->set('Reporting-Endpoints', 'csp-endpoint="'.$cspReportToUri.'"');
 
                 $csp_policy[] = "report-to csp-endpoint";
-                $csp_policy[] = "report-uri ".$csp_report_to_uri;
+                $csp_policy[] = "report-uri ".$cspReportToUri;
             }
 
             $csp_policy = join(';', $csp_policy);

--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -100,7 +100,9 @@ class SecurityHeaders
             ## start strict CSP
 
             $strictCspPolicy[] = "default-src 'self'";
-            $strictCspPolicy[] = "style-src 'self' 'nonce-" . csrf_token() . "'";
+            // FIXME: There is a LOT of dynamically loaded inline styles into elements, so this isn't going to work for now...
+            // $strictCspPolicy[] = "style-src 'self' 'nonce-" . csrf_token() . "'";
+            $strictCspPolicy[] = "style-src 'self' 'unsafe-inline'";
             $strictCspPolicy[] = "script-src 'self' 'nonce-" . csrf_token() . "'";
             $strictCspPolicy[] = "connect-src 'self'";
             $strictCspPolicy[] = "base-uri 'self'";

--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -101,6 +101,7 @@ class SecurityHeaders
             $csp_policy[] = "style-src 'self' 'unsafe-inline'";
             $csp_policy[] = "script-src 'self' 'nonce-" . csrf_token() . "'";
             $csp_policy[] = "connect-src 'self'";
+            $csp_policy[] = "base-uri 'self'";
             $csp_policy[] = "object-src 'none'";
             $csp_policy[] = "font-src 'self' data:";
             $csp_policy[] = "img-src 'self' data: ". config('app.url') . ' ' . config('app.additional_csp_urls') . ' ' . env('PUBLIC_AWS_URL') . ' https://secure.gravatar.com https://gravatar.com https://maps.google.com https://maps.gstatic.com https://*.googleapis.com';

--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -96,7 +96,7 @@ class SecurityHeaders
             $laxCspPolicy = join(';', $laxCspPolicy);
 
             $strictCspPolicy[] = "default-src 'self'";
-            $strictCspPolicy[] = "style-src 'self' 'unsafe-inline'";
+            $strictCspPolicy[] = "style-src 'self' 'nonce-" . csrf_token() . "'";
             $strictCspPolicy[] = "script-src 'self' 'nonce-" . csrf_token() . "'";
             $strictCspPolicy[] = "connect-src 'self'";
             $strictCspPolicy[] = "base-uri 'self'";

--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -92,7 +92,7 @@ class SecurityHeaders
             if (config('filesystems.disks.public.driver') == 's3') {
                 $laxCspPolicy[] = "img-src 'self' data:  " . config('filesystems.disks.public.url');
             }
-            
+
             $laxCspPolicy = join(';', $laxCspPolicy);
 
             $strictCspPolicy[] = "default-src 'self'";
@@ -100,6 +100,7 @@ class SecurityHeaders
             $strictCspPolicy[] = "script-src 'self' 'nonce-" . csrf_token() . "'";
             $strictCspPolicy[] = "connect-src 'self'";
             $strictCspPolicy[] = "base-uri 'self'";
+            $strictCspPolicy[] = "form-action 'self'";
             $strictCspPolicy[] = "object-src 'none'";
             $strictCspPolicy[] = "font-src 'self' data:";
             $strictCspPolicy[] = "img-src 'self' data: " . config('app.url') . ' ' . config('app.additional_csp_urls') . ' ' . env('PUBLIC_AWS_URL') . ' https://secure.gravatar.com https://gravatar.com https://maps.google.com https://maps.gstatic.com https://*.googleapis.com';

--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -103,8 +103,7 @@ class SecurityHeaders
             $csp_policy[] = "connect-src 'self'";
             $csp_policy[] = "object-src 'none'";
             $csp_policy[] = "font-src 'self' data:";
-            $csp_policy[] = "img-src 'self' data: https://secure.gravatar.com https://gravatar.com https://maps.google.com https://maps.gstatic.com https://*.googleapis.com";
-            $csp_policy[] = "img-src 'self' data: " . config('app.url') . ' ' . config('app.additional_csp_urls') . ' ' . env('PUBLIC_AWS_URL');
+            $csp_policy[] = "img-src 'self' data: ". config('app.url') . ' ' . config('app.additional_csp_urls') . ' ' . env('PUBLIC_AWS_URL') . ' https://secure.gravatar.com https://gravatar.com https://maps.google.com https://maps.gstatic.com https://*.googleapis.com';
 
             if (config('filesystems.disks.public.driver') == 's3') {
                 $csp_policy[] = "img-src 'self' data:  " . config('filesystems.disks.public.url');

--- a/config/app.php
+++ b/config/app.php
@@ -203,6 +203,7 @@ return [
 
     'additional_csp_urls' => env('ADDITIONAL_CSP_URLS', ''),
 
+    'csp_report_to' => env("CSP_REPORT_TO", null),
 
 
     /*

--- a/config/app.php
+++ b/config/app.php
@@ -201,6 +201,8 @@ return [
 
     'enable_csp' => env('ENABLE_CSP', true),
 
+    'enable_strict_csp' => env('ENABLE_STRICT_CSP', false),
+
     'additional_csp_urls' => env('ADDITIONAL_CSP_URLS', ''),
 
     'csp_report_to' => env("CSP_REPORT_TO", null),

--- a/resources/assets/js/snipeit.js
+++ b/resources/assets/js/snipeit.js
@@ -160,7 +160,17 @@ $(function () {
         return false;
     });
 
+    $el.on('click', '.js-suppress-click', function (event) {
+        return false;
+    });
 
+    $el.on('submit', '.js-suppress-submit', function (event) {
+        return false;
+    });
+
+    $el.on('focus', '.js-allow-write-on-focus', function (event) {
+        this.removeAttribute('readonly');
+    });
 
      /*
      * Select2

--- a/resources/assets/js/snipeit.js
+++ b/resources/assets/js/snipeit.js
@@ -160,15 +160,15 @@ $(function () {
         return false;
     });
 
-    $el.on('click', '.js-suppress-click', function (event) {
+    $el.on('click', '.js-suppress-click', function () {
         return false;
     });
 
-    $el.on('submit', '.js-suppress-submit', function (event) {
+    $el.on('submit', '.js-suppress-submit', function () {
         return false;
     });
 
-    $el.on('focus', '.js-allow-write-on-focus', function (event) {
+    $el.on('focus', '.js-allow-write-on-focus', function () {
         this.removeAttribute('readonly');
     });
 

--- a/resources/assets/js/snipeit.js
+++ b/resources/assets/js/snipeit.js
@@ -172,11 +172,6 @@ $(function () {
         this.removeAttribute('readonly');
     });
 
-
-    $el.on('click', '.js-show-hide-enc-value', function() {
-        showHideEncValue(this);
-    })
-
      /*
      * Select2
      */

--- a/resources/assets/js/snipeit.js
+++ b/resources/assets/js/snipeit.js
@@ -172,6 +172,11 @@ $(function () {
         this.removeAttribute('readonly');
     });
 
+
+    $el.on('click', '.js-show-hide-enc-value', function() {
+        showHideEncValue(this);
+    })
+
      /*
      * Select2
      */

--- a/resources/views/accessories/view.blade.php
+++ b/resources/views/accessories/view.blade.php
@@ -334,7 +334,7 @@
         @can('delete', $accessory)
             @if ($accessory->checkouts_count == 0)
                 <div class="text-center" style="padding-top:5px;">
-                    <button class="btn btn-block btn-danger btn-sm btn-social delete-asset" style="padding-top:5px;" data-toggle="modal" data-title="{{ trans('general.delete') }}" data-content="{{ trans('general.delete_confirm_no_undo', ['item' => $accessory->name]) }}" data-target="#dataConfirmModal" onClick="return false;">
+                    <button class="btn btn-block btn-danger btn-sm btn-social delete-asset js-suppress-click" style="padding-top:5px;" data-toggle="modal" data-title="{{ trans('general.delete') }}" data-content="{{ trans('general.delete_confirm_no_undo', ['item' => $accessory->name]) }}" data-target="#dataConfirmModal">
                         <x-icon type="delete" />
                     {{ trans('general.delete') }}
                     </button>

--- a/resources/views/account/accept/accept-accessory-eula.blade.php
+++ b/resources/views/account/accept/accept-accessory-eula.blade.php
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <style>
+    <style nonce="{{ csrf_token() }}">
         body {
             font-family:'Dejavu Sans', Arial, Helvetica, sans-serif;
             font-size: 11px;

--- a/resources/views/account/accept/accept-asset-eula.blade.php
+++ b/resources/views/account/accept/accept-asset-eula.blade.php
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <style>
+    <style nonce="{{ csrf_token() }}">
         body {
             font-family:'Dejavu Sans', Arial, Helvetica, sans-serif;
             font-size: 11px;

--- a/resources/views/account/accept/accept-component-eula.blade.php
+++ b/resources/views/account/accept/accept-component-eula.blade.php
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <style>
+    <style nonce="{{ csrf_token() }}">
         body {
             font-family:'Dejavu Sans', Arial, Helvetica, sans-serif;
             font-size: 11px;

--- a/resources/views/account/accept/accept-consumable-eula.blade.php
+++ b/resources/views/account/accept/accept-consumable-eula.blade.php
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <style>
+    <style nonce="{{ csrf_token() }}">
         body {
             font-family:'Dejavu Sans', Arial, Helvetica, sans-serif;
             font-size: 11px;

--- a/resources/views/account/accept/accept-license-eula.blade.php
+++ b/resources/views/account/accept/accept-license-eula.blade.php
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <style>
+    <style nonce="{{ csrf_token() }}">
         body {
             font-family:'Dejavu Sans', Arial, Helvetica, sans-serif;
             font-size: 11px;

--- a/resources/views/account/accept/create.blade.php
+++ b/resources/views/account/accept/create.blade.php
@@ -13,7 +13,7 @@
 
     <link rel="stylesheet" href="{{ url('css/signature-pad.min.css') }}">
 
-    <style>
+    <style nonce="{{ csrf_token() }}">
         .form-horizontal .control-label, .form-horizontal .radio, .form-horizontal .checkbox, .form-horizontal .radio-inline, .form-horizontal .checkbox-inline {
             padding-top: 17px;
             padding-right: 10px;

--- a/resources/views/account/view-assets.blade.php
+++ b/resources/views/account/view-assets.blade.php
@@ -44,11 +44,13 @@
               </option>
             @endforeach
           </select>
+          @push('js')
           <script nonce="{{ csrf_token() }}">
             $('#user_id').on('change', function (event) {
               this.form.submit();
             })
           </script>
+          @endpush
         </div>
       </form>
     </div>

--- a/resources/views/account/view-assets.blade.php
+++ b/resources/views/account/view-assets.blade.php
@@ -34,7 +34,7 @@
           <label for="user_id" class="control-label" style="margin-right: 10px;">
             {{ trans('general.view_user_assets') }}:
           </label>
-          <select name="user_id" id="user_id" class="form-control select2" onchange="this.form.submit()" style="width: 250px; display: inline-block;">
+          <select name="user_id" id="user_id" class="form-control select2" style="width: 250px; display: inline-block;">
             @foreach ($subordinates as $subordinate)
               <option value="{{ $subordinate->id }}" {{ (int)$selectedUserId === (int)$subordinate->id ? ' selected' : '' }}>
                 {{ $subordinate->display_name }}
@@ -44,6 +44,11 @@
               </option>
             @endforeach
           </select>
+          <script nonce="{{ csrf_token() }}">
+            $('#user_id').on('change', function (event) {
+              this.form.submit();
+            })
+          </script>
         </div>
       </form>
     </div>

--- a/resources/views/auth/two_factor.blade.php
+++ b/resources/views/auth/two_factor.blade.php
@@ -47,12 +47,14 @@
                             </a>
                         </div>
 
+                        @push('js')
                         <script nonce="{{ csrf_token() }}">
                             $("#2fa-logout-button").on('click', function(event) {
                                 document.getElementById('logout-form').submit();
                                 return false;
                             })
                         </script>
+                        @endpush
             </div>
             </form>
             <form id="logout-form" action="{{ route('logout.post') }}" method="POST" style="display: none;">

--- a/resources/views/auth/two_factor.blade.php
+++ b/resources/views/auth/two_factor.blade.php
@@ -41,18 +41,18 @@
                         <div class="box-footer">
                             <button class="btn btn-lg btn-primary btn-block">{{ trans('general.submit')  }}</button>
                         </div>
-                        <script nonce="{{ csrf_token() }}">
-                            function logout(event) {
-                                document.getElementById('logout-form').submit();
-                                return false;
-                            }
-                        </script>
-
                         <div class="col-md-12 col-sm-12 col-xs-12 text-right" style="padding-top: 10px;">
-                            <a href="{{ route('logout.get') }}" onclick="logout">
+                            <a href="{{ route('logout.get') }}" id="2fa-logout-button">
                                 {{ trans('general.cancel')  }}
                             </a>
                         </div>
+
+                        <script nonce="{{ csrf_token() }}">
+                            $("#2fa-logout-button").on('click', function(event) {
+                                document.getElementById('logout-form').submit();
+                                return false;
+                            })
+                        </script>
             </div>
             </form>
             <form id="logout-form" action="{{ route('logout.post') }}" method="POST" style="display: none;">

--- a/resources/views/auth/two_factor.blade.php
+++ b/resources/views/auth/two_factor.blade.php
@@ -41,8 +41,15 @@
                         <div class="box-footer">
                             <button class="btn btn-lg btn-primary btn-block">{{ trans('general.submit')  }}</button>
                         </div>
+                        <script nonce="{{ csrf_token() }}">
+                            function logout(event) {
+                                document.getElementById('logout-form').submit();
+                                return false;
+                            }
+                        </script>
+
                         <div class="col-md-12 col-sm-12 col-xs-12 text-right" style="padding-top: 10px;">
-                            <a href="{{ route('logout.get') }}" onclick="document.getElementById('logout-form').submit(); return false;">
+                            <a href="{{ route('logout.get') }}" onclick="logout">
                                 {{ trans('general.cancel')  }}
                             </a>
                         </div>

--- a/resources/views/components/view.blade.php
+++ b/resources/views/components/view.blade.php
@@ -246,12 +246,16 @@
   @can('delete', $component)
         <div class="col-md-12 hidden-print" style="padding-top: 5px;">
           @if ($component->isDeletable())
-              <button class="btn btn-sm btn-block btn-danger btn-social delete-asset" data-icon="fa fa-trash" data-toggle="modal" data-title="{{ trans('general.delete') }}" data-content="{{ trans('general.sure_to_delete_var', ['item' => $component->name]) }}" data-target="#dataConfirmModal" onClick="return false;">
+          <button class="btn btn-sm btn-block btn-danger btn-social delete-asset js-suppress-click" data-icon="fa fa-trash"
+            data-toggle="modal" data-title="{{ trans('general.delete') }}"
+            data-content="{{ trans('general.sure_to_delete_var', ['item' => $component->name]) }}"
+            data-target="#dataConfirmModal">
               <x-icon type="delete" />
               {{ trans('general.delete') }}
             </button>
           @else
-            <a href="#" class="btn btn-block btn-sm btn-danger btn-social hidden-print disabled" data-tooltip="true"  data-placement="top" data-title="{{ trans('general.cannot_be_deleted') }}" onClick="return false;">
+          <a href="#" class="btn btn-block btn-sm btn-danger btn-social hidden-print disabled js-suppress-click"
+            data-tooltip="true" data-placement="top" data-title="{{ trans('general.cannot_be_deleted') }}">
               <x-icon type="delete" />
               {{ trans('general.delete') }}
             </a>

--- a/resources/views/consumables/view.blade.php
+++ b/resources/views/consumables/view.blade.php
@@ -139,7 +139,7 @@
                   @can('delete', $consumable)
                     <div class="col-md-12" style="padding-top: 10px; padding-bottom: 20px">
                       @if ($consumable->deleted_at=='')
-                        <button class="btn btn-sm btn-block btn-danger btn-social hidden-print delete-asset" data-icon="fa fa-trash" data-toggle="modal" data-title="{{ trans('general.delete') }}" data-content="{{ trans('general.sure_to_delete_var', ['item' => $consumable->name]) }}" data-target="#dataConfirmModal" onClick="return false;">
+                        <button class="btn btn-sm btn-block btn-danger btn-social hidden-print delete-asset js-suppress-click" data-icon="fa fa-trash" data-toggle="modal" data-title="{{ trans('general.delete') }}" data-content="{{ trans('general.sure_to_delete_var', ['item' => $consumable->name]) }}" data-target="#dataConfirmModal">
                           <x-icon type="delete" />
                           {{ trans('general.delete') }}
                         </button>

--- a/resources/views/custom_fields/index.blade.php
+++ b/resources/views/custom_fields/index.blade.php
@@ -88,7 +88,7 @@
                   @if($fieldset->models->count() > 0)
                   <button type="submit" class="btn btn-danger btn-sm disabled" data-tooltip="true" title="{{ trans('general.cannot_be_deleted') }}" disabled><i class="fas fa-trash"></i></button>
                   @else
-                  <a type="submit" href="{{ route('fieldsets.destroy', $fieldset) }}" class="btn btn-danger btn-sm delete-asset" data-tooltip="true" title="{{ trans('general.delete') }}" data-toggle="modal" data-title="{{ trans('general.delete') }}" data-content="{{ trans('general.sure_to_delete_var', ['item' => $fieldset->name]) }}" data-icon="fa fa-trash" data-target="#dataConfirmModal" onClick="return false;"><i class="fas fa-trash"></i></a>
+                  <a type="submit" href="{{ route('fieldsets.destroy', $fieldset) }}" class="btn btn-danger btn-sm delete-asset js-suppress-click" data-tooltip="true" title="{{ trans('general.delete') }}" data-toggle="modal" data-title="{{ trans('general.delete') }}" data-content="{{ trans('general.sure_to_delete_var', ['item' => $fieldset->name]) }}" data-icon="fa fa-trash" data-target="#dataConfirmModal"><i class="fas fa-trash"></i></a>
                   @endif
                 @endcan
                   </nobr>
@@ -249,7 +249,7 @@
                       <span class="sr-only">{{ trans('button.delete') }}</span>
                     </button>
                   @else
-                    <a href="{{ route('fields.destroy', $field) }}" class="btn btn-danger btn-sm delete-asset" data-tooltip="true" title="{{ trans('general.delete') }}" data-toggle="modal" data-title="{{ trans('general.delete') }}" data-content="{{ trans('general.sure_to_delete_var', ['item' => $field->name]) }}" data-target="#dataConfirmModal" data-icon="fa fa-trash" onClick="return false;">
+                    <a href="{{ route('fields.destroy', $field) }}" class="btn btn-danger btn-sm delete-asset js-suppress-click" data-tooltip="true" title="{{ trans('general.delete') }}" data-toggle="modal" data-title="{{ trans('general.delete') }}" data-content="{{ trans('general.sure_to_delete_var', ['item' => $field->name]) }}" data-target="#dataConfirmModal" data-icon="fa fa-trash">
                       <i class="fas fa-trash" aria-hidden="true"></i>
                       <span class="sr-only">{{ trans('button.delete') }}</span>
                     </a>

--- a/resources/views/custom_fields/index.blade.php
+++ b/resources/views/custom_fields/index.blade.php
@@ -271,7 +271,7 @@
 @stop
 @section('moar_scripts')
   @include ('partials.bootstrap-table')
-  <script>
+  <script nonce="{{ csrf_token() }}">
     $(function () {
       $('th').each(function (index, raw_element) {
         var element = $(raw_element);

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -502,7 +502,7 @@
 @push('js')
 
 
-        <script src="{{ url(mix('js/dist/Chart.min.js')) }}"></script>
+        <script src="{{ url(mix('js/dist/Chart.min.js')) }}" nonce="{{ csrf_token() }}"></script>
 <script nonce="{{ csrf_token() }}">
     // ---------------------------
     // - ASSET STATUS CHART -

--- a/resources/views/groups/edit.blade.php
+++ b/resources/views/groups/edit.blade.php
@@ -7,7 +7,7 @@
 ])
 @section('content')
 
-    <style>
+    <style nonce="{{ csrf_token() }}">
         .form-horizontal .control-label {
             padding-top: 0px;
         }

--- a/resources/views/hardware/audit.blade.php
+++ b/resources/views/hardware/audit.blade.php
@@ -9,7 +9,7 @@
 {{-- Page content --}}
 @section('content')
 
-    <style>
+    <style nonce="{{ csrf_token() }}">
 
         .input-group {
             padding-left: 0px !important;

--- a/resources/views/hardware/bulk-checkout.blade.php
+++ b/resources/views/hardware/bulk-checkout.blade.php
@@ -9,7 +9,7 @@
 {{-- Page content --}}
 @section('content')
 
-<style>
+<style nonce="{{ csrf_token() }}">
   .input-group {
     padding-left: 0px !important;
   }

--- a/resources/views/hardware/bulk.blade.php
+++ b/resources/views/hardware/bulk.blade.php
@@ -278,7 +278,7 @@
 </div>
 @stop
 @section('moar_scripts')
-  <script>
+  <script nonce="{{ csrf_token() }}">
     document.addEventListener('DOMContentLoaded', function () {
       document.querySelectorAll('.clear-radio').forEach(function (button) {
         button.addEventListener('click', function () {

--- a/resources/views/hardware/checkin.blade.php
+++ b/resources/views/hardware/checkin.blade.php
@@ -8,7 +8,7 @@
 
 {{-- Page content --}}
 @section('content')
-    <style>
+    <style nonce="{{ csrf_token() }}">
 
         .input-group {
             padding-left: 0px !important;

--- a/resources/views/hardware/checkout.blade.php
+++ b/resources/views/hardware/checkout.blade.php
@@ -9,7 +9,7 @@
 {{-- Page content --}}
 @section('content')
 
-    <style>
+    <style nonce="{{ csrf_token() }}">
 
         .input-group {
             padding-left: 0px !important;

--- a/resources/views/hardware/labels.blade.php
+++ b/resources/views/hardware/labels.blade.php
@@ -14,7 +14,7 @@ $settings->labels_height = $settings->labels_height - $settings->labels_display_
 $qr_size = ($settings->alt_barcode_enabled=='1') && ($settings->label2_1d_type!='') ? $settings->labels_height - .3 : $settings->labels_height - 0.1;
 ?>
 
-<style>
+<style nonce="{{ csrf_token() }}">
     body {
         font-family: arial, helvetica, sans-serif;
         width: {{ $settings->labels_pagewidth }}in;

--- a/resources/views/hardware/quickscan-checkin.blade.php
+++ b/resources/views/hardware/quickscan-checkin.blade.php
@@ -9,7 +9,7 @@
 {{-- Page content --}}
 @section('content')
 
-    <style>
+    <style nonce="{{ csrf_token() }}">
 
         .input-group {
             padding-left: 0px !important;

--- a/resources/views/hardware/quickscan.blade.php
+++ b/resources/views/hardware/quickscan.blade.php
@@ -9,7 +9,7 @@
 {{-- Page content --}}
 @section('content')
 
-    <style>
+    <style nonce="{{ csrf_token() }}">
 
         .input-group {
             padding-left: 0px !important;

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -805,12 +805,6 @@
                                                     </div>
                                                 </div>
                                             @endforeach
-
-                                            <script nonce="{{ csrf_token() }}">
-                                                $(".js-show-hide-enc-value").on('click', function(event) {
-                                                    showHideEncValue(this);
-                                                })
-                                            </script>
                                         @endif
 
 

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -755,7 +755,7 @@
                                                             </i>
                                                         @endif
                                                         @if (($field->field_encrypted=='1') && ($asset->{$field->db_column_name()}!='') && (Gate::allows('assets.view.encrypted_custom_fields')))
-                                                            <i class="fas fa-lock" data-tooltip="true" data-placement="top" title="{{ trans('admin/custom_fields/general.value_encrypted') }}" onclick="showHideEncValue(this)" id="text-{{ $field->id }}"></i>
+                                                            <i class="fas fa-lock js-show-hide-enc-value" data-tooltip="true" data-placement="top" title="{{ trans('admin/custom_fields/general.value_encrypted') }}" id="text-{{ $field->id }}"></i>
                                                         @endif
 
                                                         @if ($field->isFieldDecryptable($asset->{$field->db_column_name()} ))
@@ -805,6 +805,12 @@
                                                     </div>
                                                 </div>
                                             @endforeach
+
+                                            <script nonce="{{ csrf_token() }}">
+                                                $(".js-show-hide-enc-value").on('click', function(event) {
+                                                    showHideEncValue(this);
+                                                })
+                                            </script>
                                         @endif
 
 

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -805,6 +805,14 @@
                                                     </div>
                                                 </div>
                                             @endforeach
+                                            
+                                            @push('js')
+                                            <script nonce="{{ csrf_token() }}">
+                                                $(".js-show-hide-enc-value").on('click', function(event) {
+                                                    showHideEncValue(this);
+                                                })
+                                            </script>
+                                            @endpush
                                         @endif
 
 

--- a/resources/views/kits/checkout.blade.php
+++ b/resources/views/kits/checkout.blade.php
@@ -9,7 +9,7 @@
 {{-- Page content --}}
 @section('content')
 
-<style>
+<style nonce="{{ csrf_token() }}">
   .input-group {
     padding-left: 0px !important;
   }

--- a/resources/views/layouts/basic.blade.php
+++ b/resources/views/layouts/basic.blade.php
@@ -22,7 +22,7 @@
 
 
     @if (($snipeSettings) && ($snipeSettings->header_color))
-        <style>
+        <style nonce="{{ csrf_token() }}">
         .main-header .navbar, .main-header .logo {
         background-color: {{ $snipeSettings->header_color }};
         background: -webkit-linear-gradient(top,  {{ $snipeSettings->header_color }} 0%,{{ $snipeSettings->header_color }} 100%);
@@ -36,7 +36,7 @@
     @endif
 
     @if (($snipeSettings) && ($snipeSettings->custom_css))
-        <style>
+        <style nonce="{{ csrf_token() }}">
             {!! $snipeSettings->show_custom_css() !!}
         </style>
     @endif

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -416,7 +416,7 @@ dir="{{ Helper::determineLanguageDirection() }}">
                                                  {{ trans('general.logout') }}
                                             </a>
 
-                                            <script nonce="{{ csrf_token() }}">
+                                            <script nonce="{{ csrf_token() }}" defer>
                                                 $("#logout-button").on('click', function(event) {
                                                     event.preventDefault();
                                                     document.getElementById('logout-form').submit();

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -1084,7 +1084,7 @@ dir="{{ Helper::determineLanguageDirection() }}">
 
         {{-- Javascript files --}}
         <script src="{{ url(mix('js/dist/all.js')) }}" nonce="{{ csrf_token() }}"></script>
-        <script src="{{ url('js/select2/i18n/'.Helper::mapBackToLegacyLocale(app()->getLocale()).'.js') }}"></script>
+        <script src="{{ url('js/select2/i18n/'.Helper::mapBackToLegacyLocale(app()->getLocale()).'.js') }}" nonce="{{ csrf_token() }}"></script>
 
         {{-- Page level javascript --}}
         @stack('js')

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -409,18 +409,19 @@ dir="{{ Helper::determineLanguageDirection() }}">
                                         @endcan
                                         <li class="divider" style="margin-top: -1px; margin-bottom: -1px"></li>
                                         <li>
-                                            <script nonce="{{ csrf_token() }}">
-                                                function logout(event) {
-                                                    event.preventDefault();
-                                                    document.getElementById('logout-form').submit();
-                                                }
-                                            </script>
 
                                             <a href="{{ route('logout.get') }}"
-                                               onclick="logout">
+                                                id="logout-button">
                                                 <x-icon type="logout" class="fa-fw" />
                                                  {{ trans('general.logout') }}
                                             </a>
+
+                                            <script nonce="{{ csrf_token() }}">
+                                                $("#logout-button").on('click', function(event) {
+                                                    event.preventDefault();
+                                                    document.getElementById('logout-form').submit();
+                                                })
+                                            </script>
 
                                             <form id="logout-form" action="{{ route('logout.post') }}" method="POST" style="display: none;">
                                                 <button type="submit" style="display: none;" title="logout"></button>

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -409,9 +409,15 @@ dir="{{ Helper::determineLanguageDirection() }}">
                                         @endcan
                                         <li class="divider" style="margin-top: -1px; margin-bottom: -1px"></li>
                                         <li>
+                                            <script nonce="{{ csrf_token() }}">
+                                                function logout(event) {
+                                                    event.preventDefault();
+                                                    document.getElementById('logout-form').submit();
+                                                }
+                                            </script>
 
                                             <a href="{{ route('logout.get') }}"
-                                               onclick="event.preventDefault(); document.getElementById('logout-form').submit();">
+                                               onclick="logout">
                                                 <x-icon type="logout" class="fa-fw" />
                                                  {{ trans('general.logout') }}
                                             </a>

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -67,7 +67,7 @@ dir="{{ Helper::determineLanguageDirection() }}">
 
     {{-- Custom CSS --}}
     @if (($snipeSettings) && ($snipeSettings->custom_css))
-        <style>
+        <style nonce="{{ csrf_token() }}">
             {!! $snipeSettings->show_custom_css() !!}
         </style>
     @endif
@@ -897,7 +897,7 @@ dir="{{ Helper::determineLanguageDirection() }}">
                     <div class="row">
                         <div class="col-md-12" style="margin-bottom: 0px;">
 
-                        <style>
+                        <style nonce="{{ csrf_token() }}">
                             .breadcrumb-item {
                                 display: inline;
                                 list-style: none;

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -416,12 +416,14 @@ dir="{{ Helper::determineLanguageDirection() }}">
                                                  {{ trans('general.logout') }}
                                             </a>
 
+                                            @push('js')
                                             <script nonce="{{ csrf_token() }}" defer>
                                                 $("#logout-button").on('click', function(event) {
                                                     event.preventDefault();
                                                     document.getElementById('logout-form').submit();
                                                 })
                                             </script>
+                                            @endpush
 
                                             <form id="logout-form" action="{{ route('logout.post') }}" method="POST" style="display: none;">
                                                 <button type="submit" style="display: none;" title="logout"></button>

--- a/resources/views/layouts/setup.blade.php
+++ b/resources/views/layouts/setup.blade.php
@@ -21,7 +21,7 @@
 
 
 
-        <style>
+        <style nonce="{{ csrf_token() }}">
           td, th {
             font-size: 14px;
           }

--- a/resources/views/licenses/view.blade.php
+++ b/resources/views/licenses/view.blade.php
@@ -583,7 +583,7 @@
             </a>
         </span>
       @else
-        <a href="#"  class="btn btn-primary bg-purple btn-sm btn-social btn-block hidden-print" style="margin-bottom: 25px;" data-toggle="modal" data-tooltip="true"  data-target="#checkinFromAllModal" data-content="{{ trans('general.sure_to_delete') }} data-title="{{  trans('general.delete') }}" onClick="return false;">
+        <a href="#"  class="btn btn-primary bg-purple btn-sm btn-social btn-block hidden-print js-suppress-click" style="margin-bottom: 25px;" data-toggle="modal" data-tooltip="true"  data-target="#checkinFromAllModal" data-content="{{ trans('general.sure_to_delete') }}" data-title="{{  trans('general.delete') }}">
           <x-icon type="checkin" />
           {{ trans('admin/licenses/general.bulk.checkin_all.button') }}
         </a>
@@ -593,13 +593,13 @@
       @can('delete', $license)
 
         @if ($license->availCount()->count() == $license->seats)
-          <a class="btn btn-block btn-danger btn-sm btn-social delete-asset" data-icon="fa fa trash" data-toggle="modal" data-title="{{ trans('general.delete') }}" data-content="{{ trans('general.delete_confirm', ['item' => $license->name]) }}" data-target="#dataConfirmModal" onClick="return false;">
+          <a class="btn btn-block btn-danger btn-sm btn-social delete-asset js-suppress-click" data-icon="fa fa trash" data-toggle="modal" data-title="{{ trans('general.delete') }}" data-content="{{ trans('general.delete_confirm', ['item' => $license->name]) }}" data-target="#dataConfirmModal">
             <x-icon type="delete" />
             {{ trans('general.delete') }}
           </a>
         @else
           <span data-tooltip="true" title=" {{ trans('admin/licenses/general.delete_disabled') }}">
-            <a href="#" class="btn btn-block btn-danger btn-sm btn-social delete-asset disabled" onClick="return false;">
+            <a href="#" class="btn btn-block btn-danger btn-sm btn-social delete-asset disabled js-suppress-click">
               <x-icon type="delete" />
               {{ trans('general.delete') }}
             </a>

--- a/resources/views/livewire/custom-field-set-default-values-for-model.blade.php
+++ b/resources/views/livewire/custom-field-set-default-values-for-model.blade.php
@@ -60,11 +60,13 @@
                                             
                                             {{-- catch the onchange event and dispatch an InputEvent ourselves so Livewire can react to it... --}}
                                             {{-- https://laracasts.com/discuss/channels/livewire/livewire-and-bootstrap-datepicker?page=1&replyId=623122--}}
+                                            @push('js')
                                             <script nonce="{{ csrf_token() }}">
                                                 $("#default-value{{ $field->id }}").on('change', function(event) {
                                                     this.dispatchEvent(new InputEvent('input'));
                                                 })
                                             </script>
+                                            @endpush
                                             <span class="input-group-addon"><x-icon type="calendar" /></span>
                                         </div>
                                     </div>

--- a/resources/views/livewire/custom-field-set-default-values-for-model.blade.php
+++ b/resources/views/livewire/custom-field-set-default-values-for-model.blade.php
@@ -56,10 +56,15 @@
                                                 name="default_values[{{ $field->id }}]"
                                                 id="default-value{{ $field->id }}"
                                                 wire:model="selectedValues.{{ $field->db_column }}"
-                                                {{-- catch the onchange event and dispatch an InputEvent ourselves so Livewire can react to it... --}}
-                                                {{-- https://laracasts.com/discuss/channels/livewire/livewire-and-bootstrap-datepicker?page=1&replyId=623122--}}
-                                                onchange="this.dispatchEvent(new InputEvent('input'))"
                                             >
+                                            
+                                            {{-- catch the onchange event and dispatch an InputEvent ourselves so Livewire can react to it... --}}
+                                            {{-- https://laracasts.com/discuss/channels/livewire/livewire-and-bootstrap-datepicker?page=1&replyId=623122--}}
+                                            <script nonce="{{ csrf_token() }}">
+                                                $("#default-value{{ $field->id }}").on('change', function(event) {
+                                                    this.dispatchEvent(new InputEvent('input'));
+                                                })
+                                            </script>
                                             <span class="input-group-addon"><x-icon type="calendar" /></span>
                                         </div>
                                     </div>

--- a/resources/views/livewire/importer.blade.php
+++ b/resources/views/livewire/importer.blade.php
@@ -319,7 +319,7 @@
         </div>
 </div>
 @script
-    <script>
+    <script nonce="{{ csrf_token() }}">
 
         {{-- TODO: Maybe change this to the file upload thing that's baked-in to Livewire? --}}
         $('#fileupload').fileupload({

--- a/resources/views/livewire/oauth-clients.blade.php
+++ b/resources/views/livewire/oauth-clients.blade.php
@@ -18,9 +18,14 @@
                 <div class="box-tools pull-right">
                         <a class="btn btn-primary"
                            wire:click="$dispatch('openModal')"
-                           onclick="$('#modal-create-client').modal('show');">
+                           id="button-create-client">
                             {{ trans('general.create') }}
                         </a>
+                        <script nonce="{{ csrf_token() }}">
+                            $('#button-create-client').on('click', function(event) {
+                                $('#modal-create-client').modal('show');
+                            })
+                        </script>
                 </div>
             </div>
 
@@ -93,12 +98,18 @@
 
                                     <a class="action-link btn btn-sm btn-warning"
                                        wire:click="editClient('{{ $client->id }}')"
-                                       onclick="$('#modal-edit-client').modal('show');">
+                                       id="button-edit-client">
                                         <i class="fas fa-pencil-alt" aria-hidden="true"></i>
                                         <span class="sr-only">
                                             {{ trans('general.update') }}
                                         </span>
                                     </a>
+
+                                    <script nonce="{{ csrf_token() }}">
+                                        $('#button-edit-client').on('click', function(event) {
+                                            $('#modal-edit-client').modal('show');
+                                        })
+                                    </script>
 
                                     <a class="action-link btn btn-danger btn-sm" wire:click="deleteClient('{{ $client->id }}')">
                                         <i class="fas fa-trash" aria-hidden="true"></i>

--- a/resources/views/livewire/oauth-clients.blade.php
+++ b/resources/views/livewire/oauth-clients.blade.php
@@ -21,11 +21,13 @@
                            id="button-create-client">
                             {{ trans('general.create') }}
                         </a>
+                        @push('js')
                         <script nonce="{{ csrf_token() }}">
                             $('#button-create-client').on('click', function(event) {
                                 $('#modal-create-client').modal('show');
                             })
                         </script>
+                        @endpush
                 </div>
             </div>
 
@@ -105,11 +107,13 @@
                                         </span>
                                     </a>
 
+                                    @push('js')
                                     <script nonce="{{ csrf_token() }}">
                                         $('#button-edit-client').on('click', function(event) {
                                             $('#modal-edit-client').modal('show');
                                         })
                                     </script>
+                                    @endpush
 
                                     <a class="action-link btn btn-danger btn-sm" wire:click="deleteClient('{{ $client->id }}')">
                                         <i class="fas fa-trash" aria-hidden="true"></i>

--- a/resources/views/livewire/oauth-clients.blade.php
+++ b/resources/views/livewire/oauth-clients.blade.php
@@ -399,7 +399,7 @@
             </div>
         </div>
     </div>
-    <script>
+    <script nonce="{{ csrf_token() }}">
         document.addEventListener('DOMContentLoaded', function() {
             Livewire.on('openModal', () => {
                 $('#modal-create-client').modal('show').on('shown.bs.modal', function() {

--- a/resources/views/livewire/personal-access-tokens.blade.php
+++ b/resources/views/livewire/personal-access-tokens.blade.php
@@ -3,10 +3,16 @@
         <div class="box-header with-border">
             <div class="text-right">
                 <a class="btn btn-info btn-sm pull-right"
-                   onclick="$('#modal-create-token').modal('show');"
+                   id="button-create-token"
                    wire:click="$dispatch('openModal')">
                     {{ trans('general.create') }}
                 </a>
+
+                <script nonce="{{ csrf_token() }}">
+                    $('#button-create-token').on('click', function(event) {
+                        $('#modal-create-token').modal('show');
+                    })
+                </script>
             </div>
         </div>
         <div class="box-body">

--- a/resources/views/livewire/personal-access-tokens.blade.php
+++ b/resources/views/livewire/personal-access-tokens.blade.php
@@ -8,11 +8,13 @@
                     {{ trans('general.create') }}
                 </a>
 
+                @push('js')
                 <script nonce="{{ csrf_token() }}">
                     $('#button-create-token').on('click', function(event) {
                         $('#modal-create-token').modal('show');
                     })
                 </script>
+                @endpush
             </div>
         </div>
         <div class="box-body">

--- a/resources/views/livewire/personal-access-tokens.blade.php
+++ b/resources/views/livewire/personal-access-tokens.blade.php
@@ -159,7 +159,7 @@
             </div>
         </div>
     </div>
-    <script>
+    <script nonce="{{ csrf_token() }}">
         window.addEventListener('tokenCreated', token => {
             $('#modal-create-token').modal('hide');
             $('#modal-access-token').modal('show');

--- a/resources/views/locations/bulk-delete.blade.php
+++ b/resources/views/locations/bulk-delete.blade.php
@@ -59,9 +59,7 @@
     </div><!--.row-->
 @stop
 @section('moar_scripts')
-    <script>
-
-
+    <script nonce="{{ csrf_token() }}">
         $("#checkAll").change(function () {
             $("input:checkbox").prop('checked', $(this).prop("checked"));
         });

--- a/resources/views/locations/print.blade.php
+++ b/resources/views/locations/print.blade.php
@@ -3,7 +3,7 @@
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <title>{{ trans('general.assigned_to', array('name' => $location->display_name)) }} </title>
-    <style>
+    <style nonce="{{ csrf_token() }}">
         body {
             font-family: "Arial, Helvetica", sans-serif;
         }

--- a/resources/views/maintenances/index.blade.php
+++ b/resources/views/maintenances/index.blade.php
@@ -48,10 +48,10 @@
         actions += '</nobr>'
         if ((row) && (row.available_actions.delete === true)) {
             actions += '<a href="{{ config('app.url') }}/hardware/maintenances/' + row.id + '" '
-                + ' class="btn btn-danger btn-sm delete-asset"  data-tooltip="true"  '
+                + ' class="btn btn-danger btn-sm delete-asset js-suppress-click"  data-tooltip="true"  '
                 + ' data-toggle="modal" '
                 + ' data-content="{{ trans('general.sure_to_delete') }} ' + row.name + '?" '
-                + ' data-title="{{  trans('general.delete') }}" onClick="return false;">'
+                + ' data-title="{{  trans('general.delete') }}">'
                 + '<i class="fas fa-trash"></i></a></nobr>';
         }
 

--- a/resources/views/modals/category.blade.php
+++ b/resources/views/modals/category.blade.php
@@ -7,7 +7,7 @@
             <h2 class="modal-title">{{ trans('admin/categories/general.create') }}</h2>
         </div>
         <div class="modal-body">
-            <form action="{{ route('api.categories.store') }}" onsubmit="return false">
+            <form action="{{ route('api.categories.store') }}" class="js-suppress-submit">
                 {{ csrf_field() }}
                 <div class="alert alert-danger" id="modal_error_msg" style="display:none">
                 </div>

--- a/resources/views/modals/kit-accessory.blade.php
+++ b/resources/views/modals/kit-accessory.blade.php
@@ -7,7 +7,7 @@
             <h4 class="modal-title">{{{{ trans('admin/kits/general.append_accessory') }}}}</h4>
         </div>
         <div class="modal-body">
-            <form action="{{ route('api.kits.accessories.store', $kitId) }}" onsubmit="return false">
+            <form action="{{ route('api.kits.accessories.store', $kitId) }}" class="js-suppress-submit">
                 {{ csrf_field() }}
                 <div class="alert alert-danger" id="modal_error_msg" style="display:none">
                 </div>

--- a/resources/views/modals/kit-consumable.blade.php
+++ b/resources/views/modals/kit-consumable.blade.php
@@ -7,7 +7,7 @@
             <h4 class="modal-title">{{ trans('admin/kits/general.append_consumable') }}</h4>
         </div>
         <div class="modal-body">
-            <form action="{{ route('api.kits.consumables.store', $kitId) }}" onsubmit="return false">
+            <form action="{{ route('api.kits.consumables.store', $kitId) }}" class="js-suppress-submit">
                 {{ csrf_field() }}
                 <div class="alert alert-danger" id="modal_error_msg" style="display:none">
                 </div>

--- a/resources/views/modals/kit-license.blade.php
+++ b/resources/views/modals/kit-license.blade.php
@@ -7,7 +7,7 @@
             <h4 class="modal-title">{{ trans('admin/kits/general.append_license') }}</h4>
         </div>
         <div class="modal-body">
-            <form action="{{ route('api.kits.licenses.store', $kitId) }}" onsubmit="return false">
+            <form action="{{ route('api.kits.licenses.store', $kitId) }}" class="js-suppress-submit">
                 {{ csrf_field() }}
                 <div class="alert alert-danger" id="modal_error_msg" style="display:none">
                 </div>

--- a/resources/views/modals/kit-model.blade.php
+++ b/resources/views/modals/kit-model.blade.php
@@ -7,7 +7,7 @@
             <h4 class="modal-title">{{ trans('admin/kits/general.append_model') }}</h4>
         </div>
         <div class="modal-body">
-            <form action="{{ route('api.kits.models.store', $kitId) }}" onsubmit="return false">
+            <form action="{{ route('api.kits.models.store', $kitId) }}" class="js-suppress-submit">
                 {{ csrf_field() }}
                 <div class="alert alert-danger" id="modal_error_msg" style="display:none">
                 </div>

--- a/resources/views/modals/location.blade.php
+++ b/resources/views/modals/location.blade.php
@@ -6,7 +6,7 @@
             <h2 class="modal-title">{{ trans('admin/locations/table.create')  }}</h2>
         </div>
         <div class="modal-body">
-            <form action="{{ route('api.locations.store') }}" onsubmit="return false">
+            <form action="{{ route('api.locations.store') }}" class="js-suppress-submit">
                     <div class="alert alert-danger" id="modal_error_msg" style="display:none">
                 </div>
 

--- a/resources/views/modals/manufacturer.blade.php
+++ b/resources/views/modals/manufacturer.blade.php
@@ -7,7 +7,7 @@
             <h2 class="modal-title">{{ trans('admin/manufacturers/table.create') }}</h2>
         </div>
         <div class="modal-body">
-            <form action="{{ route('api.manufacturers.store') }}" onsubmit="return false">
+            <form action="{{ route('api.manufacturers.store') }}" class="js-suppress-submit">
                 <div class="dynamic-form-row">
                     @include('partials.forms.edit.name', ['item' => new \App\Models\Manufacturer(), 'translated_name' => trans('admin/manufacturers/table.name')])
                 </div>

--- a/resources/views/modals/model.blade.php
+++ b/resources/views/modals/model.blade.php
@@ -6,7 +6,7 @@
             <h2 class="modal-title">{{ trans('admin/models/table.create') }}</h2>
         </div>
         <div class="modal-body">
-            <form action="{{ route('api.models.store') }}" onsubmit="return false">
+            <form action="{{ route('api.models.store') }}" class="js-suppress-submit">
                 <div class="alert alert-danger" id="modal_error_msg" style="display:none">
                 </div>
                 @include('modals.partials.name', ['required' => 'true'])

--- a/resources/views/modals/statuslabel.blade.php
+++ b/resources/views/modals/statuslabel.blade.php
@@ -6,7 +6,7 @@
             <h2 class="modal-title">{{ trans('admin/statuslabels/table.create') }}</h2>
         </div>
         <div class="modal-body">
-            <form action="{{ route('api.statuslabels.store') }}" onsubmit="return false">
+            <form action="{{ route('api.statuslabels.store') }}" class="js-suppress-submit">
                 <div class="alert alert-danger" id="modal_error_msg" style="display:none">
                 </div>
                 <div class="dynamic-form-row">

--- a/resources/views/modals/supplier.blade.php
+++ b/resources/views/modals/supplier.blade.php
@@ -6,7 +6,7 @@
             <h2 class="modal-title">{{ trans('admin/suppliers/table.create') }}</h2>
         </div>
         <div class="modal-body">
-            <form action="{{ route('api.suppliers.store') }}" onsubmit="return false">
+            <form action="{{ route('api.suppliers.store') }}" class="js-suppress-submit">
                 <div class="alert alert-danger" id="modal_error_msg" style="display:none">
                 </div>
                 <div class="dynamic-form-row">

--- a/resources/views/modals/user.blade.php
+++ b/resources/views/modals/user.blade.php
@@ -26,7 +26,7 @@
             <h2 class="modal-title">{{ trans('admin/users/table.createuser') }}</h2>
         </div>
             <div class="modal-body" style="width:100%; display:block;">
-                <form action="{{ route('api.users.store') }}" onsubmit="return false">
+                <form action="{{ route('api.users.store') }}" class="js-suppress-submit">
                     <div class="alert alert-danger" id="modal_error_msg" style="display:none">
                     </div>
                     <!-- Setup of default company, taken from asset creator -->

--- a/resources/views/modals/user.blade.php
+++ b/resources/views/modals/user.blade.php
@@ -110,7 +110,7 @@
     </div><!-- /.modal-content -->
 </div><!-- /.modal-dialog -->
 
-<script>
+<script nonce="{{ csrf_token() }}">
     $(document).ready(function(){
         $('#modal-first_name').focus();
     });

--- a/resources/views/models/bulk-delete.blade.php
+++ b/resources/views/models/bulk-delete.blade.php
@@ -63,9 +63,7 @@
     </div><!--.row-->
 @stop
 @section('moar_scripts')
-    <script>
-
-
+    <script nonce="{{ csrf_token() }}">
         $("#checkAll").change(function () {
             $("input:checkbox").prop('checked', $(this).prop("checked"));
         });

--- a/resources/views/models/view.blade.php
+++ b/resources/views/models/view.blade.php
@@ -293,7 +293,7 @@
                             {{ trans('general.delete') }}
                         </button>
                     @else
-                        <button class="btn btn-block btn-sm btn-danger btn-social delete-asset" data-toggle="modal" title="{{ trans('general.delete_what', ['item'=> trans('general.asset_model')]) }}" data-content="{{ trans('general.sure_to_delete_var', ['item' => $model->name]) }}" data-target="#dataConfirmModal" data-tooltip="true" data-icon="fa fa-trash" data-placement="top" data-title="{{ trans('general.delete_what', ['item'=> trans('general.asset_model')]) }}" onClick="return false;">
+                        <button class="btn btn-block btn-sm btn-danger btn-social delete-asset js-suppress-click" data-toggle="modal" title="{{ trans('general.delete_what', ['item'=> trans('general.asset_model')]) }}" data-content="{{ trans('general.sure_to_delete_var', ['item' => $model->name]) }}" data-target="#dataConfirmModal" data-tooltip="true" data-icon="fa fa-trash" data-placement="top" data-title="{{ trans('general.delete_what', ['item'=> trans('general.asset_model')]) }}">
                             <x-icon type="delete" />
                             {{ trans('general.delete') }}
                         </button>

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -429,7 +429,7 @@
                 actions += '<a href="{{ config('app.url') }}/' + dest + '/' + row.id + '/edit" class="actions btn btn-sm btn-warning" data-tooltip="true" title="{{ trans('general.update') }}"><x-icon type="edit" /><span class="sr-only">{{ trans('general.update') }}</span></a>&nbsp;';
             } else {
                 if ((row.available_actions) && (row.available_actions.update != true)) {
-                    actions += '<span data-tooltip="true" title="{{ trans('general.cannot_be_edited') }}"><a class="btn btn-warning btn-sm disabled" onClick="return false;"><x-icon type="edit" /></a></span>&nbsp;';
+                    actions += '<span data-tooltip="true" title="{{ trans('general.cannot_be_edited') }}"><a class="btn btn-warning btn-sm disabled js-suppress-click"><x-icon type="edit" /></a></span>&nbsp;';
                 }
             }
 
@@ -449,12 +449,12 @@
                     + ' class="actions btn btn-danger btn-sm delete-asset" data-tooltip="true"  '
                     + ' data-toggle="modal" data-icon="fa-trash"'
                     + ' data-content="{{ trans('general.sure_to_delete') }}: ' + name_for_box + '?" '
-                    + ' data-title="{{  trans('general.delete') }}" onClick="return false;">'
+                    + ' data-title="{{  trans('general.delete') }}" class="js-suppress-click">'
                     + '<x-icon type="delete" /><span class="sr-only">{{ trans('general.delete') }}</span></a>&nbsp;';
             } else {
                 // Do not show the delete button on things that are already deleted
                 if ((row.available_actions) && (row.available_actions.restore != true)) {
-                    actions += '<span data-tooltip="true" title="{{ trans('general.cannot_be_deleted') }}"><a class="btn btn-danger btn-sm delete-asset disabled" onClick="return false;"><x-icon type="delete" /><span class="sr-only">{{ trans('general.cannot_be_deleted') }}</span></a></span>&nbsp;';
+                    actions += '<span data-tooltip="true" title="{{ trans('general.cannot_be_deleted') }}"><a class="btn btn-danger btn-sm delete-asset disabled js-suppress-click"><x-icon type="delete" /><span class="sr-only">{{ trans('general.cannot_be_deleted') }}</span></a></span>&nbsp;';
                 }
 
             }
@@ -1035,7 +1035,7 @@
                 + ' data-target="#dataConfirmModal" class="actions btn btn-danger btn-sm delete-asset" data-tooltip="true"  '
                 + ' data-toggle="modal" data-icon="fa-trash"'
                 + ' data-content="{{ trans('general.file_upload_status.confirm_delete') }}: ' + row.filename + '?" '
-                + ' data-title="{{  trans('general.delete') }}" onClick="return false;" data-icon="fa-trash">'
+                + ' data-title="{{  trans('general.delete') }}" class="js-supress-click" data-icon="fa-trash">'
                 + '<x-icon type="delete" /><span class="sr-only">{{ trans('general.delete') }}</span></a>&nbsp;';
         }
     }
@@ -1080,7 +1080,7 @@
                 .replace('%DOWNLOAD_BUTTON%', (row.exists_on_disk === true) ? '<a href="'+ row.url +'" class="btn btn-sm btn-default"><x-icon type="download" /></a> ' : '<span class="btn btn-sm btn-default disabled" data-tooltip="true" title="{{ trans('general.file_upload_status.file_not_found') }}"><x-icon type="download" /></span>')
                 .replace('%NEW_WINDOW_BUTTON%', (row.exists_on_disk === true) ? '<a href="'+ row.url +'?inline=true" class="btn btn-sm btn-default" target="_blank"><x-icon type="external-link" /></a> ' : '<span class="btn btn-sm btn-default disabled" data-tooltip="true" title="{{ trans('general.file_upload_status.file_not_found') }}"><x-icon type="external-link"/></span>')
                 .replace('%DELETE_BUTTON%', (row.available_actions.delete === true) ?
-                    '<a href="'+delete_url+'" class="delete-asset btn btn-danger btn-sm" data-icon="fa-trash" data-toggle="modal" data-content="{{ trans('general.file_upload_status.confirm_delete') }} '+ row.filename +'?" data-title="{{ trans('general.delete') }}" onClick="return false;" data-target="#dataConfirmModal"><x-icon type="delete" /><span class="sr-only">{{ trans('general.delete') }}</span></a>' :
+                    '<a href="'+delete_url+'" class="delete-asset btn btn-danger btn-sm js-suppress-click" data-icon="fa-trash" data-toggle="modal" data-content="{{ trans('general.file_upload_status.confirm_delete') }} '+ row.filename +'?" data-title="{{ trans('general.delete') }}" data-target="#dataConfirmModal"><x-icon type="delete" /><span class="sr-only">{{ trans('general.delete') }}</span></a>' :
                     '<a class="btn btn-sm btn-danger disabled" data-tooltip="true" title="{{ trans('general.file_upload_status.file_not_found') }}"><x-icon type="delete" /><span class="sr-only">{{ trans('general.delete') }}</span></a>'
                 );
         })

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -4,11 +4,11 @@
 
 @push('js')
 
-<script src="{{ url(mix('js/dist/bootstrap-table.js')) }}"></script>
-<script src="{{ url(mix('js/dist/bootstrap-table-locale-all.min.js')) }}"></script>
+<script src="{{ url(mix('js/dist/bootstrap-table.js')) }}" nonce="{{ csrf_token() }}"></script>
+<script src="{{ url(mix('js/dist/bootstrap-table-locale-all.min.js')) }}" nonce="{{ csrf_token() }}"></script>
 
 <!-- load english again here, even though it's in the all.js file, because if BS table doesn't have the translation, it otherwise defaults to chinese. See https://bootstrap-table.com/docs/api/table-options/#locale -->
-<script src="{{ url(mix('js/dist/bootstrap-table-en-US.min.js')) }}"></script>
+<script src="{{ url(mix('js/dist/bootstrap-table-en-US.min.js')) }}" nonce="{{ csrf_token() }}"></script>
 
 <script nonce="{{ csrf_token() }}">
     $(function () {

--- a/resources/views/partials/confetti-js.blade.php
+++ b/resources/views/partials/confetti-js.blade.php
@@ -1,5 +1,5 @@
 @if (auth()->user() && auth()->user()->enable_confetti=='1')
-<script>
+<script nonce="{{ csrf_token() }}">
     var duration = 1500;
     var animationEnd = Date.now() + duration;
     var defaults = { startVelocity: 30, spread: 360, ticks: 60, zIndex: 0 };

--- a/resources/views/partials/label2-field-definitions.blade.php
+++ b/resources/views/partials/label2-field-definitions.blade.php
@@ -1,6 +1,6 @@
 @once
     @push('css')
-        <style>
+        <style nonce="{{ csrf_token() }}">
             :root {
                 --l2fd-background-color: rgb(246, 250, 255);
                 --l2fd-border-color:     #d2d6de;
@@ -249,7 +249,7 @@
     $selector = '[x-data="'.$name.'"]';
 @endphp
 @push('css')
-    <style>
+    <style nonce="{{ csrf_token() }}">
 
 
     </style>

--- a/resources/views/partials/label2-field-definitions.blade.php
+++ b/resources/views/partials/label2-field-definitions.blade.php
@@ -139,7 +139,7 @@
 @endonce
 
 @push('js')
-    <script>
+    <script nonce="{{ csrf_token() }}">
         document.addEventListener('alpine:init', () => {
 
             Alpine.data('{{ $name }}', () => ({

--- a/resources/views/partials/label2-preview.blade.php
+++ b/resources/views/partials/label2-preview.blade.php
@@ -45,7 +45,7 @@
 @endonce
 
 @push('js')
-    <script>
+    <script nonce="{{ csrf_token() }}">
         document.addEventListener('alpine:init', () => {
 
             Alpine.data('label2_preview', () => ({

--- a/resources/views/partials/label2-preview.blade.php
+++ b/resources/views/partials/label2-preview.blade.php
@@ -1,6 +1,6 @@
 @once
     @push('css')
-        <style>
+        <style nonce="{{ csrf_token() }}">
             :root {
                 --l2p-height: 200px;
                 --l2p-background-color: aliceblue;

--- a/resources/views/reports/custom.blade.php
+++ b/resources/views/reports/custom.blade.php
@@ -730,7 +730,7 @@
 @stop
 
 @section('moar_scripts')
-  <script>
+  <script nonce="{{ csrf_token() }}">
 
       $('.purchase-range .input-daterange').datepicker({
           clearBtn: true,

--- a/resources/views/reports/unaccepted_assets.blade.php
+++ b/resources/views/reports/unaccepted_assets.blade.php
@@ -87,7 +87,7 @@
                                        </a>
                                   </span>
                             @endif
-                            <a href="{{ route('reports/unaccepted_assets_delete', ['acceptanceId' => $item['acceptance']->id]) }}" class="btn btn-sm btn-danger delete-asset" data-tooltip="true" data-toggle="modal" data-content="{{ trans('general.delete_confirm', ['item' =>trans('admin/reports/general.acceptance_request')]) }}" data-title="{{  trans('general.delete') }}" onClick="return false;"><i class="fa fa-trash"></i></a>
+                            <a href="{{ route('reports/unaccepted_assets_delete', ['acceptanceId' => $item['acceptance']->id]) }}" class="btn btn-sm btn-danger delete-asset js-suppress-click" data-tooltip="true" data-toggle="modal" data-content="{{ trans('general.delete_confirm', ['item' =>trans('admin/reports/general.acceptance_request')]) }}" data-title="{{  trans('general.delete') }}"><i class="fa fa-trash"></i></a>
                            </form>
                         @endif
 

--- a/resources/views/settings/alerts.blade.php
+++ b/resources/views/settings/alerts.blade.php
@@ -14,7 +14,7 @@
 {{-- Page content --}}
 @section('content')
 
-    <style>
+    <style nonce="{{ csrf_token() }}">
         .checkbox label {
             padding-right: 40px;
         }

--- a/resources/views/settings/asset_tags.blade.php
+++ b/resources/views/settings/asset_tags.blade.php
@@ -14,7 +14,7 @@
 {{-- Page content --}}
 @section('content')
 
-    <style>
+    <style nonce="{{ csrf_token() }}">
         .checkbox label {
             padding-right: 40px;
         }

--- a/resources/views/settings/backups.blade.php
+++ b/resources/views/settings/backups.blade.php
@@ -228,7 +228,7 @@
     @include ('partials.bootstrap-table')
 
     
-    <script>
+    <script nonce="{{ csrf_token() }}">
       /*
       * This just disables the upload button via JS unless they have actually selected a file.
       *

--- a/resources/views/settings/backups.blade.php
+++ b/resources/views/settings/backups.blade.php
@@ -97,11 +97,10 @@
                   @can('superadmin')
                       @if (config('app.allow_backup_delete')=='true')
                       <a data-html="false"
-                         class="btn delete-asset btn-danger btn-sm {{ (config('app.lock_passwords')) ? ' disabled': '' }}" 
+                         class="btn delete-asset btn-danger btn-sm js-suppress-click {{ (config('app.lock_passwords')) ? ' disabled': '' }}" 
                          data-toggle="modal" href="{{ route('settings.backups.destroy', $file['filename']) }}" 
                          data-content="{{ trans('admin/settings/message.backup.delete_confirm') }}" 
-                         data-title="{{ trans('general.delete') }}  {{ e($file['filename']) }}?"
-                         onClick="return false;">
+                         data-title="{{ trans('general.delete') }}  {{ e($file['filename']) }}?">
                           <i class="fas fa-trash icon-white" aria-hidden="true"></i>
                           <span class="sr-only">{{ trans('general.delete') }}</span>
                       </a>
@@ -115,10 +114,9 @@
 
                           <a data-html="true"
                              href="{{ route('settings.backups.restore', $file['filename']) }}"
-                             class="btn btn-warning btn-sm restore-backup {{ (config('app.lock_passwords')) ? ' disabled': '' }}"
+                             class="btn btn-warning btn-sm restore-backup js-suppress-click {{ (config('app.lock_passwords')) ? ' disabled': '' }}"
                              data-target="#backupRestoreModal"
-                             data-title="{{ trans('admin/settings/message.backup.restore_confirm', array('filename' => e($file['filename']))) }}"
-                             onClick="return false;">
+                             data-title="{{ trans('admin/settings/message.backup.restore_confirm', array('filename' => e($file['filename']))) }}">
                       <i class="fas fa-retweet" aria-hidden="true"></i>
                       <span class="sr-only">{{ trans('general.restore') }}</span>
                     </a>

--- a/resources/views/settings/branding.blade.php
+++ b/resources/views/settings/branding.blade.php
@@ -14,7 +14,7 @@
 {{-- Page content --}}
 @section('content')
 
-    <style>
+    <style nonce="{{ csrf_token() }}">
         .checkbox label {
             padding-right: 40px;
         }

--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -35,7 +35,7 @@
 
 
 
-  <style>
+  <style nonce="{{ csrf_token() }}">
     #searchinput {
       width: 200px;
     }

--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -14,7 +14,7 @@
   <div class="pull-right">
 
 
-    <form onsubmit="return false;" role="search" aria-label="Admin Options" id="setting-search">
+    <form role="search" aria-label="Admin Options" id="setting-search" class="js-suppress-submit">
       <div class="btn-group">
         <input id="searchinput" name="search" type="search" class="search form-control" placeholder="{{ trans('admin/settings/general.filter_by_keyword') }}" aria-label="keyword search">
         <span id="searchclear" class="fas fa-times" aria-hidden="true"></span>

--- a/resources/views/settings/labels.blade.php
+++ b/resources/views/settings/labels.blade.php
@@ -87,7 +87,7 @@
                                         id="label2TemplateTable"
                                         class="table table-striped snipe-table"
                                     ></table>
-                                    <script>
+                                    <script nonce="{{ csrf_token() }}">
                                         document.addEventListener('DOMContentLoaded', () => {
                                             const chosenLabel = "{{ old('label2_template', $chosenLabel ?? '') }}";
                                             $('#label2TemplateTable').on('load-success.bs.table', (e) => {

--- a/resources/views/settings/labels.blade.php
+++ b/resources/views/settings/labels.blade.php
@@ -14,7 +14,7 @@
 {{-- Page content --}}
 @section('content')
 
-    <style>
+    <style nonce="{{ csrf_token() }}">
         .checkbox label {
             padding-right: 40px;
         }
@@ -383,7 +383,7 @@
                             <input name="labels_display_company_name" type="hidden" value="{{ old('labels_display_company_name', $setting->labels_display_company_name) }}" />
                         @else
                             <!-- Legacy settings -->
-                    <style>
+                    <style nonce="{{ csrf_token() }}">
                         .checkbox label {
                             padding-right: 40px;
                         }

--- a/resources/views/settings/ldap.blade.php
+++ b/resources/views/settings/ldap.blade.php
@@ -14,7 +14,7 @@
 {{-- Page content --}}
 @section('content')
 
-    <style>
+    <style nonce="{{ csrf_token() }}">
         .checkbox label {
             padding-right: 40px;
         }

--- a/resources/views/settings/ldap.blade.php
+++ b/resources/views/settings/ldap.blade.php
@@ -350,7 +350,7 @@
                                         <label for="ldap_pword">{{ trans('admin/settings/general.ldap_pword') }}</label>
                                     </div>
                                     <div class="col-md-8">
-                                        <input class="form-control" type="password" name="ldap_pword" id="ldap_pword" value="" autocomplete="off" onfocus="this.removeAttribute('readonly');" readonly>
+                                        <input class="form-control js-allow-write-on-focus" type="password" name="ldap_pword" id="ldap_pword" value="" autocomplete="off" readonly>
                                         @error('ldap_pword')
                                             <span class="alert-msg">
                                                  <x-icon type="x" />
@@ -895,7 +895,7 @@
                                                 <input type="text" name="ldaptest_user" id="ldaptest_user"  class="form-control" placeholder="{{trans('admin/settings/general.ldap_username_placeholder')}}">
                                             </div>
                                             <div class="col-md-4">
-                                                <input type="password" name="ldaptest_password" id="ldaptest_password" class="form-control" placeholder="{{trans('admin/settings/general.ldap_password_placeholder')}}" autocomplete="off" readonly onfocus="this.removeAttribute('readonly');">
+                                                <input type="password" name="ldaptest_password" id="ldaptest_password" class="form-control js-allow-write-on-focus" placeholder="{{trans('admin/settings/general.ldap_password_placeholder')}}" autocomplete="off" readonly>
                                             </div>
                                             <div class="col-md-3">
                                                 <a class="btn btn-default btn-sm" id="ldaptestlogin" style="margin-right: 10px;">{{ trans('admin/settings/general.ldap_test') }}</a>

--- a/resources/views/settings/localization.blade.php
+++ b/resources/views/settings/localization.blade.php
@@ -14,7 +14,7 @@
 {{-- Page content --}}
 @section('content')
 
-    <style>
+<style nonce="{{ csrf_token() }}">
         .checkbox label {
             padding-right: 40px;
         }

--- a/resources/views/settings/saml.blade.php
+++ b/resources/views/settings/saml.blade.php
@@ -14,7 +14,7 @@
 {{-- Page content --}}
 @section('content')
 
-    <style>
+    <style nonce="{{ csrf_token() }}">
         .checkbox label {
             padding-right: 40px;
         }

--- a/resources/views/setup/index.blade.php
+++ b/resources/views/setup/index.blade.php
@@ -216,7 +216,7 @@ Create a User ::
 @stop
 
 @section('moar_scripts')
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{ csrf_token() }}">
     $(document).ready(function () {
 
         // Test Mail

--- a/resources/views/statuslabels/edit.blade.php
+++ b/resources/views/statuslabels/edit.blade.php
@@ -8,7 +8,7 @@
 
 {{-- Page content --}}
 @section('content')
-<style>
+<style nonce="{{ csrf_token() }}">
     .input-group-addon {
         width: 30px;
     }

--- a/resources/views/users/bulk-edit.blade.php
+++ b/resources/views/users/bulk-edit.blade.php
@@ -14,7 +14,7 @@
 {{-- Page content --}}
 @section('content')
 
-    <style>
+    <style nonce="{{ csrf_token() }}">
         .radio {
             margin-left: -20px;
         }

--- a/resources/views/users/confirm-bulk-delete.blade.php
+++ b/resources/views/users/confirm-bulk-delete.blade.php
@@ -148,7 +148,7 @@
 @stop
 
 @section('moar_scripts')
-<script>
+<script nonce="{{ csrf_token() }}">
 
 
   // TODO: include a class that excludes certain checkboxes by class to not be select-all'd

--- a/resources/views/users/confirm-merge.blade.php
+++ b/resources/views/users/confirm-merge.blade.php
@@ -139,7 +139,7 @@
 
     @if (!(config('app.lock_passwords')))
 
-    <script>
+    <script nonce="{{ csrf_token() }}">
 
         $('button[type="submit"]').prop("disabled", true);
 

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -104,7 +104,7 @@
                       <input type="hidden" name="username" value="{{ old('username', $user->username) }}">
                     <!-- if the user is not managed by LDAP, or this is a clone operation, allow editing of the username -->
                           @if ($user->ldap_import!='1' || str_contains(Route::currentRouteName(), 'clone'))
-                              <input class="form-control" type="text" name="username" id="username" value="{{ old('username', $user->username) }}" autocomplete="off" maxlength="191" {{ (Helper::checkIfRequired($user, 'username')) ? ' required' : '' }} onfocus="this.removeAttribute('readonly');" readonly {!! (!Gate::allows('canEditAuthFields', $user)) || ((!Gate::allows('editableOnDemo')) && ($user->id)) ? ' style="cursor: not-allowed" disabled ' : '' !!}>
+                              <input class="form-control js-allow-write-on-focus" type="text" name="username" id="username" value="{{ old('username', $user->username) }}" autocomplete="off" maxlength="191" {{ (Helper::checkIfRequired($user, 'username')) ? ' required' : '' }} readonly {!! (!Gate::allows('canEditAuthFields', $user)) || ((!Gate::allows('editableOnDemo')) && ($user->id)) ? ' style="cursor: not-allowed" disabled ' : '' !!}>
                           @else
 
                               <!-- insert the old username so we don't break validation -->
@@ -151,7 +151,7 @@
 
                   <div class="col-md-6">
                         @if ($user->ldap_import!='1' || str_contains(Route::currentRouteName(), 'clone') )
-                          <input type="password" name="password" class="form-control{{ (!Gate::allows('canEditAuthFields', $user)) || ((!Gate::allows('editableOnDemo') && ($user->id))) ? ' form-control--disabled' : '' }}" id="password" value="" maxlength="500" autocomplete="off" onfocus="this.removeAttribute('readonly');" readonly {{  ((Helper::checkIfRequired($user, 'password')) && (!$user->id)) ? ' required' : '' }}{!! (!Gate::allows('canEditAuthFields', $user)) || ((!Gate::allows('editableOnDemo')) && ($user->id)) ? ' style="cursor: not-allowed" disabled ' : '' !!}>
+                          <input type="password" name="password" class="js-allow-write-on-focus form-control{{ (!Gate::allows('canEditAuthFields', $user)) || ((!Gate::allows('editableOnDemo') && ($user->id))) ? ' form-control--disabled' : '' }}" id="password" value="" maxlength="500" autocomplete="off" readonly {{  ((Helper::checkIfRequired($user, 'password')) && (!$user->id)) ? ' required' : '' }}{!! (!Gate::allows('canEditAuthFields', $user)) || ((!Gate::allows('editableOnDemo')) && ($user->id)) ? ' style="cursor: not-allowed" disabled ' : '' !!}>
                               <span id="generated-password"></span>
                               {!! $errors->first('password', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                         @else
@@ -191,7 +191,7 @@
                         {{ trans('admin/users/table.password_confirm') }}
                       </label>
                       <div class="col-md-6">
-                        <input type="password" name="password_confirmation" id="password_confirm" class="form-control" value="" maxlength="500" autocomplete="off" aria-label="password_confirmation" {{  (!$user->id) ? ' required' : '' }} onfocus="this.removeAttribute('readonly');" readonly {!! (!Gate::allows('canEditAuthFields', $user)) || ((!Gate::allows('editableOnDemo')) && ($user->id)) ? ' style="cursor: not-allowed" disabled ' : '' !!}>
+                        <input type="password" name="password_confirmation" id="password_confirm" class="form-control js-allow-write-on-focus" value="" maxlength="500" autocomplete="off" aria-label="password_confirmation" {{  (!$user->id) ? ' required' : '' }} readonly {!! (!Gate::allows('canEditAuthFields', $user)) || ((!Gate::allows('editableOnDemo')) && ($user->id)) ? ' style="cursor: not-allowed" disabled ' : '' !!}>
 
                       @cannot('canEditAuthFields', $user)
                           <p class="help-block">
@@ -264,8 +264,8 @@
                 <div class="form-group {{ $errors->has('email') ? 'has-error' : '' }}">
                   <label class="col-md-3 control-label" for="email">{{ trans('admin/users/table.email') }} </label>
                   <div class="col-md-6">
-                        <input class="form-control" type="email" name="email" id="email" maxlength="191" value="{{ old('email', $user->email) }}" autocomplete="off"
-                          readonly onfocus="this.removeAttribute('readonly');" {{  (Helper::checkIfRequired($user, 'email')) ? ' required' : '' }}{!! (!Gate::allows('canEditAuthFields', $user)) || ((!Gate::allows('editableOnDemo')) && ($user->id)) ? ' style="cursor: not-allowed" disabled ' : '' !!}>
+                        <input class="form-control js-allow-write-on-focus" type="email" name="email" id="email" maxlength="191" value="{{ old('email', $user->email) }}" autocomplete="off"
+                          readonly {{  (Helper::checkIfRequired($user, 'email')) ? ' required' : '' }}{!! (!Gate::allows('canEditAuthFields', $user)) || ((!Gate::allows('editableOnDemo')) && ($user->id)) ? ' style="cursor: not-allowed" disabled ' : '' !!}>
 
                           @cannot('canEditAuthFields', $user)
                               <!-- authed user is an admin or regular user and is trying to edit someone higher -->

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -19,7 +19,7 @@
 {{-- Page content --}}
 @section('content')
 
-<style>
+<style nonce="{{ csrf_token() }}">
     .form-horizontal .control-label {
       padding-top: 0px;
     }

--- a/resources/views/users/ldap.blade.php
+++ b/resources/views/users/ldap.blade.php
@@ -103,7 +103,7 @@
 
 @section('moar_scripts')
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{ csrf_token() }}">
     $(document).ready(function () {
         $("#sync").click(function () {
             $("#sync").removeClass("btn-warning");

--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -23,7 +23,7 @@
         };
     </script>
 
-    <style>
+    <style nonce="{{ csrf_token() }}">
         body {
             font-family: "Arial, Helvetica", sans-serif;
             padding: 20px;

--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -455,13 +455,13 @@
 {{-- Javascript files --}}
 <script src="{{ url(mix('js/dist/all.js')) }}" nonce="{{ csrf_token() }}"></script>
 
-<script src="{{ url(mix('js/dist/bootstrap-table.js')) }}"></script>
-<script src="{{ url(mix('js/dist/bootstrap-table-locale-all.min.js')) }}"></script>
+<script src="{{ url(mix('js/dist/bootstrap-table.js')) }}" nonce="{{ csrf_token() }}"></script>
+<script src="{{ url(mix('js/dist/bootstrap-table-locale-all.min.js')) }}" nonce="{{ csrf_token() }}"></script>
 
 <!-- load english again here, even though it's in the all.js file, because if BS table doesn't have the translation, it otherwise defaults to chinese. See https://bootstrap-table.com/docs/api/table-options/#locale -->
-<script src="{{ url(mix('js/dist/bootstrap-table-en-US.min.js')) }}"></script>
+<script src="{{ url(mix('js/dist/bootstrap-table-en-US.min.js')) }}" nonce="{{ csrf_token() }}"></script>
 
-<script>
+<script nonce="{{ csrf_token() }}">
     $('.snipe-table').bootstrapTable('destroy').each(function () {
         console.log('BS table loaded');
 

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -266,7 +266,7 @@
                   @if ($user->deleted_at=='')
                     <div class="col-md-12" style="padding-top: 30px;">
                         @if ($user->isDeletable())
-                            <a href="" class="delete-asset btn-block btn btn-sm btn-danger btn-social hidden-print" data-toggle="modal" data-title="{{ trans('general.delete') }}" data-content="{{ trans('general.sure_to_delete_var', ['item' => $user->display_name]) }}" data-icon="fa-trash" data-target="#dataConfirmModal" onClick="return false;" >
+                            <a href="" class="delete-asset btn-block btn btn-sm btn-danger btn-social hidden-print js-suppress-click" data-toggle="modal" data-title="{{ trans('general.delete') }}" data-content="{{ trans('general.sure_to_delete_var', ['item' => $user->display_name]) }}" data-icon="fa-trash" data-target="#dataConfirmModal">
                                 <x-icon type="delete" />
                                 {{ trans('button.delete')}}
                             </a>

--- a/resources/views/vendor/maintenancemode/app-down.blade.php
+++ b/resources/views/vendor/maintenancemode/app-down.blade.php
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="robots" content="noindex,nofollow">
     <title>{{ Lang::get(Config::get('maintenancemode.language-path', 'maintenancemode::defaults.') . '.title') }}</title>
-    <style>
+    <style nonce="{{ csrf_token() }}">
         html, body {
             width: 100%;
             height: 100%;

--- a/resources/views/vendor/maintenancemode/notification.blade.php
+++ b/resources/views/vendor/maintenancemode/notification.blade.php
@@ -9,7 +9,7 @@
     ${Config::get('maintenancemode.inject.prefix').'Enabled'} == true)
 
     @if(Config::get('maintenancemode.notification-styles', true))
-        <style>
+        <style nonce="{{ csrf_token() }}">
             .maintenance-mode-alert {
                 width: 100%;
                 padding: .5em;

--- a/resources/views/vendor/passport/authorize.blade.php
+++ b/resources/views/vendor/passport/authorize.blade.php
@@ -10,7 +10,7 @@
 
     {{-- stylesheets --}}
     <link rel="stylesheet" href="{{ url(mix('css/dist/all.css')) }}">
-    <style>
+    <style nonce="{{ csrf_token() }}">
         .passport-authorize .container {
             margin-top: 30px;
         }


### PR DESCRIPTION
At work, we're using https://internet.nl to verify that our domains are up-to-date with the latest security standards. One thing that sticks out about snipe-it is various 'insecure' CSP options, such as `script-src 'unsafe-inline'`, and the likes.

Some of this is easily fixable, but there's other items which require further attention, and may break the application if it's not properly vetted.

As such, I've added the new tentative CSP options into a section which sets it to the `Content-Security-Policy-Report-Only` header, which only reports, but does not block, based on its findings.

This would allow the new security options to be trialed, and any violations are then sent to the URL defined by env var `CSP_REPORT_TO`. If not set, it'll only report in the browser console.

---

This PR adds two environment variables:

- `ENABLE_STRICT_CSP`, default `false`, uses the new "strict"(er) CSP policy instead of the (old) "lax" one; this can break the application, so its experimental.
- `CSP_REPORT_TO`, default `null`, defines the endpoint to report violations of the new "strict" CSP policy to, basically meant for data collection of the new policy, until its vetted enough.