### PR TITLE
Adds admin to decline notification, fix asset and model name translations on asset notification

### DIFF
--- a/app/Notifications/AcceptanceAssetDeclinedNotification.php
+++ b/app/Notifications/AcceptanceAssetDeclinedNotification.php
@@ -31,6 +31,7 @@ class AcceptanceAssetDeclinedNotification extends Notification
         $this->company_name = $params['company_name'];
         $this->settings = Setting::getSettings();
         $this->qty = $params['qty'] ?? null;
+        $this->admin = $params['admin'] ?? null;
     }
 
     /**
@@ -70,7 +71,8 @@ class AcceptanceAssetDeclinedNotification extends Notification
                 'declined_date' => $this->declined_date,
                 'assigned_to'   => $this->assigned_to,
                 'company_name'  => $this->company_name,
-                'qty' => $this->qty,
+                'qty'           => $this->qty,
+                'admin'         => $this->admin,
                 'intro_text'    => trans('mail.acceptance_asset_declined'),
             ])
             ->subject(trans('mail.acceptance_asset_declined'));

--- a/resources/views/notifications/markdown/asset-acceptance.blade.php
+++ b/resources/views/notifications/markdown/asset-acceptance.blade.php
@@ -7,7 +7,7 @@
 |        |          |
 | ------------- | ------------- |
 @if (isset($item_name))
-| **{{ trans('general.name') }}** | {{ $item_name }} |
+| **{{ trans('general.asset_name') }}** | {{ $item_name }} |
 @endif
 | **{{ trans('mail.user') }}** | {{ $assigned_to }} |
 @if (isset($user->location))
@@ -32,7 +32,7 @@
 | **{{ trans('general.category') }}** | {{ $item->model->category->name }} |
 @endif
 @if ((isset($item_model)) && ($item_model!=''))
-| **{{ trans('mail.asset_name') }}** | {{ $item_model }} |
+| **{{ trans('general.model_name') }}** | {{ $item_model }} |
 @endif
 @if (isset($item->model))
 | **{{ trans('general.asset_model') }}** | {{ $item->model->name }} |


### PR DESCRIPTION
Admin was added to the decline asset notification, fixed row header translation choices for asset name and model name.

All Header changes can be seen here:
<img width="1002" height="635" alt="image" src="https://github.com/user-attachments/assets/89e61f4f-995d-4a8b-9ecc-bcf44f32d62c" />
Admin has been added to the decline notiication:
<img width="1002" height="635" alt="image" src="https://github.com/user-attachments/assets/00ccee67-bf37-4260-b5ac-cf225cafbbd7" />

