### PR TITLE
Updates the unaccepted assets translation to items

### DIFF
--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -327,7 +327,7 @@ return [
     'declined'			    => 'declined',
     'declined_note'         => 'Declined Notes',
     'unassigned'            => 'Unassigned',
-    'unaccepted_asset_report' => 'Unaccepted Assets',
+    'unaccepted_asset_report' => 'Unaccepted Items',
     'users'                 => 'Users',
     'viewall'				=> 'View All',
     'viewassets'  			=> 'View Assigned Items',

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -327,7 +327,7 @@ return [
     'declined'			    => 'declined',
     'declined_note'         => 'Declined Notes',
     'unassigned'            => 'Unassigned',
-    'unaccepted_asset_report' => 'Unaccepted Items',
+    'unaccepted_items_report' => 'Unaccepted Items',
     'users'                 => 'Users',
     'viewall'				=> 'View All',
     'viewassets'  			=> 'View Assigned Items',

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -839,7 +839,7 @@ dir="{{ Helper::determineLanguageDirection() }}">
                                     </li>
                                     <li {{!! (request()->is('reports/unaccepted_assets') ? ' class="active"' : '') !!}}>
                                         <a href="{{ url('reports/unaccepted_assets') }}">
-                                            {{ trans('general.unaccepted_asset_report') }}
+                                            {{ trans('general.unaccepted_items_report') }}
                                         </a>
                                     </li>
                                     <li  {{!! (request()->is('reports/accessories') ? ' class="active"' : '') !!}}>

--- a/resources/views/reports/unaccepted_assets.blade.php
+++ b/resources/views/reports/unaccepted_assets.blade.php
@@ -4,7 +4,7 @@
 
 {{-- Page title --}}
 @section('title')
-    {{ trans('general.unaccepted_asset_report') }}
+    {{ trans('general.unaccepted_items_report') }}
     @parent
 @stop
 


### PR DESCRIPTION
Updates the `Unaccepted Assets` translation variable to `Unaccepted Items`
<img width="1245" height="791" alt="image" src="https://github.com/user-attachments/assets/d294bbc6-5531-450b-96d1-10ecf5487877" />

routes have not been changed here.
