### PR TITLE
Loosen regex allowlist for setting character sets

### DIFF
--- a/app/Console/Commands/RestoreFromBackup.php
+++ b/app/Console/Commands/RestoreFromBackup.php
@@ -52,7 +52,7 @@ class SQLStreamer {
             /* we *could* have made the ^INSERT INTO blah VALUES$ turn on the capturing state, and closed it with
                a ^(blahblah);$ but it's cleaner to not have to manage the state machine. We're just going to
                assume that (blahblah), or (blahblah); are values for INSERT and are always acceptable. */
-            "<^/\*!40101 SET NAMES '?[a-zA-Z0-9_-]+'? \*/;$>"                                   => false, //using weird delimiters (<,>) for readability. allow quoted or unquoted charsets
+            "<^/\*![0-9]{5} SET NAMES '?[a-zA-Z0-9_-]+'? \*/;$>" => false, //using weird delimiters (<,>) for readability. allow quoted or unquoted charsets
             "<^/\*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' \*/;$>" => false, //same, now handle zero-values
         ];
 


### PR DESCRIPTION
It looks like newer versions of MySQL will actually say:

```
/*!50503 SET NAMES utf8mb4 */;
```

instead of the older:

```
\*!40101 SET NAMES utf8mb4 */;
```

Which seems to be causing some problems on the 'cleaner' mode of the Snipe-IT restore function.

I've loosened up the allowlist entry to allow *any* 5-digit number along with the `SET NAMES` part, so this should continue to keep working for a while.

I tested with an affected backup and the new allowlist entry correctly sets the character set again.