### PR TITLE
adds #17422 [FD-49345] `--expired-licenses` command parameter to `snipeit:expiring-alerts`

### DIFF
--- a/app/Console/Commands/SendExpirationAlerts.php
+++ b/app/Console/Commands/SendExpirationAlerts.php
@@ -14,11 +14,11 @@ use Illuminate\Support\Facades\Mail;
 class SendExpirationAlerts extends Command
 {
     /**
-     * The console command name.
-     *
+     * The name and signature of the console command.
+ *
      * @var string
      */
-    protected $name = 'snipeit:expiring-alerts';
+    protected $signature = 'snipeit:expiring-alerts {--expired-licenses}';
 
     /**
      * The console command description.
@@ -85,7 +85,7 @@ class SendExpirationAlerts extends Command
             }
 
             // Expiring licenses
-            $licenses = License::query()->ExpiringLicenses($alert_interval)
+            $licenses = License::query()->ExpiringLicenses($alert_interval, $this->option('expired-licenses'))
                 ->with('manufacturer','category')
                 ->orderBy('expiration_date', 'ASC')
                 ->orderBy('termination_date', 'ASC')


### PR DESCRIPTION
This adds a command parameter of `--expired-licenses` to the `snipeit:expiring-alerts` command. When this is true the `ExpiringLicenses()` scope appends all expired licenses to the query.

<img width="947" height="830" alt="image" src="https://github.com/user-attachments/assets/bccabd7a-1baf-4fcc-bdc5-e7f4c51474f5" />

fixes: #17422 