### PR TITLE
Adds a null check for items and threshold in inventory alert notification

### DIFF
--- a/app/Notifications/InventoryAlert.php
+++ b/app/Notifications/InventoryAlert.php
@@ -2,10 +2,12 @@
 
 namespace App\Notifications;
 
+use AllowDynamicProperties;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
+#[AllowDynamicProperties]
 class InventoryAlert extends Notification
 {
     use Queueable;
@@ -32,9 +34,8 @@ class InventoryAlert extends Notification
      */
     public function via()
     {
-        $notifyBy = ['mail'];
+       return (!empty($this->items) && $this->threshold !== null) ? ['mail'] : [];
 
-        return $notifyBy;
     }
 
     /**


### PR DESCRIPTION
This adds a null check on `$items` and `$threshold`. As you can null the threshold in settings. This should prevent a notification from firing if either are empty.