### PR TITLE
Fixes [RB-20083] adds a null safe operator to asset status under account view-assets

### DIFF
--- a/resources/views/account/view-assets.blade.php
+++ b/resources/views/account/view-assets.blade.php
@@ -530,7 +530,7 @@
                         </td>
                         <td>
                           <x-icon type="circle-solid" class="text-blue" />
-                          {{ $asset->assetstatus->name }}
+                          {{ $asset->assetstatus?->name }}
                           <label class="label label-default">{{ trans('general.deployed') }}</label>
                         </td>
                         <td>


### PR DESCRIPTION
This adds a null safe operator to `->assetstatus` in the view assets tab in a user account.