### PR TITLE
Actiontype enum redux

### DIFF
--- a/app/Enums/ActionType.php
+++ b/app/Enums/ActionType.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Enums;
+enum ActionType: string
+{
+    // General
+    case Create = 'create';
+    case Update = 'update';
+    case Delete = 'delete';
+    case Restore = 'restore';
+
+    // Assets/Accessories/Components/Licenses/Consumables
+    case Checkout = 'checkout';
+    case CheckinFrom = 'checkin from';
+    case Requested = 'requested';
+    case RequestCanceled = 'request canceled';
+    case Accepted = 'accepted';
+    case Declined = 'declined';
+    case Audit = 'audit';
+    case NoteAdded = 'note added';
+
+    // Users
+    case TwoFactorReset = '2FA reset';
+    case Merged = 'merged';
+
+    // Licenses
+    case DeleteSeats = 'delete seats';
+    case AddSeats = 'add seats';
+
+    // File Uploads
+    case Uploaded = 'uploaded';
+    case UploadDeleted = 'upload deleted';
+}

--- a/app/Http/Controllers/ViewAssetsController.php
+++ b/app/Http/Controllers/ViewAssetsController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Actions\CheckoutRequests\CancelCheckoutRequestAction;
 use App\Actions\CheckoutRequests\CreateCheckoutRequestAction;
+use App\Enums\ActionType;
 use App\Exceptions\AssetNotRequestable;
 use App\Models\Actionlog;
 use App\Models\Asset;
@@ -201,7 +202,7 @@ class ViewAssetsController extends Controller
         if (($item_request = $item->isRequestedBy($user)) || $cancel_by_admin) {
             $item->cancelRequest($requestingUser);
             $data['item_quantity'] = ($item_request) ? $item_request->qty : 1;
-            $logaction->logaction('request_canceled');
+            $logaction->logaction(ActionType::RequestCanceled);
 
             if (($settings->alert_email != '') && ($settings->alerts_enabled == '1') && (! config('app.lock_passwords'))) {
                 $settings->notify(new RequestAssetCancelation($data));

--- a/app/Models/Actionlog.php
+++ b/app/Models/Actionlog.php
@@ -9,6 +9,7 @@ use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Str;
+use App\Enums\ActionType;
 
 /**
  * Model for the Actionlog (the table that keeps a historical log of
@@ -335,9 +336,12 @@ class Actionlog extends SnipeModel
      * @since  [v3.0]
      * @return bool
      */
-    public function logaction($actiontype)
+    public function logaction(string|ActionType $actiontype)
     {
-        $this->action_type = $actiontype;
+        if (is_string($actiontype)) {
+            $actiontype = ActionType::from($actiontype);
+        }
+        $this->action_type = $actiontype->value;
         $this->remote_ip =  request()->ip();
         $this->user_agent = request()->header('User-Agent');
         $this->action_source = $this->determineActionSource();

--- a/app/Presenters/ActionlogPresenter.php
+++ b/app/Presenters/ActionlogPresenter.php
@@ -102,7 +102,7 @@ class ActionlogPresenter extends Presenter
             return 'fa-solid fa-rotate-right';
         }
 
-        if ($this->action_type == 'note_added') {
+        if ($this->action_type == 'note added') {
             return 'fas fa-sticky-note';
         }
 

--- a/database/migrations/2025_10_22_144927_migrate_incorrect_action_types.php
+++ b/database/migrations/2025_10_22_144927_migrate_incorrect_action_types.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+
+        /**
+         * So the concern here is that the following statement _could_ take a long time - the action_logs table is not indexed
+         * against the action_type column (and shouldn't be) so this could take a few beats. But, still, we're not talking about
+         * a particularly wide table or anything; we've certainly heard about a couple of times where people had a few million
+         * action_logs but, again, not too many more than that.
+         *
+         * But @snipe has mentioned multiple times that in some older migrations, trying to run an UPDATE in batch, there were
+         * memory issues.
+         *
+         * I've investigated and it looks like we've rarely or never done a 'batch update' the way we do below. I'm pretty sure
+         * it will be fine (famous last words...)
+         * */
+
+        DB::table('action_logs')->where('action_type', 'request_canceled')->update(['action_type' => 'request canceled']);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // no down migration for this one
+    }
+};

--- a/database/migrations/2025_10_22_144927_migrate_incorrect_action_types.php
+++ b/database/migrations/2025_10_22_144927_migrate_incorrect_action_types.php
@@ -13,16 +13,9 @@ return new class extends Migration
     {
 
         /**
-         * So the concern here is that the following statement _could_ take a long time - the action_logs table is not indexed
-         * against the action_type column (and shouldn't be) so this could take a few beats. But, still, we're not talking about
-         * a particularly wide table or anything; we've certainly heard about a couple of times where people had a few million
-         * action_logs but, again, not too many more than that.
-         *
-         * But @snipe has mentioned multiple times that in some older migrations, trying to run an UPDATE in batch, there were
-         * memory issues.
-         *
-         * I've investigated and it looks like we've rarely or never done a 'batch update' the way we do below. I'm pretty sure
-         * it will be fine (famous last words...)
+         * We actually *do* have an index on action_type, so this query shouldn't take too terribly long. I don't know
+         * that we have a ton of people canceling requests (and only certain types of request-cancellation use this
+         * erroneous action_type), so I feel pretty comfortable with this fixup. Fingers crossed!
          * */
 
         DB::table('action_logs')->where('action_type', 'request_canceled')->update(['action_type' => 'request canceled']);


### PR DESCRIPTION
This is yet another attempt to re-add the ActionType enum in the least invasive way that I can manage. The `logaction()` method now has a more complex function signature, allowing either a string *or* an ActionType. If it's a string, it's turned into an ActionType by using the baked-in `::from()` method of the backed-enum, which will ensure that only valid ActionTypes are permitted - the `::from()` method will throw an error if you use a string that cannot be converted back into an ActionType.

In the process of working with this, I did discover one place that was using `request_canceled` instead of `request canceled` so I've also added a migration to fix this in the actionlog table (and fixed the code for this going forward). It's still a little bit scary in that it _will_ iterate through the entire actionlog table, but luckily we're already indexed on the `action_type` column, so the migration should complete very quickly. I also found a place where we said `note_added` instead of `note added` so I fixed that as well.

It's tempting to go through and change _every_ instance where we use `logaction()` to pass in the appropriate ActionType enum - but that's going to cause too many changes to the code-base, all at once - which we're trying to avoid. This approach still means we get the safety of the Enum, without having to change all of the entire codebase.