### PR TITLE
Added migration to move asset model private uploads

### DIFF
--- a/database/migrations/2025_10_13_102956_move_assetmodels_files.php
+++ b/database/migrations/2025_10_13_102956_move_assetmodels_files.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Storage;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+
+        $assetmodelfiles = Storage::allFiles('private_uploads/assetmodels');
+
+        foreach ($assetmodelfiles as $file) {
+            Storage::writeStream('private_uploads/models/' . basename($file),
+                Storage::readStream($file)
+            );
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+};


### PR DESCRIPTION
In a recent change, we moved the private uploads for models from the `assetmodels` directory to a `models` directory, however on some systems, the rename didn't work as expected. This should copy those files over manually. 