### PR TITLE
Fixes RB-19608 adds safe guards, adds Audit notification for google workspace, adds tests

### DIFF
--- a/app/Notifications/AuditNotification.php
+++ b/app/Notifications/AuditNotification.php
@@ -33,6 +33,10 @@ class AuditNotification extends Notification
         //
         $this->settings = Setting::getSettings();
         $this->params = $params;
+        $item =  $params['item'];
+        if (!$item || !is_object($item)) {
+            throw new \InvalidArgumentException('Notification requires a valid item.');
+        }
     }
 
     /**
@@ -93,12 +97,12 @@ class AuditNotification extends Notification
             return MicrosoftTeamsMessage::create()
                 ->to($setting->webhook_endpoint)
                 ->type('success')
-                ->title(class_basename(get_class($params['item'])) .' '.trans('general.audited'))
+                ->title(class_basename($item).' '.trans('general.audited'))
                 ->addStartGroupToSection('activityText')
                 ->fact(trans('mail.asset'), $item)
                 ->fact(trans('general.administrator'), $admin_user->present()->viewUrl() . '|' . $admin_user->display_name);
         }
-            $message = class_basename(get_class($params['item'])) . ' Audited By '.$admin_user->display_name;
+            $message = class_basename(get_class($params['item'])) . trans('general.audited_by').' '.$admin_user->display_name;
             $details = [
                 trans('mail.asset') => htmlspecialchars_decode($item->display_name),
                 trans('mail.notes') => $note ?: '',

--- a/app/Notifications/AuditNotification.php
+++ b/app/Notifications/AuditNotification.php
@@ -84,6 +84,11 @@ class AuditNotification extends Notification
         $location = $params['location'] ?? '';
         $setting = Setting::getSettings();
 
+        //if somehow a notification triggers without an item, bail out.
+        if(!$item || !is_object($item)){
+            return null;
+        }
+
         if(!Str::contains($setting->webhook_endpoint, 'workflows')) {
             return MicrosoftTeamsMessage::create()
                 ->to($setting->webhook_endpoint)

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -39,6 +39,7 @@ return [
     'accept_items'          => 'Accept Items',
     'audit'				    => 'Audit',
     'audited'				=> 'Audited',
+    'audited_by'		    => 'Audited By',
     'audits'				=> 'Audits',
     'audit_report'			=> 'Audit Log',
     'assets'				=> 'Assets',

--- a/tests/Feature/Notifications/Webhooks/NotificationTests.php
+++ b/tests/Feature/Notifications/Webhooks/NotificationTests.php
@@ -36,6 +36,7 @@ class NotificationTests extends TestCase
         $webhook_options = [
             'enableSlackWebhook',
             'enableMicrosoftTeamsWebhook',
+            'enableGoogleChatWebhook'
         ];
 
         Notification::fake();

--- a/tests/Feature/Notifications/Webhooks/NotificationTests.php
+++ b/tests/Feature/Notifications/Webhooks/NotificationTests.php
@@ -1,0 +1,60 @@
+<?php
+namespace Tests\Feature\Notifications\Webhooks;
+
+use App\Models\Asset;
+use App\Models\User;
+use App\Notifications\AuditNotification;
+use Illuminate\Support\Facades\Notification;
+use PHPUnit\Framework\Attributes\Group;
+use Tests\TestCase;
+use Tests\Support\Settings;
+
+#[Group('notifications')]
+class NotificationTests extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Notification::fake();
+    }
+    public function testAuditNotificationThrowsWhenItemIsNull()
+    {
+        try {
+            new AuditNotification([
+                'item' => null,
+            ]);
+            $this->fail('Expected Error was not thrown');
+        } catch (\Throwable $e) {
+            $this->assertInstanceOf(\InvalidArgumentException::class, $e);
+            $this->assertSame('Notification requires a valid item.', $e->getMessage());
+        }
+    }
+
+    public function testAuditNotificationFires()
+    {
+        $webhook_options = [
+            'enableSlackWebhook',
+            'enableMicrosoftTeamsWebhook',
+        ];
+
+        Notification::fake();
+
+        foreach($webhook_options as $option) {
+
+            $this->settings->{$option}();
+
+            $user = User::factory()->create();
+            $item = Asset::factory()->create();
+
+            try {
+                $user->notify(new \App\Notifications\AuditNotification([
+                    'item'  => $item,
+                ]));
+            } catch (\InvalidArgumentException $e) {
+                $this->fail("AuditNotification threw for [{$option}]: {$e->getMessage()}");
+            }
+        }
+            Notification::assertSentTimes(AuditNotification::class, count($webhook_options));
+    }
+}

--- a/tests/Feature/Notifications/Webhooks/NotificationTests.php
+++ b/tests/Feature/Notifications/Webhooks/NotificationTests.php
@@ -40,7 +40,7 @@ class NotificationTests extends TestCase
         ];
 
         Notification::fake();
-
+        //tests every webhook option
         foreach($webhook_options as $option) {
 
             $this->settings->{$option}();

--- a/tests/Support/Settings.php
+++ b/tests/Support/Settings.php
@@ -98,7 +98,16 @@ class Settings
         return $this->update([
             'webhook_selected' => 'microsoft',
             'webhook_endpoint' => 'https://defaultd07ceb04416641fca1b9d3e0ac7600.84.environment.api.powerplatform.com:443/powerautomate/automations/direct/workflows/1babbc7a3cdd4cf99c0fbed4367cf147/triggers/manual/paths/invoke?api-version=1&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=sVXmAYF5luz3oOEjvN-G7mJqEEvFjBSETuAG8c3Qmkg',
-            ]);
+        ]);
+    }
+
+    public function enableGoogleChatWebhook(): Settings
+    {
+        return $this->update([
+            'webhook_selected' => 'google',
+            'webhook_botname'  => 'SnipeBot5000',
+            'webhook_endpoint' => 'https://chat.googleapis.com/v1/spaces/AAAATQckuT4/messages?key=AIzaSyDdI0hCZtE6vySjMm-WEfRq3CPzqKqqsHI&token=bZDaFDK4lO78HhHmC8BEWI6aAKkgqX2gFv2gHVAc8VQ',
+        ]);
     }
 
     public function disableSlackWebhook(): Settings

--- a/tests/Support/Settings.php
+++ b/tests/Support/Settings.php
@@ -93,6 +93,13 @@ class Settings
             'webhook_channel' => '#it',
         ]);
     }
+    public function enableMicrosoftTeamsWebhook(): Settings
+    {
+        return $this->update([
+            'webhook_selected' => 'microsoft',
+            'webhook_endpoint' => 'https://defaultd07ceb04416641fca1b9d3e0ac7600.84.environment.api.powerplatform.com:443/powerautomate/automations/direct/workflows/1babbc7a3cdd4cf99c0fbed4367cf147/triggers/manual/paths/invoke?api-version=1&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=sVXmAYF5luz3oOEjvN-G7mJqEEvFjBSETuAG8c3Qmkg',
+            ]);
+    }
 
     public function disableSlackWebhook(): Settings
     {

--- a/tests/Support/Settings.php
+++ b/tests/Support/Settings.php
@@ -97,7 +97,7 @@ class Settings
     {
         return $this->update([
             'webhook_selected' => 'microsoft',
-            'webhook_endpoint' => 'https://defaultd07ceb04416641fca1b9d3e0ac7600.84.environment.api.powerplatform.com:443/powerautomate/automations/direct/workflows/1babbc7a3cdd4cf99c0fbed4367cf147/triggers/manual/paths/invoke?api-version=1&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=sVXmAYF5luz3oOEjvN-G7mJqEEvFjBSETuAG8c3Qmkg',
+            'webhook_endpoint' => 'https://defaultd07ceb04416641fca1b9d3e0ac7600.84.environment.api.powerplatform.com:443/powerautomate/automations/direct/workflows/1babbc7a3cdd4cf99c0fbed4367cf147/triggers/manual/paths/invoke?api-version=1&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=sVXmAYF5luz3oOEjvN-G7mJqEEvFjBTuAG8c3Qmkg',
         ]);
     }
 
@@ -106,7 +106,7 @@ class Settings
         return $this->update([
             'webhook_selected' => 'google',
             'webhook_botname'  => 'SnipeBot5000',
-            'webhook_endpoint' => 'https://chat.googleapis.com/v1/spaces/AAAATQckuT4/messages?key=AIzaSyDdI0hCZtE6vySjMm-WEfRq3CPzqKqqsHI&token=bZDaFDK4lO78HhHmC8BEWI6aAKkgqX2gFv2gHVAc8VQ',
+            'webhook_endpoint' => 'https://chat.googleapis.com/v1/spaces/AAAATQckuT4/messages?key=AIzaSyDdI0hCZtE6vySjMm-WEfRq3CPzqKqqsHI&token=bZDaFDK4lO78HhHmC8BEWI6aAKkgqX2gFv2gHVAc8',
         ]);
     }
 


### PR DESCRIPTION
This adds safe guards to the Audit notification class where somehow `$item` was `null`. Now an exception is thrown before parsing `$item` for a notification.

This also adds google workspaces to audit notifications, I somehow did not add this before. But it is added now:
<img width="306" height="192" alt="image" src="https://github.com/user-attachments/assets/bd6a3e02-c605-425e-b3d8-f2fcebe587ae" />

This also adds two tests.
The first, tests the the exception throws for `$item` being `null`.

The second, tests that an Audit notification is sent. This tests delivery to Slack, Teams, and Google workspace webhooks.