### PR TITLE
Fixed #18082: Added user company to checked out licenses

### DIFF
--- a/app/Http/Transformers/LicenseSeatsTransformer.php
+++ b/app/Http/Transformers/LicenseSeatsTransformer.php
@@ -36,6 +36,12 @@ class LicenseSeatsTransformer
                             'name' => e($seat->user->department->name),
 
                         ] : null,
+                'company'=> ($seat->user->company) ?
+                    [
+                        'id' => (int) $seat->user->company->id,
+                        'name' => e($seat->user->company->name),
+
+                    ] : null,
                 'created_at' => Helper::getFormattedDateObject($seat->created_at, 'datetime'),
             ] : null,
             'assigned_asset' => ($seat->asset) ? [

--- a/app/Models/LicenseSeat.php
+++ b/app/Models/LicenseSeat.php
@@ -153,17 +153,24 @@ class LicenseSeat extends SnipeModel implements ICompanyableChild
     }
 
 
+    public function scopeOrderCompany($query, $order)
+    {
+
+
+        return $query->leftJoin('users as license_seat_users', 'license_seats.assigned_to', '=', 'license_seat_users.id')
+            ->leftJoin('companies as license_user_company', 'license_user_company.id', '=', 'license_seat_users.company_id')
+            ->whereNotNull('license_seats.assigned_to')
+            ->orderBy('license_user_company.name', $order);
+    }
+
+
     public function scopeByAssigned($query)
     {
 
         return $query->where(
             function ($query) {
                 $query->whereNotNull('assigned_to')
-                    ->orWhere(
-                        function ($query) {
-                            $query->whereNotNull('asset_id');
-                        }
-                    );
+                    ->orWhereNotNull('asset_id');
             }
         );
 

--- a/app/Presenters/LicensePresenter.php
+++ b/app/Presenters/LicensePresenter.php
@@ -248,10 +248,20 @@ class LicensePresenter extends Presenter
                 'title' => trans('admin/users/table.email'),
                 'visible' => true,
                 'formatter' => 'emailFormatter',
-            ], [
-                'field' => 'department',
+            ],
+            [
+                'field' => 'assigned_user.company',
                 'searchable' => false,
-                'sortable' => true,
+                'sortable' => false,
+                'switchable' => true,
+                'title' => trans('general.company'),
+                'visible' => true,
+                'formatter' => 'companiesLinkObjFormatter',
+            ],
+            [
+                'field' => 'assigned_user.department',
+                'searchable' => false,
+                'sortable' => false,
                 'switchable' => true,
                 'title' => trans('general.department'),
                 'visible' => false,


### PR DESCRIPTION
This adds the company name to the Assigned tab on licenses. 

I'm seeing a bit of oddness in the existing queries though, and I think we should strive to normalize the `assigned_to` versus `asset_id`, preferring the `assigned_type` as we do with assets. That's a bigger PR with potentially more issues lurking. (Part of the issues I'm seeing are because assets don't have a department field, whereas users do, so the sorting gets a little wonky.)

Fixes #18082