### PR TITLE
Fixes [FD-52064] Avery `L6009_A` & `L4736_A` label field overflow with scaling

### DIFF
--- a/app/Models/Labels/Sheets/Avery/L4736_A.php
+++ b/app/Models/Labels/Sheets/Avery/L4736_A.php
@@ -95,23 +95,39 @@ class L4736_A extends L4736
             $currentX += $barcodeSize + self::BARCODE_MARGIN;
             $usableWidth -= $barcodeSize + self::BARCODE_MARGIN;
         }
+        $fields = $record->get('fields');
+        $fieldCount = count($fields);
+
+        $perFeldHeight = (self::LABEL_SIZE + self::LABEL_MARGIN)
+                       + (self::FIELD_SIZE + self::FIELD_MARGIN);
+
+        $baseHeight = $fieldCount * $perFeldHeight;
+        $scale = 1.0;
+        if ($baseHeight > $usableHeight && $baseHeight > 0) {
+            $scale = $usableHeight / $baseHeight;
+        }
+
+        $labelSize   = self::LABEL_SIZE   * $scale;
+        $labelMargin = self::LABEL_MARGIN * $scale;
+        $fieldSize   = self::FIELD_SIZE   * $scale;
+        $fieldMargin = self::FIELD_MARGIN * $scale;
 
         foreach ($record->get('fields') as $field) {
             static::writeText(
                 $pdf, $field['label'],
                 $currentX, $currentY,
-                'freesans', '', self::LABEL_SIZE, 'L',
-                $usableWidth, self::LABEL_SIZE, true, 0
+                'freesans', '', $labelSize, 'L',
+                $usableWidth, $labelSize, true, 0
             );
-            $currentY += self::LABEL_SIZE + self::LABEL_MARGIN;
+            $currentY += $labelSize + $labelMargin;
 
             static::writeText(
                 $pdf, $field['value'],
                 $currentX, $currentY,
-                'freemono', 'B', self::FIELD_SIZE, 'L',
-                $usableWidth, self::FIELD_SIZE, true, 0, 0.01
+                'freemono', 'B', $fieldSize, 'L',
+                $usableWidth, $fieldSize, true, 0, 0.01
             );
-            $currentY += self::FIELD_SIZE + self::FIELD_MARGIN;
+            $currentY += $fieldSize + $fieldMargin;
         }
 
     }

--- a/app/Models/Labels/Sheets/Avery/L4736_A.php
+++ b/app/Models/Labels/Sheets/Avery/L4736_A.php
@@ -98,10 +98,10 @@ class L4736_A extends L4736
         $fields = $record->get('fields');
         $fieldCount = count($fields);
 
-        $perFeldHeight = (self::LABEL_SIZE + self::LABEL_MARGIN)
+        $perFieldHeight = (self::LABEL_SIZE + self::LABEL_MARGIN)
                        + (self::FIELD_SIZE + self::FIELD_MARGIN);
 
-        $baseHeight = $fieldCount * $perFeldHeight;
+        $baseHeight = $fieldCount * $perFieldHeight;
         $scale = 1.0;
         if ($baseHeight > $usableHeight && $baseHeight > 0) {
             $scale = $usableHeight / $baseHeight;

--- a/app/Models/Labels/Sheets/Avery/L4736_A.php
+++ b/app/Models/Labels/Sheets/Avery/L4736_A.php
@@ -112,7 +112,7 @@ class L4736_A extends L4736
         $fieldSize   = self::FIELD_SIZE   * $scale;
         $fieldMargin = self::FIELD_MARGIN * $scale;
 
-        foreach ($record->get('fields') as $field) {
+        foreach ($fields as $field) {
             static::writeText(
                 $pdf, $field['label'],
                 $currentX, $currentY,

--- a/app/Models/Labels/Sheets/Avery/L6009_A.php
+++ b/app/Models/Labels/Sheets/Avery/L6009_A.php
@@ -60,14 +60,17 @@ class L6009_A extends L6009
             $usableWidth -= $barcodeSize + self::BARCODE_MARGIN;
         }
         $fields = $record->get('fields');
+        // Below rescales the size of the field box to fit, it feels like it could/should be abstracted one class above
+        // to be usable on other labels but im unsure of how to implement that, since it uses a lot of private
+        // constants.
 
-        //Figure out how tall the label fields wants to be
+        // Figure out how tall the label fields wants to be
         $fieldCount = count($fields);
         $perFieldHeight = (self::LABEL_SIZE + self::LABEL_MARGIN)
                         + (self::FIELD_SIZE + self::FIELD_MARGIN);
 
         $baseHeight = $fieldCount * $perFieldHeight;
-        //If it doesn't fit in the available height, scale everything down
+        // If it doesn't fit in the available height, scale everything down
         $scale = 1.0;
         if ($baseHeight > $usableHeight && $baseHeight > 0) {
             $scale = $usableHeight / $baseHeight;

--- a/app/Models/Labels/Sheets/Avery/L6009_A.php
+++ b/app/Models/Labels/Sheets/Avery/L6009_A.php
@@ -59,23 +59,41 @@ class L6009_A extends L6009
             $currentX += $barcodeSize + self::BARCODE_MARGIN;
             $usableWidth -= $barcodeSize + self::BARCODE_MARGIN;
         }
+        $fields = $record->get('fields');
 
-        foreach ($record->get('fields') as $field) {
+        //Figure out how tall the label fields wants to be
+        $fieldCount = count($fields);
+        $perFieldHeight = (self::LABEL_SIZE + self::LABEL_MARGIN)
+                        + (self::FIELD_SIZE + self::FIELD_MARGIN);
+
+        $baseHeight = $fieldCount * $perFieldHeight;
+        //If it doesn't fit in the available height, scale everything down
+        $scale = 1.0;
+        if ($baseHeight > $usableHeight && $baseHeight > 0) {
+            $scale = $usableHeight / $baseHeight;
+        }
+
+        $labelSize   = self::LABEL_SIZE   * $scale;
+        $labelMargin = self::LABEL_MARGIN * $scale;
+        $fieldSize   = self::FIELD_SIZE   * $scale;
+        $fieldMargin = self::FIELD_MARGIN * $scale;
+
+        foreach ($fields as $field) {
             static::writeText(
                 $pdf, $field['label'],
                 $currentX, $currentY,
-                'freesans', '', self::LABEL_SIZE, 'L',
-                $usableWidth, self::LABEL_SIZE, true, 0
+                'freesans', '', $labelSize, 'L',
+                $usableWidth, $labelSize, true, 0
             );
-            $currentY += self::LABEL_SIZE + self::LABEL_MARGIN;
+            $currentY += $labelSize + $labelMargin;
 
             static::writeText(
                 $pdf, $field['value'],
                 $currentX, $currentY,
-                'freemono', 'B', self::FIELD_SIZE, 'L',
-                $usableWidth, self::FIELD_SIZE, true, 0, 0.01
+                'freemono', 'B', $fieldSize, 'L',
+                $usableWidth, $fieldSize, true, 0, 0.01
             );
-            $currentY += self::FIELD_SIZE + self::FIELD_MARGIN;
+            $currentY += $fieldSize + $fieldMargin;
         }
     }
 }


### PR DESCRIPTION
This fixes the overflow of fields and their values for labels `L6009_A` and `L4736_A` with scaling. This could potentially allow more fields, but there is probably a point where it would get too small. 
I wanted to have this in the Sheet class but I wasn't able to get it to work that way..

Before:
<img width="1354" height="696" alt="image" src="https://github.com/user-attachments/assets/9ca8ef8b-3395-43a8-9196-68738c7e9cab" />

After:
<img width="586" height="267" alt="image" src="https://github.com/user-attachments/assets/bfbe49ca-8415-4884-afe1-3c3418995ed5" />
