### PR TITLE
Adds #17685 better warning for bulk status change to undeployable type

### DIFF
--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -409,7 +409,6 @@ class BulkAssetsController extends Controller
                     $unassigned = $asset->assigned_to == '';
                     $deployable = $updated_status->deployable == '1' && $asset->assetstatus?->deployable == '1';
                     $pending =  $updated_status->pending === 1;
-
                     if ($unassigned || $deployable || $pending) {
                         $this->update_array['status_id'] = $updated_status->id;
                     }

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -409,6 +409,7 @@ class BulkAssetsController extends Controller
                     $unassigned = $asset->assigned_to == '';
                     $deployable = $updated_status->deployable == '1' && $asset->assetstatus?->deployable == '1';
                     $pending =  $updated_status->pending === 1;
+
                     if ($unassigned || $deployable || $pending) {
                         $this->update_array['status_id'] = $updated_status->id;
                     }

--- a/resources/lang/en-US/admin/hardware/form.php
+++ b/resources/lang/en-US/admin/hardware/form.php
@@ -57,7 +57,7 @@ return [
     'asset_location_update_default' => 'Update only default location',
     'asset_location_update_actual' => 'Update only actual location',
     'asset_not_deployable' => 'That asset status is not deployable. This asset cannot be checked out.',
-    'asset_not_deployable_checkin' => '{1} That asset status is not deployable. Using this status label will check in the asset.|[2,*] That asset status in not deployable. Using this status label will check in all checked out assets.',
+    'asset_not_deployable_checkin' => '{1} That asset status is not deployable. Using this status label will check in the asset.|[2,*] That asset status in not deployable. Using this status label will result in no change.',
     'asset_deployable' => 'This asset can be checked out.',
     'processing_spinner' => 'Processing... (This might take a bit of time on large files)',
     'processing' => 'Processing... ',

--- a/resources/lang/en-US/admin/hardware/form.php
+++ b/resources/lang/en-US/admin/hardware/form.php
@@ -57,7 +57,7 @@ return [
     'asset_location_update_default' => 'Update only default location',
     'asset_location_update_actual' => 'Update only actual location',
     'asset_not_deployable' => 'That asset status is not deployable. This asset cannot be checked out.',
-    'asset_not_deployable_checkin' => 'That asset status is not deployable. Using this status label will checkin the asset.',
+    'asset_not_deployable_checkin' => '{1} That asset status is not deployable. Using this status label will check in the asset.|[2,*] That asset status in not deployable. Using this status label will check in all checked out assets.',
     'asset_deployable' => 'This asset can be checked out.',
     'processing_spinner' => 'Processing... (This might take a bit of time on large files)',
     'processing' => 'Processing... ',

--- a/resources/lang/en-US/admin/hardware/form.php
+++ b/resources/lang/en-US/admin/hardware/form.php
@@ -58,7 +58,7 @@ return [
     'asset_location_update_actual' => 'Update only actual location',
     'asset_not_deployable' => 'That asset status is not deployable. This asset cannot be checked out.',
     'asset_not_deployable_checkin' => '{1} That asset status is not deployable. Using this status label will check in the asset.|[2,*] That asset status in not deployable. Using this status label will result in no change.',
-    'asset_deployable' => 'This asset can be checked out.',
+    'asset_deployable' => '{1} This asset can be checked out.|[2,*] These assets can be checked out.',
     'processing_spinner' => 'Processing... (This might take a bit of time on large files)',
     'processing' => 'Processing... ',
     'optional_infos'  => 'Optional Information',

--- a/resources/views/hardware/bulk.blade.php
+++ b/resources/views/hardware/bulk.blade.php
@@ -133,6 +133,7 @@
                   aria-label="status_id"
               />
               <p class="help-block">{{ trans('general.status_compatibility') }}</p>
+                <p id="selected_status_status" style="display:none;"></p>
               {!! $errors->first('status_id', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
             </div>
           </div>
@@ -288,5 +289,39 @@
         });
       });
     });
+    function status_check() {
+        var status_id = $('select[name="status_id"]').val();
+        if (status_id != '') {
+            $(".status_spinner").css("display", "inline");
+            $.ajax({
+                url: "{{config('app.url') }}/api/v1/statuslabels/" + status_id + "/deployable",
+                headers: {
+                    "X-Requested-With": 'XMLHttpRequest',
+                    "X-CSRF-TOKEN": $('meta[name="csrf-token"]').attr('content')
+                },
+                success: function (data) {
+                    $(".status_spinner").css("display", "none");
+                    $("#selected_status_status").fadeIn();
+
+                    if (data == true) {
+                        $("#selected_status_status").removeClass('text-danger');
+                        $("#selected_status_status").addClass('text-success');
+                        $("#selected_status_status").html('<x-icon type="checkmark" /> {{ trans('admin/hardware/form.asset_deployable')}}');
+
+
+                    } else {
+                        $("#assignto_selector").hide();
+                        $("#selected_status_status").removeClass('text-success');
+                        $("#selected_status_status").addClass('text-danger');
+                        $("#selected_status_status").html('<x-icon type="warning" /> {{ trans_choice('admin/hardware/form.asset_not_deployable_checkin', 2) }} ');
+                    }
+                }
+            });
+        }
+    }
+    $(function () {
+        $('select[name="status_id"]').on('change', status_check);
+    });
+
   </script>
 @endsection

--- a/resources/views/hardware/bulk.blade.php
+++ b/resources/views/hardware/bulk.blade.php
@@ -313,7 +313,8 @@
                         $("#assignto_selector").hide();
                         $("#selected_status_status").removeClass('text-success');
                         $("#selected_status_status").addClass('text-danger');
-                        $("#selected_status_status").html('<x-icon type="warning" /> {{ trans_choice('admin/hardware/form.asset_not_deployable_checkin', 2) }} ');
+                        $("#selected_status_status").html("<x-icon type=\"warning\" /> {{ trans_choice('admin/hardware/form.asset_not_deployable_checkin', 2) }} ");
+
                     }
                 }
             });

--- a/resources/views/hardware/bulk.blade.php
+++ b/resources/views/hardware/bulk.blade.php
@@ -306,7 +306,7 @@
                     if (data == true) {
                         $("#selected_status_status").removeClass('text-danger');
                         $("#selected_status_status").addClass('text-success');
-                        $("#selected_status_status").html('<x-icon type="checkmark" /> {{ trans('admin/hardware/form.asset_deployable')}}');
+                        $("#selected_status_status").html('<x-icon type="checkmark" /> {{ trans_choice('admin/hardware/form.asset_deployable', 2)}}');
 
 
                     } else {


### PR DESCRIPTION
if an undeployable status type is selected, we double down on the warning that no changes will be applied to the status of the selected items.

<img width="732" height="140" alt="image" src="https://github.com/user-attachments/assets/e4efdd83-fa40-4c27-a984-ffc918067a94" />

<img width="772" height="159" alt="Image" src="https://github.com/user-attachments/assets/8cd7ac34-8f10-497c-a4dc-4f7af244797e" />
Improves: #17685 
