### PR TITLE
Fixed #17940 - pngs not showing in acceptance PDFs

### DIFF
--- a/app/Models/CheckoutAcceptance.php
+++ b/app/Models/CheckoutAcceptance.php
@@ -184,7 +184,7 @@ class CheckoutAcceptance extends Model
 
         $pdf->AddPage();
         if ($data['logo'] != null) {
-            $pdf->writeHTML('<img src="'.$data['logo'].'">', true, 0, true, 0, '');
+            $pdf->writeHTML('<img src="@'.$data['logo'].'">', true, 0, true, 0, '');
         } else {
             $pdf->writeHTML('<h3>'.$data['site_name'].'</h3><br /><br />', true, 0, true, 0, 'C');
         }
@@ -230,7 +230,7 @@ class CheckoutAcceptance extends Model
         $pdf->Ln();
 
         if ($data['signature'] != null) {
-            $pdf->writeHTML('<img src="'.$data['signature'].'">', true, 0, true, 0, '');
+            $pdf->writeHTML('<img src="@'.$data['signature'].'">', true, 0, true, 0, '');
             $pdf->writeHTML('<hr>', true, 0, true, 0, '');
             $pdf->writeHTML(e($data['assigned_to']), true, 0, true, 0, 'C');
             $pdf->Ln();


### PR DESCRIPTION
It turns out, TCPDF handles png files slightly differently than regular images, so in certain systems, png images would not show up properly. (This has to do with the temp cache it writes to when it's trying to make the PDF - I think.)

Since we don't ever know what kind of image someone might be using for a logo, we have to base64 the logo as well. 

This regression was created [when we switched to using TCPDF directly](https://github.com/grokability/snipe-it/pull/17866) (instead of domPDF) in order to support RTL/CJK mixed PDFs, since DomPDF just... doesn't. 

We should eventually update the config to meet the wrapper's version: https://github.com/tecnickcom/TCPDF/blob/main/config/tcpdf_config.php

And also make the logo S3 capable in PDFs.

Fixes #17940. HUGE thanks for @daniel82becker-blip for the awesome help troubleshooting!