### PR TITLE
Moved import time limit inside class, added new backup time limit

### DIFF
--- a/app/Console/Commands/ObjectImportCommand.php
+++ b/app/Console/Commands/ObjectImportCommand.php
@@ -8,8 +8,6 @@ use Symfony\Component\Console\Input\InputOption;
 use Illuminate\Support\Facades\Log;
 use Symfony\Component\Console\Helper\ProgressIndicator;
 
-ini_set('max_execution_time', env('IMPORT_TIME_LIMIT', 600)); //600 seconds = 10 minutes
-ini_set('memory_limit', env('IMPORT_MEMORY_LIMIT', '500M'));
 
 /**
  * Class ObjectImportCommand
@@ -52,6 +50,9 @@ class ObjectImportCommand extends Command
      */
     public function handle()
     {
+        ini_set('max_execution_time', env('IMPORT_TIME_LIMIT', 600)); //600 seconds = 10 minutes
+        ini_set('memory_limit', env('IMPORT_MEMORY_LIMIT', '500M'));
+
         $this->progressIndicator = new ProgressIndicator($this->output);
 
         $filename = $this->argument('filename');

--- a/app/Console/Commands/SystemBackup.php
+++ b/app/Console/Commands/SystemBackup.php
@@ -37,6 +37,8 @@ class SystemBackup extends Command
      */
     public function handle()
     {
+        ini_set('max_execution_time', env('BACKUP_TIME_LIMIT', 600)); //600 seconds = 10 minutes
+
         if ($this->option('filename')) {
             $filename = $this->option('filename');
 


### PR DESCRIPTION
The ObjectImportCommand had an inadvertent side-effect of overriding the `max_execution_time` application-wide. We have been able to use this in the past to allow for longer backups to fire, but we want to be more explicit when we are overriding that value.

This 'fixes' the side-effect, and adds a new setting for `BACKUP_TIME_LIMIT`.

Tested this by commenting-out the `IMPORT_TIME_LIMIT` and setting the `BACKUP_TIME_LIMIT` instead and it did, indeed, work.