### PR TITLE
Refactor `assignee` in Checkoutable to accept null

### DIFF
--- a/app/Models/Checkoutable.php
+++ b/app/Models/Checkoutable.php
@@ -13,7 +13,7 @@ class Checkoutable
         public string $name,
         public string $type,
         public object $acceptance,
-        public object $assignee,
+        public readonly User|Asset|Location|null $assignee,
         public readonly string $plain_text_category,
         public readonly string $plain_text_model,
         public readonly string $plain_text_name,


### PR DESCRIPTION
Refactored `assignee` to allow polymorphic types as well as `null` to safely handle missing or soft deleted relationships.

If the user has been deleted, it will reflect that in the unaccepted items page with `Deleted User`:
<img width="1700" height="429" alt="image" src="https://github.com/user-attachments/assets/c2add1df-1dc5-4ee2-9663-3c01791e186b" />


