### PR TITLE
Fixes warranty part of expiring assets query

### DIFF
--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -461,15 +461,18 @@ class CheckoutableListener
             return false;
         }
 
-        return (bool) $setting->admin_cc_email;
+        return $setting->admin_cc_email || $setting->alert_email;
     }
 
     private function getFormattedAlertAddresses(): array
-    {
-        $alertAddresses = Setting::getSettings()->admin_cc_email;
+    {   $setting = Setting::getSettings();
+        $alertAddresses = [
+            $setting->admin_cc_email?? '',
+            $setting->alert_email?? '',
+            ];
 
         if ($alertAddresses !== '') {
-            return array_filter(array_map('trim', explode(',', $alertAddresses)));
+            return array_filter(array_map('trim', explode(',', implode(',',$alertAddresses))));
         }
 
         return [];

--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -461,18 +461,15 @@ class CheckoutableListener
             return false;
         }
 
-        return $setting->admin_cc_email || $setting->alert_email;
+        return (bool) $setting->admin_cc_email;
     }
 
     private function getFormattedAlertAddresses(): array
-    {   $setting = Setting::getSettings();
-        $alertAddresses = [
-            $setting->admin_cc_email?? '',
-            $setting->alert_email?? '',
-            ];
+    {
+        $alertAddresses = Setting::getSettings()->admin_cc_email;
 
         if ($alertAddresses !== '') {
-            return array_filter(array_map('trim', explode(',', implode(',',$alertAddresses))));
+            return array_filter(array_map('trim', explode(',', $alertAddresses)));
         }
 
         return [];

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -950,7 +950,10 @@ class Asset extends Depreciable
                 })->orWhere(function ($query) use ($days) {
                     $query->whereNotNull('purchase_date')
                         ->whereNotNull('warranty_months')
-                        ->whereBetween('purchase_date', [Carbon::now(), Carbon::now()->addMonths('assets.warranty_months')->addDays($days)]);
+                        ->whereRaw(
+                            'DATE_ADD(purchase_date, INTERVAL warranty_months MONTH) BETWEEN ? AND ?',
+                            [now(), now()->addDays($days)]
+                        );
                 });
             })
             ->orderBy('asset_eol_date', 'ASC')

--- a/tests/Feature/Notifications/Email/ExpiringAlertsNotificationTest.php
+++ b/tests/Feature/Notifications/Email/ExpiringAlertsNotificationTest.php
@@ -17,6 +17,7 @@ class ExpiringAlertsNotificationTest extends TestCase
      public function testExpiringAssetsEmailNotification()
      {
          Mail::fake();
+         $this->markIncompleteIfSqlite();
 
          $this->settings->enableAlertEmail('admin@example.com');
          $this->settings->setAlertInterval(30);

--- a/tests/Feature/Notifications/Email/ExpiringAlertsNotificationTest.php
+++ b/tests/Feature/Notifications/Email/ExpiringAlertsNotificationTest.php
@@ -71,6 +71,8 @@ class ExpiringAlertsNotificationTest extends TestCase
      public function testExpiringLicensesEmailNotification()
      {
          Mail::fake();
+         $this->markIncompleteIfSqlite();
+
          $this->settings->enableAlertEmail('admin@example.com');
          $this->settings->setAlertInterval(60);
 


### PR DESCRIPTION
The `getExpiringWarrantyOrEol()` method was calling `->addMonths('assets.warranty_months')` and this was being interpreted as a string and silently failing.  

This was only returning assets with an expiring EOL and the warranty expires column could be filled as complementary info if the EOL was approaching:
<img width="1022" height="372" alt="image" src="https://github.com/user-attachments/assets/d4ebfb0e-fcd9-42f1-999a-4f1fdc05ab73" />

Now expiring warranties are included again:
<img width="1106" height="402" alt="image" src="https://github.com/user-attachments/assets/f194bdcc-57fa-4537-bf1c-aa6a7da3e69c" />

