### PR TITLE
Added useLocale setting accessor for (some) mail alerts

### DIFF
--- a/app/Console/Commands/SendExpirationAlerts.php
+++ b/app/Console/Commands/SendExpirationAlerts.php
@@ -57,7 +57,7 @@ class SendExpirationAlerts extends Command
 
             if ($assets->count() > 0) {
 
-                Mail::to($recipients)->send(new ExpiringAssetsMail($assets, $alert_interval));
+                Mail::to($recipients)->locale($settings->use_locale)->send(new ExpiringAssetsMail($assets, $alert_interval));
 
                 $this->table(
                     [
@@ -91,7 +91,7 @@ class SendExpirationAlerts extends Command
                 ->orderBy('termination_date', 'ASC')
                 ->get();
             if ($licenses->count() > 0) {
-                Mail::to($recipients)->send(new ExpiringLicenseMail($licenses, $alert_interval));
+                Mail::to($recipients)->locale($settings->use_locale)->send(new ExpiringLicenseMail($licenses, $alert_interval));
 
                 $this->table(
                     [

--- a/app/Console/Commands/SendUpcomingAuditReport.php
+++ b/app/Console/Commands/SendUpcomingAuditReport.php
@@ -60,7 +60,7 @@ class SendUpcomingAuditReport extends Command
 
 
             $this->info('Sending Admin SendUpcomingAuditNotification to: ' . $settings->alert_email);
-            Mail::to($recipients)->send(new SendUpcomingAuditMail($assets, $settings->audit_warning_days));
+            Mail::to($recipients)->locale($settings->use_locale)->send(new SendUpcomingAuditMail($assets, $settings->audit_warning_days));
 
             $this->table(
                 [

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Notifiable;
@@ -118,6 +119,36 @@ class Setting extends Model
             // Catch the error if the tables dont exit
             return false;
         }
+    }
+
+    /**
+     * Get the locale to use in some places in the app where we don't
+     * have access to the user context (i.e. email notifications where the alert address
+     * might not be an actual user object or it's being run via cli.)
+     *
+     * @return \Illuminate\Database\Eloquent\Casts\Attribute
+     */
+    protected function useLocale(): Attribute
+    {
+
+        return Attribute:: make(
+            get: function(mixed $value, array $attributes) {
+
+                // Use current user's language
+                if ((request()->user()) && (request()->user()->locale)) {
+                    return request()->user()->locale;
+
+                // Fall back to app settings
+                } elseif ($attributes['locale'] != '') {
+                    return $attributes['locale'];
+                }
+
+                // Fall back to env
+                return config('app.locale');
+
+            }
+        );
+
     }
 
     /**


### PR DESCRIPTION
I'm not sure if this is a problem that actually needs to be solved tbh, but it doesn't seem like it would hurt. 

This adds a setting accessor that can be used in places where we might not know the user context, for example expiring licenses/assets reports, since that will send emails to an arbitrary set of addresses that might not have a corresponding user within the system.

This would only come up if the config language and the app language are not the same. By checking the settings table, we can override the env settings. 