### PR TITLE
Adds #7418 Option to Toggle requestables to only include unassigned && deployable

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -1297,7 +1297,7 @@ class AssetsController extends Controller
         $offset = ($request->input('offset') > $assets->count()) ? $assets->count() : app('api_offset_value');
         $limit = app('api_limit_value');
 
-        $total = (clone $assets)->count();
+        $total = $assets->count();
         $assets = $assets->skip($offset)->take($limit)->get();
 
         return (new AssetsTransformer)->transformRequestedAssets($assets, $total);

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -1225,6 +1225,7 @@ class AssetsController extends Controller
      */
     public function requestable(Request $request): JsonResponse | array
     {
+
         $this->authorize('viewRequestable', Asset::class);
 
         $allowed_columns = [
@@ -1256,9 +1257,6 @@ class AssetsController extends Controller
                 'supplier',
                 'requests'
             );
-
-
-
 
         if ($request->filled('search')) {
             $assets->TextSearch($request->input('search'));
@@ -1299,7 +1297,7 @@ class AssetsController extends Controller
         $offset = ($request->input('offset') > $assets->count()) ? $assets->count() : app('api_offset_value');
         $limit = app('api_limit_value');
 
-        $total = $assets->count();
+        $total = (clone $assets)->count();
         $assets = $assets->skip($offset)->take($limit)->get();
 
         return (new AssetsTransformer)->transformRequestedAssets($assets, $total);

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -331,6 +331,7 @@ class SettingsController extends Controller
             }
         }
 
+        $setting->request_unassigned_deployable = $request->input('request_unassigned_deployable', '0');
         $setting->unique_serial = $request->input('unique_serial', '0');
         $setting->shortcuts_enabled = $request->input('shortcuts_enabled', '0');
         $setting->show_images_in_email = $request->input('show_images_in_email', '0');

--- a/app/Http/Controllers/ViewAssetsController.php
+++ b/app/Http/Controllers/ViewAssetsController.php
@@ -155,7 +155,30 @@ class ViewAssetsController extends Controller
     public function getRequestableIndex() : View
     {
         $assets = Asset::with('model', 'defaultLoc', 'location', 'assignedTo', 'requests')->Hardware()->RequestableAssets();
-        $models = AssetModel::with('category', 'requests', 'assets')->RequestableModels()->get();
+            $onlyUnassignedDeployable = Setting::getSettings()->request_unassigned_deployable;
+        $models = AssetModel::with([
+            'category',
+            'requests',
+            'assets' => function ($q) use ($onlyUnassignedDeployable) {
+                if ($onlyUnassignedDeployable) {
+                    // Unassigned + deployable (not archived)
+                    $q->whereNull('assets.assigned_to')
+                        ->whereHas('assetstatus', function ($s) {
+                            $s->where('deployable', 1);
+                        });
+                } else {
+                    // Requestable + (deployable OR pending) but never archived
+                    $q->where('requestable', 1)
+                        ->whereHas('assetstatus', function ($s) {
+                            $s->where('archived', 0)
+                                ->where(function ($s) {
+                                    $s->where('deployable', 1)
+                                        ->orWhere('pending', 1);
+                                });
+                        });
+                }
+            },
+        ])->RequestableModels()->get();
 
         return view('account/requestable-assets', compact('assets', 'models'));
     }

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -1655,10 +1655,19 @@ class Asset extends Depreciable
     public function scopeRequestableAssets($query): Builder
     {
         $table = $query->getModel()->getTable();
+        $query = Company::scopeCompanyables($query->where($table . '.requestable', '=', 1));
+        $onlyUnassignedDeployable = Setting::getSettings()->request_unassigned_deployable;
 
-        return Company::scopeCompanyables($query->where($table.'.requestable', '=', 1))
-        ->whereHas(
-            'assetstatus', function ($query) {
+        if ($onlyUnassignedDeployable) {
+            // Unassigned + Deployable ONLY
+            $query
+                ->whereNull($table . '.assigned_to')
+                ->whereHas('assetstatus', function ($q) {
+                    $q->where('deployable', 1)
+                        ->where('archived', 0);
+                });
+        } else {
+            $query->whereHas('assetstatus', function ($query) {
                 $query->where(
                     function ($query) {
                         $query->where('deployable', '=', 1)
@@ -1666,7 +1675,9 @@ class Asset extends Depreciable
                     }
                 )->orWhere('pending', '=', 1); // we've decided that even though an asset may be 'pending', you can still request it
             }
-        );
+            );
+        }
+            return $query;
     }
 
 

--- a/database/migrations/2025_11_05_225413_add_request_only_deployable_to_settings_table.php
+++ b/database/migrations/2025_11_05_225413_add_request_only_deployable_to_settings_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->boolean('request_unassigned_deployable')->after('unique_serial')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->dropColumn('request_unassigned_deployable');
+        });
+    }
+};

--- a/resources/lang/en-US/admin/settings/general.php
+++ b/resources/lang/en-US/admin/settings/general.php
@@ -413,6 +413,8 @@ return [
     'default_avatar_help' => 'This image will be displayed as a profile if a user does not have a profile photo.',
     'restore_default_avatar' => 'Restore <a href=":default_avatar" data-toggle="lightbox" data-type="image">original system default avatar</a>',
     'restore_default_avatar_help' => '',
+    'request_unassigned_deployable_help_text' => 'Only assets with a status type of deployable and that are unassigned will be shown under requestable assets.',
+    'request_unassigned_deployable' => 'Request Unassigned Deployable Assets Only',
     'due_checkin_days' => 'Due For Checkin Warning',
     'due_checkin_days_help' => 'How many days before the expected checkin of an asset should it be listed in the "Due for checkin" page?',
     'no_groups' => 'No groups have been created yet. Visit <code>Admin Settings > Permission Groups</code> to add one.',

--- a/resources/views/account/requestable-assets.blade.php
+++ b/resources/views/account/requestable-assets.blade.php
@@ -135,7 +135,7 @@
                                                     @endcan
                                                 </td>
 
-                                                <td>{{$requestableModel->assets->where('requestable', '1')->count()}}</td>
+                                                <td>{{'requestable '.$requestableModel->assets->where('requestable', '1')->count()}} {{'Unrequestable '.$requestableModel->assets->where('requestable', '0')->count()}}</td>
 
                                                 <td>
                                                     <form  action="{{ route('account/request-item', ['itemType' => 'asset_model', 'itemId' => $requestableModel->id])}}" method="POST" accept-charset="utf-8">

--- a/resources/views/settings/general.blade.php
+++ b/resources/views/settings/general.blade.php
@@ -435,6 +435,21 @@
                                    </div>
                                </div>
 
+                           <!-- Request only Unassigned Deployable Assets -->
+                           <div class="form-group">
+                               <div class="col-md-8 col-md-offset-3">
+                                   <label class="form-control">
+                                       <input type="checkbox" name="request_unassigned_deployable" value="1" @checked(old('request_unassigned_deployable', $setting->request_unassigned_deployable)) />
+                                       {{ trans('admin/settings/general.request_unassigned_deployable') }}
+                                       {!! $errors->first('request_unassigned_deployable', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                   </label>
+
+                                   <p class="help-block">
+                                       {{ trans('admin/settings/general.request_unassigned_deployable_help_text') }}
+                                   </p>
+                               </div>
+                           </div>
+
                            <!-- Manager View -->
                            <div class="form-group {{ $errors->has('manager_view_enabled') ? 'error' : '' }}">
                                <div class="col-md-3">


### PR DESCRIPTION
This adds an option in the general settings under Miscellaneous to toggle requestables to only include Unassigned & Deployable assets.
As some workflows only care about what is available now and dont want/need a queue of who gets what next.

<img width="674" height="454" alt="image" src="https://github.com/user-attachments/assets/9b96a3df-4d03-434e-96d8-a45ccfd7b3cf" />

Here you see 1306 assets available, and the status type of pending:
<img width="987" height="678" alt="image" src="https://github.com/user-attachments/assets/089ed9c7-69fc-4328-adc2-babbb668c073" />

When toggled there are no pending and 1073:
<img width="987" height="678" alt="image" src="https://github.com/user-attachments/assets/0d4599a6-6840-4419-84cb-cc219428b303" />
Only unassigned deployable:
<img width="987" height="678" alt="image" src="https://github.com/user-attachments/assets/4303fdaa-cbf7-4f32-bd7b-11163d10e04b" />

Fixes #7418 