### PR TITLE
Fixed #18202 - copy to clipboard adding spaces in FF

### DIFF
--- a/resources/views/blade/copy-to-clipboard.blade.php
+++ b/resources/views/blade/copy-to-clipboard.blade.php
@@ -7,9 +7,8 @@
     <span class="sr-only">{{ trans('general.copy_to_clipboard') }}</span>
 </i>
 
+{{--There must not be any spaces or line breaks between the js-copy span and the slot, or it will add a space before the copied value in Firefox :( --}}
 @if (!$slot->isEmpty())
-<span class="js-copy-{{ $copy_what }}">
-    {{ $slot }}
-</span>
+<span class="js-copy-{{ $copy_what }}">{{ $slot }}</span>
 @endif
 

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -437,9 +437,7 @@
                                                 <strong>{{ trans('admin/hardware/form.tag') }}</strong>
                                             </div>
                                             <div class="col-md-9">
-                                                <x-copy-to-clipboard copy_what="assettag">
-                                                    {{ $asset->asset_tag  }}
-                                                </x-copy-to-clipboard>
+                                                <x-copy-to-clipboard copy_what="assettag">{{ $asset->asset_tag  }}</x-copy-to-clipboard>
                                             </div>
                                         </div>
                                     @endif
@@ -724,7 +722,6 @@
                                                         {{-- Hidden span used as copy target --}}
                                                         {{-- It's tempting to break out the HTML into separate lines for this, but it results in extra spaces being added onto the end of the copied value --}}
                                                         @if (($field->field_encrypted=='1') && (Gate::allows('assets.view.encrypted_custom_fields')))
-
                                                             <span class="js-copy-{{ $field->id }} visually-hidden hidden-print" style="font-size: 0px;">{{ ($field->isFieldDecryptable($asset->{$field->db_column_name()}) ? Helper::gracefulDecrypt($field, $asset->{$field->db_column_name()}) : $asset->{$field->db_column_name()}) }}</span>
                                                         @elseif (($field->field_encrypted=='1') && (Gate::denies('assets.view.encrypted_custom_fields')))
                                                             <span class="js-copy-{{ $field->id }} visually-hidden hidden-print" style="font-size: 0px;">{{ strtoupper(trans('admin/custom_fields/general.encrypted')) }}</span>

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -999,7 +999,7 @@
             }
         };
     }
-    
+
 
     function colorTagFormatter(value, row) {
         if (value) {


### PR DESCRIPTION
This removes the space in the copy-to-clipboard blade component which was causing leading spaces in Firefox, even though HTML shouldn't care about empty spaces. 

Fixes #18202