### PR TITLE
Adds [FD-52267] TZe_241 based on TZe_18mm sizes

### DIFF
--- a/app/Models/Labels/Tapes/Brother/TZe_241.php
+++ b/app/Models/Labels/Tapes/Brother/TZe_241.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Models\Labels\Tapes\Brother;
+
+class TZe_241 extends TZe_18mm
+{
+    private const LABEL_SIZE   = 5.0;
+    private const LABEL_MARGIN = 0.6;
+    private const FIELD_SIZE   = 5.0;
+    private const FIELD_MARGIN = 0.8;
+
+    public function getUnit()
+    {
+        return 'mm'; 
+    }
+    public function getWidth()
+    {
+        return 50.0; 
+    }
+    public function getSupportAssetTag()
+    {
+        return false;
+    }
+    public function getSupport1DBarcode()
+    {
+        return false;
+    }
+    public function getSupport2DBarcode()
+    {
+        return false; 
+    }
+    public function getSupportFields()
+    {
+        return 2;
+    }
+    public function getSupportLogo()
+    {
+        return false; 
+    }
+    public function getSupportTitle()
+    {
+        return false; 
+    }
+
+    public function preparePDF($pdf){}
+
+    public function write($pdf, $record)
+    {
+        $pa = $this->getPrintableArea();
+
+        $currentX      = $pa->x1;
+        $currentY      = $pa->y1;
+        $usableWidth   = $pa->w;
+        $usableHeight  = $pa->h;
+
+        $fields = $record->get('fields') ?? [];
+
+        $fieldCount = count($fields);
+
+        $perFieldHeight = (self::LABEL_SIZE + self::LABEL_MARGIN)
+            + (self::FIELD_SIZE + self::FIELD_MARGIN);
+
+        $baseHeight = $fieldCount * $perFieldHeight;
+
+        // If it doesn't fit in the available height, scale everything down
+        $scale = 1.0;
+        if ($baseHeight > $usableHeight && $baseHeight > 0) {
+            $scale = $usableHeight / $baseHeight;
+        }
+
+        $labelSize   = self::LABEL_SIZE   * $scale;
+        $labelMargin = self::LABEL_MARGIN * $scale;
+        $fieldSize   = self::FIELD_SIZE   * $scale;
+        $fieldMargin = self::FIELD_MARGIN * $scale;
+
+        foreach ($fields as $field) {
+            static::writeText(
+                $pdf, $field['label'],
+                $currentX, $currentY,
+                'freesans', '', $labelSize, 'L',
+                $usableWidth, $labelSize, true, 0
+            );
+            $currentY += $labelSize + $labelMargin;
+
+            static::writeText(
+                $pdf, $field['value'],
+                $currentX, $currentY,
+                'freemono', 'B', $fieldSize, 'L',
+                $usableWidth, $fieldSize, true, 0, 0.01
+            );
+            $currentY += $fieldSize + $fieldMargin;
+        }
+    }
+}


### PR DESCRIPTION
This adds TZe_241 with only two fields and no barcodes. I have not test printed this, but in theory it should be the right size.

<img width="1095" height="85" alt="image" src="https://github.com/user-attachments/assets/d63a7df7-7f42-44e6-aa1c-ecda24d7f7dc" />

<img width="809" height="317" alt="image" src="https://github.com/user-attachments/assets/39cf016e-03fc-414f-a9b8-decedada3e75" />

<img width="1095" height="548" alt="image" src="https://github.com/user-attachments/assets/5a6d2d86-9d29-4773-b30e-fd3ba0978461" />
