### PR TITLE
Added form row component 

### DIFF
--- a/app/Helpers/IconHelper.php
+++ b/app/Helpers/IconHelper.php
@@ -40,6 +40,8 @@ class IconHelper
                 return 'fa-solid fa-trash-arrow-up';
             case 'external-link':
                 return 'fa fa-external-link';
+            case 'link':
+                return 'fa fa-link';
             case 'email':
                 return 'fa-regular fa-envelope';
             case 'phone':

--- a/resources/views/blade/form-label.blade.php
+++ b/resources/views/blade/form-label.blade.php
@@ -1,0 +1,4 @@
+<!-- form-label blade component -->
+<label {{ $attributes->merge(['class' => 'control-label']) }}>
+    {{ $slot }}
+</label>

--- a/resources/views/blade/form-row.blade.php
+++ b/resources/views/blade/form-row.blade.php
@@ -1,0 +1,65 @@
+<!-- form-row blade component -->
+@props([
+    'name' => null,
+    'type' => 'text',
+    'item' => null,
+    'info_tooltip_text' => null,
+    'help_text' => null,
+    'label' => null,
+])
+
+<div {{ $attributes->merge(['class' => 'form-group']) }}>
+
+    @if (isset($label))
+        <x-form-label
+                :for="$name"
+                :style="$label_style ?? null"
+                class="{{ $label_class ?? null }}"
+        >
+            {{ $label }}
+        </x-form-label>
+    @endif
+
+    @php
+        $blade_type = in_array($type, ['text', 'email', 'url', 'tel', 'number', 'password']) ? 'text' : $type;
+    @endphp
+        <div class="col-xs-12 col-sm-12 col-md-8 col-lg-6 col-xl-6">
+            <x-dynamic-component
+                    :aria-label="$name"
+                    :component="'input.'.$blade_type"
+                    :id="$name"
+                    :required="Helper::checkIfRequired($item, $name)"
+                    :value="old($name, $item->{$name})"
+            />
+        </div>
+
+    @if ($info_tooltip_text)
+        <!-- Info Tooltip -->
+        <div class="col-md-1 text-left" style="padding-left:0; margin-top: 5px;">
+            <x-form-tooltip>
+                {{ $info_tooltip_text }}
+            </x-form-tooltip>
+        </div>
+    @endif
+
+
+    @error($name)
+    <!-- Form Error -->
+    <div {{ $attributes->merge(['class' => $error_offset_class]) }}>
+                <span class="alert-msg" role="alert">
+                    <i class="fas fa-times" aria-hidden="true"></i>
+                    {{ $message }}
+                </span>
+    </div>
+    @enderror
+
+    @if ($help_text)
+        <!-- Help Text -->
+        <div {{ $attributes->merge(['class' => $error_offset_class]) }}>
+            <p class="help-block">
+                {!! $help_text !!}
+            </p>
+        </div>
+    @endif
+
+</div>

--- a/resources/views/blade/form-row.blade.php
+++ b/resources/views/blade/form-row.blade.php
@@ -6,30 +6,40 @@
     'info_tooltip_text' => null,
     'help_text' => null,
     'label' => null,
+    'input_div_class' => 'col-md-8',
+    'errors_class' => $errors->has('support_url') ? ' has-error' : '',
+    'input_icon' => null,
+    'input_group_addon' => null,
+    'rows' => null,
+    'placeholder' => null,
 ])
 
-<div {{ $attributes->merge(['class' => 'form-group']) }}>
+<div {{ $attributes->merge(['class' => 'form-group'. $errors_class]) }}>
 
+    <!-- form label -->
     @if (isset($label))
-        <x-form-label
-                :for="$name"
-                :style="$label_style ?? null"
-                class="{{ $label_class ?? null }}"
-        >
-            {{ $label }}
-        </x-form-label>
+        <x-form-label  :for="$name" class="{{ $label_class ?? 'col-md-3' }}">{{ $label }}</x-form-label>
     @endif
+
 
     @php
         $blade_type = in_array($type, ['text', 'email', 'url', 'tel', 'number', 'password']) ? 'text' : $type;
     @endphp
-        <div class="col-xs-12 col-sm-12 col-md-8 col-lg-6 col-xl-6">
+
+        <div class="{{ $input_div_class }}">
             <x-dynamic-component
+                    :$name
+                    :$type
                     :aria-label="$name"
                     :component="'input.'.$blade_type"
                     :id="$name"
                     :required="Helper::checkIfRequired($item, $name)"
                     :value="old($name, $item->{$name})"
+                    :input_icon="$input_icon"
+                    :input_group_addon="$input_group_addon"
+                    :rows="$rows"
+                    :placeholder="$placeholder"
+
             />
         </div>
 
@@ -44,22 +54,23 @@
 
 
     @error($name)
-    <!-- Form Error -->
-    <div {{ $attributes->merge(['class' => $error_offset_class]) }}>
-                <span class="alert-msg" role="alert">
-                    <i class="fas fa-times" aria-hidden="true"></i>
-                    {{ $message }}
-                </span>
+    <div class="col-md-8 col-md-offset-3">
+        <span class="alert-msg" aria-hidden="true">
+            <x-icon type="x" />
+            {{ $message }}
+        </span>
     </div>
     @enderror
 
     @if ($help_text)
         <!-- Help Text -->
-        <div {{ $attributes->merge(['class' => $error_offset_class]) }}>
+        <div class="col-md-8 col-md-offset-3">
             <p class="help-block">
                 {!! $help_text !!}
             </p>
         </div>
     @endif
+
+
 
 </div>

--- a/resources/views/blade/form-tooltip.blade.php
+++ b/resources/views/blade/form-tooltip.blade.php
@@ -1,0 +1,4 @@
+<a href="#" data-tooltip="true" title="{{ $slot }}" style="padding-left: 0px;">
+    <x-icon type="more-info" style="font-size: 20px;" />
+    <span class="sr-only">{{ $slot }}</span>
+</a>

--- a/resources/views/blade/input/text.blade.php
+++ b/resources/views/blade/input/text.blade.php
@@ -1,12 +1,22 @@
 @props([
-'input_style' => null,
 'input_group_addon' => null,
+'input_icon' => null,
 'required' => false,
 'item' => null,
 ])
 <!-- input-text blade component -->
-<input
+@if ($input_group_addon)
+        <div class="input-group">
+@endif
+    <input
         {{ $attributes->merge(['class' => 'form-control']) }}
         @required($required)
-/>
+    />
+
+@if ($input_group_addon)
+    <span class="input-group-addon">
+      <x-icon :type="$input_icon" />
+    </span>
+</div>
+@endif
 

--- a/resources/views/blade/input/text.blade.php
+++ b/resources/views/blade/input/text.blade.php
@@ -1,0 +1,12 @@
+@props([
+'input_style' => null,
+'input_group_addon' => null,
+'required' => false,
+'item' => null,
+])
+<!-- input-text blade component -->
+<input
+        {{ $attributes->merge(['class' => 'form-control']) }}
+        @required($required)
+/>
+

--- a/resources/views/blade/input/textarea.blade.php
+++ b/resources/views/blade/input/textarea.blade.php
@@ -1,6 +1,6 @@
 @props([
     'value' => '',
-    'rows' => 10,
+    'rows' => 5,
 ])
 
 <textarea

--- a/resources/views/categories/edit.blade.php
+++ b/resources/views/categories/edit.blade.php
@@ -9,7 +9,13 @@
 
 @section('inputFields')
 
-@include ('partials.forms.edit.name', ['translated_name' => trans('admin/categories/general.name')])
+    <!-- Name -->
+    <x-form-row
+            :label="trans('general.name')"
+            :$item
+            name="name"
+    />
+
 
 <!-- Type -->
 <div class="form-group {{ $errors->has('category_type') ? ' has-error' : '' }}">

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -1163,21 +1163,42 @@ dir="{{ Helper::determineLanguageDirection() }}">
             var validator = $('#create-form').validate({
                 ignore: 'input[type=hidden]',
                 errorClass: 'alert-msg',
-                errorElement: 'span',
+                errorElement: 'div',
                 errorPlacement: function(error, element) {
-                    $(element).hasClass('select2') || $(element).hasClass('js-data-ajax')
+
+                    if ($(element).hasClass('select2') || $(element).hasClass('js-data-ajax')) {
                         // If the element is a select2 then append the error to the parent div
-                        ? element.parent('div').append(error)
-                        // Otherwise place it after
-                        : error.insertAfter(element);
+                        element.parent('div').append(error);
+
+                     } else if ($(element).parent().hasClass('input-group')) {
+                        var end_input_group = $(element).next('.input-group-addon').parent();
+                        error.insertAfter(end_input_group);
+                    } else {
+                        error.insertAfter(element);
+                    }
+
                 },
                 highlight: function(inputElement) {
-                    $(inputElement).parent().addClass('has-error');
-                    $(inputElement).closest('.help-block').remove();
+
+                    // We have to go two levels up if it's an input group
+                    if ($(inputElement).parent().hasClass('input-group')) {
+                        $(inputElement).parent().parent().parent().addClass('has-error');
+                    } else {
+                        $(inputElement).parent().addClass('has-error');
+                        $(inputElement).closest('.help-block').remove();
+                    }
+
                 },
                 onfocusout: function(element) {
-                    $(element).parent().removeClass('has-error');
-                    return $(element).valid();
+                    // We have to go two levels up if it's an input group
+                    if ($(element).parent().hasClass('input-group')) {
+                        $(element).parent().parent().parent().removeClass('has-error');
+                        return $(element).valid();
+                    } else {
+                        $(element).parent().removeClass('has-error');
+                        return $(element).valid();
+                    }
+
                 },
 
             });

--- a/resources/views/manufacturers/edit.blade.php
+++ b/resources/views/manufacturers/edit.blade.php
@@ -9,75 +9,89 @@
 
 {{-- Page content --}}
 @section('inputFields')
-@include ('partials.forms.edit.name', ['translated_name' => trans('admin/manufacturers/table.name')])
+
+    <!-- Name -->
+    <x-form-row
+            :label="trans('admin/manufacturers/table.name')"
+            :$item
+            name="name"
+    />
+
     <!-- URL -->
-    <div class="form-group {{ $errors->has('url') ? ' has-error' : '' }}">
-        <label for="url" class="col-md-3 control-label">{{ trans('general.url') }}
-        </label>
-        <div class="col-md-6">
-            <input class="form-control" type="text" name="url" id="url" value="{{ old('url', $item->url) }}" />
-            {!! $errors->first('url', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
-        </div>
-    </div>
+    <x-form-row
+            :label="trans('general.url')"
+            :$item
+            name="url"
+            type="url"
+            input_icon="link"
+            input_group_addon="left"
+            placeholder="https://example.com"
+    />
+
+
 
     <!-- Support URL -->
-    <div class="form-group {{ $errors->has('support_url') ? ' has-error' : '' }}">
-        <label for="support_url" class="col-md-3 control-label">{{ trans('admin/manufacturers/table.support_url') }}
-        </label>
-        <div class="col-md-6">
-            <input class="form-control" type="url" name="support_url" id="support_url" value="{{ old('support_url', $item->support_url) }}" />
-            {!! $errors->first('support_url', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
-        </div>
-    </div>
+    <x-form-row
+            :label="trans('admin/manufacturers/table.support_url')"
+            :$item
+            name="support_url"
+            type="url"
+            input_icon="link"
+            input_group_addon="left"
+            placeholder="https://example.com"
+    />
+
+
 
     <!-- Warranty Lookup URL -->
-    <div class="form-group {{ $errors->has('warranty_lookup_url') ? ' has-error' : '' }}">
-        <label for="support_url" class="col-md-3 control-label">{{ trans('admin/manufacturers/table.warranty_lookup_url') }}
-        </label>
-        <div class="col-md-6">
-            <input class="form-control" type="url" name="warranty_lookup_url" id="warranty_lookup_url" value="{{ old('warranty_lookup_url', $item->warranty_lookup_url) }}" />
-            <p class="help-block">{!! trans('admin/manufacturers/message.support_url_help') !!}</p>
-            {!! $errors->first('warranty_lookup_url', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
-        </div>
-    </div>
+    <x-form-row
+            :label="trans('admin/manufacturers/table.warranty_lookup_url')"
+            :$item
+            name="warranty_lookup_url"
+            type="url"
+            help_text="{!! trans('admin/manufacturers/message.support_url_help') !!}"
+            input_icon="link"
+            input_group_addon="left"
+            placeholder="https://example.com"
+    />
 
     <!-- Support Phone -->
-    <div class="form-group {{ $errors->has('support_phone') ? ' has-error' : '' }}">
-        <label for="support_phone" class="col-md-3 control-label">{{ trans('admin/manufacturers/table.support_phone') }}
-        </label>
-        <div class="col-md-6">
-            <input class="form-control" type="text" name="support_phone" id="support_phone" value="{{ old('support_phone', $item->support_phone) }}" />
-            {!! $errors->first('support_phone', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
-        </div>
-    </div>
+    <x-form-row
+            :label="trans('admin/manufacturers/table.support_phone')"
+            :$item
+            name="support_phone"
+            input_div_class="col-md-6"
+            type="tel"
+            input_icon="phone"
+            input_group_addon="left"
+            placeholder="1-800-555-5555"
+    />
+
 
     <!-- Support Email -->
-    <div class="form-group {{ $errors->has('support_email') ? ' has-error' : '' }}">
-        <label for="support_email" class="col-md-3 control-label">{{ trans('admin/manufacturers/table.support_email') }}
-        </label>
-        <div class="col-md-6">
-            <input class="form-control" type="email" name="support_email" id="support_email" value="{{ old('support_email', $item->support_email) }}" />
-            {!! $errors->first('support_email', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
-        </div>
-    </div>
+    <x-form-row
+            :label="trans('admin/manufacturers/table.support_email')"
+            :$item
+            name="support_email"
+            input_div_class="col-md-6"
+            type="email"
+            input_icon="email"
+            input_group_addon="left"
+            placeholder="support@example.com"
+    />
+
 
 @include ('partials.forms.edit.image-upload', ['image_path' => app('manufacturers_upload_path')])
 
-<div class="form-group{!! $errors->has('notes') ? ' has-error' : '' !!}">
-    <label for="notes" class="col-md-3 control-label">{{ trans('general.notes') }}</label>
-    <div class="col-md-8">
-        <x-input.textarea
-                name="notes"
-                id="notes"
-                :value="old('notes', $item->notes)"
-                placeholder="{{ trans('general.placeholders.notes') }}"
-                aria-label="notes"
-                rows="5"
-        />
-        {!! $errors->first('notes', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
-    </div>
-</div>
 
+    <!-- Notes -->
+    <x-form-row
+            :label="trans('general.notes')"
+            :$item
+            name="notes"
+            type="textarea"
+            placeholder="{{ trans('general.placeholders.notes') }}"
+    />
 
 
 @stop


### PR DESCRIPTION
This is a much smaller swing at the very large form row component I took earlier, handling only the manufacturers edit for now. 

The form row component itself is a bit messy, since it's got two or more elements nested within it which we have to potentially pass things to, the label component and the input itself.

I decided to back off the complex checkbox groups and radio groups for now, because *whew* that gets messy. 

This also fixes a long-running JS visual glitch that has made me bananas for a while, where if you have an input group (the bit with the icon on the end or the front of the input box, it would break the layout on the JS error. 

The overall goal here is to take the HTML/bootstrap code away from the the functionality of the forms, fixing some common issues where form fields are weird lengths on different forms. This should add consistency to the layouts, and make it much easier to upgrade bootstrap (and/or switch to some other CSS framework) in the future. 

Obviously, this will eventually touch just about form element we have, once I build in other ones, and will likely take the place of a lot of our partials over time. But this is at least a decent start.

### Before

<img width="3366" height="3208" alt="FireShot Capture 069 - Update Manufacturer __ Snipe-IT Demo - snipe-it test" src="https://github.com/user-attachments/assets/941d05f5-f3bb-4554-8b3e-ad156c6f285a" />

### After


https://github.com/user-attachments/assets/8dc5eac8-5f42-4a25-8221-81003e1c2d61

