### PR TITLE
Fixed fieldset colors on dark themes

### DIFF
--- a/resources/assets/less/overrides.less
+++ b/resources/assets/less/overrides.less
@@ -1275,6 +1275,7 @@ input[name="columnsSearch"] {
 }
 
 .callout.callout-legend h4 {
+  color: #333;
   font-size: 16px;
   font-weight: bold;
   margin-top: 5px;
@@ -1288,7 +1289,8 @@ input[name="columnsSearch"] {
 }
 
 p.callout-subtext {
- margin-top: 5px;
+  color:#333;
+  margin-top: 5px;
 }
 
 p.callout-subtext a:hover, p.callout-subtext a:visited, p.callout-subtext a:link {


### PR DESCRIPTION
This adds the correct header font color to the less rules for the legend components.
Before:
<img width="1239" height="418" alt="image" src="https://github.com/user-attachments/assets/68897c17-7aa5-4659-8600-6224cfe5becd" />

After:
<img width="1239" height="418" alt="image" src="https://github.com/user-attachments/assets/d4707cac-4d2c-4dce-829a-4579d342fbd0" />
