### PR TITLE
FIXED: Name Fields size

### DIFF
--- a/resources/views/partials/forms/edit/name.blade.php
+++ b/resources/views/partials/forms/edit/name.blade.php
@@ -1,7 +1,7 @@
 <!-- Name -->
 <div class="form-group {{ $errors->has('name') ? ' has-error' : '' }}">
     <label for="name" class="col-md-3 control-label">{{ $translated_name }}</label>
-    <div class="col-md-8 col-sm-12">
+    <div class="col-md-7 col-sm-12">
         <input class="form-control" style="width:100%;" type="text" name="name" aria-label="name" id="name" value="{{ old('name', $item->name) }}"{!!  (Helper::checkIfRequired($item, 'name')) ? ' required' : '' !!} maxlength="191" />
         {!! $errors->first('name', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>


### PR DESCRIPTION
OLD: 
<img width="868" height="466" alt="Screenshot 2025-10-22 at 14 34 31" src="https://github.com/user-attachments/assets/f3336026-0a78-4b61-8acc-f3878f57ea1b" />
same on other creates modals

NEW:
<img width="951" height="570" alt="Screenshot 2025-10-22 at 14 44 04" src="https://github.com/user-attachments/assets/7a19cd51-5f01-4961-9221-e24ddcbd0578" />
<img width="773" height="355" alt="Screenshot 2025-10-22 at 14 29 04" src="https://github.com/user-attachments/assets/5b71b6de-ce5f-4a1e-9838-845366f1baaa" />
<img width="769" height="369" alt="Screenshot 2025-10-22 at 14 29 10" src="https://github.com/user-attachments/assets/ef90f0b9-d27d-4f4e-99f1-819e469f376d" />
<img width="833" height="485" alt="Screenshot 2025-10-22 at 14 29 25" src="https://github.com/user-attachments/assets/764b6e3b-c28e-4c38-a77c-100c190c1dc7" />
