### PR TITLE
Added #17197: Ability to download uploaded import CSVs

### DIFF
--- a/app/Http/Controllers/Api/ImportController.php
+++ b/app/Http/Controllers/Api/ImportController.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Eloquent\JsonEncodingException;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 use League\Csv\Reader;
 use Onnov\DetectEncoding\EncodingDetector;
 use Symfony\Component\HttpFoundation\File\Exception\FileException;
@@ -149,7 +150,9 @@ class ImportController extends Controller
                 }
 
                 $date = date('Y-m-d-his');
-                $fixed_filename = str_slug($file->getClientOriginalName());
+
+                $fixed_filename = Str::of($file->getClientOriginalName())->basename('.csv').'.csv';
+                
                 try {
                     $file->move($path, $date.'-'.$fixed_filename);
                 } catch (FileException $exception) {
@@ -211,36 +214,47 @@ class ImportController extends Controller
         $redirectTo = 'hardware.index';
         switch ($request->get('import-type')) {
             case 'asset':
+                $model_perms = 'App\Models\Asset';
                 $redirectTo = 'hardware.index';
                 break;
             case 'assetModel':
+                $model_perms = 'App\Models\AssetModel';
                 $redirectTo = 'models.index';
                 break;
             case 'accessory':
+                $model_perms = 'App\Models\Accessory';
                 $redirectTo = 'accessories.index';
                 break;
             case 'consumable':
+                $model_perms = 'App\Models\Consumable';
                 $redirectTo = 'consumables.index';
                 break;
             case 'component':
+                $model_perms = 'App\Models\Component';
                 $redirectTo = 'components.index';
                 break;
             case 'license':
+                $model_perms = 'App\Models\License';
                 $redirectTo = 'licenses.index';
                 break;
             case 'user':
+                $model_perms = 'App\Models\User';
                 $redirectTo = 'users.index';
                 break;
             case 'location':
+                $model_perms = 'App\Models\Location';
                 $redirectTo = 'locations.index';
                 break;
             case 'supplier':
+                $model_perms = 'App\Models\Supplier';
                 $redirectTo = 'suppliers.index';
                 break;
             case 'manufacturer':
+                $model_perms = 'App\Models\Manufacturer';
                 $redirectTo = 'manufacturers.index';
                 break;
             case 'category':
+                $model_perms = 'App\Models\Category';
                 $redirectTo = 'categories.index';
                 break;
         }
@@ -251,7 +265,11 @@ class ImportController extends Controller
         //Flash message before the redirect
         Session::flash('success', trans('admin/hardware/message.import.success'));
 
-        return response()->json(Helper::formatStandardApiResponse('success', null, ['redirect_url' => route($redirectTo)]));
+        if (auth()->user()->can('view', $model_perms)) {
+            return response()->json(Helper::formatStandardApiResponse('success', null, ['redirect_url' => route($redirectTo)]));
+        }
+
+        return response()->json(Helper::formatStandardApiResponse('success', null, ['redirect_url' => route('imports.index')]));
     }
 
     /**
@@ -261,18 +279,25 @@ class ImportController extends Controller
      */
     public function destroy($import_id) : JsonResponse
     {
-        $this->authorize('create', Asset::class);
+        $this->authorize('import');
 
         if ($import = Import::find($import_id)) {
+
+
+            if ((auth()->user()->id != $import->created_by) && (!auth()->user()->isSuperUser())) {
+                return response()->json(Helper::formatStandardApiResponse('warning', null, trans('admin/hardware/message.import.file_not_deleted_warning')));
+            }
+
+
             try {
                 // Try to delete the file
                 Storage::delete('imports/'.$import->file_path);
-                $import->delete();
+                // $import->delete();
 
                 return response()->json(Helper::formatStandardApiResponse('success', null, trans('admin/hardware/message.import.file_delete_success')));
             } catch (\Exception $e) {
                 // If the file delete didn't work, remove it from the database anyway and return a warning
-                $import->delete();
+                // $import->delete();
 
                 return response()->json(Helper::formatStandardApiResponse('warning', null, trans('admin/hardware/message.import.file_not_deleted_warning')));
             }
@@ -280,4 +305,6 @@ class ImportController extends Controller
         }
         return response()->json(Helper::formatStandardApiResponse('warning', null, trans('admin/hardware/message.import.file_not_deleted_warning')));
     }
+
+
 }

--- a/app/Http/Controllers/Api/ImportController.php
+++ b/app/Http/Controllers/Api/ImportController.php
@@ -152,7 +152,7 @@ class ImportController extends Controller
                 $date = date('Y-m-d-his');
 
                 $fixed_filename = Str::of($file->getClientOriginalName())->basename('.csv').'.csv';
-                
+
                 try {
                     $file->move($path, $date.'-'.$fixed_filename);
                 } catch (FileException $exception) {
@@ -292,12 +292,12 @@ class ImportController extends Controller
             try {
                 // Try to delete the file
                 Storage::delete('imports/'.$import->file_path);
-                // $import->delete();
+                $import->delete();
 
                 return response()->json(Helper::formatStandardApiResponse('success', null, trans('admin/hardware/message.import.file_delete_success')));
             } catch (\Exception $e) {
                 // If the file delete didn't work, remove it from the database anyway and return a warning
-                // $import->delete();
+                $import->delete();
 
                 return response()->json(Helper::formatStandardApiResponse('warning', null, trans('admin/hardware/message.import.file_not_deleted_warning')));
             }

--- a/app/Http/Controllers/UploadedFilesController.php
+++ b/app/Http/Controllers/UploadedFilesController.php
@@ -2,9 +2,11 @@
 
 namespace App\Http\Controllers;
 
+use App\Helpers\Helper;
 use App\Helpers\StorageHelper;
 use App\Http\Requests\UploadFileRequest;
 use App\Models\Actionlog;
+use App\Models\Import;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -155,7 +157,31 @@ class UploadedFilesController extends Controller
         }
 
         // The file doesn't seem to really exist, so report an error
-        return redirect()->back()->withFragment('files')->with('success', trans_choice('general.file_upload_status.delete.error', 1));
+        return redirect()->back()->withFragment('files')->with('error', trans_choice('general.file_upload_status.delete.error', 1));
+
+    }
+
+    public function downloadImport(Import $import) {
+
+        $this->authorize('import');
+
+        if ($import = Import::find($import->id)) {
+
+            if ((auth()->user()->id != $import->created_by) && (!auth()->user()->isSuperUser())) {
+                return redirect()->back()->with('error', trans('general.file_upload_status.file_not_found'));
+            }
+
+            if (config('filesystems.default') == 's3_private') {
+                return redirect()->away(Storage::disk('s3_private')->temporaryUrl('private_uploads/imports/' . $import->file_path, now()->addMinutes(5)));
+            }
+
+            if (Storage::exists('private_uploads/imports/' . $import->file_path)) {
+                return response()->download(config('app.private_uploads') . '/imports/' . $import->file_path);
+            }
+
+        }
+
+        return redirect()->back()->with('error', trans('general.file_upload_status.file_not_found'));
 
     }
 

--- a/app/Livewire/Importer.php
+++ b/app/Livewire/Importer.php
@@ -673,6 +673,13 @@ class Importer extends Component
             return;
         }
 
+        if ((auth()->user()->id != $import->created_by) && (!auth()->user()->isSuperUser())) {
+            $this->message = trans('general.generic_model_not_found', ['model' => trans('general.import')]);
+            $this->message_type = 'danger';
+
+            return;
+        }
+
         if (Storage::delete('private_uploads/imports/' . $import->file_path)) {
             $import->delete();
             $this->message = trans('admin/hardware/message.import.file_delete_success');
@@ -683,7 +690,7 @@ class Importer extends Component
             return;
         }
 
-        $this->message = trans('admin/hardware/message.import.file_delete_error');
+        $this->message = trans('general.generic_model_not_found', ['model' => trans('general.import')]);
         $this->message_type = 'danger';
     }
 

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -805,6 +805,10 @@
             border-top: 0px !important;
         }
 
+        h4#progress-text {
+            color: white !important;
+        }
+
     </style>
 
     {{-- Custom CSS --}}

--- a/resources/views/livewire/importer.blade.php
+++ b/resources/views/livewire/importer.blade.php
@@ -97,9 +97,7 @@
                         </div>
                         <div class="row">
                             <div class="col-md-12 table-responsive" style="padding-top: 30px;">
-                                <table
-                                        data-id-table="upload-table"
-
+                                <table data-id-table="upload-table"
                                         data-side-pagination="client"
                                         id="upload-table"
                                         class="col-md-12 table table-striped snipe-table">
@@ -126,9 +124,26 @@
                                     @foreach($this->files as $currentFile)
 
                                     		<tr style="{{ ($this->activeFile && ($currentFile->id == $this->activeFile->id)) ? 'font-weight: bold' : '' }}" class="{{ ($this->activeFile && ($currentFile->id == $this->activeFile->id)) ? '' : '' }}">
-                                    			<td>{{ $currentFile->file_path }}</td>
+                                    			<td>
+                                                    @if ((auth()->user()->id == $currentFile->adminuser->id) || (auth()->user()->isSuperUser()))
+                                                        <a href="{{ route('imports.download', $currentFile) }}">{{ $currentFile->file_path }}</a>
+                                                    @else
+                                                        {{ $currentFile->file_path }}
+                                                    @endif
+                                                </td>
                                     			<td>{{ Helper::getFormattedDateObject($currentFile->created_at, 'datetime', false) }}</td>
-                                                <td>{{ ($currentFile->adminuser) ? $currentFile->adminuser->present()->fullName : '--'}}</td>
+                                                <td>
+                                                    @if ($currentFile->adminuser)
+                                                        @can('view', $currentFile->adminuser)
+                                                            <a href="{{ route('users.show', $currentFile->adminuser) }}">{{ $currentFile->adminuser->display_name }}</a>
+                                                        @else
+                                                            {{ $currentFile->adminuser->display_name }}
+                                                        @endcan
+                                                    @else
+                                                        ---
+                                                    @endif
+
+                                                </td>
                                     			<td>{{ Helper::formatFilesizeUnits($currentFile->filesize) }}</td>
                                                 <td class="col-md-1 text-right" style="white-space: nowrap;">
                                                     <button class="btn btn-sm btn-info" wire:click="selectFile({{ $currentFile->id }})" data-tooltip="true" data-title="{{ trans('general.import_this_file') }}">

--- a/resources/views/livewire/importer.blade.php
+++ b/resources/views/livewire/importer.blade.php
@@ -150,12 +150,20 @@
                                                         <i class="fa-solid fa-list-check" aria-hidden="true"></i>
                                                         <span class="sr-only">{{ trans('general.import') }}</span>
                                                     </button>
-                                                    <a href="#" wire:click.prevent="$set('activeFileId',null)" data-tooltip="true" data-title="{{ trans('general.delete') }}">
-                                                    <button class="btn btn-sm btn-danger" wire:click="destroy({{ $currentFile->id }})">
-                                                        <i class="fas fa-trash icon-white" aria-hidden="true"></i>
-                                                        <span class="sr-only">{{ trans('general.delete') }}</span>
-                                                    </button>
-                                                    </a>
+                                                    @if ((auth()->user()->id == $currentFile->adminuser->id) || (auth()->user()->isSuperUser()))
+                                                        <a href="#" wire:click.prevent="$set('activeFileId',null)" data-tooltip="true" data-title="{{ trans('general.delete') }}">
+                                                            <button class="btn btn-sm btn-danger" wire:click="destroy({{ $currentFile->id }})">
+                                                                <i class="fas fa-trash icon-white" aria-hidden="true"></i>
+                                                                <span class="sr-only">{{ trans('general.delete') }}</span>
+                                                            </button>
+                                                        </a>
+                                                    @else
+                                                        <a data-tooltip="true" class="btn btn-sm btn-danger disabled" data-title="{{ trans('general.delete') }}">
+                                                            <i class="fas fa-trash icon-white" aria-hidden="true"></i>
+                                                            <span class="sr-only">{{ trans('general.delete') }}</span>
+                                                        </a>
+                                                    @endif
+
                                     			</td>
                                     		</tr>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Account;
 use App\Http\Controllers\ActionlogController;
+use App\Http\Controllers\Api\ImportController;
 use App\Http\Controllers\Auth\ForgotPasswordController;
 use App\Http\Controllers\Auth\LoginController;
 use App\Http\Controllers\Auth\ResetPasswordController;
@@ -333,12 +334,24 @@ Route::group(['prefix' => 'admin', 'middleware' => ['auth', 'authorize:superuser
 |
 */
 
-Route::get('/import', Importer::class)
-    ->middleware('auth')
-    ->name('imports.index')
-    ->breadcrumbs(fn (Trail $trail) =>
-    $trail->parent('home')
-        ->push(trans('general.import'), route('imports.index')));
+Route::group(['prefix' => 'import', 'middleware' => ['auth']], function () {
+
+    Route::get('download/{import}',
+        [
+            UploadedFilesController::class,
+            'downloadImport'
+        ]
+    )->name('imports.download');
+
+    Route::get('/', Importer::class)
+        ->middleware('auth')
+        ->name('imports.index')
+        ->breadcrumbs(fn (Trail $trail) =>
+        $trail->parent('home')
+            ->push(trans('general.import'), route('imports.index')));
+
+});
+
 
 /*
 |--------------------------------------------------------------------------
@@ -743,6 +756,9 @@ Route::group(['middleware' => 'web'], function () {
         ]
     )->name('ui.files.destroy')
         ->where(['object_type' => 'assets|maintenances|hardware|models|users|locations|accessories|consumables|licenses|suppliers|components']);
+
+
+
 });
 
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -756,9 +756,6 @@ Route::group(['middleware' => 'web'], function () {
         ]
     )->name('ui.files.destroy')
         ->where(['object_type' => 'assets|maintenances|hardware|models|users|locations|accessories|consumables|licenses|suppliers|components']);
-
-
-
 });
 
 


### PR DESCRIPTION
This adds the ability for users to download previously uploaded import files. Superusers can download any of the uploaded imports, and non-superusers can only download imports they themselves have uploaded. 

This also checks to see whether or not the user actually has permission to go to the FCO they are importing. Why wouldn't they be able to, you might ask? Beat me, but I've seen it happen. Previously, this would sad panda you, if for example you were importing categories (because you needed them for asset models, which you *do* have access to see), after you imported the categories, you'd end up at a sad panda, since you can't actually see categories. Now it will redirect you back to the import index if you don't have permission to see whatever it is you're importing. 

This *also* disallows users who are not superusers from deleting files they don't own. 

It also normalizes the .csv extension on download. 

<img width="1585" height="1098" alt="Screenshot 2025-12-09 at 11 54 58 PM" src="https://github.com/user-attachments/assets/d9ef427d-a4d7-4cca-aacd-5620d15e050a" />
<img width="1583" height="1093" alt="Screenshot 2025-12-09 at 11 56 19 PM" src="https://github.com/user-attachments/assets/8d9eb04a-e035-4b13-b348-4661acb6a53c" />
