### PR TITLE
Fix #17908: typo in storage location of backups

### DIFF
--- a/resources/views/settings/backups.blade.php
+++ b/resources/views/settings/backups.blade.php
@@ -150,7 +150,7 @@
       <div class="box-body">
 
         <p>
-          {!! trans('admin/settings/general.backups_path', ['path'=> 'storage/app/backup']) !!}
+          {!! trans('admin/settings/general.backups_path', ['path'=> 'storage/app/backups']) !!}
         </p>
 
         @if (config('app.lock_passwords')===true)


### PR DESCRIPTION
Fix for https://github.com/grokability/snipe-it/issues/17908