### PR TITLE
Optimize queries for Components listing

### DIFF
--- a/app/Http/Controllers/Api/ComponentsController.php
+++ b/app/Http/Controllers/Api/ComponentsController.php
@@ -58,8 +58,8 @@ class ComponentsController extends Controller
             ];
 
         $components = Component::select('components.*')
-            ->with('company', 'location', 'category', 'assets', 'supplier', 'adminuser', 'manufacturer', 'uncontrainedAssets')
-            ->withSum('uncontrainedAssets', 'components_assets.assigned_qty');
+            ->with('company', 'location', 'category', 'supplier', 'adminuser', 'manufacturer')
+            ->withSum('uncontrainedAssets as sum_unconstrained_assets', 'components_assets.assigned_qty');
 
         $filter = [];
 
@@ -112,7 +112,8 @@ class ComponentsController extends Controller
         }
 
         // Make sure the offset and limit are actually integers and do not exceed system limits
-        $offset = ($request->input('offset') > $components->count()) ? $components->count() : app('api_offset_value');
+        $components_count = $components->count();
+        $offset = ($request->input('offset') > $components_count) ? $components_count : app('api_offset_value');
         $limit = app('api_limit_value');
 
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
@@ -143,7 +144,7 @@ class ComponentsController extends Controller
                 break;
         }
 
-        $total = $components->count();
+        $total = $components_count;
         $components = $components->skip($offset)->take($limit)->get();
 
         return (new ComponentsTransformer)->transformComponents($components, $total);

--- a/app/Models/Component.php
+++ b/app/Models/Component.php
@@ -238,14 +238,26 @@ class Component extends SnipeModel
      * @since  [v5.0]
      * @return int
      */
-    public function numCheckedOut()
+    public function numCheckedOut(bool $recalculate = false)
     {
-        $checkedout = 0;
+        /**
+         *
+         * WARNING: This method caches the result, so if you're doing something
+         * that is going to change the number of checked-out items, make sure to pass
+         * 'true' as the first parameter to force this to recalculate the number of checked-out
+         * items!!!!!
+         *
+         */
 
         // In case there are elements checked out to assets that belong to a different company
         // than this asset and full multiple company support is on we'll remove the global scope,
         // so they are included in the count.
-        return $this->uncontrainedAssets->sum('pivot.assigned_qty');
+        if (is_null($this->sum_unconstrained_assets) || $recalculate) {
+            // This, in a components-listing context, is mostly important for when it sets a 'zero' which
+            // is *not* null - so we don't have to keep recalculating for un-checked-out components
+            $this->sum_unconstrained_assets = $this->uncontrainedAssets()->sum('assigned_qty') ?? 0;
+        }
+        return $this->sum_unconstrained_assets;
     }
 
 


### PR DESCRIPTION
A customer reported that listing large numbers of components seemed to cause error 500's from the API endpoint. Taking a quick look through debugbar, it seems like we were trying to load every asset associated with every component on the page, which I can easily imagine exhausting memory.

This change removes those `with()` entries, and uses the `withSum()` Eloquent method to make the database dynamically calculate those counts for us, and modifies the `numCheckedOut()` method to try to use that value if it exists - or to dynamically calculate it if it doesn't. And that dynamic calculation _had_ been working on the 'Collection' object, rather than the database, so this adds the `()` to the relationship to make it a DB-level calculation rather than loading up all of the related objects and summing up through that collection.

The challenge here is that, because that value is now cached, if you were doing something with components and checking the value of that `numCheckedOut()` value when it _should_ have changed, it will stay the same due to the caching.

I looked through the code and it doesn't look like we do that anywhere. Still, just in case, I added a new optional parameter to `numCheckedOut()` - which defaults to `false` - that will force it to recalculate the result and save that to the cache.

Another thing I did was reduce the number of times we called `components->count()` by throwing the result into a variable.

# Tests

Tests do pass, and I did a make sure that the components index page loads correctly and displays the right values.