### PR TITLE
Fixed issue when viewing user that does not have permissions set

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -225,7 +225,9 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
         return false;
     }
 
-    public function hasIndividualPermissions() {
+    public function hasIndividualPermissions()
+    {
+        $permissions = [];
 
         if (is_object($this->permissions)) {
             $permissions = json_decode(json_encode($this->permissions), true);


### PR DESCRIPTION
If a user's permissions are null in the database, most likely due to bad data, then a hard exception is thrown (ErrorException: Undefined variable `$permissions` in /snipe-it/app/Models/User.php:238)

---

RB-20434
RB-20435