### PR TITLE
Override unique_undeleted in the form request

### DIFF
--- a/app/Http/Requests/UpdateAssetRequest.php
+++ b/app/Http/Requests/UpdateAssetRequest.php
@@ -52,7 +52,7 @@ class UpdateAssetRequest extends ImageUploadRequest
 
         // if the purchase cost is passed in as a string **and** the digit_separator is ',' (as is common in the EU)
         // then we tweak the purchase_cost rule to make it a string
-        if (Setting::getSettings()->digit_separator === '1.234,56' && is_string($this->input('purchase_cost'))) {
+        if ($setting->digit_separator === '1.234,56' && is_string($this->input('purchase_cost'))) {
             $rules['purchase_cost'] = ['nullable', 'string'];
         }
 

--- a/app/Http/Requests/UpdateAssetRequest.php
+++ b/app/Http/Requests/UpdateAssetRequest.php
@@ -33,7 +33,9 @@ class UpdateAssetRequest extends ImageUploadRequest
         $rules = array_merge(
             parent::rules(),
             (new Asset)->getRules(),
-            // this is to overwrite rulesets that include required, and rewrite unique_undeleted
+            // This overwrites the rulesets that are set at the model level (via Watson) but are not necessarily required at the request level when doing a PATCH update.
+            // Confusingly, this skips the unique_undeleted validator at the model level (and therefor the UniqueUndeletedTrait), so we have to re-add those
+            // rules here without the requiredness, since those values will already exist if you're updating an existing asset.
             [
                 'model_id'  => ['integer', 'exists:models,id,deleted_at,NULL', 'not_array'],
                 'status_id' => ['integer', 'exists:status_labels,id'],
@@ -42,7 +44,7 @@ class UpdateAssetRequest extends ImageUploadRequest
                     Rule::unique('assets', 'asset_tag')->ignore($this->asset)->withoutTrashed(),
                 ],
                 'serial' => [
-                    'nullable', 'string', 'max:255', 'not_array',
+                    'string', 'max:255', 'not_array',
                     $setting->unique_serial=='1' ? Rule::unique('assets', 'serial')->ignore($this->asset)->withoutTrashed() : 'nullable',
                 ],
             ],

--- a/app/Http/Requests/UpdateAssetRequest.php
+++ b/app/Http/Requests/UpdateAssetRequest.php
@@ -34,7 +34,7 @@ class UpdateAssetRequest extends ImageUploadRequest
             parent::rules(),
             (new Asset)->getRules(),
             // This overwrites the rulesets that are set at the model level (via Watson) but are not necessarily required at the request level when doing a PATCH update.
-            // Confusingly, this skips the unique_undeleted validator at the model level (and therefor the UniqueUndeletedTrait), so we have to re-add those
+            // Confusingly, this skips the unique_undeleted validator at the model level (and therefore the UniqueUndeletedTrait), so we have to re-add those
             // rules here without the requiredness, since those values will already exist if you're updating an existing asset.
             [
                 'model_id'  => ['integer', 'exists:models,id,deleted_at,NULL', 'not_array'],

--- a/app/Http/Requests/UpdateAssetRequest.php
+++ b/app/Http/Requests/UpdateAssetRequest.php
@@ -28,6 +28,8 @@ class UpdateAssetRequest extends ImageUploadRequest
      */
     public function rules()
     {
+        $setting = Setting::getSettings();
+
         $rules = array_merge(
             parent::rules(),
             (new Asset)->getRules(),
@@ -37,7 +39,11 @@ class UpdateAssetRequest extends ImageUploadRequest
                 'status_id' => ['integer', 'exists:status_labels,id'],
                 'asset_tag' => [
                     'min:1', 'max:255', 'not_array',
-                    Rule::unique('assets', 'asset_tag')->ignore($this->asset)->withoutTrashed()
+                    Rule::unique('assets', 'asset_tag')->ignore($this->asset)->withoutTrashed(),
+                ],
+                'serial' => [
+                    'nullable', 'string', 'max:255', 'not_array',
+                    $setting->unique_serial=='1' ? Rule::unique('assets', 'serial')->ignore($this->asset)->withoutTrashed() : 'nullable',
                 ],
             ],
         );


### PR DESCRIPTION
Not sure where this broke, but it looks like the UniqueUndeletedTrait isn't actually being invoked here, at least not on a PATCH update via the API, so it wasn't seeing its own ID, causing an erroneous "The serial must be unique" validation error when updating the original asset in the API.

This is a stab at correcting that to fix #18021