### PR TITLE
Added null safe operator in case of missing license

### DIFF
--- a/app/Models/LicenseSeat.php
+++ b/app/Models/LicenseSeat.php
@@ -76,7 +76,7 @@ class LicenseSeat extends SnipeModel implements ICompanyableChild
     protected function displayName(): Attribute
     {
         return Attribute:: make(
-            get: fn(mixed $value) => $this->license->name,
+            get: fn(mixed $value) => $this->license?->name,
         );
     }
 


### PR DESCRIPTION
This is most likely the case of bad data but avoiding a 500 is nice.

---

RB-20317
RB-20318