### PR TITLE
Fixed `alert_email` for notifications send conditional

### DIFF
--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -461,15 +461,18 @@ class CheckoutableListener
             return false;
         }
 
-        return (bool) $setting->admin_cc_email;
+        return $setting->admin_cc_email || $setting->alert_email;
     }
 
     private function getFormattedAlertAddresses(): array
-    {
-        $alertAddresses = Setting::getSettings()->admin_cc_email;
+    {   $setting = Setting::getSettings();
+        $alertAddresses = [
+            $setting->admin_cc_email?? '',
+            $setting->alert_email?? '',
+            ];
 
         if ($alertAddresses !== '') {
-            return array_filter(array_map('trim', explode(',', $alertAddresses)));
+            return array_filter(array_map('trim', explode(',', implode(',',$alertAddresses))));
         }
 
         return [];

--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -467,12 +467,12 @@ class CheckoutableListener
     private function getFormattedAlertAddresses(): array
     {   $setting = Setting::getSettings();
         $alertAddresses = [
-            $setting->admin_cc_email?? '',
-            $setting->alert_email?? '',
+            $setting->admin_cc_email ?? '',
+            $setting->alert_email ?? '',
             ];
 
         if ($alertAddresses !== '') {
-            return array_filter(array_map('trim', explode(',', implode(',',$alertAddresses))));
+            return array_filter(array_map('trim', explode(',', implode(',', $alertAddresses))));
         }
 
         return [];


### PR DESCRIPTION
Not sure how this dissappeared, but I re added the `alert_email` to checkoutable listener again. Notification are firing appropriately with this change.