### PR TITLE
Fixed [RB-20541]: Label2 Empty Row Range

### DIFF
--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -223,7 +223,7 @@ class Label implements View
                 $emptyRowsCount = (int)round($settings->label2_empty_row_count);
                 if($emptyRowsCount) {
                     // Create empty rows
-                    $emptyRows = collect(range(0, $emptyRowsCount))->map(function () {
+                    $emptyRows = collect(range(1, $emptyRowsCount))->map(function () {
                         return [
                             'label' => '',
                             'value' => '',

--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -220,7 +220,7 @@ class Label implements View
                         return $toAdd ? $myFields->push($toAdd) : $myFields;
                     }, new Collection());
 
-                (int)$emptyRowsCount = $settings->label2_empty_row_count;
+                $emptyRowsCount = (int)round($settings->label2_empty_row_count);
                 if($emptyRowsCount) {
                     // Create empty rows
                     $emptyRows = collect(range(0, $emptyRowsCount))->map(function () {

--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -220,7 +220,7 @@ class Label implements View
                         return $toAdd ? $myFields->push($toAdd) : $myFields;
                     }, new Collection());
 
-                $emptyRowsCount = $settings->label2_empty_row_count;
+                (int)$emptyRowsCount = $settings->label2_empty_row_count;
                 if($emptyRowsCount) {
                     // Create empty rows
                     $emptyRows = collect(range(0, $emptyRowsCount))->map(function () {

--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -223,7 +223,7 @@ class Label implements View
                 $emptyRowsCount = $settings->label2_empty_row_count;
                 if($emptyRowsCount) {
                     // Create empty rows
-                    $emptyRows = collect(range(1, $emptyRowsCount))->map(function () {
+                    $emptyRows = collect(range(0, $emptyRowsCount))->map(function () {
                         return [
                             'label' => '',
                             'value' => '',


### PR DESCRIPTION
This is from rollbar#20541
User was out of range due to the min being 0, but the range starting at 1.
This allows for a negative range.

This fix should prevent that from 500ing again due to being out of range.