### PR TITLE
Fixed potential exception while filtering in users index endpoint

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -162,6 +162,11 @@ class UsersController extends Controller
 
         if ($request->filled('filter')) {
             $filter = json_decode($request->input('filter'), true);
+
+            if (is_null($filter)) {
+                $filter = [];
+            }
+
             $filter = array_filter($filter, function ($key) use ($allowed_columns) {
                 return in_array($key, $allowed_columns);
             }, ARRAY_FILTER_USE_KEY);

--- a/tests/Feature/Users/Api/IndexUsersTest.php
+++ b/tests/Feature/Users/Api/IndexUsersTest.php
@@ -57,4 +57,14 @@ class IndexUsersTest extends TestCase
                 ->etc();
         });
     }
+
+    public function test_gracefully_handles_malformed_filter()
+    {
+        $this->actingAsForApi(User::factory()->viewUsers()->create())
+            ->getJson(route('api.users.index', [
+                // filter should be a json encoded array and not a string
+                'filter' => 'email:an-email-address@example.com',
+            ]))
+            ->assertOk();
+    }
 }


### PR DESCRIPTION
This PR prevents a 500 exception caused by passing invalid json to the users index api endpoint via the `filter` parameter.

---

RB-20512
RB-20513
