### PR TITLE
Moved Traits into its directory and modify the FCO's to point to them

### DIFF
--- a/app/Models/Accessory.php
+++ b/app/Models/Accessory.php
@@ -6,6 +6,7 @@ use App\Helpers\Helper;
 use App\Models\Traits\Acceptable;
 use App\Models\Traits\CompanyableTrait;
 use App\Models\Traits\HasUploads;
+use App\Models\Traits\Loggable;
 use App\Models\Traits\Searchable;
 use App\Presenters\Presentable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -9,6 +9,8 @@ use App\Http\Traits\UniqueUndeletedTrait;
 use App\Models\Traits\Acceptable;
 use App\Models\Traits\CompanyableTrait;
 use App\Models\Traits\HasUploads;
+use App\Models\Traits\Loggable;
+use App\Models\Traits\Requestable;
 use App\Models\Traits\Searchable;
 use App\Presenters\AssetPresenter;
 use App\Presenters\Presentable;

--- a/app/Models/AssetModel.php
+++ b/app/Models/AssetModel.php
@@ -2,16 +2,18 @@
 
 namespace App\Models;
 
+use App\Http\Traits\TwoColumnUniqueUndeletedTrait;
 use App\Models\Traits\HasUploads;
+use App\Models\Traits\Loggable;
+use App\Models\Traits\Requestable;
 use App\Models\Traits\Searchable;
+use App\Presenters\AssetModelPresenter;
 use App\Presenters\Presentable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Storage;
 use Watson\Validating\ValidatingTrait;
-use \App\Presenters\AssetModelPresenter;
-use App\Http\Traits\TwoColumnUniqueUndeletedTrait;
 
 /**
  * Model for Asset Models. Asset Models contain higher level

--- a/app/Models/Component.php
+++ b/app/Models/Component.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Helpers\Helper;
 use App\Models\Traits\CompanyableTrait;
 use App\Models\Traits\HasUploads;
+use App\Models\Traits\Loggable;
 use App\Models\Traits\Searchable;
 use App\Presenters\Presentable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;

--- a/app/Models/Consumable.php
+++ b/app/Models/Consumable.php
@@ -6,6 +6,7 @@ use App\Helpers\Helper;
 use App\Models\Traits\Acceptable;
 use App\Models\Traits\CompanyableTrait;
 use App\Models\Traits\HasUploads;
+use App\Models\Traits\Loggable;
 use App\Models\Traits\Searchable;
 use App\Presenters\ConsumablePresenter;
 use App\Presenters\Presentable;

--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Helpers\Helper;
 use App\Models\Traits\CompanyableTrait;
 use App\Models\Traits\HasUploads;
+use App\Models\Traits\Loggable;
 use App\Models\Traits\Searchable;
 use App\Presenters\Presentable;
 use Carbon\Carbon;

--- a/app/Models/LicenseSeat.php
+++ b/app/Models/LicenseSeat.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Models\Traits\Acceptable;
 use App\Models\Traits\CompanyableChildTrait;
+use App\Models\Traits\Loggable;
 use App\Notifications\CheckinLicenseNotification;
 use App\Notifications\CheckoutLicenseNotification;
 use App\Presenters\Presentable;

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Http\Traits\UniqueUndeletedTrait;
 use App\Models\Traits\CompanyableTrait;
 use App\Models\Traits\HasUploads;
+use App\Models\Traits\Loggable;
 use App\Models\Traits\Searchable;
 use App\Presenters\Presentable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;

--- a/app/Models/Maintenance.php
+++ b/app/Models/Maintenance.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Helpers\Helper;
 use App\Models\Traits\CompanyableChildTrait;
 use App\Models\Traits\HasUploads;
+use App\Models\Traits\Loggable;
 use App\Models\Traits\Searchable;
 use App\Presenters\Presentable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;

--- a/app/Models/Traits/Loggable.php
+++ b/app/Models/Traits/Loggable.php
@@ -1,8 +1,14 @@
 <?php
 
-namespace App\Models;
+namespace App\Models\Traits;
 
+use App\Models\Actionlog;
+use App\Models\Asset;
+use App\Models\License;
+use App\Models\LicenseSeat;
+use App\Models\Location;
 use App\Models\Setting;
+use App\Models\User;
 use App\Notifications\AuditNotification;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;

--- a/app/Models/Traits/Requestable.php
+++ b/app/Models/Traits/Requestable.php
@@ -1,8 +1,10 @@
 <?php
 
-namespace App\Models;
+namespace App\Models\Traits;
 
 use Illuminate\Support\Facades\Auth;
+use App\Models\CheckoutRequest;
+use App\Models\User;
 
 // $asset->requests
 // $asset->isRequestedBy($user)

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Http\Traits\UniqueUndeletedTrait;
 use App\Models\Traits\CompanyableTrait;
 use App\Models\Traits\HasUploads;
+use App\Models\Traits\Loggable;
 use App\Models\Traits\Searchable;
 use App\Presenters\Presentable;
 use App\Presenters\UserPresenter;


### PR DESCRIPTION
This moves the two Traits of `Requestable` and `Loggable` into the Traits sub-directory of the Models directory.

Unfortunately my IDE decided to re-order some of them, which adds a little bit of noise, but generally this looks pretty smooth. One thing I *did* have to do was a `composer dump` to clean out the various class-caches and whatnot that Composer uses. I'm pretty sure we recommend that (and automate it) so I don't think that should be too much of a problem.

I decided _not_ to move the single Interface we have into an Interfaces (or Contracts?) directory, since there's only one and I don't know how interested we are in making others.