### PR TITLE
Fixes [FD-52064] LabelWriter label font choice for fields, adds scaling to all labels.

### DIFF
--- a/app/Models/Labels/Tapes/Dymo/LabelWriter_11354.php
+++ b/app/Models/Labels/Tapes/Dymo/LabelWriter_11354.php
@@ -12,6 +12,8 @@ class LabelWriter_11354 extends LabelWriter
     private const TITLE_MARGIN     =   0.50;
     private const FIELD_SIZE       =   2.80;
     private const FIELD_MARGIN     =   0.15;
+    private const LABEL_SIZE       = 2.8;
+    private const LABEL_MARGIN     = 0.6;
 
     public function getUnit()
     {
@@ -102,22 +104,47 @@ class LabelWriter_11354 extends LabelWriter
             $currentY += self::TITLE_SIZE + self::TITLE_MARGIN;
         }
 
-        foreach ($record->get('fields') as $field) {
+        $fields = $record->get('fields');
+        // Below rescales the size of the field box to fit, it feels like it could/should be abstracted one class above
+        // to be usable on other labels but im unsure of how to implement that, since it uses a lot of private
+        // constants.
+
+        // Figure out how tall the label fields wants to be
+        $fieldCount = count($fields);
+        $perFieldHeight = (self::LABEL_SIZE + self::LABEL_MARGIN)
+            + (self::FIELD_SIZE + self::FIELD_MARGIN);
+        $usableHeight = $pa->h
+            - self::TAG_SIZE
+            - self::BARCODE_MARGIN;
+
+        $baseHeight = $fieldCount * $perFieldHeight;
+        // If it doesn't fit in the available height, scale everything down
+        $scale = 1.0;
+        if ($baseHeight > $usableHeight && $baseHeight > 0) {
+            $scale = $usableHeight / $baseHeight;
+        }
+
+        $labelSize   = self::LABEL_SIZE   * $scale;
+        $labelMargin = self::LABEL_MARGIN * $scale;
+        $fieldSize   = self::FIELD_SIZE   * $scale;
+        $fieldMargin = self::FIELD_MARGIN * $scale;
+
+        foreach ($fields as $field) {
             static::writeText(
                 $pdf, $field['label'],
                 $currentX, $currentY,
-                'freesans', '', self::TITLE_SIZE, 'L',
-                $usableWidth, self::TITLE_SIZE, true, 0
+                'freesans', '', $labelSize, 'L',
+                $usableWidth, $labelSize, true, 0
             );
-            $currentY += self::TITLE_SIZE + self::TITLE_MARGIN;
+            $currentY += $labelSize + $labelMargin;
 
             static::writeText(
                 $pdf, $field['value'],
                 $currentX, $currentY,
-                'freemono', 'B', self::FIELD_SIZE, 'L',
-                $usableWidth, self::FIELD_SIZE, true, 0, 0.5
+                'freemono', 'B', $fieldSize, 'L',
+                $usableWidth, $fieldSize, true, 0, 0.01
             );
-            $currentY += self::FIELD_SIZE + self::FIELD_MARGIN;
+            $currentY += $fieldSize + $fieldMargin;
         }
     }
 

--- a/app/Models/Labels/Tapes/Dymo/LabelWriter_11354.php
+++ b/app/Models/Labels/Tapes/Dymo/LabelWriter_11354.php
@@ -104,10 +104,18 @@ class LabelWriter_11354 extends LabelWriter
 
         foreach ($record->get('fields') as $field) {
             static::writeText(
-                $pdf, (($field['label']) ? $field['label'].' ' : '') . $field['value'],
+                $pdf, $field['label'],
                 $currentX, $currentY,
-                'freesans', '', self::FIELD_SIZE, 'L',
-                $usableWidth, self::FIELD_SIZE, true, 0, 0.3
+                'freesans', '', self::TITLE_SIZE, 'L',
+                $usableWidth, self::TITLE_SIZE, true, 0
+            );
+            $currentY += self::TITLE_SIZE + self::TITLE_MARGIN;
+
+            static::writeText(
+                $pdf, $field['value'],
+                $currentX, $currentY,
+                'freemono', 'B', self::FIELD_SIZE, 'L',
+                $usableWidth, self::FIELD_SIZE, true, 0, 0.5
             );
             $currentY += self::FIELD_SIZE + self::FIELD_MARGIN;
         }

--- a/app/Models/Labels/Tapes/Dymo/LabelWriter_1933081.php
+++ b/app/Models/Labels/Tapes/Dymo/LabelWriter_1933081.php
@@ -91,14 +91,47 @@ class LabelWriter_1933081 extends LabelWriter
             $currentY += self::TITLE_SIZE + self::TITLE_MARGIN;
         }
 
-        foreach ($record->get('fields') as $field) {
+        $fields = $record->get('fields');
+        // Below rescales the size of the field box to fit, it feels like it could/should be abstracted one class above
+        // to be usable on other labels but im unsure of how to implement that, since it uses a lot of private
+        // constants.
+
+        // Figure out how tall the label fields wants to be
+        $fieldCount = count($fields);
+        $perFieldHeight = (self::LABEL_SIZE + self::LABEL_MARGIN)
+            + (self::FIELD_SIZE + self::FIELD_MARGIN);
+        $usableHeight = $pa->h
+            - self::TAG_SIZE           // bottom tag text
+            - self::BARCODE_MARGIN;    // gap between fields and 1D
+
+        $baseHeight = $fieldCount * $perFieldHeight;
+        // If it doesn't fit in the available height, scale everything down
+        $scale = 1.0;
+        if ($baseHeight > $usableHeight && $baseHeight > 0) {
+            $scale = $usableHeight / $baseHeight;
+        }
+
+        $labelSize   = self::LABEL_SIZE   * $scale;
+        $labelMargin = self::LABEL_MARGIN * $scale;
+        $fieldSize   = self::FIELD_SIZE   * $scale;
+        $fieldMargin = self::FIELD_MARGIN * $scale;
+
+        foreach ($fields as $field) {
             static::writeText(
-                $pdf, (($field['label']) ? $field['label'].' ' : '') . $field['value'],
+                $pdf, $field['label'],
                 $currentX, $currentY,
-                'freesans', '', self::FIELD_SIZE, 'L',
-                $usableWidth, self::FIELD_SIZE, true, 0, 0.3
+                'freesans', '', $labelSize, 'L',
+                $usableWidth, $labelSize, true, 0
             );
-            $currentY += self::FIELD_SIZE + self::FIELD_MARGIN;
+            $currentY += $labelSize + $labelMargin;
+
+            static::writeText(
+                $pdf, $field['value'],
+                $currentX, $currentY,
+                'freemono', 'B', $fieldSize, 'L',
+                $usableWidth, $fieldSize, true, 0, 0.01
+            );
+            $currentY += $fieldSize + $fieldMargin;
         }
 
         if ($record->has('barcode1d')) {

--- a/app/Models/Labels/Tapes/Dymo/LabelWriter_2112283.php
+++ b/app/Models/Labels/Tapes/Dymo/LabelWriter_2112283.php
@@ -91,21 +91,47 @@ class LabelWriter_2112283 extends LabelWriter
             $currentY += self::TITLE_SIZE + self::TITLE_MARGIN;
         }
 
-        foreach ($record->get('fields') as $field) {
-            static::writeText(
-                $pdf, (($field['label']) ? $field['label'].' ' : '') . $field['value'],
-                $currentX, $currentY,
-                'freesans', '', self::FIELD_SIZE, 'L',
-                $usableWidth, self::FIELD_SIZE, true, 0, 0.3
-            );
-            $currentY += self::FIELD_SIZE + self::FIELD_MARGIN;
+        $fields = $record->get('fields');
+        // Below rescales the size of the field box to fit, it feels like it could/should be abstracted one class above
+        // to be usable on other labels but im unsure of how to implement that, since it uses a lot of private
+        // constants.
+
+        // Figure out how tall the label fields wants to be
+        $fieldCount = count($fields);
+        $perFieldHeight = (self::LABEL_SIZE + self::LABEL_MARGIN)
+            + (self::FIELD_SIZE + self::FIELD_MARGIN);
+        $usableHeight = $pa->h
+            - self::TAG_SIZE           // bottom tag text
+            - self::BARCODE_MARGIN;    // gap between fields and 1D
+
+        $baseHeight = $fieldCount * $perFieldHeight;
+        // If it doesn't fit in the available height, scale everything down
+        $scale = 1.0;
+        if ($baseHeight > $usableHeight && $baseHeight > 0) {
+            $scale = $usableHeight / $baseHeight;
         }
 
-        if ($record->has('barcode1d')) {
-            static::write1DBarcode(
-                $pdf, $record->get('barcode1d')->content, $record->get('barcode1d')->type,
-                $currentX, $barcodeSize + self::BARCODE_MARGIN, $usableWidth - self::TAG_SIZE, self::TAG_SIZE
+        $labelSize   = self::LABEL_SIZE   * $scale;
+        $labelMargin = self::LABEL_MARGIN * $scale;
+        $fieldSize   = self::FIELD_SIZE   * $scale;
+        $fieldMargin = self::FIELD_MARGIN * $scale;
+
+        foreach ($fields as $field) {
+            static::writeText(
+                $pdf, $field['label'],
+                $currentX, $currentY,
+                'freesans', '', $labelSize, 'L',
+                $usableWidth, $labelSize, true, 0
             );
+            $currentY += $labelSize + $labelMargin;
+
+            static::writeText(
+                $pdf, $field['value'],
+                $currentX, $currentY,
+                'freemono', 'B', $fieldSize, 'L',
+                $usableWidth, $fieldSize, true, 0, 0.01
+            );
+            $currentY += $fieldSize + $fieldMargin;
         }
     }
 

--- a/app/Models/Labels/Tapes/Dymo/LabelWriter_2112283.php
+++ b/app/Models/Labels/Tapes/Dymo/LabelWriter_2112283.php
@@ -133,6 +133,12 @@ class LabelWriter_2112283 extends LabelWriter
             );
             $currentY += $fieldSize + $fieldMargin;
         }
+        if ($record->has('barcode1d')) {
+            static::write1DBarcode(
+                $pdf, $record->get('barcode1d')->content, $record->get('barcode1d')->type,
+                $currentX, $barcodeSize + self::BARCODE_MARGIN, $usableWidth - self::TAG_SIZE, self::TAG_SIZE
+            );
+        }
     }
 
 }


### PR DESCRIPTION
This fixs the format of the labelWriter labels we have to a different font for the label title and the label value, also adds scaling to the labels.

`LabelWriter_11354` 
Before:
<img width="250" height="140" alt="image" src="https://github.com/user-attachments/assets/4f1b14b6-2327-475e-9cf4-959124153f91" />
After:
<img width="466" height="269" alt="image" src="https://github.com/user-attachments/assets/fcb26e51-5503-47d9-863d-d370a096718d" />

`LabelWriter_1933081`
Before:
<img width="830" height="235" alt="image" src="https://github.com/user-attachments/assets/3c27e50b-a1c2-4c02-8515-9c9291c43e78" />

After:
<img width="1153" height="322" alt="image" src="https://github.com/user-attachments/assets/12dcfe8f-0a75-443e-80b5-940dfd0e8339" />

`LabelWriter_2112283`
Before:
<img width="830" height="372" alt="image" src="https://github.com/user-attachments/assets/56726d09-4ccf-48d8-95ec-ceed7f168570" />

After:
<img width="830" height="372" alt="image" src="https://github.com/user-attachments/assets/cb267853-ac98-4682-9f1a-23d06c645c09" />

