### PR TITLE
Fixed form label alignments in settings section

### DIFF
--- a/resources/lang/en-US/admin/settings/general.php
+++ b/resources/lang/en-US/admin/settings/general.php
@@ -416,6 +416,9 @@ return [
     'manager_view' => 'Manager View',
     'manager_view_enabled_text' => 'Enable Manager View',
     'manager_view_enabled_help' => 'Allow managers to view assigned items to their direct and indirect reports in their account view.',
+    'redirect_url' => 'Redirect URL',
+    'client_secret' => 'Client Secret',
+    'client_id' => 'Client ID',
 
     'username_formats' => [
         'username_format'		=> 'Username Format',

--- a/resources/views/partials/forms/edit/uploadLogo.blade.php
+++ b/resources/views/partials/forms/edit/uploadLogo.blade.php
@@ -1,10 +1,10 @@
 <!-- {{ $logoVariable }}logo image upload -->
 
 <div class="form-group">
-    <div class="col-md-3 text-right">
-        <label {!! $errors->has($logoVariable) ? 'class="alert-msg"' : '' !!} for="{{ $logoVariable }}">
+    <div class="col-md-3 control-label{!! $errors->has($logoVariable) ? ' error' : '' !!}">
+        <strong>
         {{ trans($logoLabel) }}
-        </label>
+        </strong>
     </div>
     <div class="col-md-9">
         <label class="btn btn-default{{ (config('app.lock_passwords')) ? ' disabled' : '' }}">

--- a/resources/views/settings/alerts.blade.php
+++ b/resources/views/settings/alerts.blade.php
@@ -41,13 +41,13 @@
                     <div class="col-md-12">
 
 
-                        <fieldset name="remote-login"">
+                        <fieldset name="remote-login">
                             <x-form-legend>
                                 {{ trans('admin/settings/general.legends.general') }}
                             </x-form-legend>
 
                             <!-- Menu Alerts Enabled -->
-                            <div class="form-group {{ $errors->has('show_alerts_in_menu') ? 'error' : '' }}">
+                            <div class="form-group{{ $errors->has('show_alerts_in_menu') ? ' error' : '' }}">
                                 <div class="col-md-9 col-md-offset-3">
                                     <label class="form-control">
                                         <input type="checkbox" name="show_alerts_in_menu" value="1" @checked(old('show_alerts_in_menu', $setting->show_alerts_in_menu))>
@@ -68,16 +68,16 @@
 
                         </fieldset>
 
-                        <fieldset name="alert-addresses"">
+                        <fieldset name="alert-addresses">
                             <x-form-legend>
                                 {{ trans('admin/settings/general.legends.email') }}
                             </x-form-legend>
 
                             <!-- Alert Email -->
                             <div class="form-group {{ $errors->has('alert_email') ? 'error' : '' }}">
-                                <div class="col-md-3 text-right">
-                                    <label for="alert_email">{{ trans('admin/settings/general.alert_email') }}</label>
-                                </div>
+
+                                <label for="alert_email" class="col-md-3 control-label">{{ trans('admin/settings/general.alert_email') }}</label>
+
                                 <div class="col-md-8 input-group">
                                     <input type="text" name="alert_email" value="{{ old('alert_email', $setting->alert_email) }}" class="form-control" placeholder="admin@yourcompany.com,it@yourcompany.com" maxlength="191">
                                     <span class="input-group-addon">
@@ -93,9 +93,8 @@
 
                             <!-- Admin CC Email -->
                             <div class="form-group {{ $errors->has('admin_cc_email') ? 'error' : '' }}">
-                                <div class="col-md-3 text-right">
-                                    <label for="admin_cc_email">{{ trans('admin/settings/general.admin_cc_email') }}</label>
-                                </div>
+
+                               <label for="admin_cc_email" class="col-md-3 control-label">{{ trans('admin/settings/general.admin_cc_email') }}</label>
                                 <div class="col-md-8 input-group">
                                     <input type="email" name="admin_cc_email" value="{{ old('admin_cc_email', $setting->admin_cc_email) }}" class="form-control" placeholder="admin@yourcompany.com" maxlength="191">
                                     <span class="input-group-addon">
@@ -131,7 +130,7 @@
                             </div>
                         </fieldset>
 
-                        <fieldset name="remote-login"">
+                        <fieldset name="remote-login">
 
                             <x-form-legend>
                                 {{ trans('admin/settings/general.legends.intervals') }}
@@ -139,9 +138,9 @@
 
                             <!-- Inventory alert threshold -->
                             <div class="form-group {{ $errors->has('alert_threshold') ? 'error' : '' }}">
-                                <div class="col-md-3 text-right">
-                                    <label for="alert_threshold">{{ trans('admin/settings/general.alert_inv_threshold') }}</label>
-                                </div>
+
+                                <label for="alert_threshold" class="col-md-3 control-label">{{ trans('admin/settings/general.alert_inv_threshold') }}</label>
+
                                 <div class="col-md-8">
                                     <input class="form-control" placeholder="5" maxlength="3" style="width: 100px;" name="alert_threshold" type="number" value="{{ old('alert_threshold', $setting->alert_threshold) }}" id="alert_threshold">
                                     {!! $errors->first('alert_threshold', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
@@ -151,9 +150,8 @@
 
                             <!-- Inventory alert interval -->
                             <div class="form-group {{ $errors->has('alert_interval') ? 'error' : '' }}">
-                                <div class="col-md-3 text-right">
-                                    <label for="alert_interval">{{ trans('admin/settings/general.alert_interval') }}</label>
-                                </div>
+
+                                <label for="alert_interval" class="col-md-3 control-label">{{ trans('admin/settings/general.alert_interval') }}</label>
                                 <div class="input-group col-xs-10 col-sm-6 col-md-4 col-lg-3 col-xl-3">
                                     <input class="form-control" placeholder="30" maxlength="3" name="alert_interval" type="number" value="{{ old('alert_interval', $setting->alert_interval) }}" id="alert_interval">
                                     <span class="input-group-addon">{{ trans('general.days') }}</span>
@@ -164,9 +162,8 @@
 
                             <!-- Due for checkin days -->
                             <div class="form-group {{ $errors->has('due_checkin_days') ? 'error' : '' }}">
-                                <div class="col-md-3 text-right">
-                                    <label for="due_checkin_days">{{ trans('admin/settings/general.due_checkin_days') }}</label>
-                                </div>
+
+                                <label for="due_checkin_days" class="col-md-3 control-label">{{ trans('admin/settings/general.due_checkin_days') }}</label>
                                 <div class="input-group col-xs-10 col-sm-6 col-md-4 col-lg-3 col-xl-3">
                                     <input class="form-control" placeholder="14" maxlength="3" name="due_checkin_days" type="number" id="due_checkin_days" value="{{ old('due_checkin_days', $setting->due_checkin_days) }}">
                                     <span class="input-group-addon">{{ trans('general.days') }}</span>
@@ -179,9 +176,8 @@
 
                             <!-- Alert warning threshold -->
                             <div class="form-group {{ $errors->has('audit_warning_days') ? 'error' : '' }}">
-                                <div class="col-md-3 text-right">
-                                    <label for="audit_warning_days">{{ trans('admin/settings/general.audit_warning_days') }}</label>
-                                </div>
+
+                                <label for="audit_warning_days" class="col-md-3 control-label">{{ trans('admin/settings/general.audit_warning_days') }}</label>
                                 <div class="input-group col-xs-10 col-sm-6 col-md-4 col-lg-3 col-xl-3">
                                     <input class="form-control" placeholder="14" maxlength="3" min="0" name="audit_warning_days" type="number" id="audit_warning_days" value="{{ old('audit_warning_days', $setting->audit_warning_days) }}">
                                     <span class="input-group-addon">{{ trans('general.days') }}</span>
@@ -194,9 +190,9 @@
 
                             <!-- Audit interval -->
                             <div class="form-group {{ $errors->has('audit_interval') ? 'error' : '' }}">
-                                <div class="col-md-3 text-right">
-                                    <label for="audit_interval">{{ trans('admin/settings/general.audit_interval') }}</label>
-                                </div>
+
+                                <label for="audit_interval" class="col-md-3 control-label">{{ trans('admin/settings/general.audit_interval') }}</label>
+
                                 <div class="input-group col-xs-10 col-sm-6 col-md-6 col-lg-3 col-xl-3">
                                     <input class="form-control" placeholder="12" maxlength="3" name="audit_interval" type="number" id="audit_interval" value="{{ old('audit_interval', $setting->audit_interval) }}">
                                     <span class="input-group-addon">{{ trans('general.months') }}</span>

--- a/resources/views/settings/asset_tags.blade.php
+++ b/resources/views/settings/asset_tags.blade.php
@@ -42,23 +42,20 @@
 
                         <!-- auto ids -->
                         <div class="form-group">
-                            <div class="col-md-5">
-                                <strong>{{  trans('admin/settings/general.auto_increment_assets') }}</strong>
-                            </div>
-                            <div class="col-md-7">
+                            <div class="col-md-8 col-md-offset-3">
                                 <label class="form-control">
                                     <input type="checkbox" name="auto_increment_assets" value="1" @checked(old('auto_increment_assets', $setting->auto_increment_assets)) aria-label="auto_increment_assets">
-                                    {{ trans('admin/settings/general.enabled') }}
+                                    {{  trans('admin/settings/general.auto_increment_assets') }}
                                 </label>
                             </div>
                         </div>
 
                         <div class="form-group">
-                            <div class="col-md-5">
-                                <label for="next_auto_tag_base">{{ trans('admin/settings/general.next_auto_tag_base') }}</label>
-                            </div>
-                            <div class="col-md-7">
-                                <input class="form-control" style="width: 150px;" aria-label="next_auto_tag_base" name="next_auto_tag_base" type="text" value="{{ old('next_auto_tag_base', $setting->next_auto_tag_base) }}" id="next_auto_tag_base">
+
+                            <label for="next_auto_tag_base" class="col-md-3 control-label">{{ trans('admin/settings/general.next_auto_tag_base') }}</label>
+
+                            <div class="col-md-8">
+                                <input class="form-control" style="width: 200px;" aria-label="next_auto_tag_base" name="next_auto_tag_base" type="text" value="{{ old('next_auto_tag_base', $setting->next_auto_tag_base) }}" id="next_auto_tag_base">
                                 {!! $errors->first('next_auto_tag_base', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                             </div>
                         </div>
@@ -66,26 +63,26 @@
 
                         <!-- auto prefix -->
                         <div class="form-group {{ $errors->has('auto_increment_prefix') ? 'error' : '' }}">
-                            <div class="col-md-5">
-                                <label for="auto_increment_prefix">{{ trans('admin/settings/general.auto_increment_prefix') }}</label>
-                            </div>
-                            <div class="col-md-7">
+
+                            <label for="auto_increment_prefix" class="col-md-3 control-label">{{ trans('admin/settings/general.auto_increment_prefix') }}</label>
+
+                            <div class="col-md-8">
                                 @if ($setting->auto_increment_assets == 1)
-                                    <input class="form-control" style="width: 150px;" aria-label="auto_increment_prefix" name="auto_increment_prefix" type="text" id="auto_increment_prefix" value="{{ old('auto_increment_prefix', $setting->auto_increment_prefix) }}">
+                                    <input class="form-control"  maxlength="100" style="width: 200px;" aria-label="auto_increment_prefix" name="auto_increment_prefix" type="text" id="auto_increment_prefix" value="{{ old('auto_increment_prefix', $setting->auto_increment_prefix) }}">
                                     {!! $errors->first('auto_increment_prefix', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @else
-                                    <input class="form-control" disabled="disabled" style="width: 150px;" aria-label="auto_increment_prefix" name="auto_increment_prefix" type="text" id="auto_increment_prefix" value="{{ old('auto_increment_prefix', $setting->auto_increment_prefix) }}">
+                                    <input class="form-control" maxlength="100" disabled="disabled" style="width: 200px;" aria-label="auto_increment_prefix" name="auto_increment_prefix" type="text" id="auto_increment_prefix" value="{{ old('auto_increment_prefix', $setting->auto_increment_prefix) }}">
                                 @endif
                             </div>
                         </div>
 
                         <!-- auto zerofill -->
                         <div class="form-group {{ $errors->has('zerofill_count') ? 'error' : '' }}">
-                            <div class="col-md-5">
-                                <label for="zerofill_count">{{ trans('admin/settings/general.zerofill_count') }}</label>
-                            </div>
+
+                            <label for="zerofill_count" class="col-md-3 control-label">{{ trans('admin/settings/general.zerofill_count') }}</label>
+
                             <div class="col-md-7">
-                                <input class="form-control" style="width: 150px;" aria-label="zerofill_count" name="zerofill_count" type="text" value="{{ old('zerofill_count', $setting->zerofill_count) }}" id="zerofill_count">
+                                <input class="form-control" maxlength="100" style="width: 200px;" aria-label="zerofill_count" name="zerofill_count" type="text" value="{{ old('zerofill_count', $setting->zerofill_count) }}" id="zerofill_count">
                                 {!! $errors->first('zerofill_count', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                             </div>
                         </div>

--- a/resources/views/settings/branding.blade.php
+++ b/resources/views/settings/branding.blade.php
@@ -51,25 +51,22 @@
 
                     <div class="col-md-12">
 
-                        <fieldset name="logo-preferences"">
+                        <fieldset name="logo-preferences">
                             <x-form-legend>
                                 {{ trans('admin/settings/general.legends.logos') }}
                             </x-form-legend>
 
                             <!-- Site name -->
-                            <div class="form-group {{ $errors->has('site_name') ? 'error' : '' }}">
-
-                                <div class="col-md-3 text-right">
-                                    <label for="site_name">{{ trans('admin/settings/general.site_name') }}</label>
-                                </div>
-                                <div class="col-md-7 required">
+                            <div class="form-group{{ $errors->has('site_name') ? ' error' : '' }}">
+                                <label for="site_name" class="col-md-3 control-label">{{ trans('admin/settings/general.site_name') }}</label>
+                                <div class="col-md-8 required">
                                     @if (config('app.lock_passwords')===true)
-                                        <input class="form-control" disabled="disabled" placeholder="Snipe-IT Asset Management" name="site_name" type="text" value="{{ old('site_name', $setting->site_name) }}" id="site_name">
+                                        <input maxlength="191" class="form-control" disabled="disabled" placeholder="Snipe-IT Asset Management" name="site_name" type="text" value="{{ old('site_name', $setting->site_name) }}" id="site_name">
                                         <p class="text-warning">
                                             <x-icon type="locked" />
                                             {{ trans('general.feature_disabled') }}</p>
                                     @else
-                                        <input class="form-control" placeholder="Snipe-IT Asset Management" required="required" name="site_name" type="text" value="{{ old('site_name', $setting->site_name) }}" id="site_name">
+                                        <input maxlength="191" class="form-control" placeholder="Snipe-IT Asset Management" required="required" name="site_name" type="text" value="{{ old('site_name', $setting->site_name) }}" id="site_name">
                                     @endif
                                     {!! $errors->first('site_name', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 </div>
@@ -81,9 +78,9 @@
 
                             <!-- Branding -->
                             <div class="form-group {{ $errors->has('brand') ? 'error' : '' }}">
-                                <div class="col-md-3 text-right">
-                                    <label for="brand">{{ trans('admin/settings/general.web_brand') }}</label>
-                                </div>
+
+                                <label for="brand" class="col-md-3 control-label">{{ trans('admin/settings/general.web_brand') }}</label>
+
                                 <div class="col-md-9">
                                     <x-input.select
                                         name="brand"
@@ -161,7 +158,6 @@
                             @if (($setting->default_avatar == '') || (($setting->default_avatar == 'default.png') && (Storage::disk('public')->missing('default.png'))))
                             <!-- Restore Default Avatar -->
                             <div class="form-group">
-
                                 <div class="col-md-9 col-md-offset-3">
                                     <label class="form-control">
                                         <input type="checkbox" name="restore_default_avatar" value="1" @checked(old('restore_default_avatar', $setting->restore_default_avatar)) />
@@ -175,8 +171,8 @@
                             @endif
 
                             <!-- Load gravatar -->
-                            <div class="form-group {{ $errors->has('load_remote') ? 'error' : '' }}">
-                                <div class="col-md-3 text-right">
+                            <div class="form-group{{ $errors->has('load_remote') ? ' error' : '' }}">
+                                <div class="col-md-3 control-label">
                                     <strong>{{ trans('admin/settings/general.load_remote') }}</strong>
                                 </div>
                                 <div class="col-md-9">
@@ -196,7 +192,7 @@
 
                             <!-- Include logo in print assets -->
                             <div class="form-group">
-                                <div class="col-md-3 text-right">
+                                <div class="col-md-3 control-label">
                                     <strong>{{ trans('admin/settings/general.logo_print_assets') }}</strong>
                                 </div>
                                 <div class="col-md-9">
@@ -211,7 +207,7 @@
 
                             <!-- show urls in emails-->
                             <div class="form-group">
-                                <div class="col-md-3 text-right">
+                                <div class="col-md-3 control-label">
                                     <strong>{{ trans('admin/settings/general.show_url_in_emails') }}</strong>
                                 </div>
                                 <div class="col-md-9">
@@ -225,16 +221,16 @@
                         </fieldset>
                         <!-- colors and skins -->
 
-                        <fieldset name="color-preferences"">
+                        <fieldset name="color-preferences">
                             <x-form-legend>
                                 {{ trans('admin/settings/general.legends.colors') }}
                             </x-form-legend>
 
                             <!-- Header color -->
                             <div class="form-group {{ $errors->has('header_color') ? 'error' : '' }}">
-                                <div class="col-md-3 text-right">
-                                    <label for="header_color">{{ trans('admin/settings/general.header_color') }}</label>
-                                </div>
+
+                                    <label for="header_color" class="col-md-3 control-label">{{ trans('admin/settings/general.header_color') }}</label>
+
                                 <div class="col-md-5 col-xs-5 col-sm-3 col-md-4 col-lg-3 col-xl-3">
                                     <div class="input-group header-color">
                                         <input class="form-control" placeholder="#FF0000" aria-label="header_color" name="header_color" type="text" id="header_color" value="{{ old('header_color', ($setting->header_color ?? '#3c8dbc')) }}">
@@ -248,9 +244,7 @@
 
                             <!-- Skin -->
                             <div class="form-group {{ $errors->has('skin') ? 'error' : '' }}">
-                                <div class="col-md-3 text-right">
-                                    <label for="skin">{{ trans('general.skin') }}</label>
-                                </div>
+                                <label for="skin" class="col-md-3 control-label">{{ trans('general.skin') }}</label>
                                 <div class="col-md-9">
                                     <x-input.skin name="skin" :selected="old('skin', $setting->skin)" />
                                     {!! $errors->first('skin', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
@@ -259,9 +253,9 @@
 
                             <!-- Custom css -->
                             <div class="form-group {{ $errors->has('custom_css') ? 'error' : '' }}">
-                                <div class="col-md-3 text-right">
-                                    <label for="custom_css">{{ trans('admin/settings/general.custom_css') }}</label>
-                                </div>
+
+                                <label for="custom_css" class="col-md-3 control-label">{{ trans('admin/settings/general.custom_css') }}</label>
+
                                 <div class="col-md-9">
                                     @if (config('app.lock_passwords')===true)
                                         <x-input.textarea
@@ -302,17 +296,17 @@
 
                             <!-- colors and skins -->
 
-                            <fieldset name="footer-preferences"">
+                            <fieldset name="footer-preferences">
                                 <x-form-legend>
                                     {{ trans('admin/settings/general.legends.footer') }}
                                 </x-form-legend>
 
                                 <!-- Support Footer -->
                                 <div class="form-group {{ $errors->has('support_footer') ? 'error' : '' }}">
-                                    <div class="col-md-3 text-right">
-                                        <label for="support_footer">{{ trans('admin/settings/general.support_footer') }}</label>
-                                    </div>
-                                    <div class="col-md-9">
+
+                                    <label for="support_footer" class="col-md-3 control-label">{{ trans('admin/settings/general.support_footer') }}</label>
+
+                                    <div class="col-md-8">
                                         @if (config('app.lock_passwords')===true)
                                             <x-input.select
                                                 name="support_footer"
@@ -343,9 +337,9 @@
 
                                 <!-- Version Footer -->
                                 <div class="form-group {{ $errors->has('version_footer') ? 'error' : '' }}">
-                                    <div class="col-md-3 text-right">
-                                        <label for="version_footer">{{ trans('admin/settings/general.version_footer') }}</label>
-                                    </div>
+
+                                    <label for="version_footer" class="col-md-3 control-label">{{ trans('admin/settings/general.version_footer') }}</label>
+
                                     <div class="col-md-9">
                                         @if (config('app.lock_passwords')===true)
                                             <x-input.select
@@ -376,9 +370,9 @@
 
                                 <!-- Additional footer -->
                                 <div class="form-group {{ $errors->has('footer_text') ? 'error' : '' }}">
-                                    <div class="col-md-3 text-right">
-                                        <label for="footer_text">{{ trans('admin/settings/general.footer_text') }}</label>
-                                    </div>
+
+                                    <label for="footer_text" class="col-md-3 control-label">{{ trans('admin/settings/general.footer_text') }}</label>
+
                                     <div class="col-md-9">
                                         @if (config('app.lock_passwords')===true)
                                             <x-input.textarea

--- a/resources/views/settings/general.blade.php
+++ b/resources/views/settings/general.blade.php
@@ -63,15 +63,15 @@
 
                        </fieldset>
 
-                       <fieldset">
+                       <fieldset>
                            <x-form-legend>
                                {{ trans('admin/settings/general.legends.formats') }}
                            </x-form-legend>
                            <!-- Email domain -->
                            <div class="form-group {{ $errors->has('email_domain') ? 'error' : '' }}">
-                               <div class="col-md-3 text-right">
-                                   <label for="email_domain">{{ trans('general.email_domain') }}</label>
-                               </div>
+
+                               <label for="email_domain" class="col-md-3 control-label">{{ trans('general.email_domain') }}</label>
+
                                <div class="col-md-8">
                                    <input class="form-control" placeholder="example.com" name="email_domain" type="text" value="{{ old('email_domain', $setting->email_domain) }}" id="email_domain">
                                    <span class="help-block">{{ trans('general.email_domain_help')  }}</span>
@@ -82,9 +82,9 @@
 
                            <!-- Email format -->
                            <div class="form-group {{ $errors->has('email_format') ? 'error' : '' }}">
-                               <div class="col-md-3 text-right">
-                                   <label for="email_format">{{ trans('admin/settings/general.email_formats.email_format') }}</label>
-                               </div>
+
+                               <label for="email_format" class="col-md-3 control-label">{{ trans('admin/settings/general.email_formats.email_format') }}</label>
+
                                <div class="col-md-8">
                                    <x-input.email-format-select
                                        name="email_format"
@@ -98,9 +98,9 @@
 
                            <!-- Username format -->
                            <div class="form-group {{ $errors->has('username_format') ? 'error' : '' }}">
-                               <div class="col-md-3 text-right">
-                                   <label for="username_format">{{ trans('admin/settings/general.username_formats.username_format') }}</label>
-                               </div>
+
+                               <label for="username_format" class="col-md-3 control-label">{{ trans('admin/settings/general.username_formats.username_format') }}</label>
+
                                <div class="col-md-8">
                                    {!! Form::username_format('username_format', old('username_format', $setting->username_format), 'select2') !!}
                                    {!! $errors->first('username_format', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
@@ -114,7 +114,7 @@
                        </fieldset>
 
 
-                       <fieldset">
+                       <fieldset>
                            <x-form-legend>
                                {{ trans('admin/settings/general.legends.profiles') }}
                            </x-form-legend>
@@ -150,9 +150,8 @@
 
                            <!-- Default EULA -->
                            <div class="form-group {{ $errors->has('default_eula_text') ? 'error' : '' }}">
-                               <div class="col-md-3 text-right">
-                                   <label for="default_eula_text">{{ trans('admin/settings/general.default_eula_text') }}</label>
-                               </div>
+                               <label for="default_eula_text" class="col-md-3 control-label">{{ trans('admin/settings/general.default_eula_text') }}</label>
+
                                <div class="col-md-8">
                                    <x-input.textarea
                                            name="default_eula_text"
@@ -174,9 +173,9 @@
 
                            <!-- Thumb Size -->
                            <div class="form-group {{ $errors->has('thumbnail_max_h') ? 'error' : '' }}">
-                               <div class="col-md-3 text-right">
-                                   <label for="thumbnail_max_h">{{ trans('admin/settings/general.thumbnail_max_h') }}</label>
-                               </div>
+
+                               <label for="thumbnail_max_h" class="col-md-3 control-label">{{ trans('admin/settings/general.thumbnail_max_h') }}</label>
+
                                <div class="col-md-8">
                                    <input class="form-control" style="max-width: 100px;" placeholder="50" maxlength="3" name="thumbnail_max_h" type="number" value="{{ old('thumbnail_max_h', ($setting->thumbnail_max_h ?? '25')) }}" id="thumbnail_max_h">
                                    <p class="help-block">{{ trans('admin/settings/general.thumbnail_max_h_help') }}</p>
@@ -186,7 +185,7 @@
 
                            <!-- Model List prefs -->
                            <div class="form-group {{ $errors->has('show_in_model_list') ? 'error' : '' }}">
-                               <div class="col-md-3 text-right">
+                               <div class="col-md-3">
                                    <strong>{{ trans('admin/settings/general.show_in_model_list') }}</strong>
                                </div>
                                <div class="col-md-8">
@@ -248,16 +247,16 @@
                        </fieldset>
 
 
-                       <fieldset">
+                       <fieldset>
                            <x-form-legend>
                                {{ trans('general.email') }}
                            </x-form-legend>
 
                            <!-- Mail test -->
                            <div class="form-group">
-                               <div class="col-md-3 text-right">
-                                   <label for="login_note">{{trans('admin/settings/general.test_mail')}}</label>
-                               </div>
+
+                               <label for="login_note" class="col-md-3 control-label">{{trans('admin/settings/general.test_mail')}}</label>
+
                                <div class="col-md-8" id="mailtestrow">
                                    <a class="btn btn-default btn-sm pull-left" id="mailtest" style="margin-right: 10px;">
                                        {{ trans('admin/settings/general.mail_test') }}</a>
@@ -320,9 +319,9 @@
 
                            <!-- login text -->
                            <div class="form-group {{ $errors->has('login_note') ? 'error' : '' }}">
-                               <div class="col-md-3 text-right">
-                                   <label for="login_note">{{ trans('admin/settings/general.login_note') }}</label>
-                               </div>
+
+                               <label for="login_note" class="col-md-3 control-label">{{ trans('admin/settings/general.login_note') }}</label>
+
                                <div class="col-md-8">
                                    @if (config('app.lock_passwords'))
 
@@ -339,9 +338,9 @@
 
                                <!-- dash chart -->
                                <div class="form-group {{ $errors->has('dash_chart_type') ? 'error' : '' }}">
-                                   <div class="col-md-3 text-right">
-                                       <label for="show_in_model_list">{{ trans('general.pie_chart_type') }}</label>
-                                   </div>
+
+                                   <label for="show_in_model_list" class="col-md-3 control-label">{{ trans('general.pie_chart_type') }}</label>
+
                                    <div class="col-md-8">
                                        <x-input.select
                                            name="dash_chart_type"
@@ -354,9 +353,9 @@
 
                                <!-- dashboard text -->
                                <div class="form-group {{ $errors->has('dashboard_message') ? 'error' : '' }}">
-                                   <div class="col-md-3 text-right">
-                                       <label for="dashboard_message">{{ trans('admin/settings/general.dashboard_message') }}</label>
-                                   </div>
+
+                                   <label for="dashboard_message" class="col-md-3 control-label">{{ trans('admin/settings/general.dashboard_message') }}</label>
+
                                    <div class="col-md-8">
                                        @if (config('app.lock_passwords'))
 
@@ -382,9 +381,9 @@
 
                            <!-- Privacy Policy Footer-->
                            <div class="form-group {{ $errors->has('privacy_policy_link') ? 'error' : '' }}">
-                               <div class="col-md-3 text-right">
-                                   <label for="privacy_policy_link">{{ trans('admin/settings/general.privacy_policy_link') }}</label>
-                               </div>
+
+                               <label for="privacy_policy_link" class="col-md-3 control-label">{{ trans('admin/settings/general.privacy_policy_link') }}</label>
+
                                <div class="col-md-8">
 
                                    @if (config('app.lock_passwords'))
@@ -406,9 +405,9 @@
                            
                                <!-- Depreciation method -->
                                <div class="form-group {{ $errors->has('depreciation_method') ? 'error' : '' }}">
-                                   <div class="col-md-3 text-right">
-                                       <label for="depreciation_method">{{ trans('admin/depreciations/general.depreciation_method') }}</label>
-                                   </div>
+
+                                   <label for="depreciation_method" class="col-md-3 control-label">{{ trans('admin/depreciations/general.depreciation_method') }}</label>
+
                                    <div class="col-md-8">
                                        <x-input.select
                                            name="depreciation_method"
@@ -438,7 +437,7 @@
 
                            <!-- Manager View -->
                            <div class="form-group {{ $errors->has('manager_view_enabled') ? 'error' : '' }}">
-                               <div class="col-md-3 text-right">
+                               <div class="col-md-3">
                                    <strong>{{ trans('admin/settings/general.manager_view') }}</strong>
                                </div>
                                <div class="col-md-8">

--- a/resources/views/settings/google.blade.php
+++ b/resources/views/settings/google.blade.php
@@ -38,11 +38,11 @@
 
                         <!-- Google Redirect URL -->
                         <div class="form-group">
-                            <div class="col-md-3 text-right">
-                                <strong>Redirect URL</strong>
+                            <div class="col-md-3 control-label">
+                                <strong>{{ trans('admin/settings/general.redirect_url') }}</strong>
                             </div>
                             <div class="col-md-8">
-                                <p class="form-control-static" style="margin-top: -5px"><code>{{ config('app.url') }}/google/callback</code></p>
+                                <p class="form-control-static"><code>{{ config('app.url') }}/google/callback</code></p>
                                 <p class="help-block">{!! trans('admin/settings/general.google_callback_help') !!}</p>
                             </div>
                         </div>
@@ -64,9 +64,9 @@
 
                         <!-- Google Client ID -->
                         <div class="form-group {{ $errors->has('google_client_id') ? 'error' : '' }}">
-                            <div class="col-md-3 text-right">
-                                <label for="google_client_id">Client ID</label>
-                            </div>
+
+                           <label for="google_client_id" class="col-md-3 control-label">{{ trans('admin/settings/general.client_id') }}</label>
+
                             <div class="col-md-8">
                                 <input
                                     class="form-control"
@@ -86,9 +86,9 @@
 
                         <!-- Google Client Secret -->
                         <div class="form-group {{ $errors->has('google_client_secret') ? 'error' : '' }}">
-                            <div class="col-md-3 text-right">
-                                <label for="google_client_secret">Client Secret</label>
-                            </div>
+
+                            <label for="google_client_secret" class="col-md-3 control-label">{{ trans('admin/settings/general.client_secret') }}</label>
+
                             <div class="col-md-8">
 
                                 @if (config('app.lock_passwords')===true)

--- a/resources/views/settings/ldap.blade.php
+++ b/resources/views/settings/ldap.blade.php
@@ -85,8 +85,8 @@
                             </x-form-legend>
                                 <!-- Enable LDAP -->
                                 <div class="form-group {{ $errors->has('ldap_integration') ? 'error' : '' }}">
-                                    <div class="col-md-3 text-right">
-                                        <label for="ldap_enabled">{{ trans('admin/settings/general.ldap_integration') }}</label>
+                                    <div class="col-md-3 control-label">
+                                        <strong>{{ trans('admin/settings/general.ldap_integration') }}</strong>
                                     </div>
                                     <div class="col-md-8">
 
@@ -107,8 +107,8 @@
 
                                 <!-- AD Flag -->
                                 <div class="form-group">
-                                    <div class="col-md-3 text-right">
-                                        <label for="is_ad">{{ trans('admin/settings/general.ad') }}</label>
+                                    <div class="col-md-3 control-label">
+                                        <strong>{{ trans('admin/settings/general.ad') }}</strong>
                                     </div>
                                     <div class="col-md-8">
                                         <label class="form-control">
@@ -133,8 +133,8 @@
 
                                 <!-- LDAP Password Sync -->
                                 <div class="form-group">
-                                    <div class="col-md-3 text-right">
-                                        <label for="ldap_pw_sync">{{ trans('admin/settings/general.ldap_pw_sync') }}</label>
+                                    <div class="col-md-3 control-label">
+                                        <strong>{{ trans('admin/settings/general.ldap_pw_sync') }}</strong>
                                     </div>
                                     <div class="col-md-8">
                                         <label class="form-control">
@@ -162,9 +162,9 @@
 
                                 <!-- AD Domain -->
                                 <div class="form-group {{ $errors->has('ad_domain') ? 'error' : '' }}">
-                                    <div class="col-md-3 text-right">
-                                        <label for="ad_domain">{{ trans('admin/settings/general.ad_domain') }}</label>
-                                    </div>
+
+                                   <label for="ad_domain" class="col-md-3 control-label">{{ trans('admin/settings/general.ad_domain') }}</label>
+
                                     <div class="col-md-8">
                                         <input class="form-control" placeholder="{{ trans('general.example') .'example.com' }}" name="ad_domain" type="text" id="ad_domain" value="{{ old('ad_domain', $setting->ad_domain) }}">
                                         <p class="help-block">{{ trans('admin/settings/general.ad_domain_help') }}</p>
@@ -186,11 +186,11 @@
 
                                 <!-- LDAP Client-Side TLS key -->
                                 <div class="form-group {{ $errors->has('ldap_client_tls_key') ? 'error' : '' }}">
-                                    <div class="col-md-3 text-right">
-                                        <label for="ldap_client_tls_key">
-                                            {{ trans('admin/settings/general.ldap_client_tls_key') }}
-                                        </label>
-                                    </div>
+
+                                    <label for="ldap_client_tls_key" class="col-md-3 control-label">
+                                        {{ trans('admin/settings/general.ldap_client_tls_key') }}
+                                    </label>
+
                                     <div class="col-md-8">
                                         <x-input.textarea
                                             name="ldap_client_tls_key"
@@ -215,9 +215,9 @@
 
                                 <!-- LDAP Client-Side TLS certificate -->
                                 <div class="form-group {{ $errors->has('ldap_client_tls_cert') ? 'error' : '' }}">
-                                    <div class="col-md-3 text-right">
-                                        <label for="ldap_client_tls_cert">{{ trans('admin/settings/general.ldap_client_tls_cert') }}</label>
-                                    </div>
+
+                                    <label for="ldap_client_tls_cert" class="col-md-3 control-label">{{ trans('admin/settings/general.ldap_client_tls_cert') }}</label>
+
                                     <div class="col-md-8">
                                         <x-input.textarea
                                             name="ldap_client_tls_cert"
@@ -243,9 +243,9 @@
 
                                 <!-- LDAP Server -->
                                 <div class="form-group {{ $errors->has('ldap_server') ? 'error' : '' }}">
-                                    <div class="col-md-3 text-right">
-                                        <label for="ldap_server">{{ trans('admin/settings/general.ldap_server') }}</label>
-                                    </div>
+
+                                    <label for="ldap_server" class="col-md-3 control-label">{{ trans('admin/settings/general.ldap_server') }}</label>
+
                                     <div class="col-md-8">
                                         <input class="form-control" placeholder="{{ trans('general.example') .'ldap://ldap.example.com' }}" name="ldap_server" type="text" id="ldap_server" value="{{ old('ldap_server', $setting->ldap_server) }}">
                                         @error('ldap_server')
@@ -268,8 +268,8 @@
 
                                 <!-- Start TLS -->
                                 <div class="form-group">
-                                    <div class="col-md-3 text-right">
-                                        <label for="ldap_tls">{{ trans('admin/settings/general.ldap_tls') }}</label>
+                                    <div class="col-md-3 control-label">
+                                        <strong>{{ trans('admin/settings/general.ldap_tls') }}</strong>
                                     </div>
                                     <div class="col-md-8">
                                         <label class="form-control">
@@ -294,8 +294,8 @@
 
                                 <!-- Ignore LDAP Certificate -->
                                 <div class="form-group {{ $errors->has('ldap_server_cert_ignore') ? 'error' : '' }}">
-                                    <div class="col-md-3 text-right">
-                                        <label for="ldap_server_cert_ignore">{{ trans('admin/settings/general.ldap_server_cert') }}</label>
+                                    <div class="col-md-3 control-label">
+                                        <strong>{{ trans('admin/settings/general.ldap_server_cert') }}</strong>
                                     </div>
                                     <div class="col-md-8">
                                         <label class="form-control">
@@ -323,9 +323,9 @@
 
                                 <!-- LDAP Username -->
                                 <div class="form-group {{ $errors->has('ldap_uname') ? 'error' : '' }}">
-                                    <div class="col-md-3 text-right">
-                                        <label for="ldap_uname">{{ trans('admin/settings/general.ldap_uname') }}</label>
-                                    </div>
+
+                                    <label for="ldap_uname" class="col-md-3 control-label">{{ trans('admin/settings/general.ldap_uname') }}</label>
+
                                     <div class="col-md-8">
                                         <input class="form-control" autocomplete="off" placeholder="{{ trans('general.example') .'binduser@example.com' }}" name="ldap_uname" type="text" id="ldap_uname" value="{{ old('ldap_uname', $setting->ldap_uname) }}">
                                         @error('ldap_uname')
@@ -346,9 +346,9 @@
 
                                 <!-- LDAP pword -->
                                 <div class="form-group {{ $errors->has('ldap_pword') ? 'error' : '' }}">
-                                    <div class="col-md-3 text-right">
-                                        <label for="ldap_pword">{{ trans('admin/settings/general.ldap_pword') }}</label>
-                                    </div>
+
+                                    <label for="ldap_pword" class="col-md-3 control-label">{{ trans('admin/settings/general.ldap_pword') }}</label>
+
                                     <div class="col-md-8">
                                         <input class="form-control" type="password" name="ldap_pword" id="ldap_pword" value="" autocomplete="off" onfocus="this.removeAttribute('readonly');" readonly>
                                         @error('ldap_pword')
@@ -369,9 +369,9 @@
 
                                 <!-- LDAP basedn -->
                                 <div class="form-group {{ $errors->has('ldap_basedn') ? 'error' : '' }}">
-                                    <div class="col-md-3 text-right">
-                                        <label for="ldap_basedn">{{ trans('admin/settings/general.ldap_basedn') }}</label>
-                                    </div>
+
+                                    <label for="ldap_basedn" class="col-md-3 control-label">{{ trans('admin/settings/general.ldap_basedn') }}</label>
+
                                     <div class="col-md-8">
                                         <input class="form-control" placeholder="{{ trans('general.example') .'cn=users/authorized,dc=example,dc=com' }}" name="ldap_basedn" type="text" id="ldap_basedn" value="{{ old('ldap_basedn', $setting->ldap_basedn) }}">
                                         @error('ldap_basedn')
@@ -392,9 +392,9 @@
 
                                 <!-- LDAP filter -->
                                 <div class="form-group {{ $errors->has('ldap_filter') ? 'error' : '' }}">
-                                    <div class="col-md-3 text-right">
-                                        <label for="ldap_filter">{{ trans('admin/settings/general.ldap_filter') }}</label>
-                                    </div>
+
+                                    <label for="ldap_filter" class="col-md-3 control-label">{{ trans('admin/settings/general.ldap_filter') }}</label>
+
                                     <div class="col-md-8">
                                         <input type="text" name="ldap_filter" id="ldap_filter" value="{{  old('ldap_filter', $setting->ldap_filter) }}" class="form-control" placeholder="{{  trans('general.example') .'&(cn=*)' }}">
                                         @error('ldap_filter')
@@ -415,9 +415,9 @@
 
                             <!-- LDAP Auth Filter Query -->
                             <div class="form-group {{ $errors->has('ldap_auth_filter_query') ? 'error' : '' }}">
-                                <div class="col-md-3 text-right">
-                                    <label for="ldap_auth_filter_query">{{ trans('admin/settings/general.ldap_auth_filter_query') }}</label>
-                                </div>
+
+                                <label for="ldap_auth_filter_query" class="col-md-3 control-label">{{ trans('admin/settings/general.ldap_auth_filter_query') }}</label>
+
                                 <div class="col-md-8">
 
                                     <input type="text" name="ldap_auth_filter_query" id="ldap_auth_filter_query" value="{{  old('ldap_auth_filter_query', $setting->ldap_auth_filter_query) }}" class="form-control" placeholder="{{ trans('general.example') .'uid='  }}">
@@ -439,10 +439,10 @@
 
                             <!--  Default LDAP Permissions Group Select -->
 
-                            <div class="form-group{{ $errors->has('group') ? ' has-error' : '' }}">
-                                <div class="col-md-3 text-right">
-                                    <label for="ldap_default_group">{{ trans('admin/settings/general.ldap_default_group') }}</label>
-                                </div>
+                            <div class="form-group{{ $errors->has('ldap_default_group') ? ' has-error' : '' }}">
+
+                                <label for="ldap_default_group" class="col-md-3 control-label">{{ trans('admin/settings/general.ldap_default_group') }}</label>
+
 
                                 <div class="col-md-8">
 
@@ -490,9 +490,9 @@
 
                             <!-- LDAP  username field-->
                             <div class="form-group {{ $errors->has('ldap_username_field') ? 'error' : '' }}">
-                                <div class="col-md-3 text-right">
-                                    <label for="ldap_username_field">{{ trans('admin/settings/general.ldap_username_field') }}</label>
-                                </div>
+
+                                <label for="ldap_username_field" class="col-md-3 control-label">{{ trans('admin/settings/general.ldap_username_field') }}</label>
+
                                 <div class="col-md-8">
                                     <input type="text" name="ldap_username_field" id="ldap_username_field" value="{{  old('ldap_username_field', $setting->ldap_username_field) }}" class="form-control" placeholder="{{  trans('general.example') .'samaccountname' }}">
                                     @error('ldap_username_field')
@@ -507,9 +507,9 @@
 
                             <!-- LDAP Last Name Field -->
                             <div class="form-group {{ $errors->has('ldap_lname_field') ? 'error' : '' }}">
-                                <div class="col-md-3 text-right">
-                                    <label for="ldap_lname_field">{{ trans('admin/settings/general.ldap_lname_field') }}</label>
-                                </div>
+
+                                <label for="ldap_lname_field" class="col-md-3 control-label">{{ trans('admin/settings/general.ldap_lname_field') }}</label>
+
                                 <div class="col-md-8">
                                     <input type="text" name="ldap_lname_field" id="ldap_lname_field" value="{{  old('ldap_lname_field', $setting->ldap_lname_field) }}" class="form-control" placeholder="{{  trans('general.example') .'sn' }}">
                                     @error('ldap_lname_field')
@@ -524,9 +524,9 @@
 
                             <!-- LDAP First Name field -->
                             <div class="form-group {{ $errors->has('ldap_fname_field') ? 'error' : '' }}">
-                                <div class="col-md-3 text-right">
-                                    <label for="ldap_fname_field">{{ trans('admin/settings/general.ldap_fname_field') }}</label>
-                                </div>
+
+                                <label for="ldap_fname_field" class="col-md-3 control-label">{{ trans('admin/settings/general.ldap_fname_field') }}</label>
+
                                 <div class="col-md-8">
                                     <input type="text" name="ldap_fname_field" id="ldap_fname_field" value="{{  old('ldap_fname_field', $setting->ldap_fname_field) }}" class="form-control" placeholder="{{ trans('general.example') .'givenname'  }}">
                                     @error('ldap_fname_field')
@@ -541,9 +541,9 @@
 
                             <!-- LDAP Display Name Field -->
                             <div class="form-group {{ $errors->has('ldap_display_name') ? 'error' : '' }}">
-                                <div class="col-md-3 text-right">
-                                    <label for="ldap_lname_field">{{ trans('admin/settings/general.ldap_display_name') }}</label>
-                                </div>
+
+                                <label for="ldap_lname_field" class="col-md-3 control-label">{{ trans('admin/settings/general.ldap_display_name') }}</label>
+
                                 <div class="col-md-8">
                                     <input type="text" name="ldap_display_name" id="ldap_display_name" value="{{  old('ldap_display_name', $setting->ldap_display_name) }}" class="form-control" placeholder="{{  trans('general.example') .'displayname' }}">
                                     <p class="help-block">{{ trans('admin/settings/general.ldap_display_name_help') }}</p>
@@ -559,9 +559,9 @@
 
                             <!-- LDAP emp number -->
                             <div class="form-group {{ $errors->has('ldap_emp_num') ? 'error' : '' }}">
-                                <div class="col-md-3 text-right">
-                                    <label for="ldap_emp_num">{{ trans('admin/settings/general.ldap_emp_num') }}</label>
-                                </div>
+
+                                 <label for="ldap_emp_num" class="col-md-3 control-label">{{ trans('admin/settings/general.ldap_emp_num') }}</label>
+
                                 <div class="col-md-8">
                                     <input class="form-control" placeholder="{{ trans('general.example') .'employeenumber/employeeid' }}" name="ldap_emp_num" type="text" id="ldap_emp_num" value="{{ old('ldap_emp_num', $setting->ldap_emp_num) }}">
                                     @error('ldap_emp_num')
@@ -581,9 +581,9 @@
                             </div>
                             <!-- LDAP department -->
                             <div class="form-group {{ $errors->has('ldap_dept') ? 'error' : '' }}">
-                                <div class="col-md-3 text-right">
-                                    <label for="ldap_dept">{{ trans('admin/settings/general.ldap_dept') }}</label>
-                                </div>
+
+                                 <label for="ldap_dept" class="col-md-3 control-label">{{ trans('admin/settings/general.ldap_dept') }}</label>
+
                                 <div class="col-md-8">
                                     <input class="form-control" placeholder="{{ trans('general.example') .'department' }}" name="ldap_dept" type="text" id="ldap_dept" value="{{ old('ldap_dept', $setting->ldap_dept) }}">
 
@@ -604,9 +604,9 @@
                             </div>
                             <!-- LDAP Manager -->
                             <div class="form-group {{ $errors->has('ldap_dept') ? 'error' : '' }}">
-                                <div class="col-md-3 text-right">
-                                    <label for="ldap_manager">{{ trans('admin/settings/general.ldap_manager') }}</label>
-                                </div>
+
+                                <label for="ldap_manager" class="col-md-3 control-label">{{ trans('admin/settings/general.ldap_manager') }}</label>
+
                                 <div class="col-md-8">
                                     <input class="form-control" placeholder=" {{ trans('general.example') .'manager' }}" name="ldap_manager" type="text" value="{{ old('ldap_manager', $setting->ldap_manager) }}">
                                     @error('ldap_manager')
@@ -627,9 +627,9 @@
 
                             <!-- LDAP email -->
                             <div class="form-group {{ $errors->has('ldap_email') ? 'error' : '' }}">
-                                <div class="col-md-3 text-right">
-                                    <label for="ldap_email">{{ trans('admin/settings/general.ldap_email') }}</label>
-                                </div>
+
+                                <label for="ldap_email" class="col-md-3 control-label">{{ trans('admin/settings/general.ldap_email') }}</label>
+
                                 <div class="col-md-8">
                                     <input class="form-control" placeholder="{{ trans('general.example') .'mail' }}" name="ldap_email" type="text" id="ldap_email" value="{{ old('ldap_email', $setting->ldap_email) }}">
                                     @error('ldap_email')
@@ -650,9 +650,9 @@
 
                             <!-- LDAP Phone -->
                             <div class="form-group {{ $errors->has('ldap_phone') ? 'error' : '' }}">
-                                <div class="col-md-3 text-right">
-                                    <label for="ldap_phone">{{ trans('admin/settings/general.ldap_phone') }}</label>
-                                </div>
+
+                                <label for="ldap_phone" class="col-md-3 control-label">{{ trans('admin/settings/general.ldap_phone') }}</label>
+
                                 <div class="col-md-8">
                                     <input class="form-control" placeholder="{{ trans('general.example') .'telephonenumber' }}" name="ldap_phone" type="text" id="ldap_phone" value="{{ old('ldap_phone', $setting->ldap_phone_field) }}">
                                     @error('ldap_phone')
@@ -673,9 +673,9 @@
 
                             <!-- LDAP Mobile -->
                             <div class="form-group {{ $errors->has('ldap_mobile') ? 'error' : '' }}">
-                                <div class="col-md-3 text-right">
-                                    <label for="ldap_mobile">{{ trans('admin/settings/general.ldap_mobile') }}</label>
-                                </div>
+
+                                <label for="ldap_mobile" class="col-md-3 control-label">{{ trans('admin/settings/general.ldap_mobile') }}</label>
+
                                 <div class="col-md-8">
                                     <input class="form-control" placeholder="{{ trans('general.example') .'mobile' }}" name="ldap_mobile" type="text" id="ldap_mobile" value="{{ old('ldap_mobile', $setting->ldap_mobile) }}">
                                     @error('ldap_mobile')
@@ -689,9 +689,9 @@
 
                             <!-- LDAP Job title -->
                             <div class="form-group {{ $errors->has('ldap_jobtitle') ? 'error' : '' }}">
-                                <div class="col-md-3 text-right">
-                                    <label for="ldap_jobtitle">{{ trans('admin/settings/general.ldap_jobtitle') }}</label>
-                                </div>
+
+                                <label for="ldap_jobtitle" class="col-md-3 control-label">{{ trans('admin/settings/general.ldap_jobtitle') }}</label>
+
                                 <div class="col-md-8">
                                     <input class="form-control" placeholder="{{ trans('general.example') .'title' }}" name="ldap_jobtitle" type="text" id="ldap_jobtitle" value="{{ old('ldap_jobtitle', $setting->ldap_jobtitle) }}">
                                     @error('ldap_jobtitle')
@@ -712,9 +712,9 @@
 
                             <!-- LDAP address -->
                             <div class="form-group {{ $errors->has('ldap_address') ? 'error' : '' }}">
-                                <div class="col-md-3 text-right">
-                                    <label for="ldap_address">{{ trans('admin/settings/general.ldap_address') }}</label>
-                                </div>
+
+                                <label for="ldap_address" class="col-md-3 control-label">{{ trans('admin/settings/general.ldap_address') }}</label>
+
                                 <div class="col-md-8">
                                     <input class="form-control" name="ldap_address" placeholder="{{ trans('general.example') .'streetaddress' }}"  type="text" id="ldap_address" value="{{ old('ldap_address', $setting->ldap_address) }}">
                                     @error('ldap_address')
@@ -728,9 +728,9 @@
 
                             <!-- LDAP city -->
                             <div class="form-group {{ $errors->has('ldap_city') ? 'error' : '' }}">
-                                <div class="col-md-3 text-right">
-                                    <label for="ldap_city">{{ trans('admin/settings/general.ldap_city') }}</label>
-                                </div>
+
+                                <label for="ldap_city" class="col-md-3 control-label">{{ trans('admin/settings/general.ldap_city') }}</label>
+
                                 <div class="col-md-8">
                                     <input class="form-control" placeholder="{{ trans('general.example') .'l' }}" name="ldap_city" type="text" id="ldap_city" value="{{ old('ldap_city', $setting->ldap_city) }}">
                                     @error('ldap_city')
@@ -744,9 +744,9 @@
 
                             <!-- LDAP state -->
                             <div class="form-group {{ $errors->has('ldap_state') ? 'error' : '' }}">
-                                <div class="col-md-3 text-right">
-                                    <label for="ldap_state">{{ trans('admin/settings/general.ldap_state') }}</label>
-                                </div>
+
+                                <label for="ldap_state" class="col-md-3 control-label">{{ trans('admin/settings/general.ldap_state') }}</label>
+
                                 <div class="col-md-8">
                                     <input class="form-control" placeholder="{{ trans('general.example') .'st' }}"  name="ldap_state" type="text" id="ldap_state" value="{{ old('ldap_state', $setting->ldap_state) }}">
                                     @error('ldap_state')
@@ -760,9 +760,9 @@
 
                             <!-- LDAP zip -->
                             <div class="form-group {{ $errors->has('ldap_zip') ? 'error' : '' }}">
-                                <div class="col-md-3 text-right">
-                                    <label for="ldap_zip">{{ trans('admin/settings/general.ldap_zip') }}</label>
-                                </div>
+
+                                <label for="ldap_zip" class="col-md-3 control-label">{{ trans('admin/settings/general.ldap_zip') }}</label>
+
                                 <div class="col-md-8">
                                     <input class="form-control" name="ldap_zip" type="text" id="ldap_zip" placeholder="{{ trans('general.example') .'postalcode' }}"  value="{{ old('ldap_zip', $setting->ldap_zip) }}">
                                     @error('ldap_zip')
@@ -777,9 +777,9 @@
 
                             <!-- LDAP Country -->
                             <div class="form-group {{ $errors->has('ldap_country') ? 'error' : '' }}">
-                                <div class="col-md-3 text-right">
-                                    <label for="ldap_country">{{ trans('admin/settings/general.ldap_country') }}</label>
-                                </div>
+
+                                <label for="ldap_country" class="col-md-3 control-label">{{ trans('admin/settings/general.ldap_country') }}</label>
+
                                 <div class="col-md-8">
                                     <input class="form-control" placeholder="{{ trans('general.example') .'co' }}" name="ldap_country" type="text" id="ldap_country" value="{{ old('ldap_country', $setting->ldap_country) }}">
                                     @error('ldap_country')
@@ -800,9 +800,9 @@
 
                             <!-- LDAP Location -->
                             <div class="form-group {{ $errors->has('ldap_location') ? 'error' : '' }}">
-                                <div class="col-md-3 text-right">
-                                    <label for="ldap_location">{{ trans('admin/settings/general.ldap_location') }}</label>
-                                </div>
+
+                                <label for="ldap_location" class="col-md-3 control-label">{{ trans('admin/settings/general.ldap_location') }}</label>
+
                                 <div class="col-md-8">
                                     <input class="form-control" placeholder="{{ trans('general.example') .'physicaldeliveryofficename' }}" name="ldap_location" type="text" id="ldap_location" value="{{ old('ldap_location', $setting->ldap_location) }}">
                                     <p class="help-block">{!! trans('admin/settings/general.ldap_location_help') !!}</p>
@@ -824,9 +824,9 @@
 
                             <!-- LDAP active flag -->
                             <div class="form-group {{ $errors->has('ldap_active_flag') ? 'error' : '' }}">
-                                <div class="col-md-3 text-right">
-                                    <label for="ldap_active_flag">{{ trans('admin/settings/general.ldap_active_flag') }}</label>
-                                </div>
+
+                                <label for="ldap_active_flag" class="col-md-3 control-label">{{ trans('admin/settings/general.ldap_active_flag') }}</label>
+
                                 <div class="col-md-8">
                                     <input type="text" name="ldap_active_flag" id="ldap_active_flag" value="{{  old('ldap_active_flag', $setting->ldap_active_flag) }}" class="form-control">
                                     <p class="help-block">{!! trans('admin/settings/general.ldap_activated_flag_help') !!}</p>
@@ -849,11 +849,11 @@
 
                             <!-- LDAP invert active flag -->
                             <div class="form-group">
-                                <div class="col-md-3 text-right">
-                                    <label for="ldap_invert_active_flag">
-                                        {{ trans('admin/settings/general.ldap_invert_active_flag') }}
-                                    </label>
-                                </div>
+
+                                <label for="ldap_invert_active_flag" class="col-md-3 control-label">
+                                    {{ trans('admin/settings/general.ldap_invert_active_flag') }}
+                                </label>
+
                                 <div class="col-md-8">
                                     <label class="form-control">
                                         <input type="checkbox" name="ldap_invert_active_flag" value="1" id="ldap_invert_active_flag" @checked(old('ldap_invert_active_flag', $setting->ldap_invert_active_flag)) />
@@ -890,9 +890,9 @@
 
                                 <!-- LDAP Login test -->
                                 <div class="form-group">
-                                    <div class="col-md-3 text-right">
-                                        <label for="test_ldap_login"> {{trans('admin/settings/general.ldap_test_login')}} </label>
-                                    </div>
+
+                                    <label for="test_ldap_login" class="col-md-3 control-label"> {{trans('admin/settings/general.ldap_test_login')}} </label>
+
                                     <div class="col-md-8">
                                         <div class="row">
                                             <div class="col-md-4">
@@ -901,7 +901,7 @@
                                             <div class="col-md-4">
                                                 <input type="password" name="ldaptest_password" id="ldaptest_password" class="form-control" placeholder="{{trans('admin/settings/general.ldap_password_placeholder')}}" autocomplete="off" readonly onfocus="this.removeAttribute('readonly');">
                                             </div>
-                                            <div class="col-md-3 text-right">
+                                            <div class="col-md-3">
                                                 <a class="btn btn-default btn-sm" id="ldaptestlogin" style="margin-right: 10px;">{{ trans('admin/settings/general.ldap_test') }}</a>
                                             </div>
 
@@ -951,9 +951,9 @@
 
                                 <!-- LDAP Forgotten password -->
                                 <div class="form-group {{ $errors->has('custom_forgot_pass_url') ? 'error' : '' }}">
-                                    <div class="col-md-3 text-right">
-                                        <label for="custom_forgot_pass_url">{{ trans('admin/settings/general.custom_forgot_pass_url') }}</label>
-                                    </div>
+
+                                    <label for="custom_forgot_pass_url" class="col-md-3 control-label">{{ trans('admin/settings/general.custom_forgot_pass_url') }}</label>
+
                                     <div class="col-md-8">
                                         <input class="form-control" placeholder="{{ trans('general.example') .'https://my.ldapserver-forgotpass.com' }}" name="custom_forgot_pass_url" type="url" id="custom_forgot_pass_url" value="{{ old('custom_forgot_pass_url', $setting->custom_forgot_pass_url) }}">
                                         <p class="help-block">{{ trans('admin/settings/general.custom_forgot_pass_url_help') }}</p>

--- a/resources/views/settings/localization.blade.php
+++ b/resources/views/settings/localization.blade.php
@@ -41,10 +41,10 @@
                     <div class="col-md-12">
 
                         <!-- Language -->
-                        <div class="form-group {{ $errors->has('site_name') ? 'error' : '' }}">
-                            <div class="col-md-3 col-xs-12">
-                                <label for="site_name">{{ trans('admin/settings/general.default_language') }}</label>
-                            </div>
+                        <div class="form-group {{ $errors->has('locale') ? 'error' : '' }}">
+
+                           <label for="site_name" class="col-md-3 control-label">{{ trans('admin/settings/general.default_language') }}</label>
+
                             <div class="col-md-5 col-xs-12">
                                 <x-input.locale-select name="locale" :selected="old('locale', $setting->locale)" />
 
@@ -54,9 +54,9 @@
 
                         <!-- name display format -->
                         <div class="form-group {{ $errors->has('name_display_format') ? 'error' : '' }}">
-                            <div class="col-md-3 col-xs-12">
-                                <label for="name_display_format">{{ trans('general.name_display_format') }}</label>
-                            </div>
+
+                            <label for="name_display_format" class="col-md-3 control-label">{{ trans('general.name_display_format') }}</label>
+
                             <div class="col-md-5 col-xs-12">
                                 <x-input.select
                                     name="name_display_format"
@@ -72,9 +72,9 @@
 
                         <!-- Date format -->
                         <div class="form-group {{ $errors->has('time_display_format') ? 'error' : '' }}">
-                            <div class="col-md-3 col-xs-12">
-                                <label for="time_display_format">{{ trans('general.time_and_date_display') }}</label>
-                            </div>
+
+                            <label for="time_display_format" class="col-md-3 control-label">{{ trans('general.time_and_date_display') }}</label>
+
                             <div class="col-md-5 col-xs-12">
                                 <x-input.date-display-format name="date_display_format" :selected="old('date_display_format', $setting->date_display_format)" style="min-width:100%" />
                             </div>
@@ -88,9 +88,9 @@
 
                         <!-- Currency -->
                         <div class="form-group {{ $errors->has('default_currency') ? 'error' : '' }}">
-                            <div class="col-md-3 col-xs-12">
-                                <label for="default_currency">{{ trans('admin/settings/general.default_currency') }}</label>
-                            </div>
+
+                                <label for="default_currency" class="col-md-3 control-label">{{ trans('admin/settings/general.default_currency') }}</label>
+
                             <div class="col-md-9 col-xs-12">
                                 <input
                                     class="form-control select2-container"

--- a/resources/views/settings/saml.blade.php
+++ b/resources/views/settings/saml.blade.php
@@ -46,7 +46,7 @@
 
                         <!-- Enable SAML -->
                         <div class="form-group{{ $errors->has('saml_integration') ? ' error' : '' }}">
-                            <div class="col-md-3 text-right">
+                            <div class="control-label col-md-3">
                                 <strong>{{ trans('admin/settings/general.saml_integration') }}</strong>
                             </div>
                             <div class="col-md-9">
@@ -69,20 +69,20 @@
                                     <div class="col-md-9 col-md-offset-3">
                                     <!-- SAML SP Details -->
                                     <!-- SAML SP Entity ID -->
-                                    <label for="saml_sp_entitiyid">{{ trans('admin/settings/general.saml_sp_entityid') }}</label>
+                                    <label for="saml_sp_entitiyid" class="control-label col-md-3">{{ trans('admin/settings/general.saml_sp_entityid') }}</label>
                                     <input class="form-control" readonly="" name="saml_sp_entitiyid" type="text" value="{{ config('app.url') }}" id="saml_sp_entitiyid">
                                     <br>
                                     <!-- SAML SP ACS -->
-                                    <label for="saml_sp_acs_url">{{ trans('admin/settings/general.saml_sp_acs_url') }}</label>
+                                    <label for="saml_sp_acs_url" class="control-label col-md-3">{{ trans('admin/settings/general.saml_sp_acs_url') }}</label>
                                     <input class="form-control" readonly="" name="saml_sp_acs_url" type="text" value="{{ route('saml.acs') }}" id="saml_sp_acs_url">
                                     <br>
                                     <!-- SAML SP SLS -->
-                                    <label for="saml_sp_sls_url">{{ trans('admin/settings/general.saml_sp_sls_url') }}</label>
+                                    <label for="saml_sp_sls_url" class="control-label col-md-3">{{ trans('admin/settings/general.saml_sp_sls_url') }}</label>
                                     <input class="form-control" readonly="" name="saml_sp_sls_url" type="text" value="{{ route('saml.sls') }}" id="saml_sp_sls_url">
                                     <br>
                                     <!-- SAML SP Certificate -->
                                     @if (!empty($setting->saml_sp_x509cert))
-                                         <label for="saml_sp_x509cert">{{ trans('admin/settings/general.saml_sp_x509cert') }}</label>
+                                         <label for="saml_sp_x509cert" class="control-label col-md-3">{{ trans('admin/settings/general.saml_sp_x509cert') }}</label>
                                             <x-input.textarea
                                                 name="saml_sp_x509cert"
                                                 id="saml_sp_x509cert"
@@ -93,7 +93,7 @@
                                         <br>
                                     @endif
                                     <!-- SAML SP Metadata URL -->
-                                    <label for="saml_sp_metadata_url">{{ trans('admin/settings/general.saml_sp_metadata_url') }}</label>
+                                    <label for="saml_sp_metadata_url" class="control-label col-md-3">{{ trans('admin/settings/general.saml_sp_metadata_url') }}</label>
                                     <input class="form-control" readonly="" name="saml_sp_metadata_url" type="text" value="{{ route('saml.metadata') }}" id="saml_sp_metadata_url">
                                     <br>
                                     <p class="help-block">
@@ -108,10 +108,10 @@
 
                         <!-- SAML IdP Metadata -->
                         <div class="form-group {{ $errors->has('saml_idp_metadata') ? 'error' : '' }}">
-                        <div class="col-md-3 text-right">
-                            <label for="saml_idp_metadata">{{ trans('admin/settings/general.saml_idp_metadata') }}</label>
-                        </div>
-                        <div class="col-md-9">
+
+                            <label for="saml_idp_metadata" class="control-label col-md-3">{{ trans('admin/settings/general.saml_idp_metadata') }}</label>
+
+                        <div class="col-md-8">
                             <x-input.textarea
                                 name="saml_idp_metadata"
                                 id="saml_idp_metadata"
@@ -131,9 +131,9 @@
 
                         <!-- SAML Attribute Mapping Username -->
                         <div class="form-group {{ $errors->has('saml_attr_mapping_username') ? 'error' : '' }}">
-                            <div class="col-md-3 text-right">
-                                <label for="saml_attr_mapping_username">{{ trans('admin/settings/general.saml_attr_mapping_username') }}</label>
-                            </div>
+
+                            <label for="saml_attr_mapping_username" class="control-label col-md-3">{{ trans('admin/settings/general.saml_attr_mapping_username') }}</label>
+
                             <div class="col-md-9">
                                 <input class="form-control" name="saml_attr_mapping_username" type="text" id="saml_attr_mapping_username" value="{{ old('saml_attr_mapping_username', $setting->saml_attr_mapping_username) }}">
                                 <p class="help-block">{{ trans('admin/settings/general.saml_attr_mapping_username_help') }}</p>
@@ -143,7 +143,7 @@
 
                         <!-- SAML Force Login -->
                         <div class="form-group">
-                            <div class="col-md-3 text-right">
+                            <div class="control-label col-md-3">
                                 <strong>{{  trans('admin/settings/general.saml_forcelogin_label') }}</strong>
                             </div>
                             <div class="col-md-9">
@@ -159,7 +159,7 @@
 
                         <!-- SAML Single Log Out -->
                         <div class="form-group">
-                            <div class="col-md-3 text-right">
+                            <div class="control-label col-md-3">
                                 <strong>{{ trans('admin/settings/general.saml_slo_label') }}</strong>
                             </div>
                             <div class="col-md-9">
@@ -174,9 +174,8 @@
 
                         <!-- SAML Custom Options -->
                         <div class="form-group {{ $errors->has('saml_custom_settings') ? 'error' : '' }}">
-                        <div class="col-md-3 text-right">
-                            <label for="saml_custom_settings">{{ trans('admin/settings/general.saml_custom_settings') }}</label>
-                        </div>
+                        <label for="saml_custom_settings" class="control-label col-md-3">{{ trans('admin/settings/general.saml_custom_settings') }}</label>
+
                         <div class="col-md-9">
                             <x-input.textarea
                                 name="saml_custom_settings"

--- a/resources/views/settings/security.blade.php
+++ b/resources/views/settings/security.blade.php
@@ -44,9 +44,9 @@
 
                             <!-- Two Factor -->
                             <div class="form-group {{ $errors->has('brand') ? 'error' : '' }}">
-                                <div class="col-md-3 text-right">
-                                    <label for="two_factor_enabled">{{ trans('admin/settings/general.two_factor_enabled_text') }}</label>
-                                </div>
+
+                                <label for="two_factor_enabled" class="col-md-3 control-label">{{ trans('admin/settings/general.two_factor_enabled_text') }}</label>
+
                                 <div class="col-md-9">
                                     <x-input.select
                                         name="two_factor_enabled"
@@ -73,9 +73,9 @@
 
                             <!-- Min characters -->
                             <div class="form-group {{ $errors->has('pwd_secure_min') ? 'error' : '' }}">
-                                <div class="col-md-3 text-right  text-right">
-                                    <label for="pwd_secure_min">{{ trans('admin/settings/general.pwd_secure_min') }}</label>
-                                </div>
+
+                                <label for="pwd_secure_min" class="col-md-3 control-label">{{ trans('admin/settings/general.pwd_secure_min') }}</label>
+
                                 <div class="col-md-9">
                                     <input class="form-control" style="width: 60px;" name="pwd_secure_min" type="number" value="{{ old('pwd_secure_min', $setting->pwd_secure_min) }}" id="pwd_secure_min" maxlength="2" min="8">
                                     {!! $errors->first('pwd_secure_min', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
@@ -89,7 +89,7 @@
 
                             <!-- Common Passwords -->
                             <div class="form-group {{ $errors->has('pwd_secure_complexity.*') ? 'error' : '' }}">
-                                <div class="col-md-3 text-right">
+                                <div class="col-md-3 control-label">
                                     <label for="pwd_secure_complexity">{{ trans('admin/settings/general.pwd_secure_complexity') }}</label>
                                 </div>
                                 <div class="col-md-9">
@@ -132,10 +132,11 @@
                             <x-form-legend>
                                 {{ trans('admin/settings/general.login_remote_user_text') }}
                             </x-form-legend>
+
                             <!-- Remote User Authentication -->
                             <div class="form-group {{ $errors->has('login_remote_user') ? 'error' : '' }}">
 
-                                <div class="col-md-9 col-md-offset-3">
+                                <div class="col-md-8 col-md-offset-3">
                                     <!--  Enable Remote User Login -->
 
                                     @if (config('app.lock_passwords'))
@@ -151,45 +152,53 @@
                                             {{ trans('admin/settings/general.login_remote_user_enabled_help') }}
                                         </p>
                                 </div>
-                                <div class="col-md-3 text-right">
-                                        <!-- Use custom remote user header name -->
-                                        <label for="login_remote_user_header_name">{{ trans('admin/settings/general.login_remote_user_header_name_text') }}</label>
-                                </div>
-                                <div class="col-md-9">
+                            </div>
+
+                            <!-- Use custom remote user header name -->
+                            <div class="form-group {{ $errors->has('login_remote_user_header_name') ? 'error' : '' }}">
+
+                                <label for="login_remote_user_header_name" class="control-label col-md-3">{{ trans('admin/settings/general.login_remote_user_header_name_text') }}</label>
+
+                                <div class="col-md-8">
                                         <input class="form-control" name="login_remote_user_header_name" type="text" value="{{ old('login_remote_user_header_name', $setting->login_remote_user_header_name) }}" id="login_remote_user_header_name">
                                         {!! $errors->first('login_remote_user_header_name', '<span class="alert-msg">:message</span>') !!}
                                         <p class="help-block">
                                             {{ trans('admin/settings/general.login_remote_user_header_name_help') }}
                                         </p>
                                 </div>
-                                <div class="col-md-3 text-right">
-                                        <!-- Custom logout url to redirect to authentication provider -->
-                                        <label for="login_remote_user_custom_logout_url">{{ trans('admin/settings/general.login_remote_user_custom_logout_url_text') }}</label>
-                                </div>
-                                <div class="col-md-9">
+                            </div>
+
+                            <!-- Custom logout url to redirect to authentication provider -->
+                            <div class="form-group {{ $errors->has('login_remote_user_custom_logout_url') ? 'error' : '' }}">
+                                <label for="login_remote_user_custom_logout_url" class="control-label col-md-3">{{ trans('admin/settings/general.login_remote_user_custom_logout_url_text') }}</label>
+
+                                <div class="col-md-8">
                                         <input class="form-control" aria-label="login_remote_user_custom_logout_url" name="login_remote_user_custom_logout_url" type="url" value="{{ old('login_remote_user_custom_logout_url', $setting->login_remote_user_custom_logout_url) }}" id="login_remote_user_custom_logout_url">
                                         {!! $errors->first('login_remote_user_custom_logout_url', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                         <p class="help-block">
                                             {{ trans('admin/settings/general.login_remote_user_custom_logout_url_help') }}
                                         </p>
                                 </div>
+                            </div>
+
+                            <!--  Disable other logins mechanism -->
+                            <div class="form-group {{ $errors->has('login_common_disabled') ? 'error' : '' }}">
                                 @if ($setting->login_remote_user_enabled == '1')
-                                    <div class="col-md-3 text-right">
-                                        <!--  Disable other logins mechanism -->
+                                    <div class="col-md-8 col-md-offset-3">
                                         <label class="form-control">
                                             <input type="checkbox" name="login_common_disabled" value="1" @checked(old('login_common_disabled', $setting->login_common_disabled)) aria-label="login_common_disabled"/>
                                             {{ trans('admin/settings/general.login_common_disabled_text') }}
                                         </label>
-                                    </div>
-                                    <div class="col-md-9">
+
                                         {!! $errors->first('login_common_disabled', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                         <p class="help-block">
                                             {{ trans('admin/settings/general.login_common_disabled_help') }}
                                         </p>
-                                        @endif
-                                    </div>
-
                                 @endif
+
+                            </div>
+
+                            @endif
                         </fieldset>
 
 


### PR DESCRIPTION
This just corrects the label alignment on smaller screens for the admin settings section.

### Before
<img width="565" height="497" alt="Screenshot 2025-10-29 at 11 14 43 AM" src="https://github.com/user-attachments/assets/a63fe333-62c7-44f7-9049-98bcd31a2593" />




### After
<img width="546" height="506" alt="Screenshot 2025-10-29 at 11 14 28 AM" src="https://github.com/user-attachments/assets/6e9cf739-9fc6-4142-8189-9bd0fc4b3352" />