### PR TITLE
fix: update mysqldump options to use --ssl-mode=DISABLED for modern versions

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -18,9 +18,10 @@ $dump_options = [
     //'add_extra_option' => '--optionname=optionvalue',
 ];
 
-// Some versions of mysql do not support the --skip-ssl option and will fail if it is even set
+// For modern versions of mysqldump, use --ssl-mode=DISABLED
 if (env('DB_DUMP_SKIP_SSL') == 'true') {
-    $dump_options['skip_ssl'] = true;
+    // Correctly add the option as a string to the 'add_extra_option' key.
+    $dump_options['add_extra_option'] = '--ssl-mode=DISABLED';
 }
 
 


### PR DESCRIPTION
I still have this [issue 17004](https://github.com/grokability/snipe-it/issues/17004#issuecomment-3403831007) in the latest deployment. This is a quick fix to it already tested locally.
In the recent version of mariadb the argument changed and should follow as committed.