### PR TITLE
Logs changes

### DIFF
--- a/app/Enums/ActionType.php
+++ b/app/Enums/ActionType.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Enums;
+enum ActionType: string
+{
+    // General
+    case Create = 'create';
+    case Update = 'update';
+    case Delete = 'delete';
+    case Restore = 'restore';
+
+    // Assets/Accessories/Components/Licenses/Consumables
+    case Checkout = 'checkout';
+    case CheckinFrom = 'checkin from';
+    case Requested = 'requested';
+    case RequestCanceled = 'request canceled';
+    case Accepted = 'accepted';
+    case Declined = 'declined';
+    case Audit = 'audit';
+    case NoteAdded = 'note added';
+
+    // Users
+    case TwoFactorReset = '2FA reset';
+    case Merged = 'merged';
+
+    // Licenses
+    case DeleteSeats = 'delete seats';
+    case AddSeats = 'add seats';
+
+    // File Uploads
+    case Uploaded = 'uploaded';
+    case UploadDeleted = 'upload deleted';
+}

--- a/app/Http/Controllers/LocationsController.php
+++ b/app/Http/Controllers/LocationsController.php
@@ -335,13 +335,7 @@ class LocationsController extends Controller
             }
 
             if ($location->restore()) {
-                $logaction = new Actionlog();
-                $logaction->item_type = Location::class;
-                $logaction->item_id = $location->id;
-                $logaction->created_at = date('Y-m-d H:i:s');
-                $logaction->created_by = auth()->id();
-                $logaction->logaction('restore');
-
+                //Note - the LogsChanges trait on Locations will automatically do a 'restore' action in the action_log when this fires
                 return redirect()->route('locations.index')->with('success', trans('admin/locations/message.restore.success'));
             }
 

--- a/app/Http/Controllers/ViewAssetsController.php
+++ b/app/Http/Controllers/ViewAssetsController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Actions\CheckoutRequests\CancelCheckoutRequestAction;
 use App\Actions\CheckoutRequests\CreateCheckoutRequestAction;
+use App\Enums\ActionType;
 use App\Exceptions\AssetNotRequestable;
 use App\Models\Actionlog;
 use App\Models\Asset;
@@ -201,7 +202,7 @@ class ViewAssetsController extends Controller
         if (($item_request = $item->isRequestedBy($user)) || $cancel_by_admin) {
             $item->cancelRequest($requestingUser);
             $data['item_quantity'] = ($item_request) ? $item_request->qty : 1;
-            $logaction->logaction('request_canceled');
+            $logaction->logaction(ActionType::RequestCanceled);
 
             if (($settings->alert_email != '') && ($settings->alerts_enabled == '1') && (! config('app.lock_passwords'))) {
                 $settings->notify(new RequestAssetCancelation($data));

--- a/app/Models/Actionlog.php
+++ b/app/Models/Actionlog.php
@@ -9,6 +9,7 @@ use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Str;
+use App\Enums\ActionType;
 
 /**
  * Model for the Actionlog (the table that keeps a historical log of
@@ -335,9 +336,12 @@ class Actionlog extends SnipeModel
      * @since  [v3.0]
      * @return bool
      */
-    public function logaction($actiontype)
+    public function logaction(string|ActionType $actiontype)
     {
-        $this->action_type = $actiontype;
+        if (is_string($actiontype)) {
+            $actiontype = ActionType::from($actiontype);
+        }
+        $this->action_type = $actiontype->value;
         $this->remote_ip =  request()->ip();
         $this->user_agent = request()->header('User-Agent');
         $this->action_source = $this->determineActionSource();

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Gate;
 use Watson\Validating\ValidatingTrait;
 use App\Helpers\Helper;
 use Illuminate\Support\Str;
+use App\Models\Traits\LogsChanges;
 
 /**
  * Model for Categories. Categories are a higher-level group
@@ -27,6 +28,7 @@ class Category extends SnipeModel
     protected $presenter = \App\Presenters\CategoryPresenter::class;
     use Presentable;
     use SoftDeletes;
+    use LogsChanges;
 
     protected $table = 'categories';
     protected $hidden = ['created_by', 'deleted_at'];

--- a/app/Models/CustomField.php
+++ b/app/Models/CustomField.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Http\Traits\UniqueUndeletedTrait;
+use App\Models\Traits\LogsChanges;
 use EasySlugger\Utf8Slugger;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -14,6 +15,7 @@ class CustomField extends Model
     use HasFactory;
     use ValidatingTrait,
         UniqueUndeletedTrait;
+    use LogsChanges;
 
     /**
      *

--- a/app/Models/CustomFieldset.php
+++ b/app/Models/CustomFieldset.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Traits\LogsChanges;
 use App\Rules\AlphaEncrypted;
 use App\Rules\BooleanEncrypted;
 use App\Rules\DateEncrypted;
@@ -22,6 +23,7 @@ class CustomFieldset extends Model
 {
     use HasFactory;
     use ValidatingTrait;
+    use LogsChanges;
 
     protected $guarded = ['id'];
 

--- a/app/Models/Department.php
+++ b/app/Models/Department.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Http\Traits\UniqueUndeletedTrait;
 use App\Models\Traits\CompanyableTrait;
+use App\Models\Traits\LogsChanges;
 use App\Models\Traits\Searchable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Watson\Validating\ValidatingTrait;
@@ -22,7 +23,7 @@ class Department extends SnipeModel
      */
     protected $injectUniqueIdentifier = true;
 
-    use ValidatingTrait, UniqueUndeletedTrait;
+    use ValidatingTrait, UniqueUndeletedTrait, LogsChanges;
 
     protected $casts = [
         'manager_id'   => 'integer',

--- a/app/Models/Depreciation.php
+++ b/app/Models/Depreciation.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Traits\LogsChanges;
 use App\Models\Traits\Searchable;
 use App\Presenters\Presentable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -10,6 +11,7 @@ use Watson\Validating\ValidatingTrait;
 class Depreciation extends SnipeModel
 {
     use HasFactory;
+    use LogsChanges;
 
     protected $presenter = \App\Presenters\DepreciationPresenter::class;
     use Presentable;

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Traits\LogsChanges;
 use App\Models\Traits\Searchable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Watson\Validating\ValidatingTrait;
@@ -9,6 +10,7 @@ use Watson\Validating\ValidatingTrait;
 class Group extends SnipeModel
 {
     use HasFactory;
+    use LogsChanges;
 
     protected $table = 'permission_groups';
 

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -6,6 +6,7 @@ use App\Http\Traits\UniqueUndeletedTrait;
 use App\Models\Traits\CompanyableTrait;
 use App\Models\Traits\HasUploads;
 use App\Models\Traits\Loggable;
+use App\Models\Traits\LogsChanges;
 use App\Models\Traits\Searchable;
 use App\Presenters\Presentable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -17,7 +18,7 @@ class Location extends SnipeModel
 {
     use HasFactory;
     use CompanyableTrait;
-    use Loggable;
+    use LogsChanges;
 
     protected $presenter = \App\Presenters\LocationPresenter::class;
     use Presentable;

--- a/app/Models/Manufacturer.php
+++ b/app/Models/Manufacturer.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Traits\LogsChanges;
 use App\Models\Traits\Searchable;
 use App\Presenters\Presentable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -16,6 +17,7 @@ class Manufacturer extends SnipeModel
     protected $presenter = \App\Presenters\ManufacturerPresenter::class;
     use Presentable;
     use SoftDeletes;
+    use LogsChanges;
 
     protected $table = 'manufacturers';
 

--- a/app/Models/PredefinedKit.php
+++ b/app/Models/PredefinedKit.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Traits\LogsChanges;
 use App\Models\Traits\Searchable;
 use App\Presenters\Presentable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -19,6 +20,7 @@ class PredefinedKit extends SnipeModel
     protected $presenter = \App\Presenters\PredefinedKitPresenter::class;
     use HasFactory;
     use Presentable;
+    use LogsChanges;
     protected $table = 'kits';
 
     /**

--- a/app/Models/ReportTemplate.php
+++ b/app/Models/ReportTemplate.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Traits\LogsChanges;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -14,6 +15,7 @@ class ReportTemplate extends Model
     use HasFactory;
     use SoftDeletes;
     use ValidatingTrait;
+    use LogsChanges;
 
     protected $casts = [
         'options' => 'array',

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Traits\LogsChanges;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -21,7 +22,7 @@ use Illuminate\Support\Facades\Log;
 class Setting extends Model
 {
     use HasFactory;
-    use Notifiable, ValidatingTrait;
+    use Notifiable, ValidatingTrait, LogsChanges;
 
     /**
      * The cache property so that multiple invocations of this will only load the Settings record from disk only once

--- a/app/Models/Statuslabel.php
+++ b/app/Models/Statuslabel.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Http\Traits\UniqueUndeletedTrait;
+use App\Models\Traits\LogsChanges;
 use App\Models\Traits\Searchable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -14,6 +15,7 @@ class Statuslabel extends SnipeModel
     use SoftDeletes;
     use ValidatingTrait;
     use UniqueUndeletedTrait;
+    use LogsChanges;
 
     protected $injectUniqueIdentifier = true;
 

--- a/app/Models/Supplier.php
+++ b/app/Models/Supplier.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Http\Traits\UniqueUndeletedTrait;
+use App\Models\Traits\LogsChanges;
 use App\Models\Traits\Searchable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -12,6 +13,7 @@ class Supplier extends SnipeModel
 {
     use HasFactory;
     use SoftDeletes;
+    use LogsChanges;
 
     protected $table = 'suppliers';
 

--- a/app/Models/Traits/LogsChanges.php
+++ b/app/Models/Traits/LogsChanges.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Models\Traits;
+
+use App\Enums\ActionType;
+use App\Models\Actionlog;
+trait LogsChanges {
+
+    private ?ActionType $action_type = null;
+    private array $meta = [];
+    static function bootLogsChanges() {
+        static::creating(function ($model) {
+            \Log::error("CREATING!");
+            $model->action_type = ActionType::Create;
+        });
+
+        static::updating(function ($model) {
+            \Log::error("UPDATING!");
+            if(!$model->action_type) {
+                \Log::error("No action type - so definitely doing 'update'!");
+                $model->action_type = ActionType::Update;
+            }
+        });
+
+        static::restoring(function ($model) {
+            $model->action_type = ActionType::Restore;
+        });
+
+        /* The main functionality is here: */
+        static::saving(function ($model) {
+            \Log::error("recording changes.......");
+            $model->record_changes();
+        });
+
+        static::saved(function ($model) {
+            \Log::error("SAVED!!!!");
+            $model->add_action_log();
+        });
+
+        static::deleted(function ($model) {
+            $model->action_type = ActionType::Delete;
+            $model->add_action_log();
+            \Log::error("deleted!!!!!!!!!!!");
+        });
+    }
+
+    function record_changes()
+    {
+        $changed = [];
+
+        // something here with custom fields is needed? or will getRawOriginal et al just do that for us?
+        foreach ($this->getRawOriginal() as $key => $value) { //on 'create' this doesn't write down the new attributes
+            if ($this->getRawOriginal()[$key] != $this->getAttributes()[$key]) {
+                $changed[$key]['old'] = $this->getRawOriginal()[$key];
+                $changed[$key]['new'] = $this->getAttributes()[$key];
+
+                if (property_exists($this, 'hidden') && in_array($key, $this->hidden)) {
+                    $changed[$key]['old'] = '*************'; //FIXME deleted_at is hidden?!
+                    $changed[$key]['new'] = '*************';
+                }
+            }
+        }
+        $this->meta = $changed;
+    }
+
+    function add_action_log()
+    {
+        if(!$this->action_type && !$this->meta) {
+            \Log::warning("No action type set, and no changes to record. Not logging.");
+            return;
+        }
+        if($this->action_type == ActionType::Update && !$this->meta) {
+            \Log::warning("An update with no actual changes to record. Not logging");
+            return;
+        }
+        $logAction = new Actionlog();
+        $logAction->action_type = $this->action_type->value;
+        $logAction->item()->associate($this);
+        $logAction->created_at = date('Y-m-d H:i:s');
+        $logAction->action_date = date('Y-m-d H:i:s');
+        // target_id and target_type?
+        // need IP and user-agent!!!!!
+        $logAction->created_by = auth()->id();
+        $logAction->log_meta = json_encode($this->meta); // this gets weird on 'create'
+        if($logAction->save()) {
+            //success! Reset for more actions later...
+            $this->action_type = null;
+            $this->meta = [];
+        }
+    }
+}

--- a/app/Models/Traits/LogsChanges.php
+++ b/app/Models/Traits/LogsChanges.php
@@ -4,6 +4,7 @@ namespace App\Models\Traits;
 
 use App\Enums\ActionType;
 use App\Models\Actionlog;
+
 trait LogsChanges {
 
     private ?ActionType $action_type = null;
@@ -22,9 +23,14 @@ trait LogsChanges {
             }
         });
 
-        static::restoring(function ($model) {
-            $model->action_type = ActionType::Restore;
-        });
+        // The Settings object does not use soft-deletes, so it has no 'restoring' method
+        // so to be generic, we just look for that method existing at all, and don't call
+        // it if it doesn't.
+        if (method_exists(self::class, 'restoring')) {
+            static::restoring(function ($model) {
+                $model->action_type = ActionType::Restore;
+            });
+        }
 
         /* The main functionality is here: */
         static::saving(function ($model) {
@@ -81,7 +87,7 @@ trait LogsChanges {
         // target_id and target_type?
         // need IP and user-agent!!!!!
         $logAction->created_by = auth()->id();
-        $logAction->log_meta = json_encode($this->meta); // this gets weird on 'create'
+        $logAction->log_meta = $this->meta ? json_encode($this->meta) : null; // this gets weird on 'create'
         if($logAction->save()) {
             //success! Reset for more actions later...
             $this->action_type = null;

--- a/app/Presenters/ActionlogPresenter.php
+++ b/app/Presenters/ActionlogPresenter.php
@@ -102,7 +102,7 @@ class ActionlogPresenter extends Presenter
             return 'fa-solid fa-rotate-right';
         }
 
-        if ($this->action_type == 'note_added') {
+        if ($this->action_type == 'note added') {
             return 'fas fa-sticky-note';
         }
 

--- a/database/migrations/2025_10_22_144927_migrate_incorrect_action_types.php
+++ b/database/migrations/2025_10_22_144927_migrate_incorrect_action_types.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+
+        /**
+         * So the concern here is that the following statement _could_ take a long time - the action_logs table is not indexed
+         * against the action_type column (and shouldn't be) so this could take a few beats. But, still, we're not talking about
+         * a particularly wide table or anything; we've certainly heard about a couple of times where people had a few million
+         * action_logs but, again, not too many more than that.
+         *
+         * But @snipe has mentioned multiple times that in some older migrations, trying to run an UPDATE in batch, there were
+         * memory issues.
+         *
+         * I've investigated and it looks like we've rarely or never done a 'batch update' the way we do below. I'm pretty sure
+         * it will be fine (famous last words...)
+         * */
+
+        DB::table('action_logs')->where('action_type', 'request_canceled')->update(['action_type' => 'request canceled']);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // no down migration for this one
+    }
+};

--- a/database/migrations/2025_10_22_144927_migrate_incorrect_action_types.php
+++ b/database/migrations/2025_10_22_144927_migrate_incorrect_action_types.php
@@ -13,16 +13,9 @@ return new class extends Migration
     {
 
         /**
-         * So the concern here is that the following statement _could_ take a long time - the action_logs table is not indexed
-         * against the action_type column (and shouldn't be) so this could take a few beats. But, still, we're not talking about
-         * a particularly wide table or anything; we've certainly heard about a couple of times where people had a few million
-         * action_logs but, again, not too many more than that.
-         *
-         * But @snipe has mentioned multiple times that in some older migrations, trying to run an UPDATE in batch, there were
-         * memory issues.
-         *
-         * I've investigated and it looks like we've rarely or never done a 'batch update' the way we do below. I'm pretty sure
-         * it will be fine (famous last words...)
+         * We actually *do* have an index on action_type, so this query shouldn't take too terribly long. I don't know
+         * that we have a ton of people canceling requests (and only certain types of request-cancellation use this
+         * erroneous action_type), so I feel pretty comfortable with this fixup. Fingers crossed!
          * */
 
         DB::table('action_logs')->where('action_type', 'request_canceled')->update(['action_type' => 'request canceled']);

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -1081,6 +1081,8 @@
 
         var item_destination = '';
         var item_icon;
+        var full_url = '';
+        var url_name = '';
 
         if ((value) && (value.type)) {
 
@@ -1111,13 +1113,29 @@
             } else if (value.type == 'model') {
                 item_destination = 'models'
                 item_icon = '';
+            } else if (value.type == 'category') {
+                item_destination = 'categories';
+            } else if (value.type == 'setting') {
+                full_url = 'admin';
+                url_name = '{{ trans('general.settings') }}';
+            } else if (value.type == 'customField' || value.type == 'customFieldset') {
+                full_url = 'fields';
+                url_name = '{{ trans('admin/custom_fields/general.custom_fields') }}'; //doesn't show META - FIXME!!!
+            } else if (value.type == 'predefinedKit') {
+                item_destination = 'kits';
+            } else if (value.type == 'reportTemplate') {
+                item_destination = 'reports/templates';
+            } else {
+                item_destination = value.type + 's'; //dumb pluralization
             }
 
             // display the username if it's checked out to a user, but don't do it if the username's there already
             if (value.username && !value.name.match('\\(') && !value.name.match('\\)')) {
                 value.name = value.name + ' (' + value.username + ')';
             }
-
+            if (full_url && url_name) { // TODO - I don't like how this looks/works
+                return '<nobr><a href="{{ config('app.url') }}/' + full_url + '" data-tooltip="true" title="' + value.type + '"><i class="' + item_icon + ' text-{{ $snipeSettings->skin!='' ? $snipeSettings->skin : 'blue' }} "></i>' + url_name + '</a></nobr>';
+            }
             return '<nobr><a href="{{ config('app.url') }}/' + item_destination +'/' + value.id + '" data-tooltip="true" title="' + value.type + '"><i class="' + item_icon + ' text-{{ $snipeSettings->skin!='' ? $snipeSettings->skin : 'blue' }} "></i> ' + value.name + '</a></nobr>';
 
         } else {


### PR DESCRIPTION
(This change is 'stacked' against the other PR I have open about the action_type Enum).

This is the start of the universal 'LogsChanges' trait, which we should be able to apply to things like Categories, and Status Labels, and other things like that, so we can log any changes that are made to settings or configuration.

Right now, it does successfully log creation, deletion, updates, and restores. I expect to apply it to most of the Models that we have that aren't "checkoutable".

The output you get in the action_logs looks roughly correct, but the links back to the original objects don't work yet (of course).

Does this approach make sense? Should I try to fill out just _one_ Model (I'm using Categories for my sample case), or should I just apply it everywhere? I'm pretty sure I can also log changes to the Settings table the exact same way - the very same `log_meta` should be able to report back anything that changes on the table like any other.

# Open Questions
- [ ] Did I miss any tables that I should be recording?
- [ ] Are there any other tables that should be in the new adminlogs table, because they are 'sensitive'?
- [ ] Do I need to put something together to be able to view the adminlogs, or are we OK with just recording those changes for now?
- [ ] Is there something else I should be doing in the Actionlog "Activity Report" - I don't know which icons I should use to represent things like "Permission Groups" or "Labels" or whatever?
- [ ] Are we OK with not adding new History tabs to the various objects that we're now recording?
- [ ] Should I be setting 'targets' on these actionlogs? I'm leaving them `null` for now
- [ ] I switched Location from using the `Loggable` trait to the new `LogsChanges` trait. I only saw one place where any `logBlah()` method was used (on 'restore' from soft-deleted) - and that use-case is at least fully subsumed by `LogsChanges`. Did I miss something, or are there any other reasons to stick with `Loggable` here?