### PR TITLE
Fixed - LDAP test needs to be fixed to match new behavior

### DIFF
--- a/tests/Unit/LdapTest.php
+++ b/tests/Unit/LdapTest.php
@@ -121,7 +121,7 @@ class LdapTest extends TestCase
         $ldap_set_option->expects($this->exactly(12));
 
         //
-        $this->getFunctionMock("App\\Models", "ldap_bind")->expects($this->exactly(4))->willReturn(
+        $this->getFunctionMock("App\\Models", "ldap_bind")->expects($this->exactly(3))->willReturn(
             true, /* initial admin connection for 'fast path' */
             false, /* the actual login for the user */
             false, /* the direct login for the user binding-as-themselves in the legacy path */


### PR DESCRIPTION
We changed the number of times that a failing LDAP connection would call `ldap_bind` to work around some timeout issues when doing local-login fallback. As such, we have to change the expected count of the number of calls to `ldap_bind` in the tests.

I'm still a little weirded-out by how these tests work, mocking various PHP functions the way they do. But, unfortunately, we can't figure out any other way to get us _some_ amount of test coverage for our very critical LDAP subsystem. So this is what we end up with :/