### PR TITLE
Fixed #18034 - Shows success message on partial bulk delete success

### DIFF
--- a/app/Http/Controllers/BulkSuppliersController.php
+++ b/app/Http/Controllers/BulkSuppliersController.php
@@ -19,6 +19,8 @@ class BulkSuppliersController extends Controller
         $this->authorize('delete', Supplier::class);
 
         $errors = [];
+        $success_count = 0;
+
         foreach ($request->ids as $id) {
             $supplier = Supplier::find($id);
             if (is_null($supplier)) {
@@ -45,6 +47,9 @@ class BulkSuppliersController extends Controller
             }
         }
         if (count($errors) > 0) {
+            if ($success_count > 0) {
+                return redirect()->route('suppliers.index')->with('success', trans_choice('admin/suppliers/message.delete.partial_success', $success_count, ['count' => $success_count]))->with('multi_error_messages', $errors);
+            }
             return redirect()->route('suppliers.index')->with('multi_error_messages', $errors);
         } else {
             return redirect()->route('suppliers.index')->with('success', trans('admin/suppliers/message.delete.bulk_success'));

--- a/resources/lang/en-US/admin/categories/message.php
+++ b/resources/lang/en-US/admin/categories/message.php
@@ -20,8 +20,9 @@ return array(
     'delete' => array(
         'confirm'                => 'Are you sure you wish to delete this category?',
         'error'                  => 'There was an issue deleting the category. Please try again.',
-        'success'                => 'The category was deleted successfully.',
-        'bulk_success'           => 'The Categories were deleted successfully.',
+        'success'                => 'Category was deleted successfully.',
+        'bulk_success'           => 'Categories were deleted successfully.',
+        'partial_success'        => 'Category deleted successfully. See additional information below. | :count categories were deleted successfully. See additional information below.',
     )
 
 );

--- a/resources/lang/en-US/admin/manufacturers/message.php
+++ b/resources/lang/en-US/admin/manufacturers/message.php
@@ -24,8 +24,9 @@ return array(
     'delete' => array(
         'confirm' => 'Are you sure you wish to delete this manufacturer?',
         'error'   => 'There was an issue deleting the manufacturer. Please try again.',
-        'success'                => 'The Manufacturer was deleted successfully.',
-        'bulk_success'           => 'The Manufacturers were deleted successfully.',
+        'success'                => 'Manufacturer deleted successfully.',
+        'bulk_success'           => 'Manufacturers deleted successfully.',
+        'partial_success'        => 'Manufacturer deleted successfully. See additional information below. | :count manufacturers were deleted successfully. See additional information below.',
     )
 
 );

--- a/resources/lang/en-US/admin/suppliers/message.php
+++ b/resources/lang/en-US/admin/suppliers/message.php
@@ -22,6 +22,7 @@ return array(
         'success' => 'Supplier was deleted successfully.',
         'not_found'               => 'Supplier not found.',
         'bulk_success'            => 'Suppliers were deleted successfully.',
+        'partial_success'        => 'Supplier deleted successfully. See additional information below. | :count suppliers were deleted successfully. See additional information below.',
     )
 
 );


### PR DESCRIPTION
This adds a success flash as well as the error/warning flash so users are aware that *some* of their items were deleted.

<img width="1110" height="265" alt="Screenshot 2025-10-13 at 2 26 41 PM" src="https://github.com/user-attachments/assets/566c6b8e-2a5a-46b2-af3d-ec71a4173407" />


Fixes #18034, first seen in https://github.com/grokability/snipe-it/pull/17573
