### PR TITLE
Added - switch to new Enum for ActionType

### DIFF
--- a/app/Enums/ActionType.php
+++ b/app/Enums/ActionType.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Enums;
+enum ActionType: string
+{
+    case Restore = 'restore';
+    case TwoFactorReset = '2FA reset';
+    case CheckinFrom = 'checkin from';
+    case RequestCanceled = 'request canceled';
+    case Requested = 'requested';
+    case DeleteSeats = 'delete seats';
+    case AddSeats = 'add seats';
+    case Update = 'update';
+    case Create = 'create';
+    case Delete = 'delete';
+    case Uploaded = 'uploaded';
+    case NoteAdded = 'note added';
+    case Audit = 'audit';
+    case Checkout = 'checkout';
+    case Merged = 'merged';
+    case Accepted = 'accepted';
+    case UploadDeleted = 'upload deleted';
+    case Declined = 'declined';
+}

--- a/app/Models/Actionlog.php
+++ b/app/Models/Actionlog.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Models\Traits\CompanyableTrait;
 use App\Models\Traits\Searchable;
+use App\Enums\ActionType;
 use App\Presenters\Presentable;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -42,6 +43,13 @@ class Actionlog extends SnipeModel
         'target_type',
         'stored_eula'
     ];
+
+    protected function casts(): array
+    {
+        return [
+            'action_type' => ActionType::class,
+        ];
+    }
 
     use Searchable;
 

--- a/tests/Feature/Importing/Api/ImportAccessoriesTest.php
+++ b/tests/Feature/Importing/Api/ImportAccessoriesTest.php
@@ -75,7 +75,7 @@ class ImportAccessoriesTest extends ImportDataTestCase implements TestsPermissio
             ->where('item_id', $newAccessory->id)
             ->sole();
 
-        $this->assertEquals('create', $activityLog->action_type);
+        $this->assertEquals('create', $activityLog->action_type->value);
         $this->assertEquals('importer', $activityLog->action_source);
         $this->assertEquals($newAccessory->company->id, $activityLog->company_id);
 

--- a/tests/Feature/Importing/Api/ImportAssetsTest.php
+++ b/tests/Feature/Importing/Api/ImportAssetsTest.php
@@ -84,14 +84,14 @@ class ImportAssetsTest extends ImportDataTestCase implements TestsPermissionsReq
 
         $this->assertCount(2, $activityLogs);
 
-        $this->assertEquals('checkout', $activityLogs[0]->action_type);
+        $this->assertEquals('checkout', $activityLogs[0]->action_type->value);
         $this->assertEquals(Asset::class, $activityLogs[0]->item_type);
         $this->assertEquals($assignee->id, $activityLogs[0]->target_id);
         $this->assertEquals(User::class, $activityLogs[0]->target_type);
         $this->assertEquals('Checkout from CSV Importer', $activityLogs[0]->note);
         $this->assertHasTheseActionLogs($newAsset, ['create', 'checkout']); // TODO - order reversed but passes?!
 
-        $this->assertEquals('create', $activityLogs[1]->action_type);
+        $this->assertEquals('create', $activityLogs[1]->action_type->value);
         $this->assertNull($activityLogs[1]->target_id);
         $this->assertEquals(Asset::class, $activityLogs[1]->item_type);
         $this->assertNull($activityLogs[1]->note);

--- a/tests/Feature/Importing/Api/ImportComponentsTest.php
+++ b/tests/Feature/Importing/Api/ImportComponentsTest.php
@@ -75,7 +75,7 @@ class ImportComponentsTest extends ImportDataTestCase implements TestsPermission
             ->where('item_id', $newComponent->id)
             ->sole();
 
-        $this->assertEquals('create', $activityLog->action_type);
+        $this->assertEquals('create', $activityLog->action_type->value);
         $this->assertEquals('importer', $activityLog->action_source);
         $this->assertEquals($newComponent->company->id, $activityLog->company_id);
 

--- a/tests/Feature/Importing/Api/ImportConsumablesTest.php
+++ b/tests/Feature/Importing/Api/ImportConsumablesTest.php
@@ -75,7 +75,7 @@ class ImportConsumablesTest extends ImportDataTestCase implements TestsPermissio
             ->where('item_id', $newConsumable->id)
             ->sole();
 
-        $this->assertEquals('create', $activityLog->action_type);
+        $this->assertEquals('create', $activityLog->action_type->value);
         $this->assertEquals('importer', $activityLog->action_source);
         $this->assertEquals($newConsumable->company->id, $activityLog->company_id);
 

--- a/tests/Support/AssertHasActionLogs.php
+++ b/tests/Support/AssertHasActionLogs.php
@@ -12,7 +12,7 @@ trait AssertHasActionLogs
     public function assertHasTheseActionLogs(Model $item, array $statuses)
     {
         //note we have to do a 'reorder()' here because there is an implicit "order_by created_at" baked in to the relationship
-        Assert::assertEquals($statuses, $item->assetlog()->reorder('id')->pluck('action_type')->toArray(), "Failed asserting that action logs match");
+        Assert::assertEquals($statuses, $item->assetlog()->reorder('id')->pluck('action_type')->map(fn($item) => $item->value)->toArray(), "Failed asserting that action logs match");
     }
 
 }


### PR DESCRIPTION
This probably needs some clicking around to make sure everything works how we expect. But it's an attempt to take my other, bigger PR around `action_type` in the `ActionLogs` table to change it into an Enum. Instead of embedding this change along with many others into a far larger PR, this just breaks out this relatively small change.

One of the really nice advantages we get with this is if you try to set a 'wrong value' as an `action_type` you will actually get a compiler error - stating that the value you're trying to use is not supported by the Enum. It hasn't come up for us very often, but I like the idea of making sure it _never_ comes up.

This also has a nice advantage of being relatively bite-sized.