### PR TITLE
Fixes FD-52005 Adds null safe operators to unacceptable items report

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -1148,7 +1148,9 @@ class ReportsController extends Controller
             $query->withTrashed();
         }
 
-        $itemsForReport = $query->get()->map(fn ($unaccepted) => Checkoutable::fromAcceptance($unaccepted));
+        $itemsForReport = $query->get()
+            ->filter(fn ($unaccepted) => $unaccepted->checkoutable)
+            ->map(fn ($unaccepted) => Checkoutable::fromAcceptance($unaccepted));
 
         return view('reports/unaccepted_assets', compact('itemsForReport','showDeleted' ));
     }
@@ -1288,7 +1290,9 @@ class ReportsController extends Controller
                 $acceptances->withTrashed();
             }
 
-        $itemsForReport = $acceptances->get()->map(fn ($unaccepted) => Checkoutable::fromAcceptance($unaccepted));
+        $itemsForReport = $acceptances->get()
+                ->filter(fn ($unaccepted) => $unaccepted->checkoutable)
+                ->map(fn ($unaccepted) => Checkoutable::fromAcceptance($unaccepted));
 
         $rows = [];
 

--- a/app/Models/Checkoutable.php
+++ b/app/Models/Checkoutable.php
@@ -26,7 +26,7 @@ class Checkoutable
         $acceptance = $unaccepted;
 
         $assignee = $acceptance->assignedTo;
-        $company = $unaccepted_row->company ? optional($unaccepted_row->company)->present()->nameUrl() : '';
+        $company = $unaccepted_row?->company?->present()?->nameUrl() ?? '';
         $category = $model = $name = $tag = '';
         $type = $acceptance->checkoutable_item_type ?? '';
 
@@ -70,10 +70,10 @@ class Checkoutable
             acceptance: $acceptance,
             assignee: $assignee,
             //plain text for CSVs
-            plain_text_category: ($unaccepted_row->model?->category?->name ?? $unaccepted_row->license->category?->name ?? $unaccepted_row->category?->name ?? ''),
-            plain_text_model: ($unaccepted_row->model?->name ?? $unaccepted_row->model_number ?? ''),
-            plain_text_name: ($unaccepted_row->name ?? $unaccepted_row->license?->name ?? ''),
-            plain_text_company: ($unaccepted_row->company)->name ?? $unaccepted_row->license->company?->name ?? '',
+            plain_text_category: $unaccepted_row?->model?->category?->name ?? $unaccepted_row?->license?->category?->name ?? $unaccepted_row?->category?->name ?? '',
+            plain_text_model: $unaccepted_row?->model?->name ?? $unaccepted_row?->model_number ?? '',
+            plain_text_name: $unaccepted_row?->name ?? $unaccepted_row?->license?->name ?? '',
+            plain_text_company: $unaccepted_row?->company->name ?? $unaccepted_row?->license?->company?->name ?? '',
         );
     }
 }


### PR DESCRIPTION
Filters out pending acceptances that do not have a checkoutable or where checkoutable is null, also this adds null safe operators around the `$unacceptable_rows`. Not sure how the variable could be null here, but it occurred in RB. So this should prevent that.

