### PR TITLE
Adds #11741 currently assigned license table to license checkout

### DIFF
--- a/resources/lang/ca-ES/admin/users/general.php
+++ b/resources/lang/ca-ES/admin/users/general.php
@@ -7,6 +7,7 @@ return [
     'bulk_update_warn'	=> 'You are about to edit the properties of :user_count users. Please note that you cannot change your own user attributes using this form, and must make edits to your own user individually.',
     'bulk_update_help'	=> 'This form allows you to update multiple users at once. Only fill in the fields you need to change. Any fields left blank will remain unchanged.',
     'current_assets'    => 'Assets currently checked out to this user',
+    'current_items'     => ':item currently checked out to this user',
     'clone'             => 'Clone User',
     'contact_user'      => 'Contact :name',
     'edit'              => 'Edit User',

--- a/resources/lang/ca-ES/admin/users/general.php
+++ b/resources/lang/ca-ES/admin/users/general.php
@@ -7,7 +7,6 @@ return [
     'bulk_update_warn'	=> 'You are about to edit the properties of :user_count users. Please note that you cannot change your own user attributes using this form, and must make edits to your own user individually.',
     'bulk_update_help'	=> 'This form allows you to update multiple users at once. Only fill in the fields you need to change. Any fields left blank will remain unchanged.',
     'current_assets'    => 'Assets currently checked out to this user',
-    'current_items'     => ':item currently checked out to this user',
     'clone'             => 'Clone User',
     'contact_user'      => 'Contact :name',
     'edit'              => 'Edit User',

--- a/resources/lang/en-US/admin/users/general.php
+++ b/resources/lang/en-US/admin/users/general.php
@@ -7,6 +7,7 @@ return [
     'bulk_update_warn'	=> 'You are about to edit the properties of :user_count users. Please note that you cannot change your own user attributes using this form, and must make edits to your own user individually.',
     'bulk_update_help'	=> 'This form allows you to update multiple users at once. Only fill in the fields you need to change. Any fields left blank will remain unchanged.',
     'current_assets'    => 'Assets currently checked out to this user',
+    'current_items'     => ':item currently checked out to this user',
     'clone'             => 'Clone User',
     'contact_user'      => 'Contact :name',
     'edit'              => 'Edit User',

--- a/resources/views/licenses/checkout.blade.php
+++ b/resources/views/licenses/checkout.blade.php
@@ -15,7 +15,7 @@
 @section('content')
 <div class="row">
         <!-- left column -->
-    <div class="col-md-8">
+    <div class="col-md-7">
         <form class="form-horizontal" method="post" action="" autocomplete="off">
             {{csrf_field()}}
 
@@ -115,6 +115,21 @@
             </div> <!-- /.box-->
         </form>
     </div> <!-- /.col-md-7-->
+    <!-- right column -->
+    <div class="col-md-5" id="current_license_box" style="display:none;">
+        <div class="box box-primary">
+            <div class="box-header with-border">
+                <h2 class="box-title">{{ trans('admin/users/general.current_items', ['item' => trans('general.licenses')]) }}</h2>
+            </div>
+            <div class="box-body">
+                <div id="current_license_content">
+                </div>
+            </div>
+        </div>
+    </div>
 </div>
-
 @stop
+
+@section('moar_scripts')
+    @include('partials.licenses-assigned')
+@endsection

--- a/resources/views/partials/licenses-assigned.blade.php
+++ b/resources/views/partials/licenses-assigned.blade.php
@@ -1,0 +1,67 @@
+<script nonce="{{ csrf_token() }}">
+
+    // create the assigned assets listing box for the right side of the screen
+    $(function() {
+        $('#assigned_user').on("change",function () {
+            var userid = $('#assigned_user option:selected').val();
+
+            if(userid=='') {
+                console.warn('no user selected');
+                $('#current_license_box').fadeOut();
+                $('#current_license_content').html("");
+            } else {
+
+                $.ajax({
+                    type: 'GET',
+                    url: '{{ config('app.url') }}/api/v1/users/' + userid + '/licenses',
+                    headers: {
+                        "X-Requested-With": 'XMLHttpRequest',
+                        "X-CSRF-TOKEN": $('meta[name="csrf-token"]').attr('content')
+                    },
+
+                    dataType: 'json',
+                    success: function (data) {
+                        $('#current_license_box').fadeIn();
+
+                        var table_html = '<div class="row">';
+                        table_html += '<div class="col-md-12">';
+                        table_html += '<table class="table table-striped">';
+                        table_html += '<thead><tr>';
+                        table_html += '<th>{{ trans('admin/licenses/form.name') }}</th>';
+                        table_html += '<th>{{ trans('admin/licenses/form.license_key') }}</th>';
+                        table_html += '</tr></thead><tbody>';
+
+                        $('#current_license_content').append('');
+
+                        if (data.rows.length > 0) {
+
+                            for (var i in data.rows) {
+                                var license = data.rows[i];
+                                table_html += '<tr>';
+                                table_html += '<td><a href="{{ config('app.url') }}/licenses/' + license.id + '">';
+
+                                if ((license.name == '') && (license.name != null)) {
+                                    table_html += " " + license.name;
+                                } else {
+                                    table_html += license.name;
+                                }
+
+                                table_html += '</a></td>';
+                                table_html += '<td class="col-md-4">' + license.product_key + '</td>';
+                                table_html += "</tr>";
+                            }
+                        } else {
+                            table_html += '<tr><td colspan="4">{{ trans('admin/users/message.user_has_no_assets_assigned') }}</td></tr>';
+                        }
+                        $('#current_license_content').html(table_html + '</tbody></table></div></div>');
+
+                    },
+                    error: function (data) {
+                        $('#current_license_box').fadeOut();
+                    }
+                });
+            }
+        });
+    });
+</script>
+<?php

--- a/resources/views/partials/licenses-assigned.blade.php
+++ b/resources/views/partials/licenses-assigned.blade.php
@@ -1,6 +1,6 @@
 <script nonce="{{ csrf_token() }}">
-
-    // create the assigned assets listing box for the right side of the screen
+    let canViewKeys = @json(Gate::check('viewKeys', $license));
+    // create the assigned licenses listing box for the right side of the screen
     $(function() {
         $('#assigned_user').on("change",function () {
             var userid = $('#assigned_user option:selected').val();
@@ -45,10 +45,11 @@
                                 } else {
                                     table_html += license.name;
                                 }
-
-                                table_html += '</a></td>';
-                                table_html += '<td class="col-md-4">' + license.product_key + '</td>';
-                                table_html += "</tr>";
+                                    table_html += '</a></td>';
+                                if (canViewKeys) {
+                                    table_html += '<td class="col-md-4">' + license.product_key + '</td>';
+                                }
+                                    table_html += "</tr>";
                             }
                         } else {
                             table_html += '<tr><td colspan="4">{{ trans('admin/users/message.user_has_no_assets_assigned') }}</td></tr>';


### PR DESCRIPTION
This adds a table of currently assigned licenses to the license checkout view. This functions the same as the currently assigned assets in the asset checkout view.

<img width="1089" height="724" alt="image" src="https://github.com/user-attachments/assets/6f25cd8c-44e0-47a3-b232-3b8f6255458a" />

<img width="1089" height="724" alt="image" src="https://github.com/user-attachments/assets/c1c5006f-ff6a-425c-9da7-9626b6539836" />

Fixes: #11741 