### PR TITLE
Fixed #18112 - fix consumable and license acceptances

### DIFF
--- a/app/Http/Controllers/Account/AcceptanceController.php
+++ b/app/Http/Controllers/Account/AcceptanceController.php
@@ -115,9 +115,6 @@ class AcceptanceController extends Controller
         }
 
         $item = $acceptance->checkoutable_type::find($acceptance->checkoutable_id);
-        $lastCheckout = $item->checkouts()->latest()->first();
-        $admin = $lastCheckout?->adminuser;
-
 
         // If signatures are required, make sure we have one
         if (Setting::getSettings()->require_accept_signature == '1') {
@@ -165,7 +162,6 @@ class AcceptanceController extends Controller
             'signature' => (($sig_filename && array_key_exists('1', $encoded_image))) ? $encoded_image[1] : null,
             'logo' => ($encoded_logo) ?? null,
             'date_settings' => $settings->date_display_format,
-            'admin' => $admin?->present()->fullName,
             'qty' => $acceptance->qty ?? 1,
         ];
 

--- a/app/Notifications/AcceptanceAssetAcceptedNotification.php
+++ b/app/Notifications/AcceptanceAssetAcceptedNotification.php
@@ -34,7 +34,6 @@ use Illuminate\Notifications\Notification;
         $this->file = $params['file'] ?? null;
         $this->qty = $params['qty'] ?? null;
         $this->note = $params['note'] ?? null;
-        $this->admin = $params['admin'] ?? null;
 
     }
 
@@ -77,7 +76,6 @@ use Illuminate\Notifications\Notification;
                 'accepted_date' => $this->accepted_date,
                 'assigned_to'   => $this->assigned_to,
                 'company_name'  => $this->company_name,
-                'admin'         => $this->admin,
                 'qty' => $this->qty,
                 'intro_text'    => trans('mail.acceptance_asset_accepted'),
             ])

--- a/app/Notifications/AcceptanceAssetAcceptedToUserNotification.php
+++ b/app/Notifications/AcceptanceAssetAcceptedToUserNotification.php
@@ -32,7 +32,6 @@ use Illuminate\Notifications\Notification;
         $this->settings = Setting::getSettings();
         $this->file = $params['file'] ?? null;
         $this->qty = $params['qty'] ?? null;
-        $this->admin = $params['admin'] ?? null;
     }
 
     /**
@@ -70,7 +69,6 @@ use Illuminate\Notifications\Notification;
                 'accepted_date' => $this->accepted_date,
                 'assigned_to'   => $this->assigned_to,
                 'company_name'  => $this->company_name,
-                'admin'         => $this->admin,
                 'qty' => $this->qty,
                 'intro_text'    => trans_choice('mail.acceptance_asset_accepted_to_user', $this->qty, ['qty' => $this->qty, 'site_name' => $this->settings->site_name]),
             ])

--- a/resources/views/notifications/markdown/asset-acceptance.blade.php
+++ b/resources/views/notifications/markdown/asset-acceptance.blade.php
@@ -43,9 +43,6 @@
 @if (isset($qty))
 | **{{ trans('general.qty') }}** | {{ $qty }} |
 @endif
-@if (isset($admin))
-| **{{ trans('general.administrator') }}** | {{ $admin }} |
-@endif
 @endcomponent
 
 {{ trans('mail.best_regards') }}


### PR DESCRIPTION
Currently attempting to accept (or decline) a consumable or license results an exception being thrown:

```
BadMethodCallException: Call to undefined method App\Models\Consumable::checkouts()
```
> (or `LicenseSeat::checkouts()`)

---

This PR fixes #18112 by removing the "Administrator" row from the acceptance notifications:

| Before | After |
|--------|--------|
| <img width="2492" height="3130" alt="CleanShot 2025-10-28 at 12 53 03@2x" src="https://github.com/user-attachments/assets/ced6328a-9674-47e4-bf70-0c5bfb69f3ad" /> | <img width="2492" height="3130" alt="CleanShot 2025-10-28 at 12 53 10@2x" src="https://github.com/user-attachments/assets/31304cec-9f27-4d25-ad21-25375fcffc6b" /> |

---

The problem lines were recently but, as mentioned in the issue, they are not guaranteed to reference the correct administrator so I pulled the reference for the time being:

```php
$lastCheckout = $item->checkouts()->latest()->first();
$admin = $lastCheckout?->adminuser;
```

---

Fixes #18112
Fixes RB-20449
Fixes RB-20450
