### PR TITLE
Fixes #18138 redirect to Previous Page from accessories edit screen

### DIFF
--- a/app/Http/Controllers/Accessories/AccessoriesController.php
+++ b/app/Http/Controllers/Accessories/AccessoriesController.php
@@ -182,7 +182,11 @@ class AccessoriesController extends Controller
 
             $accessory = $request->handleImages($accessory);
 
-            session()->put(['redirect_option' => $request->get('redirect_option')]);
+            if($request->get('redirect_option') === 'back'){
+                session()->put(['redirect_option' => 'index']);
+            } else {
+                session()->put(['redirect_option' => $request->get('redirect_option')]);
+            }
 
             if ($accessory->save()) {
                 return Helper::getRedirectOption($request, $accessory->id, 'Accessories')


### PR DESCRIPTION
This fixes the update method to redirect back to accessories index after editing an accessory.

Fixes:
#18138 