### PR TITLE
Fixes `admin` parameter acceptance notifications

### DIFF
--- a/app/Http/Controllers/Account/AcceptanceController.php
+++ b/app/Http/Controllers/Account/AcceptanceController.php
@@ -165,7 +165,7 @@ class AcceptanceController extends Controller
             'signature' => (($sig_filename && array_key_exists('1', $encoded_image))) ? $encoded_image[1] : null,
             'logo' => ($encoded_logo) ?? null,
             'date_settings' => $settings->date_display_format,
-            'admin' => $admin?->present()?->fullName,
+            'admin' => $admin?->present()->fullName,
             'qty' => $acceptance->qty ?? 1,
         ];
 

--- a/app/Http/Controllers/Account/AcceptanceController.php
+++ b/app/Http/Controllers/Account/AcceptanceController.php
@@ -115,7 +115,8 @@ class AcceptanceController extends Controller
         }
 
         $item = $acceptance->checkoutable_type::find($acceptance->checkoutable_id);
-
+        $lastCheckout = $item->checkouts()->latest()->first();
+        $admin = $lastCheckout?->adminuser;
 
 
         // If signatures are required, make sure we have one
@@ -164,10 +165,9 @@ class AcceptanceController extends Controller
             'signature' => (($sig_filename && array_key_exists('1', $encoded_image))) ? $encoded_image[1] : null,
             'logo' => ($encoded_logo) ?? null,
             'date_settings' => $settings->date_display_format,
-            'admin' => auth()->user()->present()?->fullName,
+            'admin' => $admin->present()?->fullName,
             'qty' => $acceptance->qty ?? 1,
         ];
-
 
         if ($request->input('asset_acceptance') == 'accepted') {
 

--- a/app/Http/Controllers/Account/AcceptanceController.php
+++ b/app/Http/Controllers/Account/AcceptanceController.php
@@ -165,7 +165,7 @@ class AcceptanceController extends Controller
             'signature' => (($sig_filename && array_key_exists('1', $encoded_image))) ? $encoded_image[1] : null,
             'logo' => ($encoded_logo) ?? null,
             'date_settings' => $settings->date_display_format,
-            'admin' => $admin->present()?->fullName,
+            'admin' => $admin?->present()?->fullName,
             'qty' => $acceptance->qty ?? 1,
         ];
 


### PR DESCRIPTION
The admin parameter in the acceptance controllernow points to the correct person.
Fixes: #18069 
<img width="720" height="579" alt="image" src="https://github.com/user-attachments/assets/95b64591-8fc9-423e-acb5-0d543fd16386" />
