### PR TITLE
Fixed #18065: Ensure that private_key_bits is always an int

### DIFF
--- a/app/Http/Requests/SettingsSamlRequest.php
+++ b/app/Http/Requests/SettingsSamlRequest.php
@@ -109,7 +109,7 @@ class SettingsSamlRequest extends FormRequest
                 ];
 
                 $pkey = openssl_pkey_new([
-                    'private_key_bits' => config('app.saml_key_size'),
+                    'private_key_bits' => (int) config('app.saml_key_size'),
                     'private_key_type' => OPENSSL_KEYTYPE_RSA,
                 ]);
 


### PR DESCRIPTION
This PR fixes #18065 by ensuring that `private_key_bits` is cast to an `int` before passing it to `openssl_pkey_new`.