### PR TITLE
Fixed "Bulk checkin / delete" for users in dark mode

### DIFF
--- a/resources/lang/en-US/admin/users/general.php
+++ b/resources/lang/en-US/admin/users/general.php
@@ -37,7 +37,7 @@ return [
     'superadmin_permission_warning' => 'Only superadmins may grant a user superadmin access.',
     'admin_permission_warning' => 'Only users with admins rights or greater may grant a user admin access.',
     'remove_group_memberships' => 'Remove Group Memberships',
-    'warning_deletion_information' => 'You are about to checkin ALL items from the :count user(s) listed below. Super admin names are highlighted in red.',
+    'warning_deletion_information' => 'You are about to checkin ALL items from the :count user(s) listed below.',
     'update_user_assets_status' => 'Update all assets for these users to this status',
     'checkin_user_properties' => 'Check in all properties associated with these users',
     'remote_label'   => 'This is a remote user',

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -465,7 +465,7 @@ return [
     'backup_delete_not_allowed'     => 'Deleting backups has been disabled in the .env file. Contact support or your systems administrator.',
     'additional_files'           => 'Additional Files',
     'shitty_browser'        => 'No signature detected. If you are using an older browser, please use a more modern browser to complete your asset acceptance.',
-    'bulk_soft_delete'      =>'Also soft-delete these users. Their asset history will remain intact unless/until you purge deleted records in the Admin Settings.',
+    'bulk_soft_delete'      =>'Also soft-delete these users. Their item history will remain intact unless/until you purge deleted records in the Admin Settings.',
     'bulk_checkin_delete_success' => 'Your selected users have been deleted and their items have been checked in.',
     'bulk_checkin_success' => 'The items for the selected users have been checked in.',
     'set_to_null'           => 'Delete values for this selection|Delete values for all :selection_count selections ',
@@ -649,6 +649,7 @@ return [
     'upload_deleted'        => 'Upload Deleted',
     'child_locations' => 'Child Locations',
     'append' => 'Append',
+    'optional' => 'OPTIONAL',
 
 // Add form placeholders here
     'placeholders' => [

--- a/resources/lang/en-US/tooltips.php
+++ b/resources/lang/en-US/tooltips.php
@@ -1,0 +1,24 @@
+<?php
+
+return array(
+
+    'disabled_assoc'  => [
+        'accessory' => 'This accessory cannot be deleted because it still has items, users, or locations associated with it',
+        'asset' => 'This asset cannot be deleted because it still has items associated with it',
+        'category' => 'This category cannot be deleted because it still has items associated with it',
+        'company' => 'This company cannot be deleted because it still has items or users associated with it',
+        'component' => 'This component cannot be deleted because it still has items associated with it',
+        'custom_field' => 'This custom field cannot be deleted because it is still associated with at least one fieldset',
+        'department' => 'This department cannot be deleted because it still has users associated with it',
+        'location' => 'This location cannot be deleted because it still has items or users associated with it',
+        'manufacturer' => 'This manufacturer cannot be deleted because it still has items associated with it',
+        'supplier' => 'This supplier cannot be deleted because it still has items associated with it',
+        'user' => 'This user cannot be deleted because it still has items associated with it',
+        'user_self' => 'You cannot delete yourself',
+    ],
+
+    'checkin_all' => [
+        'user' => 'Checkin all items for this user and optionally delete them. You will be able to confirm this on the next page.'
+    ],
+
+);

--- a/resources/views/users/confirm-bulk-delete.blade.php
+++ b/resources/views/users/confirm-bulk-delete.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts/default')
 {{-- Page title --}}
 @section('title')
-{!! trans('general.bulk_checkin_delete') !!}
+{{ trans('general.bulk_checkin_delete') }}
 @parent
 @stop
 
@@ -33,8 +33,32 @@
 
           <div class="col-md-12">
             <div class="table-responsive">
-              <table class="display table table-hover">
+              <table class="display table table-striped">
                 <thead>
+                <tr>
+                    <td colspan="8">
+                        <x-input.select
+                                name="status_id"
+                                id="status_id"
+                                :options="$statuslabel_list"
+                                :selected="old('status_id')"
+                                required
+                                style="width:350px"
+                                aria-label="status_id"
+                        />
+                        <label>
+                            {{ trans('admin/users/general.update_user_assets_status') }}
+                        </label>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="8">
+                        <label class="form-control">
+                            <input type="checkbox" name="delete_user" value="1">
+                            <span class="text-warning"><i class="fa fa-warning"></i> <strong>{{ trans('general.optional') }}:  {{ trans('general.bulk_soft_delete') }}</strong></span>
+                        </label>
+                    </td>
+                </tr>
                   <tr>
                     <th class="col-md-1">
                       <!-- <input type="checkbox" id="checkAll"> -->
@@ -65,7 +89,7 @@
                 </thead>
                 <tbody>
                   @foreach ($users as $user)
-                  <tr {!! ($user->isSuperUser() ? ' class="danger"':'') !!}>
+                  <tr>
                     <td>
                       @if (Auth::id()!=$user->id)
                       <input type="checkbox" name="ids[]" value="{{ $user->id }}"  checked="checked">
@@ -75,10 +99,29 @@
                     </td>
 
                     <td>
-                      <span {!! (Auth::user()->id==$user->id ? ' style="text-decoration: line-through"' : '') !!}>
-                        {{ $user->display_name }} ({{ $user->username }})
-                      </span>
-                      {{ (Auth::id()==$user->id ? ' (cannot delete yourself)' : '') }}
+
+                        @if (auth()->user()->id == $user->id)
+                            
+                            <span {!! (Auth::user()->id==$user->id ? ' style="text-decoration: line-through" class="text-danger"' : '') !!}>
+                                {{ $user->display_name }} ({{ $user->username }})
+                            </span>
+                        @elseif ($user->isSuperUser())
+                            <span class="text-danger">
+                                <i class="fas fa-crown text-danger"></i> {{ $user->display_name }} ({{ $user->username }})
+                            </span>
+                        @elseif ($user->isAdmin())
+                            <span class="text-warning">
+                                <i class="fas fa-crown text-warning"></i> {{ $user->display_name }} ({{ $user->username }})
+                            </span>
+                        @else
+                            {{ $user->display_name }} ({{ $user->username }})
+                        @endif
+
+
+                        @if (auth()->user()->id == $user->id)
+                            <i class="fas fa-x text-danger"></i> {{ trans('tooltips.disabled_assoc.user_self') }}
+                        @endif
+
                     </td>
                     <td>
                       @foreach ($user->groups as $group)
@@ -105,31 +148,7 @@
                   </tr>
                   @endforeach
                 </tbody>
-                <tfoot>
 
-                  <tr>
-                    <td colspan="8">
-                      <x-input.select
-                          name="status_id"
-                          id="status_id"
-                          :options="$statuslabel_list"
-                          :selected="old('status_id')"
-                          required
-                          style="width:250px"
-                          aria-label="status_id"
-                      />
-                      <label>{{ trans('admin/users/general.update_user_assets_status') }}</label>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td colspan="8" class="col-md-12 alert-danger">
-                      <label class="form-control">
-                        <input type="checkbox" name="delete_user" value="1">
-                        <span><i class="fa fa-warning fa-2x"></i> {{ trans('general.bulk_soft_delete') }}</span>
-                      </label>
-                    </td>
-                  </tr>
-                </tfoot>
               </table>
             </div> <!--/table-responsive-->
           </div><!--/col-md-12-->

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -276,26 +276,32 @@
             @can('update', $user)
                   @if ($user->deleted_at=='')
                     <div class="col-md-12" style="padding-top: 30px;">
-                        @if ($user->isDeletable())
+                        @if (($user->isDeletable()) && ($user->id!=auth()->user()->id))
                             <a href="" class="delete-asset btn-block btn btn-sm btn-danger btn-social hidden-print" data-toggle="modal" data-title="{{ trans('general.delete') }}" data-content="{{ trans('general.sure_to_delete_var', ['item' => $user->display_name]) }}" data-icon="fa-trash" data-target="#dataConfirmModal" onClick="return false;" >
                                 <x-icon type="delete" />
                                 {{ trans('button.delete')}}
                             </a>
-                            @else
-                            <button class="btn-block btn btn-sm btn-danger btn-social hidden-print disabled">
+                        @elseif ($user->id == auth()->user()->id)
+                            <button class="btn-block btn btn-sm btn-danger btn-social hidden-print disabled" data-tooltip="true" data-title="{{ trans('tooltips.disabled_assoc.user_self') }}">
+                                <x-icon type="delete" />
+                                {{ trans('button.delete')}}
+                            </button>
+                        @else
+                            <button class="btn-block btn btn-sm btn-danger btn-social hidden-print disabled" data-tooltip="true" data-title="{{ trans('tooltips.disabled_assoc.user') }}">
                                 <x-icon type="delete" />
                                 {{ trans('button.delete')}}
                             </button>
                         @endif
                     </div>
                     <div class="col-md-12" style="padding-top: 5px;">
+
                       <form action="{{ route('users/bulkedit') }}" method="POST">
                         <!-- CSRF Token -->
                         <input type="hidden" name="_token" value="{{ csrf_token() }}" />
                         <input type="hidden" name="bulk_actions" value="delete" />
 
                         <input type="hidden" name="ids[{{ $user->id }}]" value="{{ $user->id }}" />
-                        <button class="btn btn-block btn-sm btn-danger btn-social hidden-print">
+                        <button class="btn btn-block btn-sm btn-danger btn-social hidden-print" data-tooltip="true" data-title="{{ trans('tooltips.checkin_all.user') }}">
                             <x-icon type="checkin-and-delete" />
                             {{ trans('button.checkin_and_delete') }}
                         </button>

--- a/routes/web/users.php
+++ b/routes/web/users.php
@@ -100,7 +100,7 @@ Route::group(['prefix' => 'users', 'middleware' => ['auth']], function () {
     )->name('users/bulkedit')
         ->breadcrumbs(fn (Trail $trail) =>
         $trail->parent('users.index')
-            ->push(trans('general.bulk_checkin_delete'), route('ldap/user')));
+            ->push(trans('general.bulk_checkin_delete'), route('users.index')));
 
     Route::post(
         'merge',

--- a/routes/web/users.php
+++ b/routes/web/users.php
@@ -17,7 +17,7 @@ Route::group(['prefix' => 'users', 'middleware' => ['auth']], function () {
     )->name('ldap/user')
         ->breadcrumbs(fn (Trail $trail) =>
         $trail->parent('users.index')
-            ->push(trans('general.ldap_user_sync'), route('ldap/user')));;
+            ->push(trans('general.ldap_user_sync'), route('ldap/user')));
 
     Route::post(
         'ldap',
@@ -97,7 +97,10 @@ Route::group(['prefix' => 'users', 'middleware' => ['auth']], function () {
             Users\BulkUsersController::class, 
             'edit'
         ]
-    )->name('users/bulkedit');
+    )->name('users/bulkedit')
+        ->breadcrumbs(fn (Trail $trail) =>
+        $trail->parent('users.index')
+            ->push(trans('general.bulk_checkin_delete'), route('ldap/user')));
 
     Route::post(
         'merge',


### PR DESCRIPTION
This tweaks the bulk checkin + optional delete screen to be better compatible in dark mode, but also adds the breadcrumbs and moves a few things around for clarity and UX.

### Before
<img width="4650" height="5060" alt="FireShot Capture 086 - Bulk Checkin _ Delete Users __ Snipe-IT Demo -  snipe-it test" src="https://github.com/user-attachments/assets/8f7b4a07-b732-4c27-9a5a-a94289355152" />

### After
<img width="4650" height="5080" alt="FireShot Capture 084 - Bulk Checkin _ Delete Users __ Snipe-IT Demo -  snipe-it test" src="https://github.com/user-attachments/assets/8de96d92-5422-4131-bb45-c616cd521c77" />
<img width="4650" height="5080" alt="FireShot Capture 085 - Bulk Checkin _ Delete Users __ Snipe-IT Demo -  snipe-it test" src="https://github.com/user-attachments/assets/eecf4e6d-1e9c-4e80-a6d2-5b7cb1cf725b" />

