### PR TITLE
Fixes #18325: Ensure existing permission group users are maintained when editing a group

### DIFF
--- a/app/Http/Controllers/GroupsController.php
+++ b/app/Http/Controllers/GroupsController.php
@@ -55,7 +55,7 @@ class GroupsController extends Controller
         // Show the page
         return view('groups/edit', compact('permissions', 'selectedPermissions', 'groupPermissions'))
             ->with('group', $group)
-            ->with('associated_users', [])
+            ->with('associated_users', collect())
             ->with('unselected_users', $users)
             ->with('all_users_count', $users_count);
     }

--- a/resources/views/groups/edit.blade.php
+++ b/resources/views/groups/edit.blade.php
@@ -55,7 +55,7 @@
         @if(($all_users_count ) && ($all_users_count < config('app.max_unpaginated_records')))
 
         <!-- This hidden input will store the selected user IDs as a comma-separated string to avoid max_input_vars and max_multipart_body_parts php.ini issues -->
-        <input type="hidden" name="users_to_sync" id="hidden_ids_box" class="form-control" value="{{ ($associated_users && is_array($associated_users)) ? implode(",", $associated_users->pluck('id')->toArray()) :  '' }}"/>
+        <input type="hidden" name="users_to_sync" id="hidden_ids_box" class="form-control" value="{{ $associated_users->pluck('id')->implode(',') }}"/>
 
         <div class="addremove-multiselect">
                 <div class="col-lg-5 col-sm-5 col-xs-12">


### PR DESCRIPTION
Fixes #18325

The existing associated users for a permission group are being passed to the view as a Collection in `app/Http/Controllers/GroupsController.php`:

```php
public function edit(Group $group): View|RedirectResponse
    {
        $permissions = config("permissions");
        $groupPermissions = $group->decodePermissions();

        if (!is_array($groupPermissions) || !$groupPermissions) {
            $groupPermissions = [];
        }

        $selected_array = Helper::selectedPermissionsArray(
            $permissions,
            $groupPermissions,
        );

        $users_query = User::where("show_in_list", 1)->whereNull("deleted_at");
        $users_count = $users_query->count();

        $associated_users = collect();
        $unselected_users = collect();

        if ($users_count <= config("app.max_unpaginated_records")) {
            $associated_users = $group
                ->users()
                ->where("show_in_list", 1)
                ->orderBy("first_name", "asc")
                ->orderBy("last_name", "asc")
                ->get();
            // Get the unselected users
            $unselected_users = User::where("show_in_list", 1)
                ->whereNotIn("id", $associated_users->pluck("id")->toArray())
                ->orderBy("first_name", "asc")
                ->orderBy("last_name", "asc")
                ->get();
        }

        return view(
            "groups.edit",
            compact(
                "group",
                "permissions",
                "selected_array",
                "groupPermissions",
            ),
        )
            ->with("associated_users", $associated_users)
            ->with("unselected_users", $unselected_users)
            ->with("all_users_count", $users_count);
    }
```

However, in the `groups.edit` view, the value of the `users_to_sync` hidden field is checking if the `$associated_users` prop is an array. Since that prop is actually a Collection, this check fails, and the value defaults to an empty string even if there are users already associated with this group.

```html
<input type="hidden" name="users_to_sync" id="hidden_ids_box" class="form-control" value="{{ ($associated_users && is_array($associated_users)) ? implode(",", $associated_users->pluck('id')->toArray()) :  '' }}"/>
```

Once the form is submitted, unless the users have been updated (i.e. users were added or removed to the group as part of the update -- I assume this is thanks to select2 pulling the existing members back in), all existing pivot records for the group are dropped from the `users_groups` table in the database when `$group->users()->sync($associated_users)` is called in the controller's update method since `$associated_users` consists solely of an empty string.

The fix removes the conditional and uses Collection methods directly: `pluck('id')->implode(',')`. This works for both groups with no existing members (returning an empty string) and groups with existing members (returning a comma-separated list of user IDs), ensuring user-group associations are maintained when the group is updated.