### PR TITLE
Fixes inconsistent negative symbol at Audit Log Report when Next Audit Date is set to the current date

### DIFF
--- a/app/Models/Actionlog.php
+++ b/app/Models/Actionlog.php
@@ -375,7 +375,7 @@ class Actionlog extends SnipeModel
         }
 
         // Show as negative number if the next audit date is before the audit date we're looking at
-        if ($this->created_at > $override_default_next) {
+        if ($this->created_at->toDateString() > $override_default_next->toDateString()) {
             $next_audit_days = '-'.$next_audit_days;
         }
 


### PR DESCRIPTION
Hello! 

I found another one, this one is a bit tricky and might be an edge case but still, I think it still confuses someone when a negative symbol is inconsistent between each other in Audit Log, so please check it out if you think so.

## Preconditions 📝
- I set audit interval in Notification admin settings to be empty
![Screenshot_26-11-2025_13101_localhost](https://github.com/user-attachments/assets/f9dca43e-e8fd-4259-838b-94867bfffb88)

- I have 2 assets and audited both with different treatment (check images below for differences)
**First Test Asset**
![Screenshot_26-11-2025_1371_localhost](https://github.com/user-attachments/assets/4d63fcc4-a0ee-4011-8ade-aefe6fae31d6)
**Second Test Asset**
![Screenshot_26-11-2025_13720_localhost](https://github.com/user-attachments/assets/39ccc943-d32e-420e-b8bc-0fee7acefd9f)


## Bug 🐛
On Audit Log page, it displayed a negative symbol only for the **First Asset**. 
![Screenshot 2025-11-26 130903](https://github.com/user-attachments/assets/d375daff-ed74-4b90-9f86-0184c5617321)

This happens because: 
1. _Filled_ **Next Audit Date** input only gives the date format only (`2025-11-26`)
2. _Emptied_ **Next Audit Date** has a logic to use the **Actionlog Date** (which includes time) and adds it with the **Audit Interval** (`2026-11-26 12:09:44`)

So, referring to the current comparison logic
```php
// Show as negative number if the next audit date is before the audit date we're looking at
if ($this->created_at > $override_default_next) {
    $next_audit_days = '-'.$next_audit_days;
}
``` 

Then it would be: 
- First Asset: 2025-11-26 12:08:11 > 2025-11-26 → True (display negative)
- Second Asset: 2025-11-26 12:09:44 > 2026-11-26 12:09:44 → False (not displaying negative)

## Proposed Solution 💡
Uses the `toDateString()` to compare only the dates, so the comparing logic is always equal (date vs date), giving a consistent comparison logic to decide negative symbol

```php
// Show as negative number if the next audit date is before the audit date we're looking at
if ($this->created_at->toDateString() > $override_default_next->toDateString()) {
    $next_audit_days = '-'.$next_audit_days;
}
``` 

## Fixed Result ✅
![Screenshot 2025-11-26 130947](https://github.com/user-attachments/assets/5ee6ab5c-7702-4129-a574-55acc6dc06b7)

