### PR TITLE
Fixed #18148 and #17451 - return int for user_count, fixed validation

### DIFF
--- a/app/Http/Controllers/Api/DepartmentsController.php
+++ b/app/Http/Controllers/Api/DepartmentsController.php
@@ -27,18 +27,19 @@ class DepartmentsController extends Controller
         $allowed_columns = ['id', 'name', 'image', 'users_count', 'notes'];
 
         $departments = Department::select(
-            'departments.id',
-            'departments.name',
-            'departments.phone',
-            'departments.fax',
-            'departments.location_id',
-            'departments.company_id',
-            'departments.manager_id',
-            'departments.created_at',
-            'departments.updated_at',
-            'departments.image',
-            'departments.notes',
-        )->with('users')->with('location')->with('manager')->with('company')->withCount('users as users_count');
+            [
+                'departments.id',
+                'departments.name',
+                'departments.phone',
+                'departments.fax',
+                'departments.location_id',
+                'departments.company_id',
+                'departments.manager_id',
+                'departments.created_at',
+                'departments.updated_at',
+                'departments.image',
+                'departments.notes'
+            ])->with('users')->with('location')->with('manager')->with('company')->withCount('users as users_count');
 
         if ($request->filled('search')) {
             $departments = $departments->TextSearch($request->input('search'));
@@ -105,7 +106,7 @@ class DepartmentsController extends Controller
         $department->manager_id = ($request->filled('manager_id') ? $request->input('manager_id') : null);
 
         if ($department->save()) {
-            return response()->json(Helper::formatStandardApiResponse('success', $department, trans('admin/departments/message.create.success')));
+            return response()->json(Helper::formatStandardApiResponse('success', (new DepartmentsTransformer)->transformDepartment($department), trans('admin/departments/message.create.success')));
         }
         return response()->json(Helper::formatStandardApiResponse('error', null, $department->getErrors()));
 
@@ -121,7 +122,7 @@ class DepartmentsController extends Controller
     public function show($id) : array
     {
         $this->authorize('view', Department::class);
-        $department = Department::findOrFail($id);
+        $department = Department::withCount('users as users_count')->findOrFail($id);
         return (new DepartmentsTransformer)->transformDepartment($department);
     }
 

--- a/app/Http/Transformers/DepartmentsTransformer.php
+++ b/app/Http/Transformers/DepartmentsTransformer.php
@@ -43,7 +43,7 @@ class DepartmentsTransformer
                     'id' => (int) $department->location->id,
                     'name' => e($department->location->name),
                 ] : null,
-                'users_count' => e($department->users_count),
+                'users_count' => (int) ($department->users_count),
                 'notes' => Helper::parseEscapedMarkedownInline($department->notes),
                 'created_at' => Helper::getFormattedDateObject($department->created_at, 'datetime'),
                 'updated_at' => Helper::getFormattedDateObject($department->updated_at, 'datetime'),

--- a/app/Models/Department.php
+++ b/app/Models/Department.php
@@ -31,7 +31,7 @@ class Department extends SnipeModel
     ];
 
     protected $rules = [
-        'name'        => 'required|max:255|is_unique_department',
+        'name'        => 'required|max:255|is_unique_across_company_and_location:departments,name',
         'location_id' => 'numeric|nullable|exists:locations,id',
         'company_id'  => 'numeric|nullable|exists:companies,id',
         'manager_id'  => 'numeric|nullable|exists:users,id',

--- a/resources/lang/en-US/validation.php
+++ b/resources/lang/en-US/validation.php
@@ -174,7 +174,7 @@ return [
     'ulid' => 'The :attribute field must be a valid ULID.',
     'uuid' => 'The :attribute field must be a valid UUID.',
     'fmcs_location' => 'Full multiple company support and location scoping is enabled in the Admin Settings, and the selected location and selected company are not compatible.',
-
+    'is_unique_across_company_and_location' => 'The :attribute must be unique within the selected company and location.',
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes  #18148 and #17451, correctly now returning the users count when viewing a specific department via API, casting it as an integer, and also fixes the validation. Previously, the validation wasn't working as expected, so you could have repeated department names. The validator now correctly checks for uniqueness across company and location ID (if they are provided.)

This is technically a breaking change, since we're also now using the transformers to format the create/update responses, however I don't think most folks use the departments API endpoint much, since the validation issue has been a bug forever and nobody mentioned it. 

```json
{
    "status": "success",
    "messages": "Department updated successfully.",
    "payload": {
        "id": 30,
        "name": "Test from API",
        "phone": null,
        "fax": null,
        "image": null,
        "company": {
            "id": 2,
            "name": "Lowe LLC"
        },
        "manager": null,
        "location": {
            "id": 5,
            "name": "East Chadrickstad"
        },
        "users_count": 0,
        "notes": "TEST AGAIN",
        "created_at": {
            "datetime": "2025-11-04 15:30:24",
            "formatted": "Tue Nov 04, 2025 3:30PM"
        },
        "updated_at": {
            "datetime": "2025-11-04 16:02:09",
            "formatted": "Tue Nov 04, 2025 4:02PM"
        },
        "available_actions": {
            "update": true,
            "delete": true
        }
    }
}
```

I also think the custom validator is a little less horrible-looking now. 