### PR TITLE
Check That Email Exists on Recipient in Checkout Acceptance

### DIFF
--- a/app/Http/Controllers/Account/AcceptanceController.php
+++ b/app/Http/Controllers/Account/AcceptanceController.php
@@ -216,7 +216,7 @@ class AcceptanceController extends Controller
             try {
                 $recipient = User::find($acceptance->alert_on_response_id);
 
-                if ($recipient) {
+                if ($recipient?->email) {
                     Log::debug('Attempting to send email acceptance.');
                     Mail::to($recipient)->send(new CheckoutAcceptanceResponseMail(
                         $acceptance,


### PR DESCRIPTION
On the tin, before we were just checking that the user `$recipient` existed before attempting to send the email, now we're checking that that `$recipient` actually has an email. 