### PR TITLE
Change title_class to ucfirst in Object Import Command to allow AssetModel

### DIFF
--- a/app/Console/Commands/ObjectImportCommand.php
+++ b/app/Console/Commands/ObjectImportCommand.php
@@ -56,7 +56,7 @@ class ObjectImportCommand extends Command
         $this->progressIndicator = new ProgressIndicator($this->output);
 
         $filename = $this->argument('filename');
-        $class = title_case($this->option('item-type'));
+        $class = ucfirst($this->option('item-type'));
         $classString = "App\\Importer\\{$class}Importer";
         $importer = new $classString($filename);
         $importer->setCallbacks([$this, 'log'], [$this, 'progress'], [$this, 'errorCallback'])


### PR DESCRIPTION
Related to Issue #18305 php artisan snipeit:import --item-type=AssetModel error:
`Class "App\Importer\AssetmodelImporter" not found`
Change title_class to ucfirst in Object Import Command to allow AssetModel.