### PR TITLE
Fixed #17363 - Emdash Character Encoding error

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -437,14 +437,7 @@ class ReportsController extends Controller
             $handle = fopen('php://output', 'w');
             stream_set_timeout($handle, 2000);
 
-            //this is handling emdash encoding, and is preventing that character from becoming something like ‚Äî
             fprintf($handle, chr(0xEF).chr(0xBB).chr(0xBF));
-
-            //U+00EC is accent grave in model number
-            //U+00EE is circumflex in model name
-            //why is the same character a value of 2 off of each other?
-            //why are we all getting different outputs for this emdash?
-            //exporting and opening with a text editor doesn't fuck it up? so its NOT on export. It's an Excel problem.
 
             $header = [];
 

--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -444,7 +444,7 @@ class ReportsController extends Controller
             //U+00EE is circumflex in model name
             //why is the same character a value of 2 off of each other?
             //why are we all getting different outputs for this emdash?
-            //holy shit, exporting and opening with a text editor doesn't fuck it up? so its NOT on export. It's an Excel problem.
+            //exporting and opening with a text editor doesn't fuck it up? so its NOT on export. It's an Excel problem.
 
             $header = [];
 

--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -440,6 +440,8 @@ class ReportsController extends Controller
             if ($request->filled('use_bom')) {
                 fprintf($handle, chr(0xEF).chr(0xBB).chr(0xBF));
             }
+            //this means: ï»¿ in utf-8
+            //i think this might be where we can start digging. tho, we always use utf-8 encoding on exports?
 
             $header = [];
 

--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -436,14 +436,12 @@ class ReportsController extends Controller
             // Open output stream
             $handle = fopen('php://output', 'w');
             stream_set_timeout($handle, 2000);
-            
-            if ($request->filled('use_bom')) {
-                fprintf($handle, chr(0xEF).chr(0xBB).chr(0xBF));
-            }
-            //this means: ï»¿ in utf-8
-            //i think this might be where we can start digging. tho, we always use utf-8 encoding on exports?
 
-            //should we just always use_bom? when would we not want to. use_bom is a fix i found on stack overflow
+            //this is handling emdash encoding, and is preventing that character from becoming something like ‚Äî
+            fprintf($handle, chr(0xEF).chr(0xBB).chr(0xBF));
+
+            //U+00EC is accent grave in model number
+            //U+00EE is circumflex in model name
 
             $header = [];
 

--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -442,6 +442,9 @@ class ReportsController extends Controller
 
             //U+00EC is accent grave in model number
             //U+00EE is circumflex in model name
+            //why is the same character a value of 2 off of each other?
+            //why are we all getting different outputs for this emdash?
+            //holy shit, exporting and opening with a text editor doesn't fuck it up? so its NOT on export. It's an Excel problem.
 
             $header = [];
 

--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -443,6 +443,8 @@ class ReportsController extends Controller
             //this means: ï»¿ in utf-8
             //i think this might be where we can start digging. tho, we always use utf-8 encoding on exports?
 
+            //should we just always use_bom? when would we not want to. use_bom is a fix i found on stack overflow
+
             $header = [];
 
             if ($request->filled('id')) {

--- a/database/migrations/2013_11_13_075318_create_models_table.php
+++ b/database/migrations/2013_11_13_075318_create_models_table.php
@@ -19,7 +19,6 @@ class CreateModelsTable extends Migration
             $table->integer('category_id')->nullable();
             $table->timestamps();
             $table->engine = 'InnoDB';
-            //making a note here. Interestingly we state the model and modelno cloumns as strings. Tableplus stores as a var_string.
         });
     }
 

--- a/database/migrations/2013_11_13_075318_create_models_table.php
+++ b/database/migrations/2013_11_13_075318_create_models_table.php
@@ -19,6 +19,7 @@ class CreateModelsTable extends Migration
             $table->integer('category_id')->nullable();
             $table->timestamps();
             $table->engine = 'InnoDB';
+            //making a note here. Interestingly we state the model and modelno cloumns as strings. Tableplus stores as a var_string.
         });
     }
 


### PR DESCRIPTION
Fix for the encoding error seen in https://github.com/grokability/snipe-it/issues/17363

Additionally, on Mac OS, this can also be fixed by importing the file through excel, and NOT opening it through the OS shell.
In excel, you can then import as csv, and choose UTF-8
<img width="837" height="845" alt="Screenshot 2025-10-07 at 20 40 32" src="https://github.com/user-attachments/assets/e04a517a-884f-4b69-830a-337b842124c7" />