### PR TITLE
Fixes [FD-50838] adjust `Tze_24mm_E` 2D barcode 20% bigger, scales fields, center label more

### DIFF
--- a/app/Models/Labels/Tapes/Brother/TZe_24mm_E.php
+++ b/app/Models/Labels/Tapes/Brother/TZe_24mm_E.php
@@ -30,12 +30,12 @@ class TZe_24mm_E extends TZe_24mm
         $pa = $this->getPrintableArea();
 
         $currentX = $pa->x1;
-        $currentY = $pa->y1;
+        $currentY = $pa->y1 -2;
         $usableWidth = $pa->w;
 
 
         $usableHeight = $pa->h - self::BARCODE1D_SIZE;
-        $barcodeSize = $usableHeight - self::TAG_SIZE;
+        $barcodeSize = ($usableHeight - self::TAG_SIZE) * 1.2;
 
         if ($record->has('barcode2d')) {
             static::writeText(
@@ -70,10 +70,27 @@ class TZe_24mm_E extends TZe_24mm
             $currentY += self::TITLE_SIZE + self::TITLE_MARGIN;
         }
 
-        foreach ($record->get('fields') as $field) {
+        $fields = $record->get('fields');
+        // Figure out how tall the label fields wants to be
+        $fieldCount = count($fields);
+        $perFieldHeight = (self::LABEL_SIZE + self::LABEL_MARGIN)
+            + (self::FIELD_SIZE + self::FIELD_MARGIN);
+
+        $baseHeight = $fieldCount * $perFieldHeight;
+        // If it doesn't fit in the available height, scale everything down
+        $scale = 1.0;
+        if ($baseHeight > $usableHeight && $baseHeight > 0) {
+            $scale = $usableHeight / $baseHeight;
+        }
+
+        $labelSize   = self::LABEL_SIZE   * $scale;
+        $fieldSize   = self::FIELD_SIZE   * $scale;
+        $fieldMargin = self::FIELD_MARGIN * $scale;
+
+        foreach ($fields as $field) {
             // Write label and value on the same line
             // Calculate label width with proportional character spacing
-            $labelWidth = $pdf->GetStringWidth($field['label'], 'freesans', '', self::LABEL_SIZE);
+            $labelWidth = $pdf->GetStringWidth($field['label'], 'freesans', '', $labelSize);
             $charCount = strlen($field['label']);
             $spacingPerChar = 0.5;
             $totalSpacing = $charCount * $spacingPerChar;
@@ -82,18 +99,18 @@ class TZe_24mm_E extends TZe_24mm
             static::writeText(
                 $pdf, $field['label'],
                 $currentX, $currentY,
-                'freesans', 'B', self::LABEL_SIZE, 'L',
-                $adjustedWidth, self::LABEL_SIZE, true, 0, $spacingPerChar
+                'freesans', 'B', $labelSize, 'L',
+                $adjustedWidth, $labelSize, true, 0, $spacingPerChar
             );
 
             static::writeText(
                 $pdf, $field['value'],
                 $currentX + $adjustedWidth + 2, $currentY,
-                'freesans', 'B', self::FIELD_SIZE, 'L',
-                $usableWidth - $adjustedWidth - 2, self::FIELD_SIZE, true, 0, 0.3
+                'freesans', 'B', $fieldSize, 'L',
+                $usableWidth - $adjustedWidth - 2, $fieldSize, true, 0, 0.3
             );
 
-            $currentY += max(self::LABEL_SIZE, self::FIELD_SIZE) + self::FIELD_MARGIN;
+            $currentY += max($labelSize, $fieldSize) +$fieldMargin;
         }
 
         


### PR DESCRIPTION
Noticed fields were overlapping for `Tze_24mm_E`. This adds scaling to fields, enlarges the 2D barcode 20%, and centers the label more.

Before:
<img width="671" height="240" alt="image" src="https://github.com/user-attachments/assets/af338475-8b8b-4558-bdeb-7b24e0f0fa4e" />
After:
<img width="671" height="240" alt="image" src="https://github.com/user-attachments/assets/fd6add78-a09c-418c-ad54-72ddc68f06dd" />
