### PR TITLE
Fixes inaccurate monthly depreciation value displayed at depreciation report when using a floor value

### DIFF
--- a/app/Http/Transformers/DepreciationReportTransformer.php
+++ b/app/Http/Transformers/DepreciationReportTransformer.php
@@ -63,7 +63,7 @@ class DepreciationReportTransformer
          */
         if (($asset->model) && ($asset->model->depreciation) && ($asset->model->depreciation->months !== 0)) {
             $depreciated_value = Helper::formatCurrencyOutput($asset->getDepreciatedValue());
-            $monthly_depreciation =Helper::formatCurrencyOutput($asset->purchase_cost / $asset->model->depreciation->months);
+            $monthly_depreciation =Helper::formatCurrencyOutput($asset->getMonthlyDepreciation());
             $diff = Helper::formatCurrencyOutput(($asset->purchase_cost - $asset->getDepreciatedValue()));
         }
         else if($asset->model->eol !== null) {


### PR DESCRIPTION
Hello there! So apparently, I'm laying my hands on the code around reporting and stumbled upon this bug.

And.. yes, I have tested this on the demo website, and it appears to still be there :0

Here, I would give the exact steps (preconditions) on how I reproduce the bug, and also my proposed solution. 

Feel free to adjust if it's not quite well! 
Thanks!

## Preconditions 📝
- I have an asset with information as below
![asset-information](https://github.com/user-attachments/assets/23a105c3-8541-42c6-945b-223be8de33bd)
> Current date when testing this was **26th November 2025**, so the asset would fully depreciate at **1st of December 2025**
- Depreciation type being used is defined as below
![depreciation-type-detail](https://github.com/user-attachments/assets/2440835c-22a7-4e5f-a2f0-59475b741d2e)
- System is using **linear method**
![depreciation-setting](https://github.com/user-attachments/assets/392e4a60-98ab-453b-9383-8603f7eca880)

## Bug 🐛
On Depreciation Report page, it displayed an inaccurate value for **Monthly Depreciation** as `DepreciationReportTransformer` **ignores the floor value**!
*_based from **Straight-line Depreciation** calculation_
![report-before](https://github.com/user-attachments/assets/220370fc-ece0-4a4b-8d0a-f3798d94a1d0)


## Proposed Solution 💡
Utilize defined formula at parent class `app\Models\Depreciable.php`
```php
public function getMonthlyDepreciation()
{

    return ($this->purchase_cost-$this->calculateDepreciation())/$this->get_depreciation()->months;

}
``` 

## Fixed Result ✅
![report-after](https://github.com/user-attachments/assets/0b47cec1-c655-47be-8599-2cf0a66bdef5)
