### PR TITLE
Fixed #18097 - check for CJK in field labels as well as content

### DIFF
--- a/app/Models/CheckoutAcceptance.php
+++ b/app/Models/CheckoutAcceptance.php
@@ -190,6 +190,11 @@ class CheckoutAcceptance extends Model
         }
 
         $pdf->Ln();
+
+        // Check for CJK in the translation string for date. (This is a good proxy for the rest of the document)
+        Helper::hasRtl(trans('general.date')) ? $pdf->setRTL(true) : $pdf->setRTL(false);
+        Helper::isCjk(trans('general.date')) ? $pdf->SetFont('cid0cs', '', 9) : $pdf->SetFont('dejavusans', '', 8, '', true);
+
         $pdf->writeHTML(trans('general.date') . ': ' . Helper::getFormattedDateObject(now(), 'datetime', false), true, 0, true, 0, '');
 
         if ($data['company_name'] != null) {
@@ -224,7 +229,6 @@ class CheckoutAcceptance extends Model
         foreach ($eula_lines as $eula_line) {
             Helper::hasRtl($eula_line) ? $pdf->setRTL(true) : $pdf->setRTL(false);
             Helper::isCjk($eula_line) ? $pdf->SetFont('cid0cs', '', 9) : $pdf->SetFont('dejavusans', '', 8, '', true);
-
             $pdf->writeHTML(Helper::parseEscapedMarkedown($eula_line), true, 0, true, 0, '');
         }
         $pdf->Ln();
@@ -239,8 +243,11 @@ class CheckoutAcceptance extends Model
             $pdf->Ln();
         }
 
+        Helper::hasRtl(trans('general.notes')) ? $pdf->setRTL(true) : $pdf->setRTL(false);
+        Helper::isCjk(trans('general.notes')) ? $pdf->SetFont('cid0cs', '', 9) : $pdf->SetFont('dejavusans', '', 8, '', true);
+
         if ($data['note'] != null) {
-            Helper::isCjk($data['note']) ? $pdf->SetFont('cid0cs', '', 9) : $pdf->SetFont('dejavusans', '', 8, '', true);
+            Helper::isCjk(trans('general.notes')) ? $pdf->SetFont('cid0cs', '', 9) : $pdf->SetFont('dejavusans', '', 8, '', true);
             $pdf->writeHTML(trans('general.notes') . ': ' . e($data['note']), true, 0, true, 0, '');
             $pdf->Ln();
         }


### PR DESCRIPTION
In https://github.com/grokability/snipe-it/pull/17866, we introduced CJK detection to the acceptance PDFs, however we were only checking the value of the record, not the translated strings themselves. 

This is a bit hacky, in that it's checking the translated string, and sometimes those strings might not be fully translated, but I picked fields that are very common throughout the system, so are more likely to be translated. 

### User has language set to CJK
<img width="1007" height="519" alt="Screenshot 2025-10-27 at 12 33 51 PM" src="https://github.com/user-attachments/assets/a367c81c-3124-4a0e-ae55-eea9f0261a71" />

### User has language set to non-CJK

<img width="1006" height="482" alt="Screenshot 2025-10-27 at 12 38 14 PM" src="https://github.com/user-attachments/assets/1d311061-aeff-40ae-aae7-61001cbe285f" />

Fixes #18097 




