### PR TITLE
Fixed #17329 Audit Warning Threshold could be negative

### DIFF
--- a/app/Http/Requests/StoreNotificationSettings.php
+++ b/app/Http/Requests/StoreNotificationSettings.php
@@ -32,7 +32,7 @@ class StoreNotificationSettings extends FormRequest
             ],
             'alert_threshold'                     => 'numeric|nullable',
             'alert_interval'                      => 'numeric|nullable|gt:0',
-            'audit_warning_days'                  => 'numeric|nullable',
+            'audit_warning_days'                  => 'numeric|nullable|gte:0',
             'due_checkin_days'                    => 'numeric|nullable|gt:0',
             'audit_interval'                      => 'numeric|nullable|gt:0',
         ];

--- a/resources/views/settings/alerts.blade.php
+++ b/resources/views/settings/alerts.blade.php
@@ -183,7 +183,7 @@
                                     <label for="audit_warning_days">{{ trans('admin/settings/general.audit_warning_days') }}</label>
                                 </div>
                                 <div class="input-group col-xs-10 col-sm-6 col-md-4 col-lg-3 col-xl-3">
-                                    <input class="form-control" placeholder="14" maxlength="3" name="audit_warning_days" type="number" id="audit_warning_days" value="{{ old('audit_warning_days', $setting->audit_warning_days) }}">
+                                    <input class="form-control" placeholder="14" maxlength="3" min="0" name="audit_warning_days" type="number" id="audit_warning_days" value="{{ old('audit_warning_days', $setting->audit_warning_days) }}">
                                     <span class="input-group-addon">{{ trans('general.days') }}</span>
                                 </div>
                                 <div class="col-md-8 col-md-offset-3">


### PR DESCRIPTION
Audit Warning Threshold could be negative.
This fixes the field so it must be greater than or equal to 0.
The field can still be null.

<img width="688" height="716" alt="Screenshot 2025-10-28 at 16 18 19" src="https://github.com/user-attachments/assets/7c359275-40f8-4e91-9a46-d7b8b9ee54f7" />

Fixes #17329 