### PR TITLE
Added filter form request to validate JSON

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -3,37 +3,38 @@
 namespace App\Http\Controllers\Api;
 
 use App\Events\CheckoutableCheckedIn;
-use App\Http\Requests\StoreAssetRequest;
-use App\Http\Requests\UpdateAssetRequest;
-use App\Http\Traits\MigratesLegacyAssetLocations;
-use App\Http\Transformers\ComponentsTransformer;
-use App\Models\AccessoryCheckout;
-use App\Models\CheckoutAcceptance;
-use App\Models\LicenseSeat;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Http\JsonResponse;
-use Illuminate\Support\Facades\Crypt;
-use Illuminate\Support\Facades\Gate;
 use App\Helpers\Helper;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\AssetCheckoutRequest;
+use App\Http\Requests\FilterRequest;
+use App\Http\Requests\StoreAssetRequest;
+use App\Http\Requests\UpdateAssetRequest;
+use App\Http\Traits\MigratesLegacyAssetLocations;
 use App\Http\Transformers\AssetsTransformer;
+use App\Http\Transformers\ComponentsTransformer;
 use App\Http\Transformers\LicensesTransformer;
 use App\Http\Transformers\SelectlistTransformer;
+use App\Models\AccessoryCheckout;
 use App\Models\Asset;
 use App\Models\AssetModel;
+use App\Models\CheckoutAcceptance;
 use App\Models\Company;
 use App\Models\CustomField;
 use App\Models\License;
+use App\Models\LicenseSeat;
 use App\Models\Location;
 use App\Models\Setting;
 use App\Models\User;
+use App\View\Label;
 use Carbon\Carbon;
-use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Route;
-use App\View\Label;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Validator;
 
@@ -56,7 +57,7 @@ class AssetsController extends Controller
      * @param int $assetId
      * @since [v4.0]
      */
-    public function index(Request $request, $action = null, $upcoming_status = null) : JsonResponse | array
+    public function index(FilterRequest $request, $action = null, $upcoming_status = null) : JsonResponse | array
     {
 
 

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -31,6 +31,7 @@ use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Facades\Log;
 use App\Http\Requests\DeleteUserRequest;
 use Illuminate\Http\JsonResponse;
+use App\Http\Requests\FilterRequest;
 
 class UsersController extends Controller
 {
@@ -42,7 +43,7 @@ class UsersController extends Controller
      *
      * @return array
      */
-    public function index(Request $request) : array
+    public function index(FilterRequest $request) : array
     {
         $this->authorize('view', User::class);
 

--- a/app/Http/Requests/FilterRequest.php
+++ b/app/Http/Requests/FilterRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Rules\ValidJson;
+use Illuminate\Foundation\Http\FormRequest;
+
+class FilterRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'filter' => ['nullable', new ValidJson()],
+        ];
+    }
+}

--- a/app/Rules/ValidJson.php
+++ b/app/Rules/ValidJson.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class ValidJson implements ValidationRule
+{
+    /**
+     * Run the validation rule.
+     *
+     * @param  \Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (!json_validate($value)) {
+            $fail(trans('validation.json'));
+        }
+    }
+}

--- a/tests/Feature/Users/Api/IndexUsersTest.php
+++ b/tests/Feature/Users/Api/IndexUsersTest.php
@@ -65,6 +65,36 @@ class IndexUsersTest extends TestCase
                 // filter should be a json encoded array and not a string
                 'filter' => 'email:an-email-address@example.com',
             ]))
-            ->assertOk();
+            ->assertStatusMessageIs('error')
+            ->assertJson(function (AssertableJson $json) {
+                $json->has('messages.filter')->etc();
+            });
+    }
+
+    public function testReturnsResultViaFilter()
+    {
+
+        User::factory()->count(3)->create(['first_name' => 'Awesome', 'last_name' => 'Admin', 'email' => 'awesome@example.org']);
+        $this->actingAsForApi(User::factory()->viewUsers()->create())
+            ->getJson(route('api.users.index', [
+                'filter' => '{"first_name":"Awesome","last_name":"Admin","email":"awesome@example.org"}',
+            ]))
+            ->assertOk()
+            ->assertJsonStructure([
+                'total',
+                'rows',
+            ])
+            ->assertJson(fn(AssertableJson $json) => $json->has('rows', 3)->etc());
+
+        $this->actingAsForApi(User::factory()->viewUsers()->create())
+            ->getJson(route('api.users.index', [
+                'filter' => '{"first_name":"Not Awesome"}',
+            ]))
+            ->assertOk()
+            ->assertJsonStructure([
+                'total',
+                'rows',
+            ])
+            ->assertJson(fn(AssertableJson $json) => $json->has('rows', 0)->etc());
     }
 }


### PR DESCRIPTION
This builds upon #18208 by adding a form request for the index API controllers. 

We were seeing a lot of rollbars from hosted customers where the `filter` payload being passed was invalid, being passed as `?filter=email:foo@example.org` versus the valid version, `?filter={"email":"foo@example.org"}`:

<img width="727" height="93" alt="Screenshot 2025-11-22 at 2 07 18 PM" src="https://github.com/user-attachments/assets/25ea70d2-77a5-40e9-be1d-d9b0b2b7c2eb" />

This was previously resulting in a `TypeError: array_filter(): Argument #1 ($array) must be of type array, null given` error, since we try to `json_decode()` that `filter` value. The hard error was fixed #18208, but resulted in us silently ignoring the query instead of returning a validation error, which meant the entire result set would be returned. With this PR, the result of invalid JSON there will be:

```json
{
    "status": "error",
    "messages": {
        "filter": [
            "The filter field must be a valid JSON string."
        ]
    },
    "payload": null
}
```

I suspect most people with integrations with that API filter haven't been checking the results of the query at all, since it would have been returning a hard 500, so perhaps it doesn't even matter, but this at least returns a useful error instead of potentially erroneous results where the filter was ignored.

This also adds another test and refines the existing one that was looking for the filter field.

We don't typically use form requests for the index pages, since they're not really *submitting* a form, but instead only passing query strings to search on, but this seemed like a worthwhile one since it *is* dealing with the *request*. We'll see what the other devs think though.

