### PR TITLE
Improved upcoming audit email layout and cli feedback

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -308,6 +308,54 @@ class Asset extends Depreciable
 
     }
 
+
+    protected function lastAuditFormattedDate(): Attribute
+    {
+
+        return Attribute:: make(
+            get: fn(mixed $value, array $attributes) => Helper::getFormattedDateObject($this->last_audit_date, 'datetime', false)
+        );
+    }
+
+    protected function lastAuditDiff(): Attribute
+    {
+        return Attribute:: make(
+            get: fn(mixed $value, array $attributes) => $this->warrantyExpires ? round((Carbon::now()->diffInDays($this->warrantyExpires))) : null,
+        );
+
+    }
+
+    protected function lastAuditDiffForHumans(): Attribute
+    {
+        return Attribute:: make(
+            get: fn(mixed $value, array $attributes) =>  $attributes['last_audit_date'] ? Carbon::parse($attributes['last_audit_date'])->diffForHumans() : null,
+        );
+
+    }
+
+    protected function nextAuditFormattedDate(): Attribute
+    {
+
+        return Attribute:: make(
+            get: fn(mixed $value, array $attributes) => Helper::getFormattedDateObject($this->next_audit_date, 'date', false)
+        );
+    }
+
+    protected function nextAuditDiffInDays(): Attribute
+    {
+        return Attribute:: make(
+            get: fn(mixed $value, array $attributes) => $attributes['next_audit_date'] ? Carbon::now()->diffInDays($attributes['next_audit_date']) : null,
+        );
+    }
+
+    protected function nextAuditDiffForHumans(): Attribute
+    {
+        return Attribute:: make(
+            get: fn(mixed $value, array $attributes) => $attributes['next_audit_date'] ? Carbon::parse($attributes['next_audit_date'])->diffForHumans() : null,
+        );
+
+    }
+
     protected function eolDate(): Attribute
     {
 
@@ -324,6 +372,7 @@ class Asset extends Depreciable
         );
 
     }
+
 
 
     protected function eolFormattedDate(): Attribute

--- a/app/Models/SnipeModel.php
+++ b/app/Models/SnipeModel.php
@@ -32,7 +32,7 @@ class SnipeModel extends Model
     protected function expiresDiffInDays(): Attribute
     {
         return Attribute:: make(
-            get: fn(mixed $value, array $attributes) => $attributes['expiration_date'] ? Carbon::now()->diffInDays($attributes['expiration_date']) : null,
+            get: fn(mixed $value, array $attributes) => in_array('expiration_date', $attributes) ? Carbon::now()->diffInDays($attributes['expiration_date']) : null,
         );
     }
 
@@ -40,14 +40,14 @@ class SnipeModel extends Model
     protected function expiresDiffForHumans(): Attribute
     {
         return Attribute:: make(
-            get: fn(mixed $value, array $attributes) => $attributes['expiration_date'] ? Carbon::parse($attributes['expiration_date'])->diffForHumans() : null,
+            get: fn(mixed $value, array $attributes) => in_array('expiration_date', $attributes) ? Carbon::parse($attributes['expiration_date'])->diffForHumans() : null,
         );
     }
 
     protected function expiresFormattedDate(): Attribute
     {
         return Attribute:: make(
-            get: fn(mixed $value, array $attributes) => $attributes['expiration_date'] ? Helper::getFormattedDateObject($attributes['expiration_date'], 'date', false) : null,
+            get: fn(mixed $value, array $attributes) => in_array('expiration_date', $attributes) ? Helper::getFormattedDateObject($attributes['expiration_date'], 'date', false) : null,
         );
     }
 

--- a/resources/views/notifications/markdown/upcoming-audits.blade.php
+++ b/resources/views/notifications/markdown/upcoming-audits.blade.php
@@ -1,43 +1,35 @@
 @component('mail::message')
 
-### {{ trans_choice('mail.upcoming-audits', $assets->count(), ['count' => $assets->count(), 'threshold' => $threshold]) }}
+{{ trans_choice('mail.upcoming-audits', $assets->count(), ['count' => $assets->count(), 'threshold' => $threshold]) }}
 
-
-<table style="width:100%">
-<thead>
-<tr>
-    <th style="vertical-align: top"> </th>
-    <th style="vertical-align: top">{{ trans('mail.name') }}</th>
-    <th style="vertical-align: top">{{ trans('general.last_audit') }}</th>
-    <th style="vertical-align: top">{{ trans('general.next_audit_date') }}</th>
-    <th style="vertical-align: top">{{ trans('mail.Days') }}</th>
-    <th style="vertical-align: top">{{ trans('mail.supplier') }}</th>
-    <th style="vertical-align: top">{{ trans('mail.assigned_to') }}</th>
-    <th style="vertical-align: top">{{ trans('general.notes') }}</th>
-</tr>
-
-
+<x-mail::table>
+|        |        |          |
+| ------------- | ------------- | ------------- |
 @foreach ($assets as $asset)
-@php
-$next_audit_date = Helper::getFormattedDateObject($asset->next_audit_date, 'date', false);
-$last_audit_date = Helper::getFormattedDateObject($asset->last_audit_date, 'date', false);
-$diff = (int) Carbon::parse(Carbon::now())->diffInDays($asset->next_audit_date, true);
-$icon = ($diff <= 7) ? '🚨' : (($diff <= 14) ? '⚠️' : ' ');
-@endphp
-
-<tr>
-    <td style="vertical-align: top">{{ $icon }}</td>
-    <td style="vertical-align: top"><a href="{{ route('hardware.show', $asset->id) }}">{{ $asset->display_name }}</a></td>
-    <td style="vertical-align: top">{{ $last_audit_date }}</td>
-    <td style="vertical-align: top">{{ $next_audit_date }}</td>
-    <td style="vertical-align: top">{{ $diff }}</td>
-    <td style="vertical-align: top">{{ ($asset->supplier ? e($asset->supplier->name) : '') }}</td>
-    <td style="vertical-align: top">{{ ($asset->assignedTo ? $asset->display_name : '') }}</td>
-    <td style="vertical-align: top">{!! nl2br(e($asset->notes)) !!}</td>
-</tr>
-
+| {{ ($asset->next_audit_diff_in_days <= 7) ? '🚨' : (($asset->next_audit_diff_in_days <= 14) ? '⚠️' : '⚠️') }} **{{ trans('mail.name') }}** | <a href="{{ route('hardware.show', $asset->id) }}">{{ $asset->display_name }}</a> |
+@if ($asset->serial)
+| **{{ trans('general.serial_number') }}** | {{ $asset->serial }} |
+@endif
+@if ($asset->purchase_date)
+| **{{ trans('general.purchase_date') }}** | {{ $asset->purchase_date_formatted }} |
+@endif
+@if ($asset->last_audit_date)
+| **{{ trans('general.last_audit') }}** | {{ $asset->last_audit_formatted_date }} ({{ $asset->last_audit_diff_for_humans }}) |
+@endif
+@if ($asset->next_audit_date)
+| **{{ trans('general.next_audit_date') }}** | {{ $asset->next_audit_formatted_date }} ({{ $asset->next_audit_diff_for_humans }}) |
+@endif
+@if ($asset->supplier)
+| **{{ trans('mail.supplier') }}** | {{ ($asset->supplier ? e($asset->supplier->name) : '') }} |
+@endif
+@if ($asset->assignedTo)
+| **{{ trans('mail.assigned_to') }}** | {{ e($asset->assignedTo->present()->display_name) }} |
+@endif
+| <hr> | <hr> |
 @endforeach
-</table>
+</x-mail::table>
 
-
+<x-mail::button :url="route('assets.audit.due')">
+    {{ trans_choice('general.audit_due_days', $threshold, ['days' => $threshold]) }}
+</x-mail::button>
 @endcomponent


### PR DESCRIPTION
The audit email was getting a bit wide, so I've switched the layout to accommodate all of the fields a little better, and added the purchase date and a big button that links to the audit page.

I also fixed a bug where we were not correctly displaying the assigned to if the asset was not currently assigned. 

### Email Before
<img width="1230" height="1037" alt="Screenshot 2025-10-07 at 2 09 44 PM" src="https://github.com/user-attachments/assets/c297a948-7861-4043-8040-918ea6e7da73" />

### CLI Before
<img width="1424" height="869" alt="Screenshot 2025-10-07 at 2 09 54 PM" src="https://github.com/user-attachments/assets/e8e79683-805b-44c2-9880-383c4925e431" />

### Email After
<img width="1301" height="1063" alt="Screenshot 2025-10-07 at 2 11 53 PM" src="https://github.com/user-attachments/assets/93830867-b930-4ee1-a940-650b8530e390" />
<img width="1241" height="899" alt="Screenshot 2025-10-07 at 2 12 01 PM" src="https://github.com/user-attachments/assets/50957567-a2d1-4a24-9c7a-5b7d61f8dfa5" />

### CLI After
<img width="1424" height="869" alt="Screenshot 2025-10-07 at 2 11 34 PM" src="https://github.com/user-attachments/assets/bd0ec6c3-aadb-4b8a-bafd-c856593f3977" />