### PR TITLE
Fixed unreadable table on dark mode for asset model bulk edit, added breadcrumbs

### DIFF
--- a/resources/views/hardware/bulk-delete.blade.php
+++ b/resources/views/hardware/bulk-delete.blade.php
@@ -2,7 +2,7 @@
 
 {{-- Page title --}}
 @section('title')
-{{ trans('admin/hardware/form.bulk_delete') }}
+{{ trans('general.bulk_delete') }}
 @parent
 @stop
 

--- a/resources/views/hardware/bulk-delete.blade.php
+++ b/resources/views/hardware/bulk-delete.blade.php
@@ -11,7 +11,7 @@
 @section('content')
 <div class="row">
   <!-- left column -->
-  <div class="col-md-12">
+  <div class="col-md-8 col-md-offset-2">
     <p>{{ trans('admin/hardware/form.bulk_delete_help') }}</p>
     <form class="form-horizontal" method="post" action="{{ route('hardware.bulkdelete.store') }}" autocomplete="off" role="form">
       {{csrf_field()}}

--- a/resources/views/hardware/bulk-delete.blade.php
+++ b/resources/views/hardware/bulk-delete.blade.php
@@ -6,10 +6,6 @@
 @parent
 @stop
 
-@section('header_right')
-<a href="{{ URL::previous() }}" class="btn btn-primary pull-right">
-  {{ trans('general.back') }}</a>
-@stop
 
 {{-- Page content --}}
 @section('content')
@@ -17,16 +13,19 @@
   <!-- left column -->
   <div class="col-md-12">
     <p>{{ trans('admin/hardware/form.bulk_delete_help') }}</p>
-    <form class="form-horizontal" method="post" action="{{ route('hardware/bulkdelete') }}" autocomplete="off" role="form">
+    <form class="form-horizontal" method="post" action="{{ route('hardware.bulkdelete.store') }}" autocomplete="off" role="form">
       {{csrf_field()}}
       <div class="box box-default">
-        <div class="box-header with-border">
-          <h2 class="box-title" style="color: red">{{ trans('admin/hardware/form.bulk_delete_warn', ['asset_count' => count($assets)]) }}</h2>
-        </div>
 
         <div class="box-body">
-          <table class="table table-striped table-condensed">
-            <thead>
+
+            <div class="callout callout-warning">
+                <i class="fas fa-exclamation-triangle"></i>
+                {{ trans('admin/hardware/form.bulk_delete_warn', ['asset_count' => count($assets)]) }}
+            </div>
+
+          <table class="table table-striped">
+
               <tr>
                 <th></th>
                 <th>{{ trans('admin/hardware/table.id') }}</th>
@@ -34,7 +33,7 @@
                 <th>{{ trans('admin/hardware/table.location')}}</th>
                 <th>{{ trans('admin/hardware/table.assigned_to') }}</th>
               </tr>
-            </thead>
+
             <tbody>
               @foreach ($assets as $asset)
               <tr>
@@ -60,7 +59,7 @@
         </div><!-- /.box-body -->
 
         <div class="box-footer text-right">
-          <a class="btn btn-link" href="{{ URL::previous() }}">
+          <a class="btn btn-link pull-left" href="{{ URL::previous() }}">
             {{ trans('button.cancel') }}
           </a>
           <button type="submit" class="btn btn-success" id="submit-button">

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -290,7 +290,7 @@
                                 <div class="col-md-12 hidden-print" style="padding-top: 5px;">
                                     <form
                                         method="POST"
-                                        action="{{ route('hardware/bulkedit') }}"
+                                        action="{{ route('hardware.bulkdelete.store') }}"
                                         accept-charset="UTF-8"
                                         class="form-inline"
                                         target="_blank"

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -801,6 +801,10 @@
             color: var(--color-fg) !important;
         }
 
+        .table > tbody + tbody {
+            border-top: 0px !important;
+        }
+
     </style>
 
     {{-- Custom CSS --}}

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -43,25 +43,25 @@
 
         :root {
             color-scheme: light dark;
-            --main-theme-color: {{ $snipeSettings->header_color ?? '#5fa4cc' }};
-            --btn-theme-text-color: {{ $nav_link_color ?? 'light-dark(hsl(from var(--main-theme-color) h s calc(l + 10)),hsl(from var(--main-theme-color) h s calc(l - 10)))' }};
             --btn-theme-hover-text-color: {{ $nav_link_color ?? 'light-dark(hsl(from var(--main-theme-color) h s calc(l - 10)),hsl(from var(--main-theme-color) h s calc(l - 10)))' }};
             --btn-theme-hover: {{ $nav_link_color ?? 'light-dark(hsl(from var(--main-theme-color) h s calc(l - 10)),hsl(from var(--main-theme-color) h s calc(l - 10)))' }};
+            --btn-theme-text-color: {{ $nav_link_color ?? 'light-dark(hsl(from var(--main-theme-color) h s calc(l + 10)),hsl(from var(--main-theme-color) h s calc(l - 10)))' }};
+            --color-fg: light-dark(#373636, #ffffff);
+            --main-footer-bg-color: light-dark(#ffffff,#3d4144);
+            --main-footer-text-color: light-dark(#605e5e, #d2d6de);
+            --main-footer-top-border-color: light-dark(#d2d6de,#605e5e);
+            --main-theme-color: {{ $snipeSettings->header_color ?? '#5fa4cc' }};
+            --nav-hover-text-color: {{ $nav_link_color ?? 'light-dark(hsl(from var(--main-theme-color) h s calc(l - 10)),hsl(from var(--main-theme-color) h s calc(l - 10)))' }};
+            --nav-primary-text-color: {{ $nav_link_color ?? 'light-dark(hsl(from var(--main-theme-color) h s calc(l - 10)),hsl(from var(--main-theme-color) h s calc(l - 10)))' }};
+            --search-highlight: #e9d15b;
+            --sidenav-hover-color-bg: #4c4b4b;
             --sidenav-text-hover-color: #fff;
             --sidenav-text-nohover-color: #b8c7ce;
-            --sidenav-hover-color-bg: #4c4b4b;
-            --search-highlight: #e9d15b;
-            --color-fg: light-dark(#373636, #ffffff);
             --text-danger: light-dark(#a94442,#dd4b39);
+            --text-help: light-dark(#605e5e,#a6a4a4);
+            --text-info: light-dark(#31708f,#2baae6);
             --text-success: light-dark(#039516,#4ced61);
             --text-warning: light-dark(#da9113,#f3a51f);
-            --text-info: light-dark(#31708f,#2baae6);
-            --text-help: light-dark(#605e5e,#a6a4a4);
-            --nav-primary-text-color: {{ $nav_link_color ?? 'light-dark(hsl(from var(--main-theme-color) h s calc(l - 10)),hsl(from var(--main-theme-color) h s calc(l - 10)))' }};
-            --nav-hover-text-color: {{ $nav_link_color ?? 'light-dark(hsl(from var(--main-theme-color) h s calc(l - 10)),hsl(from var(--main-theme-color) h s calc(l - 10)))' }};
-            --main-footer-bg-color: light-dark(#ffffff,#3d4144);
-            --main-footer-top-border-color: light-dark(#d2d6de,#605e5e);
-            --main-footer-text-color: light-dark(#605e5e, #d2d6de);
 
         }
 
@@ -80,18 +80,18 @@
             --callout-left-border: var(--box-header-top-border-color);
             --color-bg: #ecf0f5;
             --header-color: #000000;
+            --input-group-bg: hsl(from var(--box-bg) h s calc(l - 5));
+            --input-group-fg: hsl(from var(--input-group-bg) h s calc(l - 50));
             --link-color: {{ $link_light_color ?? '#296282' }};
             --link-hover:  hsl(from var(--link-color) h s calc(l - 10));
             --main-theme-hover: hsl(from var(--main-theme-color) h s calc(l - 10));
             --tab-bottom-border: 1px solid var(--box-header-top-border-color);
-            --table-border-row: 1px solid #ecf0f5;
             --table-border-row-top: 1px solid #ecf0f5;
+            --table-border-row: 1px solid #ecf0f5;
             --table-stripe-bg-alt: rgba(211, 211, 211, 0.25);
             --table-stripe-bg: #ffffff;
             --text-legend-help: var(--text-help);
             --text-warning: #da9113;
-            --input-group-bg: hsl(from var(--box-bg) h s calc(l - 5));
-            --input-group-fg: hsl(from var(--input-group-bg) h s calc(l - 50));
 
         }
 
@@ -110,6 +110,8 @@
             --callout-left-border: #323131;
             --color-bg: #222222;
             --header-color: #ffffff;
+            --input-group-bg: hsl(from var(--box-bg) h s calc(l + 10));
+            --input-group-fg: hsl(from var(--input-group-bg) h s calc(l + 50));
             --link-color: {{ $link_dark_color ?? '#5fa4cc' }};
             --link-hover:  hsl(from var(--link-color) h s calc(l + 15));
             --main-theme-hover: hsl(from var(--main-theme-color) h s calc(l - 10));
@@ -118,8 +120,6 @@
             --table-stripe-bg-alt: #323131;
             --table-stripe-bg: #494747;
             --text-legend-help: #d6d6d6;
-            --input-group-bg: hsl(from var(--box-bg) h s calc(l + 10));
-            --input-group-fg: hsl(from var(--input-group-bg) h s calc(l + 50));
 
         }
 

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -84,6 +84,7 @@
             --link-hover:  hsl(from var(--link-color) h s calc(l - 10));
             --main-theme-hover: hsl(from var(--main-theme-color) h s calc(l - 10));
             --tab-bottom-border: 1px solid var(--box-header-top-border-color);
+            --table-border-row: 1px solid #ecf0f5;
             --table-border-row-top: 1px solid #ecf0f5;
             --table-stripe-bg-alt: rgba(211, 211, 211, 0.25);
             --table-stripe-bg: #ffffff;
@@ -437,7 +438,7 @@
         .table > tbody > tr > td,
         .table > tfoot > tr > td
         {
-            border-top: var(--table-border-row);
+            border-top: var(--table-border-row) !important;
         }
 
 

--- a/resources/views/models/bulk-edit.blade.php
+++ b/resources/views/models/bulk-edit.blade.php
@@ -2,15 +2,10 @@
 
 {{-- Page title --}}
 @section('title')
-    Bulk Edit
+    {{ trans('general.bluk_edit') }}
     @parent
 @stop
 
-
-@section('header_right')
-    <a href="{{ URL::previous() }}" class="btn btn-sm btn-theme pull-right">
-        {{ trans('general.back') }}</a>
-@stop
 
 {{-- Page content --}}
 @section('content')

--- a/resources/views/models/bulk-edit.blade.php
+++ b/resources/views/models/bulk-edit.blade.php
@@ -30,21 +30,20 @@
 
 
                         <table class="table">
-                            <tbody>
-                        @foreach ($models as $model)
+                            @foreach ($models as $model)
 
-                            <tr{!!  (($model->assets_count > 0 ) ? ' class="warning"' : ' class="success"') !!}>
-                                    <td>
-                                        <i class="fa {!!  (($model->assets_count > 0 ) ? 'fa-warning info' : 'fa-check success') !!}"></i>
-                                        {{ $model->display_name }}
+                                <tr>
+                                        <td>
+                                            <i class="fa {!!  (($model->assets_count > 0 ) ? 'fa-warning text-warning' : 'fa-check success') !!}"></i>
+                                            {{ $model->display_name }}
 
-                                            @if ($model->model_number)
-                                                ({{ $model->model_number }})
-                                            @endif
+                                                @if ($model->model_number)
+                                                    ({{ $model->model_number }})
+                                                @endif
+                                            </td>
+                                            <td>{{ $model->assets_count }} assets
                                         </td>
-                                        <td>{{ $model->assets_count }} assets
-                                    </td>
-                            </tr>
+                                </tr>
 
                         @endforeach
                         </table>
@@ -100,15 +99,9 @@
                                 <div class="col-md-9">
                                     <div class="form-inline" style="display: flex; align-items: center; gap: 8px;">
                                         <input type="checkbox" name="require_serial" value="1" id="require_serial" aria-label="require_serial" />
-                                        <a
-                                                href="#"
-                                                data-tooltip="true"
-                                                title="{{ trans('admin/hardware/general.require_serial_help') }}"
-                                                style="display: inline-flex; align-items: center;"
-                                        >
-                                            <x-icon type="info-circle" />
-                                            <span class="sr-only">{{ trans('admin/hardware/general.require_serial_help') }}</span>
-                                        </a>
+                                        <x-form-tooltip>
+                                            {{ trans('admin/hardware/general.require_serial_help') }}
+                                        </x-form-tooltip>
                                     </div>
                                 </div>
                             </div>
@@ -142,7 +135,7 @@
 
                     <div class="box-footer text-right">
                         <a class="btn btn-link pull-left" href="{{ URL::previous() }}" method="post" enctype="multipart/form-data">{{ trans('button.cancel') }}</a>
-                        <button type="submit" class="btn btn-success" id="submit-button"><x-icon type="checkmark" /> {{ trans('general.update') }}</button>
+                        <button type="submit" class="btn btn-success" id="submit-button"><x-icon type="checkmark" /> {{ trans('general.save') }}</button>
                     </div><!-- /.box-footer -->
                 </div> <!--/.box.box-default-->
             </form>

--- a/resources/views/models/bulk-edit.blade.php
+++ b/resources/views/models/bulk-edit.blade.php
@@ -29,7 +29,7 @@
                         </div>
 
 
-                        <table class="table">
+                        <table class="table table-striped">
                             @foreach ($models as $model)
 
                                 <tr>

--- a/resources/views/partials/asset-bulk-actions.blade.php
+++ b/resources/views/partials/asset-bulk-actions.blade.php
@@ -1,7 +1,7 @@
 <div id="{{ (isset($id_divname)) ? $id_divname : 'assetsBulkEditToolbar' }}" style="min-width:400px">
     <form
     method="POST"
-    action="{{ route('hardware/bulkedit') }}"
+    action="{{ route('hardware.bulkedit.show') }}"
     accept-charset="UTF-8"
     class="form-inline"
     id="{{ (isset($id_formname)) ? $id_formname : 'assetsBulkForm' }}"

--- a/routes/web/hardware.php
+++ b/routes/web/hardware.php
@@ -146,7 +146,7 @@ Route::group(
         )->name('hardware.bulkedit.show')
         ->breadcrumbs(fn (Trail $trail) =>
         $trail->parent('hardware.index')
-            ->push(trans('general.bulk_edit'), route('hardware.index')));
+            ->push(trans('general.bulk_delete'), route('hardware.index')));
 
         Route::post(
             'bulkdelete',

--- a/routes/web/hardware.php
+++ b/routes/web/hardware.php
@@ -143,12 +143,15 @@ Route::group(
         Route::post(
             'bulkedit',
             [BulkAssetsController::class, 'edit']
-        )->name('hardware/bulkedit');
+        )->name('hardware.bulkedit.show')
+        ->breadcrumbs(fn (Trail $trail) =>
+        $trail->parent('hardware.index')
+            ->push(trans('general.bulk_edit'), route('hardware.index')));
 
         Route::post(
             'bulkdelete',
             [BulkAssetsController::class, 'destroy']
-        )->name('hardware/bulkdelete');
+        )->name('hardware.bulkdelete.store');
 
         Route::post(
             'bulkrestore',

--- a/routes/web/models.php
+++ b/routes/web/models.php
@@ -59,7 +59,10 @@ Route::group(['prefix' => 'models', 'middleware' => ['auth']], function () {
             BulkAssetModelsController::class, 
             'edit'
         ]
-    )->name('models.bulkedit.index');
+    )->name('models.bulkedit.index')
+    ->breadcrumbs(fn (Trail $trail) =>
+    $trail->parent('models.index')
+        ->push(trans('general.bulk_edit'), route('models.index')));
 
     Route::post(
         'bulksave',

--- a/tests/Feature/Assets/Ui/BulkDeleteAssetsTest.php
+++ b/tests/Feature/Assets/Ui/BulkDeleteAssetsTest.php
@@ -76,7 +76,7 @@ class BulkDeleteAssetsTest extends TestCase
         $id_array = $assets->pluck('id')->toArray();
 
         $response = $this->actingAs($user)
-            ->from(route('hardware/bulkedit'))
+            ->from(route('hardware.bulkdelete.store'))
             ->post('/hardware/bulkdelete', [
             'ids'          => $id_array,
             'bulk_actions' => 'delete',
@@ -109,7 +109,7 @@ class BulkDeleteAssetsTest extends TestCase
         $this->assertTrue($test_ran, "Test never actually ran!");
 
         $response = $this->actingAs($user)
-            ->from(route('hardware/bulkedit'))
+            ->from(route('hardware.bulkdelete.store'))
             ->post(route('hardware/bulkrestore'), [
                 'ids'          => [$asset->id],
             ])->assertStatus(302);
@@ -132,7 +132,7 @@ class BulkDeleteAssetsTest extends TestCase
         $asset = Asset::factory()->create();
 
         $this->actingAs($user)
-            ->from(route('hardware/bulkedit'))
+            ->from(route('hardware.bulkdelete.store'))
             ->post('/hardware/bulkdelete', [
                 'ids'          => [$asset->id],
                 'bulk_actions' => 'delete',
@@ -159,7 +159,7 @@ class BulkDeleteAssetsTest extends TestCase
         $asset = Asset::factory()->deleted()->create();
 
         $this->actingAs($user)
-            ->from(route('hardware/bulkedit'))
+            ->from(route('hardware.bulkdelete.store'))
             ->post(route('hardware/bulkrestore'), [
                 'ids'          => [$asset->id],
                 'bulk_actions' => 'restore',
@@ -186,7 +186,7 @@ class BulkDeleteAssetsTest extends TestCase
         ]);
 
         $response = $this->actingAs($user)
-                ->from(route('hardware/bulkedit'))
+                ->from(route('hardware.bulkdelete.store'))
                 ->post('/hardware/bulkdelete', [
                     'ids'          => [$asset->id],
                     'bulk_actions' => 'delete',


### PR DESCRIPTION
This fixes the light-on-light text in the table for bulk editing asset models, and also adds/fixes some of the breadcrumbs associated with bulk actions.

### Before
<img width="1244" height="838" alt="Screenshot 2025-12-07 at 2 14 03 PM" src="https://github.com/user-attachments/assets/fc47ba10-efd0-41df-8509-f976c43a0590" />

### After
<img width="1243" height="1094" alt="Screenshot 2025-12-07 at 2 14 16 PM" src="https://github.com/user-attachments/assets/cb99f904-f992-4461-a67a-efb0d0ba358e" />
<img width="1234" height="1096" alt="Screenshot 2025-12-07 at 2 14 25 PM" src="https://github.com/user-attachments/assets/d6a3ec03-e47b-4bdd-87ca-8824d052c220" />
