### PR TITLE
Fixed bulk error display to be more consistent and correct HTML

### DIFF
--- a/resources/views/notifications.blade.php
+++ b/resources/views/notifications.blade.php
@@ -149,22 +149,22 @@
 
 @if ($messages = session()->get('multi_error_messages'))
     <div class="col-md-12">
-        <div class="alert alert alert-danger fade in">
+        <div class="alert alert alert-warning fade in">
             <button type="button" class="close" data-dismiss="alert">&times;</button>
             <i class="fas fa-exclamation-triangle faa-pulse animated"></i>
             <strong>{{ trans('general.notification_error') }}: </strong>
-            @foreach(array_splice($messages, 0,3) as $key => $message)
-                <ul>
+            <ul>
+                @foreach(array_splice($messages, 0,3) as $key => $message)
                     <li>{{ $message }}</li>
-                </ul>
-            @endforeach
+                @endforeach
+            </ul>
             <details>
                 <summary>{{ trans('general.show_all') }}</summary>
+                <ul>
                 @foreach(array_splice($messages, 3) as $key => $message)
-                    <ul>
-                        <li>{{ $message }}</li>
-                    </ul>
+                  <li>{{ $message }}</li>
                 @endforeach
+                </ul>
             </details>
         </div>
     </div>


### PR DESCRIPTION
This fixes some of the HTML in the bulk error messages to have consistent spacing. I also changed it to be a warning, although we may want to change that back.

### Before
<img width="1128" height="336" alt="Screenshot 2025-10-13 at 1 24 30 PM" src="https://github.com/user-attachments/assets/662ca32d-2e95-414e-840e-f81ea9693308" />

### After
<img width="1152" height="301" alt="Screenshot 2025-10-13 at 1 58 07 PM" src="https://github.com/user-attachments/assets/db21771b-016b-4374-9c33-dd688dcabe5d" />

Partially addresses #18034, first seen in #17573

**The issue that no success message is shown on a partial success or the fact that the text still says "show all" when all have been disclosed already have not been addressed in this PR.**