### PR TITLE
Fixed #18024 License Seat update/patch method

### DIFF
--- a/app/Http/Controllers/Api/LicenseSeatsController.php
+++ b/app/Http/Controllers/Api/LicenseSeatsController.php
@@ -122,17 +122,22 @@ class LicenseSeatsController extends Controller
 
         // check if this update is a checkin operation
         // 1. are relevant fields touched at all?
-        $touched = $licenseSeat->isDirty('assigned_to') || $licenseSeat->isDirty('asset_id');
-        // 2. are they cleared? if yes then this is a checkin operation
-        $is_checkin = ($touched && $licenseSeat->assigned_to === null && $licenseSeat->asset_id === null);
+        $assignmentTouched = $licenseSeat->isDirty('assigned_to') || $licenseSeat->isDirty('asset_id');
+        $anythingTouched = $licenseSeat->isDirty();
 
-        if (! $touched) {
-            // nothing to update
-            return response()->json(Helper::formatStandardApiResponse('success', $licenseSeat, trans('admin/licenses/message.update.success')));
+        if (! $anythingTouched) {
+            return response()->json(
+                Helper::formatStandardApiResponse('success', $licenseSeat, trans('admin/licenses/message.update.success'))
+            );
         }
-        if( $touched && $licenseSeat->unreassignable_seat) {
+        if( $assignmentTouched && $licenseSeat->unreassignable_seat) {
             return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/licenses/message.checkout.unavailable')));
         }
+
+        // 2. are they cleared? if yes then this is a checkin operation
+        $is_checkin = ($assignmentTouched && $licenseSeat->assigned_to === null && $licenseSeat->asset_id === null);
+        $target = null;
+
         // the logging functions expect only one "target". if both asset and user are present in the request,
         // we simply let assets take precedence over users...
         if ($licenseSeat->isDirty('assigned_to')) {
@@ -142,25 +147,23 @@ class LicenseSeatsController extends Controller
             $target = $is_checkin ? $oldAsset : Asset::find($licenseSeat->asset_id);
         }
 
-        if (is_null($target)){
+        if ($assignmentTouched && is_null($target)){
             return response()->json(Helper::formatStandardApiResponse('error', null, 'Target not found'));
         }
 
         if ($licenseSeat->save()) {
-
-            if ($is_checkin) {
-                if(!$licenseSeat->license->reassignable){
-                    $licenseSeat->unreassignable_seat = true;
-                    $licenseSeat->save();
+            if($assignmentTouched) {
+                if ($is_checkin) {
+                    if (!$licenseSeat->license->reassignable) {
+                        $licenseSeat->unreassignable_seat = true;
+                        $licenseSeat->save();
+                    }
+                    $licenseSeat->logCheckin($target, $licenseSeat->notes);
+                } else {
+                    // in this case, relevant fields are touched but it's not a checkin operation. so it must be a checkout operation.
+                    $licenseSeat->logCheckout($request->input('notes'), $target);
                 }
-                $licenseSeat->logCheckin($target, $licenseSeat->notes);
-
-                return response()->json(Helper::formatStandardApiResponse('success', $licenseSeat, trans('admin/licenses/message.update.success')));
             }
-
-            // in this case, relevant fields are touched but it's not a checkin operation. so it must be a checkout operation.
-            $licenseSeat->logCheckout($request->input('notes'), $target);
-
             return response()->json(Helper::formatStandardApiResponse('success', $licenseSeat, trans('admin/licenses/message.update.success')));
         }
 


### PR DESCRIPTION
This fixes the update/patch api method to register changes to fields when there isn't a `target` change.

Before if you were to update `notes` it would return early because there was no change to assigned_to or asset_id. Now, fields update even if there isn't a `target` change.
a note change only requires the correct parameters for the URL:
<img width="516" height="1064" alt="image" src="https://github.com/user-attachments/assets/c65c516b-9923-49d9-8513-9318f2c4f451" />
<img width="2101" height="406" alt="image" src="https://github.com/user-attachments/assets/e7727fbd-928b-4fcf-9a91-0da9b6d34f60" />
Fixes #18024
