### PR TITLE
Added #18289: Livewire notifications

### DIFF
--- a/app/Livewire/Notifications.php
+++ b/app/Livewire/Notifications.php
@@ -34,11 +34,9 @@ use Livewire\Attributes\On;
  *   tag: 'bulk-import'
  * });
  *
- * Dismiss by tag:
- * Livewire.dispatch('dismissNotificationByTag', 'bulk-import');
- *
- * Dismiss by id (you usually call this from a close button in Blade):
- * Livewire.dispatch('dismissNotification', someId);
+ * Dismiss all notifcations:
+ * Livewire.dispatch('dismissAllNotifications');
+ * 
  */
 class Notifications extends Component
 {
@@ -201,29 +199,6 @@ class Notifications extends Component
     protected function addAlert(array $alert): void
     {
         $this->liveAlerts[] = $alert;
-    }
-
-
-    /**
-     * Dismiss by alert unique ID.
-     */
-    #[On('dismissNotification')]
-    public function dismiss(string $id): void
-    {
-        $this->liveAlerts = array_values(
-            array_filter($this->liveAlerts, fn ($a) => $a['id'] !== $id)
-        );
-    }
-
-    /**
-     * Dismiss all alerts sharing a tag.
-     */
-    #[On('dismissNotificationByTag')]
-    public function dismissByTag(string $tag): void
-    {
-        $this->liveAlerts = array_values(
-            array_filter($this->liveAlerts, fn ($a) => $a['tag'] !== $tag)
-        );
     }
 
     /**

--- a/app/Livewire/Notifications.php
+++ b/app/Livewire/Notifications.php
@@ -1,0 +1,242 @@
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+use Livewire\Attributes\On;
+
+/**
+ * Live (in-page) notifications component.
+ *
+ * Supports:
+ * - Dispatching events with basic (type, message)
+ * - Extended payload (type, title, message, description, icon, html, confetti, auto, tag)
+ * - Replacing an existing alert by tag (so you can "update progress" style messages)
+ * - Dismissing by id or by tag
+ * - Optional legacy string-only usage
+ *
+ * JS Examples (Livewire v3):
+ *
+ * Livewire.dispatch('showNotification', {
+ *   type: 'success',
+ *   title: 'Asset Saved',
+ *   message: 'MacBook Pro added.',
+ *   description: 'Tag: MBP-4418<br>Assigned to Jane Doe',
+ *   icon: 'fas fa-laptop',
+ *   html: true,
+ *   tag: 'asset-create'
+ * });
+ *
+ * Update same tagged notification later:
+ * Livewire.dispatch('showNotification', {
+ *   type: 'info',
+ *   message: 'Processing (70%)',
+ *   tag: 'bulk-import'
+ * });
+ *
+ * Dismiss by tag:
+ * Livewire.dispatch('dismissNotificationByTag', 'bulk-import');
+ *
+ * Dismiss by id (you usually call this from a close button in Blade):
+ * Livewire.dispatch('dismissNotification', someId);
+ */
+class Notifications extends Component
+{
+    /**
+     * Each alert structure:
+     * [
+     *   'id'          => string,
+     *   'type'        => 'success'|'danger'|'warning'|'info',
+     *   'tag'         => string|null,
+     *   'title'       => string|null,
+     *   'message'     => string,
+     *   'description' => string|null,
+     *   'icon'        => string|null,
+     *   'html'        => bool,
+     *   'created_at'  => int         (timestamp)
+     * ]
+     *
+     * @var array<int, array<string,mixed>>
+     */
+
+    public array $liveAlerts=[];
+
+    /**
+     * Main notification listener.
+     * We bind both 'showNotification' (your current event) and 'notify' (optional alias).
+     */
+    
+    #[On('showNotification')]
+    #[On('notify')]
+    public function notify(
+        $type=null,
+        $message=null,
+        $title=null,
+        $description=null,
+        $icon=null,
+        $html=null,
+        $tag=null,
+        $payload=null // wrapper form: { payload: { ... } }
+    ): void {
+        // Wrapper form: { payload: { ...full data... } }
+        if (is_array($payload)) {
+            $this->ingestArray($payload);
+            return;
+        }
+
+        // Legacy simple usage: Livewire.dispatch('showNotification', 'Quick saved!')
+        if (is_string($type) && $message === null && $title === null) {
+            $this->pushAlert([
+                'type'    => 'success',
+                'message' => $type,
+                'tag'     => $tag,
+            ]);
+            return;
+        }
+
+        // Must have a type + message at minimum
+        if (!$type || !$message) {
+            return;
+        }
+
+        $this->pushAlert([
+            'type'        => $type,
+            'message'     => $message,
+            'title'       => $title,
+            'description' => $description,
+            'icon'        => $icon,
+            'html'        => (bool) $html,
+            'tag'         => $tag,
+        ]);
+    }
+
+    /**
+     * Ingest an associative array payload (supports multiple key name variants).
+     */
+    protected function ingestArray(array $arr): void
+    {
+        $this->pushAlert([
+            'type'        => $arr['type']        ?? $arr['level'] ?? 'info',
+            'message'     => $arr['message']     ?? $arr['msg'] ?? null,
+            'title'       => $arr['title']       ?? $arr['heading'] ?? null,
+            'description' => $arr['description'] ?? $arr['desc'] ?? null,
+            'icon'        => $arr['icon']        ?? null,
+            'html'        => (bool) ($arr['html'] ?? false),
+            'tag'         => $arr['tag'] ?? null,
+        ]);
+    }
+
+    /**
+     * Normalize a semantic type into a Bootstrap alert class fragment.
+     */
+    protected function normalizeType(string $type): string
+    {
+        return match (strtolower($type)) {
+            'error', 'danger', 'fail', 'failed' => 'danger',
+            'ok', 'status'                     => 'success',
+            default                            => strtolower($type),
+        };
+    }
+
+    /**
+     * Provide default icon classes if none supplied.
+     */
+    protected function defaultIcon(string $type): string
+    {
+        return match ($type) {
+            'success' => 'fas fa-check faa-pulse animated',
+            'danger'  => 'fas fa-exclamation-triangle faa-pulse animated',
+            'warning' => 'fas fa-exclamation-triangle faa-pulse animated',
+            default   => 'fas fa-info-circle faa-pulse animated',
+        };
+    }
+
+    /**
+     * Insert or replace an alert (if tag provided & already exists).
+     */
+    protected function pushAlert(array $data): void
+    {
+        if (empty($data['message'])) {
+            return;
+        }
+    
+        $alert = $this->buildAlert($data);
+    
+        if ($alert['tag'] !== null && $this->replaceTaggedAlert($alert)) {
+            return;
+        }
+    
+        $this->addAlert($alert);
+    }
+
+    protected function buildAlert(array $data): array
+    {
+        $type = $this->normalizeType($data['type'] ?? 'info');
+    
+        return [
+            'id'          => uniqid('al_', true),
+            'type'        => $type,
+            'tag'         => $data['tag'] ?? null,
+            'title'       => $data['title'] ?? null,
+            'message'     => $data['message'],
+            'description' => $data['description'] ?? null,
+            'icon'        => $data['icon'] ?? $this->defaultIcon($type),
+            'html'        => $data['html'] ?? false,
+        'created_at'  => time(),
+        ];
+    }
+
+    protected function replaceTaggedAlert(array $alert): bool
+    {
+        foreach ($this->liveAlerts as $index => $liveAlert) {
+            if ($liveAlert['tag'] === $alert['tag']) {
+                $this->liveAlerts[$index] = $alert;
+                return true;
+            }
+        }
+    
+        return false;
+    }
+
+    protected function addAlert(array $alert): void
+    {
+        $this->liveAlerts[] = $alert;
+    }
+
+
+    /**
+     * Dismiss by alert unique ID.
+     */
+    #[On('dismissNotification')]
+    public function dismiss(string $id): void
+    {
+        $this->liveAlerts = array_values(
+            array_filter($this->liveAlerts, fn ($a) => $a['id'] !== $id)
+        );
+    }
+
+    /**
+     * Dismiss all alerts sharing a tag.
+     */
+    #[On('dismissNotificationByTag')]
+    public function dismissByTag(string $tag): void
+    {
+        $this->liveAlerts = array_values(
+            array_filter($this->liveAlerts, fn ($a) => $a['tag'] !== $tag)
+        );
+    }
+
+    /**
+     * Dismiss everything (add a button if you want).
+     */
+    #[On('dismissAllNotifications')]
+    public function dismissAll(): void
+    {
+        $this->liveAlerts = [];
+    }
+
+    public function render()
+    {
+        return view('livewire.notifications');
+    }
+}

--- a/resources/views/components/alert.blade.php
+++ b/resources/views/components/alert.blade.php
@@ -1,0 +1,45 @@
+@props([
+    'type'     => 'info',    // success | danger | warning | info | error
+    'icon'     => null,
+    'heading'  => null,
+    'html'     => false,
+    'confetti' => false,
+    'id'       => null,
+])
+
+@php
+    // Normalize "error" to Bootstrap's "danger"
+    $normalized = $type === 'error' ? 'danger' : $type;
+
+    // Default icon set (Font Awesome 5 in your project already)
+    $iconClass = $icon ?? match($normalized) {
+        'success' => 'fas fa-check faa-pulse animated',
+        'danger'  => 'fas fa-exclamation-triangle faa-pulse animated',
+        'warning' => 'fas fa-exclamation-triangle faa-pulse animated',
+        default   => 'fas fa-info-circle faa-pulse animated',
+    };
+
+    $wrapperId = $id ? 'id="'.$id.'"' : '';
+@endphp
+
+<div class="col-md-12" {!! $wrapperId !!}>
+    <div class="alert alert-{{ $normalized }}">
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close">&times;</button>
+        @if($iconClass)
+            <i class="{{ $iconClass }}"></i>
+        @endif
+        @if($heading)
+            <strong>{{ $heading }}:</strong>
+        @endif
+
+        @if($html)
+            {!! $slot !!}
+        @else
+            {{ $slot }}
+        @endif
+    </div>
+</div>
+
+@if($confetti)
+    @include('partials.confetti-js')
+@endif

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -1657,7 +1657,7 @@
                             </div>
                         @endif
 
-                        @include('notifications')
+                        <livewire:notifications />
                     </div>
 
 

--- a/resources/views/livewire/notifications.blade.php
+++ b/resources/views/livewire/notifications.blade.php
@@ -1,0 +1,21 @@
+<div id="livewire-notifications-root">
+    {{-- Existing redirect/session flashes --}}
+    @include('notifications')
+
+    {{-- Live (dynamic) alerts --}}
+    @foreach($liveAlerts as $alert)
+        @include('partials.live-alert', ['alert' => $alert])
+    @endforeach
+
+    {{-- Javascript --}}
+    @script
+    <script>
+        // Livewire event bridging. This isn't the best way but it works for now...
+        Livewire.on('showNotificationInFrontend', (params) => {
+            //console.log(params);
+            Livewire.dispatch('showNotification', params[0]);
+        });
+    </script>
+    @endscript
+
+</div>

--- a/resources/views/notifications.blade.php
+++ b/resources/views/notifications.blade.php
@@ -1,195 +1,136 @@
+@php
+    $pull = function(string $key) {
+        return session()->has($key) ? session()->get($key) : null;
+    };
+@endphp
+
 @if ($errors->any())
-<div class="col-md-12" id="error-notification">
-    <div class="alert alert-danger fade in">
-        <button type="button" class="close" data-dismiss="alert">&times;</button>
-        <i class="fas fa-exclamation-triangle faa-pulse animated"></i>
-        <strong>{{ trans('general.notification_error') }}:</strong>
-         {{ trans('general.notification_error_hint') }}
-    </div>
-</div>
-
+    <x-alert
+        type="danger"
+        :heading="trans('general.notification_error')"
+        id="validation-errors"
+    >
+        {{ trans('general.notification_error_hint') }}
+    </x-alert>
 @endif
 
-
-@if ($message = session()->get('status'))
-    <div class="col-md-12" id="success-notification">
-        <div class="alert alert-success fade in">
-            <button type="button" class="close" data-dismiss="alert">&times;</button>
-            <i class="fas fa-check faa-pulse animated"></i>
-            <strong>{{ trans('general.notification_success') }}: </strong>
-            {{ $message }}
-        </div>
-    </div>
+@if ($msg = $pull('status'))
+    <x-alert type="success" :heading="trans('general.notification_success')" id="status-notification">
+        {{ $msg }}
+    </x-alert>
 @endif
 
-
-@if ($message = session()->get('success'))
-<div class="col-md-12" id="success-notification">
-    <div class="alert alert-success fade in">
-        <button type="button" class="close" data-dismiss="alert">&times;</button>
-        <i class="fas fa-check faa-pulse animated"></i>
-        <strong>{{ trans('general.notification_success') }}: </strong>
-        {{ $message }}
-    </div>
-</div>
-@include ('partials.confetti-js')
+@if ($msg = $pull('success'))
+    <x-alert type="success" :heading="trans('general.notification_success')" id="success-notification" confetti="true">
+        {{ $msg }}
+    </x-alert>
 @endif
 
-
-@if ($message = session()->get('success-unescaped'))
-    <div class="col-md-12" id="success-notification">
-        <div class="alert alert-success fade in">
-            <button type="button" class="close" data-dismiss="alert">&times;</button>
-            <i class="fas fa-check faa-pulse animated"></i>
-            <strong>{{ trans('general.notification_success') }}: </strong>
-            {!!  $message !!}
-        </div>
-    </div>
-    @include ('partials.confetti-js')
+@if ($msg = $pull('success-unescaped'))
+    <x-alert type="success" :heading="trans('general.notification_success')" id="success-unescaped-notification" html="true" confetti="true">
+        {!! $msg !!}
+    </x-alert>
 @endif
 
-
-@if ($assets = session()->get('assets'))
+@if ($assets = $pull('assets'))
     @foreach ($assets as $asset)
-        <div class="col-md-12" id="multi-error-notification">
-            <div class="alert alert-info fade in">
-                <button type="button" class="close" data-dismiss="alert">&times;</button>
-                <i class="fas fa-info-circle faa-pulse animated"></i>
-                <strong>{{ trans('general.asset_information') }}:</strong>
-                <ul>
-                    @isset ($asset->model->name)
-                        <li><b>{{ trans('general.model_name') }} </b> {{ $asset->model->name }}</li>
-                    @endisset
-                    @isset ($asset->name)
-                        <li><b>{{ trans('general.asset_name') }} </b> {{ $asset->model->name }}</li>
-                    @endisset
-                    <li><b>{{ trans('general.asset_tag') }}</b> {{ $asset->asset_tag }}</li>
-                    @isset ($asset->notes)
-                        <li><b>{{ trans('general.notes') }}</b> {{ $asset->notes }}</li>
-                    @endisset
-                </ul>
-
-            </div>
-        </div>
+        <x-alert type="info" :heading="trans('general.asset_information')" html="true" :id="'asset-info-'.$loop->index">
+            <ul style="margin:0;padding-left:18px;">
+                @isset($asset->model->name)
+                    <li><strong>{{ trans('general.model_name') }}</strong> {{ $asset->model->name }}</li>
+                @endisset
+                @isset($asset->name)
+                    <li><strong>{{ trans('general.asset_name') }}</strong> {{ $asset->name }}</li>
+                @endisset
+                <li><strong>{{ trans('general.asset_tag') }}</strong> {{ $asset->asset_tag }}</li>
+                @isset($asset->notes)
+                    <li><strong>{{ trans('general.notes') }}</strong> {{ $asset->notes }}</li>
+                @endisset
+            </ul>
+        </x-alert>
     @endforeach
 @endif
 
-
-@if ($consumables = session()->get('consumables'))
+@if ($consumables = $pull('consumables'))
     @foreach ($consumables as $consumable)
-        <div class="col-md-12" id="success-notification">
-            <div class="alert alert-info fade in">
-                <button type="button" class="close" data-dismiss="alert">&times;</button>
-                <i class="fas fa-info-circle faa-pulse animated"></i>
-                <strong>{{ trans('general.consumable_information') }}: </strong>
-                <ul><li><b>{{ trans('general.consumable_name') }}</b> {{ $consumable->name }}</li></ul>
-            </div>
-        </div>
+        <x-alert type="info" :heading="trans('general.consumable_information')" html="true" :id="'consumable-info-'.$loop->index">
+            <ul style="margin:0;padding-left:18px;">
+                <li><strong>{{ trans('general.consumable_name') }}</strong> {{ $consumable->name }}</li>
+            </ul>
+        </x-alert>
     @endforeach
 @endif
 
-
-@if ($accessories = session()->get('accessories'))
+@if ($accessories = $pull('accessories'))
     @foreach ($accessories as $accessory)
-        <div class="col-md-12">
-            <div class="alert alert-info fade in">
-                <button type="button" class="close" data-dismiss="alert">&times;</button>
-                <i class="fas fa-info-circle faa-pulse animated"></i>
-                <strong>{{ trans('general.accessory_information') }}:</strong>
-                <ul><li><b>{{ trans('general.accessory_name') }}</b> {{ $accessory->name }}</li></ul>
-            </div>
-        </div>
+        <x-alert type="info" :heading="trans('general.accessory_information')" html="true" :id="'accessory-info-'.$loop->index">
+            <ul style="margin:0;padding-left:18px;">
+                <li><strong>{{ trans('general.accessory_name') }}</strong> {{ $accessory->name }}</li>
+            </ul>
+        </x-alert>
     @endforeach
 @endif
 
-
-@if ($message = session()->get('error'))
-<div class="col-md-12">
-    <div class="alert alert alert-danger fade in">
-        <button type="button" class="close" data-dismiss="alert">&times;</button>
-        <i class="fas fa-exclamation-triangle faa-pulse animated"></i>
-        <strong>{{ trans('general.error') }}: </strong>
-        {{ $message }}
-    </div>
-</div>
+@if ($msg = $pull('error'))
+    <x-alert type="danger" :heading="trans('general.error')" id="error-notification">
+        {{ $msg }}
+    </x-alert>
 @endif
 
-
-@if ($messages = session()->get('error_messages'))
-@foreach ($messages as $message)        
-<div class="col-md-12">
-    <div class="alert alert alert-danger fade in">
-        <button type="button" class="close" data-dismiss="alert">&times;</button>
-        <i class="fas fa-exclamation-triangle faa-pulse animated"></i>
-        <strong>{{ trans('general.notification_error') }}: </strong>
-        {{ $message }}
-    </div>
-</div>
-@endforeach
+@if ($messages = $pull('error_messages'))
+    @foreach ($messages as $message)
+        <x-alert type="danger" :heading="trans('general.notification_error')" :id="'error-msg-'.$loop->index">
+            {{ $message }}
+        </x-alert>
+    @endforeach
 @endif
 
-
-@if ($messages = session()->get('bulk_asset_errors'))
-<div class="col-md-12">
-    <div class="alert alert alert-danger fade in">
-        <button type="button" class="close" data-dismiss="alert">&times;</button>
-        <i class="fas fa-exclamation-triangle faa-pulse animated"></i>
-        <strong>{{ trans('general.notification_error') }}: </strong>
-       {{ trans('general.notification_bulk_error_hint') }}
-            @foreach($messages as $key => $message)
-                @for ($x = 0; $x < count($message); $x++)
-                <ul>
-                    <li>{{ $message[$x] }}</li>
+@if ($bulk = $pull('bulk_asset_errors'))
+    <x-alert type="danger" :heading="trans('general.notification_error')" html="true" id="bulk-asset-errors">
+        {{ trans('general.notification_bulk_error_hint') }}
+        @foreach ($bulk as $key => $set)
+            @foreach ($set as $entry)
+                <ul style="margin:0;padding-left:18px;">
+                    <li>{{ $entry }}</li>
                 </ul>
-            @endfor
             @endforeach
-    </div>
-</div>
+        @endforeach
+    </x-alert>
 @endif
 
 @if ($messages = session()->get('multi_error_messages'))
     <div class="col-md-12">
-        <div class="alert alert alert-warning fade in">
+        <div class="alert alert-warning fade in">
             <button type="button" class="close" data-dismiss="alert">&times;</button>
             <i class="fas fa-exclamation-triangle faa-pulse animated"></i>
             <strong>{{ trans('general.notification_error') }}: </strong>
             <ul>
-                @foreach(array_splice($messages, 0,3) as $key => $message)
+                @foreach(array_splice($messages, 0, 3) as $message)
                     <li>{{ $message }}</li>
                 @endforeach
             </ul>
-            <details>
-                <summary>{{ trans('general.show_all') }}</summary>
-                <ul>
-                @foreach(array_splice($messages, 3) as $key => $message)
-                  <li>{{ $message }}</li>
-                @endforeach
-                </ul>
-            </details>
+            @if (count($messages) > 0)
+                <details>
+                    <summary>{{ trans('general.show_all') }}</summary>
+                    <ul>
+                        @foreach($messages as $message)
+                            <li>{{ $message }}</li>
+                        @endforeach
+                    </ul>
+                </details>
+            @endif
         </div>
     </div>
 @endif
 
-
-@if ($message = session()->get('warning'))
-<div class="col-md-12">
-    <div class="alert alert-warning fade in">
-        <button type="button" class="close" data-dismiss="alert">&times;</button>
-        <i class="fas fa-exclamation-triangle faa-pulse animated"></i>
-        <strong>{{ trans('general.notification_warning') }}: </strong>
-        {{ $message }}
-    </div>
-</div>
+@if ($msg = $pull('warning'))
+    <x-alert type="warning" :heading="trans('general.notification_warning')" id="warning-notification">
+        {{ $msg }}
+    </x-alert>
 @endif
 
-
-@if ($message = session()->get('info'))
-<div class="col-md-12">
-    <div class="alert alert-info fade in">
-        <button type="button" class="close" data-dismiss="alert">&times;</button>
-        <i class="fas fa-info-circle faa-pulse animated"></i>
-        <strong>{{ trans('general.notification_info') }}: </strong>
-        {{ $message }}
-    </div>
-</div>
+@if ($msg = $pull('info'))
+    <x-alert type="info" :heading="trans('general.notification_info')" id="info-notification">
+        {{ $msg }}
+    </x-alert>
 @endif

--- a/resources/views/partials/live-alert.blade.php
+++ b/resources/views/partials/live-alert.blade.php
@@ -1,0 +1,37 @@
+@php
+    $id = $alert['id'];
+    $type = $alert['type']; // already normalized (success|danger|warning|info)
+    $icon = $alert['icon'] ?? null;
+    $title = $alert['title'] ?? null;
+    $message = $alert['message'] ?? '';
+    $description = $alert['description'] ?? null;
+    $html = $alert['html'] ?? false;
+@endphp
+
+<div class="col-md-12" id="live-alert-{{ $id }}" wire:key="live-alert-{{ $id }}">
+    <div class="alert alert-{{ $type }}">
+        <button type="button" class="close" wire:click="dismiss('{{ $id }}')" aria-label="Close">&times;</button>
+        @if($icon)
+            <i class="{{ $icon }}"></i>
+        @endif
+        @if($title)
+            <strong>{{ $title }}@if(!$html && $message){{ ': ' }}@endif</strong>
+        @endif
+
+        @if($html)
+            {!! $message !!}
+        @else
+            {{ $message }}
+        @endif
+
+        @if($description)
+            <div class="small" style="margin-top:4px;opacity:.85;">
+                @if($html)
+                    {!! $description !!}
+                @else
+                    {{ $description }}
+                @endif
+            </div>
+        @endif
+    </div>
+</div>

--- a/tests/Feature/NotificationsComponentTest.php
+++ b/tests/Feature/NotificationsComponentTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Feature;
+
+use Livewire\Livewire;
+use Tests\TestCase;
+use Illuminate\Support\Facades\Session;
+
+class NotificationsComponentTest extends TestCase
+{
+    public function testItCanAddSimpleDynamicSuccessNotification()
+    {
+        Livewire::test('notifications')
+            ->call('notify', 'success', 'Saved!')
+            ->assertSee('Saved!')
+            ->assertSee('alert-success');
+    }
+
+    public function testItCanAddDynamicNotificationWithTitleDescriptionAndAcon()
+    {
+        Livewire::test('notifications')
+            ->call('notify', 'success', 'Saved!', 'Asset Created', 'MacBook added', 'fas fa-laptop')
+            ->assertSee('Asset Created')
+            ->assertSee('MacBook added')
+            ->assertSee('fas fa-laptop')
+            ->assertSee('alert-success');
+    }
+
+    public function testItCanAddDynamicNotificationWithHtmlMessage()
+    {
+        Livewire::test('notifications')
+            ->call('notify', 'success', '<strong>Bold</strong> text', null, null, null, true)
+            ->assertSeeHtml('<strong>Bold</strong> text');
+    }
+
+    public function testItCanReplaceDynamicNotificationByTag()
+    {
+        $component = Livewire::test('notifications')
+            ->call('notify', 'info', 'First message', null, null, null, false, false, 'progress');
+
+        $component->assertSee('First message');
+
+        $component->call('notify', 'info', 'Second message', null, null, null, false, false, 'progress');
+        $component->assertSee('Second message');
+        $component->assertDontSee('First message');
+    }
+
+    public function testItCanDismissDynamicNotificationById()
+    {
+        $component = Livewire::test('notifications')
+            ->call('notify', 'info', 'Dismiss me!', null, null, null, false, false, 'tag1');
+        $alertId = $component->get('liveAlerts')[0]['id'];
+
+        $component->call('dismiss', $alertId)
+            ->assertDontSee('Dismiss me!');
+    }
+
+    public function testLegacySessionSuccessNotificationIsRendered()
+    {
+        Session::flash('success', 'Legacy flash success!');
+        Livewire::test('notifications')
+            ->assertSee('Legacy flash success!')
+            ->assertSee('alert-success');
+    }
+
+    public function testLegacySessionErrorNotificationIsRendered()
+    {
+        Session::flash('error', 'Legacy error!');
+        Livewire::test('notifications')
+            ->assertSee('Legacy error!')
+            ->assertSee('alert-danger');
+    }
+
+    public function testLegacySessionSuccessUnescapedNotificationIsRendered()
+    {
+        Session::flash('success-unescaped', '<b>Legacy Unescaped</b>');
+        Livewire::test('notifications')
+            ->assertSeeHtml('<b>Legacy Unescaped</b>');
+    }
+
+    public function testLegacySessionWarningNotificationIsRendered()
+    {
+        Session::flash('warning', 'Legacy warning!');
+        Livewire::test('notifications')
+            ->assertSee('Legacy warning!')
+            ->assertSee('alert-warning');
+    }
+
+    public function testLegacySessionInfoNotificationIsRendered()
+    {
+        Session::flash('info', 'Legacy info!');
+        Livewire::test('notifications')
+            ->assertSee('Legacy info!')
+            ->assertSee(values: 'alert-info');
+    }
+
+    public function testLegacySessionBulkAssetErrorsAreRendered()
+    {
+        Session::flash('bulk_asset_errors', [
+            'row1' => ['Missing tag'],
+            'row2' => ['Model not found', 'Serial required'],
+        ]);
+        Livewire::test('notifications')
+            ->assertSee('Missing tag')
+            ->assertSee('Model not found')
+            ->assertSee('Serial required');
+    }
+}

--- a/tests/Feature/NotificationsComponentTest.php
+++ b/tests/Feature/NotificationsComponentTest.php
@@ -45,16 +45,6 @@ class NotificationsComponentTest extends TestCase
         $component->assertDontSee('First message');
     }
 
-    public function testItCanDismissDynamicNotificationById()
-    {
-        $component = Livewire::test('notifications')
-            ->call('notify', 'info', 'Dismiss me!', null, null, null, false, false, 'tag1');
-        $alertId = $component->get('liveAlerts')[0]['id'];
-
-        $component->call('dismiss', $alertId)
-            ->assertDontSee('Dismiss me!');
-    }
-
     public function testLegacySessionSuccessNotificationIsRendered()
     {
         Session::flash('success', 'Legacy flash success!');


### PR DESCRIPTION
Hi,

we are developing a new advanced search and predefined filters (See https://github.com/grokability/snipe-it/issues/17494), and we needed a way to show notifications from JS on the frontend. So we developed a solution to do that over livewire.

Issue: #18289 

**Usage:**
```js
Livewire.dispatch('showNotification', {
   type: 'success',
   title: 'Asset Saved',
   message: 'MacBook Pro added.',
   description: 'Tag: MBP-4418<br>Assigned to Jane Doe',
   icon: 'fas fa-laptop',
   html: true,
   tag: 'asset-create'
 });

 // Update same tagged notification later:
 Livewire.dispatch('showNotification', {
   type: 'info',
   message: 'Processing (70%)',
   tag: 'bulk-import'
 });

 // Dismiss all notifcations:
 Livewire.dispatch('dismissAllNotifications');
```

**It supports:**
 - Dispatching events with basic (type, message)
 - Extended payload (type, title, message, description, icon, html, confetti, auto, tag)
 - Replacing an existing alert by tag (so you can "update progress" style messages)
 - Optional legacy string-only usage

**Livewire Notifications Component:**

* Added a new `Notifications` Livewire component (`app/Livewire/Notifications.php`) supporting dynamic notifications with extended payloads, tag-based replacement, and dismissals.
* Updated the default layout to render the new Livewire notifications component instead of the legacy Blade include (`resources/views/layouts/default.blade.php`).

**View Layer Refactor:**

* Created a new Blade view for the Livewire notifications component that renders both legacy session flashes and new dynamic alerts (`resources/views/livewire/notifications.blade.php`).
* Added a partial for rendering individual live alerts with support for icons, titles, descriptions, and HTML content (`resources/views/partials/live-alert.blade.php`).
* Introduced a reusable alert Blade component for consistent alert rendering (`resources/views/components/alert.blade.php`).

**Testing:**

* Added some tests for the notifications component, covering dynamic alerts, tag replacement, dismissals, and legacy session flashes (`tests/Feature/NotificationsComponentTest.php`).

In  #18264 @marcusmoore mentioned that we should move this in a separate PR.