### PR TITLE
Fix Content-Type Header not being set correctly for testWebhook

### DIFF
--- a/app/Livewire/SlackSettingsForm.php
+++ b/app/Livewire/SlackSettingsForm.php
@@ -159,7 +159,7 @@ class SlackSettingsForm extends Component
             ]);
 
         try {
-            $test = $webhook->post($this->webhook_endpoint, ['body' => $payload, ['headers' => ['Content-Type' => 'application/json']]]);
+            $test = $webhook->post($this->webhook_endpoint, ['body' => $payload, 'headers' => ['Content-Type' => 'application/json']]);
 
             if(($test->getStatusCode() == 302)||($test->getStatusCode() == 301)){
                 return session()->flash('error' , trans('admin/settings/message.webhook.error_redirect', ['endpoint' => $this->webhook_endpoint]));


### PR DESCRIPTION
The `Content-Type` header was not being set correctly in the fix for #15946. The `headers` key should not be in an array in the `options` array; it should be a key of the `options` array itself.

I am not sure if Slack was rejecting this as well, but I noticed it while setting up a Discord webhook.