### PR TITLE
Fixes Manager View not displaying subordinates EULAs properly in View Assets page

### DIFF
--- a/app/Http/Controllers/Api/ProfileController.php
+++ b/app/Http/Controllers/Api/ProfileController.php
@@ -14,6 +14,7 @@ use Laravel\Passport\TokenRepository;
 use Illuminate\Contracts\Validation\Factory as ValidationFactory;
 use Illuminate\Support\Facades\Gate;
 use App\Models\CustomField;
+use App\Models\User;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Http\JsonResponse;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -179,10 +180,17 @@ class ProfileController extends Controller
      *@since [v8.1.16]
      * @author [Godfrey Martinez] [<gmartinez@grokability.com>]
      */
-    public function eulas(ProfileTransformer $transformer)
+    public function eulas(ProfileTransformer $transformer, Request $request)
     {
-        // Only return this user's EULAs
-        $eulas = auth()->user()->eulas;
+        if($request->filled('user_id') && $request->input('user_id') != 0) {
+            // Return selected user's EULAs
+            $eulas = User::find($request->input('user_id'))->eulas;
+        }
+        else {
+            // Only return this user's EULAs
+            $eulas = auth()->user()->eulas;
+        }
+
         return response()->json(
             $transformer->transformFiles($eulas, $eulas->count())
         );

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Http\Requests\ImageUploadRequest;
 use App\Http\Transformers\ProfileTransformer;
 use App\Models\Actionlog;
+use App\Models\Asset;
 use App\Models\Setting;
 use App\Models\User;
 use App\Notifications\CurrentInventory;
@@ -249,7 +250,10 @@ class ProfileController extends Controller
         $logentry = Actionlog::where('filename', $filename)->first();
 
         // Make sure the user has permission to view this file
-        if (auth()->id() != $logentry->target_id) {
+        // Also allow if the user (manager) able to view both users and assets
+        $allowed_to_view_users_assets = Gate::allows('view', User::class) && Gate::allows('view', Asset::class);
+
+        if (auth()->id() != $logentry->target_id && !$allowed_to_view_users_assets) {
             return redirect()->route('account')->with('error', trans('general.generic_model_not_found', ['model' => 'file']));
         }
 

--- a/resources/views/account/view-assets.blade.php
+++ b/resources/views/account/view-assets.blade.php
@@ -759,7 +759,7 @@
                     data-sort-order="asc"
                     data-sort-name="name"
                     class="table table-striped snipe-table table-hover"
-                    data-url="{{ route('api.self.eulas') }}"
+                    data-url="{{ route('api.self.eulas', ['user_id' => e(request('user_id'))]) }}"
                     data-export-options='{
                     "fileName": "export-eula-{{ str_slug($user->username) }}-{{ date('Y-m-d') }}",
                     "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","delete","purchasecost", "icon"]


### PR DESCRIPTION
Hello again,

I realized when using Manager View in View Assets page, and then checking subordinates who has done accepted/declined EULAs, it only appears badge count for the tab but with **empty records in the table**!

## Preconditions 📝
- I had Manager View turned on in `Admin Settings > General`
- I have 2 users, one is **a manager**, and one is **the subordinate**
- The subordinate user had checked out an asset that requires EULAs and accepted it

## Bug 🐛
On the View Assets page, I navigated the view to the subordinate user named "Test User", and as you can see it displays empty record in the table even though the tab section had shown the badge count

**From Superadmin** 
<img width="1786" height="530" alt="image" src="https://github.com/user-attachments/assets/170601d4-18a3-4576-a19d-7fedd78bd63c" />

**From Manager**
<img width="1787" height="512" alt="image" src="https://github.com/user-attachments/assets/4c044f8c-67ad-43d5-9ef9-86fa81e4434a" />

## Proposed Solution 💡
Adjusted both `ProfileController` to use the existing request parameter `user_id` from View Assets page (this doesn' change anything for the routing)

> For the EULA file download, I used a Gate Policy for viewing Asset and User in order for the current user (manager) to able to download it

## Fixed Result ✅
**From Superadmin** 
<img width="1788" height="673" alt="image" src="https://github.com/user-attachments/assets/19f0746b-2a00-4eda-84fb-d129a014a764" />

**From Manager**
<img width="1783" height="659" alt="image" src="https://github.com/user-attachments/assets/25e63f0c-52fa-41e1-97fe-c886b7223e80" />


