### PR TITLE
Adds Label QR code options

### DIFF
--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -144,19 +144,25 @@ class Label implements View
                             case 'ht_tag': 
                                 $barcode2DTarget = route('ht/assetTag', $asset->asset_tag); 
                                 break;
-                            case 'plain_asset_id': 
+                            case 'location':
+                                $barcode2DTarget = $asset->location_id
+                                    ? route('locations.show', $asset->location_id)
+                                    : null;
+                                break;
+                            case 'plain_asset_id':
                                 $barcode2DTarget = (string) $asset->id; 
                                 break;
                             case 'plain_asset_tag': 
                                 $barcode2DTarget = $asset->asset_tag; 
                                 break;
                             case 'plain_serial_number': 
-                                $barcode2DTarget = $asset->serial; 
+                                $barcode2DTarget = $asset->serial ?? 'None';
                                 break;
-                            case 'location':
-                                $barcode2DTarget = $asset->location_id
-                                    ? route('locations.show', $asset->location_id)
-                                    : null;
+                            case 'plain_model_number':
+                                $barcode2DTarget = $asset->model_id;
+                                break;
+                            case 'plain_manufacturer':
+                                $barcode2DTarget = $asset->model->manufacturer ?? '';
                                 break;
                             case 'hardware_id':
                             default:

--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -158,11 +158,11 @@ class Label implements View
                             case 'plain_serial_number': 
                                 $barcode2DTarget = $asset->serial ?? 'None';
                                 break;
-                            case 'plain_model_number':
-                                $barcode2DTarget = $asset->model_id;
+                            case 'plain_model_name':
+                                $barcode2DTarget = $asset->model->name;
                                 break;
                             case 'plain_manufacturer':
-                                $barcode2DTarget = $asset->model->manufacturer ?? '';
+                                $barcode2DTarget = $asset->model->manufacturer?->name ?? '';
                                 break;
                             case 'hardware_id':
                             default:

--- a/resources/views/settings/labels.blade.php
+++ b/resources/views/settings/labels.blade.php
@@ -304,11 +304,11 @@
                                         :options="['hardware_id'=>'/hardware/{id} ('.trans('admin/settings/general.default').')',
                                                    'ht_tag'=>'/ht/{asset_tag}',
                                                    'location' => '/location/{location_id}',
-                                                   'plain_asset_tag' => '{asset_tag}',
-                                                   'plain_serial_number' => '{serial_number}',
-                                                   'plain_model_number' => '{model_id}',
-                                                   'plain_asset_id' => '{asset_id}',
-                                                   'plain_manufacturer' => '{manufacturer}',
+                                                   'plain_asset_id' => 'Asset Id',
+                                                   'plain_asset_tag' => 'Asset Tag',
+                                                   'plain_serial_number' => 'Serial Number',
+                                                   'plain_model_name' => 'Model Name',
+                                                   'plain_manufacturer' => 'Manufacturer Name',
                                                    ]"
                                         :selected="old('label2_2d_target', $setting->label2_2d_target)"
                                         class="col-md-4"

--- a/resources/views/settings/labels.blade.php
+++ b/resources/views/settings/labels.blade.php
@@ -304,6 +304,11 @@
                                         :options="['hardware_id'=>'/hardware/{id} ('.trans('admin/settings/general.default').')',
                                                    'ht_tag'=>'/ht/{asset_tag}',
                                                    'location' => '/location/{location_id}',
+                                                   'plain_asset_tag' => '{asset_tag}',
+                                                   'plain_serial_number' => '{serial_number}',
+                                                   'plain_model_number' => '{model_id}',
+                                                   'plain_asset_id' => '{asset_id}',
+                                                   'plain_manufacturer' => '{manufacturer}',
                                                    ]"
                                         :selected="old('label2_2d_target', $setting->label2_2d_target)"
                                         class="col-md-4"


### PR DESCRIPTION
This adds several options for the QR code options for labels. Such as Model Name, Location, Serial, Asset Tag and Asset ID. This does not add Custom Fields.
<img width="620" height="287" alt="image" src="https://github.com/user-attachments/assets/45a18c21-bd84-4a12-8063-28f4c2432345" />
