### PR TITLE
Fixed #17924 - added url to maintenances

### DIFF
--- a/app/Http/Controllers/Api/MaintenancesController.php
+++ b/app/Http/Controllers/Api/MaintenancesController.php
@@ -52,6 +52,10 @@ class MaintenancesController extends Controller
             $maintenances->where('maintenances.created_by', '=', $request->input('created_by'));
         }
 
+        if ($request->filled('url')) {
+            $maintenances->where('maintenances.url', '=', $request->input('url'));
+        }
+
         if ($request->filled('asset_maintenance_type')) {
             $maintenances->where('asset_maintenance_type', '=', $request->input('asset_maintenance_type'));
         }

--- a/app/Http/Controllers/MaintenancesController.php
+++ b/app/Http/Controllers/MaintenancesController.php
@@ -78,6 +78,7 @@ class MaintenancesController extends Controller
             $maintenance->is_warranty = $request->input('is_warranty');
             $maintenance->cost = $request->input('cost');
             $maintenance->notes = $request->input('notes');
+            $maintenance->url = $request->input('url');
 
             // Save the asset maintenance data
             $maintenance->asset_id = $asset->id;
@@ -152,6 +153,7 @@ class MaintenancesController extends Controller
         $maintenance->name = $request->input('name');
         $maintenance->start_date = $request->input('start_date');
         $maintenance->completion_date = $request->input('completion_date');
+        $maintenance->url = $request->input('url');
 
 
         // Todo - put this in a getter/setter?

--- a/app/Http/Transformers/MaintenancesTransformer.php
+++ b/app/Http/Transformers/MaintenancesTransformer.php
@@ -66,6 +66,7 @@ class MaintenancesTransformer
                     'id' => $assetmaintenance->supplier->id,
                     'name'=> e($assetmaintenance->supplier->name)
                     ] : null,
+            'url'         => ($assetmaintenance->url) ? e($assetmaintenance->url) : null,
             'cost'          => Helper::formatCurrencyOutput($assetmaintenance->cost),
             'asset_maintenance_type'          => e($assetmaintenance->asset_maintenance_type),
             'start_date'         => Helper::getFormattedDateObject($assetmaintenance->start_date, 'date'),

--- a/app/Models/Maintenance.php
+++ b/app/Models/Maintenance.php
@@ -58,6 +58,7 @@ class Maintenance extends SnipeModel implements ICompanyableChild
         'asset_maintenance_time',
         'notes',
         'cost',
+        'url',
     ];
 
     use Searchable;

--- a/app/Models/Maintenance.php
+++ b/app/Models/Maintenance.php
@@ -38,6 +38,7 @@ class Maintenance extends SnipeModel implements ICompanyableChild
         'completion_date'        => 'date_format:Y-m-d|nullable|after_or_equal:start_date',
         'notes'                  => 'string|nullable',
         'cost'                   =>  'numeric|nullable|gte:0|max:99999999999999999.99',
+        'url'                    =>  'nullable|url|max:255',
     ];
 
 

--- a/app/Presenters/MaintenancesPresenter.php
+++ b/app/Presenters/MaintenancesPresenter.php
@@ -112,6 +112,12 @@ class MaintenancesPresenter extends Presenter
                 'title' => trans('admin/maintenances/form.completion_date'),
                 'formatter' => 'dateDisplayFormatter',
             ], [
+                'field' => 'url',
+                'searchable' => true,
+                'sortable' => true,
+                'title' => trans('general.url'),
+                'formatter' => 'externalLinkFormatter',
+            ], [
                 'field' => 'notes',
                 'searchable' => true,
                 'sortable' => true,

--- a/database/factories/MaintenanceFactory.php
+++ b/database/factories/MaintenanceFactory.php
@@ -31,6 +31,7 @@ class MaintenanceFactory extends Factory
             'start_date' => $this->faker->date(),
             'is_warranty' => $this->faker->boolean(),
             'notes' => $this->faker->paragraph(),
+            'url' => $this->faker->url(),
         ];
     }
 }

--- a/database/migrations/2025_10_07_113331_add_url_to_maintenances.php
+++ b/database/migrations/2025_10_07_113331_add_url_to_maintenances.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('maintenances', function (Blueprint $table) {
+            if (!Schema::hasColumn('maintenances', 'url')) {
+                $table->text('url')->after('name')->nullable()->default(null);
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('maintenances', function (Blueprint $table) {
+            if (Schema::hasColumn('maintenances', 'url')) {
+                $table->dropColumn('url');
+            }
+        });
+    }
+};

--- a/resources/views/maintenances/edit.blade.php
+++ b/resources/views/maintenances/edit.blade.php
@@ -153,6 +153,7 @@
           </div>
         </div>
 
+
         <!-- Asset Maintenance Cost -->
         <div class="form-group {{ $errors->has('cost') ? ' has-error' : '' }}">
           <label for="cost" class="col-md-3 control-label">{{ trans('admin/maintenances/form.cost') }}</label>
@@ -170,6 +171,15 @@
             </div>
           </div>
         </div>
+
+        <div class="form-group {{ $errors->has('url') ? ' has-error' : '' }}">
+          <label for="url" class="col-md-3 control-label">{{ trans('general.url') }}</label>
+          <div class="col-md-7">
+            <input class="form-control" name="url" type="url" id="url" value="{{ old('url', $item->url) }}" placeholder="https://example.com">
+            {!! $errors->first('url', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+          </div>
+        </div>
+
 
         @include ('partials.forms.edit.image-upload', ['image_path' => app('maintenances_path')])
 

--- a/resources/views/maintenances/view.blade.php
+++ b/resources/views/maintenances/view.blade.php
@@ -138,6 +138,20 @@ use Carbon\Carbon;
                 </div>
               </div> <!-- /row -->
 
+              @if ($maintenance->url)
+                <div class="row">
+                  <div class="col-md-3">
+                    {{ trans('general.url') }}
+                  </div>
+                  <div class="col-md-9">
+                    <a href="{{ $maintenance->url }}">
+                      {{ $maintenance->url }}
+                      <x-icon type="external-link" />
+                    </a>
+                  </div>
+                </div> <!-- /row -->
+              @endif
+
               <div class="row">
                 <div class="col-md-3">
                   {{ trans('admin/maintenances/form.asset_maintenance_time') }}

--- a/tests/Feature/Maintenances/Api/CreateMaintenanceTest.php
+++ b/tests/Feature/Maintenances/Api/CreateMaintenanceTest.php
@@ -41,6 +41,7 @@ class CreateMaintenanceTest extends TestCase
                 'completion_date' => '2021-01-10',
                 'is_warranty' => '1',
                 'cost' => '100.00',
+                'url' => 'https://snipeitapp.com',
                 'image' => UploadedFile::fake()->image('test_image.png'),
                 'notes' => 'A note',
             ])
@@ -62,6 +63,7 @@ class CreateMaintenanceTest extends TestCase
             'start_date' => '2021-01-01',
             'completion_date' => '2021-01-10',
             'notes' => 'A note',
+            'url' => 'https://snipeitapp.com',
             'image' => $maintenance->image,
             'created_by' => $actor->id,
         ]);

--- a/tests/Feature/Maintenances/Api/EditMaintenanceTest.php
+++ b/tests/Feature/Maintenances/Api/EditMaintenanceTest.php
@@ -38,6 +38,7 @@ class EditMaintenanceTest extends TestCase
                 'is_warranty' => '1',
                 'image' => UploadedFile::fake()->image('test_image.png'),
                 'notes' => 'A note',
+                'url' => 'https://snipeitapp.com',
             ])
             ->assertOk();
 
@@ -57,6 +58,7 @@ class EditMaintenanceTest extends TestCase
             'completion_date' => '2021-01-10',
             'asset_maintenance_time' => '9',
             'notes' => 'A note',
+            'url' => 'https://snipeitapp.com',
             'image' => $maintenance->image,
         ]);
 

--- a/tests/Feature/Maintenances/Ui/CreateMaintenanceTest.php
+++ b/tests/Feature/Maintenances/Ui/CreateMaintenanceTest.php
@@ -46,6 +46,7 @@ class CreateMaintenanceTest extends TestCase
                 'cost' => '100.00',
                 'image' => UploadedFile::fake()->image('test_image.png'),
                 'notes' => 'A note',
+                'url' => 'https://snipeitapp.com',
             ])
             ->assertSessionHasNoErrors()
             ->assertRedirect(route('maintenances.index'));
@@ -67,6 +68,7 @@ class CreateMaintenanceTest extends TestCase
             'completion_date' => '2021-01-10',
             'asset_maintenance_time' => '9',
             'notes' => 'A note',
+            'url' => 'https://snipeitapp.com',
             'cost' => '100.00',
             'image' => $maintenance->image,
             'created_by' => $actor->id,

--- a/tests/Feature/Maintenances/Ui/EditMaintenanceTest.php
+++ b/tests/Feature/Maintenances/Ui/EditMaintenanceTest.php
@@ -38,6 +38,7 @@ class EditMaintenanceTest extends TestCase
                 'image' => UploadedFile::fake()->image('test_image.png'),
                 'cost' => '100.99',
                 'notes' => 'A note',
+                'url' => 'https://snipeitapp.com',
             ])
             ->assertSessionHasNoErrors()
             ->assertRedirect(route('maintenances.index'));
@@ -58,6 +59,7 @@ class EditMaintenanceTest extends TestCase
             'completion_date' => '2021-01-10',
             'asset_maintenance_time' => '9',
             'notes' => 'A note',
+            'url' => 'https://snipeitapp.com',
             'cost' => '100.99',
         ]);
 


### PR DESCRIPTION
This adds a url field to the maintenances section. 

<img width="1567" height="961" alt="Screenshot 2025-10-07 at 11 52 54 AM" src="https://github.com/user-attachments/assets/24665be8-87ca-4d88-8a82-d4a6a6c8311e" />
<img width="1568" height="959" alt="Screenshot 2025-10-07 at 11 55 42 AM" src="https://github.com/user-attachments/assets/1ae72324-ccec-4c5f-908e-b2c8f4accb26" />

Fixes #17924