### PR TITLE
Fixes FD51910 requestable asset model available quantity count

### DIFF
--- a/app/Http/Controllers/ViewAssetsController.php
+++ b/app/Http/Controllers/ViewAssetsController.php
@@ -156,7 +156,6 @@ class ViewAssetsController extends Controller
     public function getRequestableIndex() : View
     {
         $assets = Asset::with('model', 'defaultLoc', 'location', 'assignedTo', 'requests')->Hardware()->RequestableAssets();
-            $onlyUnassignedDeployable = Setting::getSettings()->request_unassigned_deployable;
         $models = AssetModel::with([
             'category',
             'requests',


### PR DESCRIPTION
This adjusts the asset model query to search for only deployable or pending and excludes archived assets. Assets have to be requestable as well.
Before under Asset Models: 
<img width="800" height="305" alt="image" src="https://github.com/user-attachments/assets/3d0cb081-f8ef-489b-b124-387d6830175e" />
After:
<img width="912" height="357" alt="image" src="https://github.com/user-attachments/assets/05f1f3fb-9bec-4405-b066-de896893856b" />

The count for macbook pros in this case under assets is the same now:
<img width="277" height="215" alt="image" src="https://github.com/user-attachments/assets/c4bff37d-c167-4c32-9cba-650a2d72a1f9" />

Fixes FD51910 