### PR TITLE
Fixed #18317 - Longer double scrollbar issue

### DIFF
--- a/resources/views/accessories/view.blade.php
+++ b/resources/views/accessories/view.blade.php
@@ -72,7 +72,6 @@
                 <div class="tab-content">
 
                     <div class="tab-pane active" id="checkedout">
-                        <div class="table table-responsive">
                           <div class="row">
                               <div class="col-md-12">
                                 <table
@@ -89,16 +88,14 @@
                                     "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                                     }'>
                                 </table>
-                            </div><!--col-md-9-->
-                          </div> <!-- close tab-pane div -->
-                        </div>
+                            </div><!--./col-md-12-->
+                          </div> <!-- ./row -->
                     </div>
 
                     <!-- history tab pane -->
                      <div class="tab-pane fade" id="history">
-                         <div class="table-responsive">
-                             <div class="row">
-                                 <div class="col-md-12">
+                         <div class="row">
+                             <div class="col-md-12">
                                 <table
                                         data-columns="{{ \App\Presenters\HistoryPresenter::dataTableLayout() }}"
                                         class="table table-striped snipe-table"
@@ -108,14 +105,13 @@
                                         data-side-pagination="server"
                                         data-sort-order="desc"
                                         data-export-options='{
-                       "fileName": "export-{{ str_slug($accessory->name) }}-history-{{ date('Y-m-d') }}",
-                       "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
-                     }'
+                                           "fileName": "export-{{ str_slug($accessory->name) }}-history-{{ date('Y-m-d') }}",
+                                           "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
+                                         }'
                                         data-url="{{ route('api.activity.index', ['item_id' => $accessory->id, 'item_type' => 'accessory']) }}">
-                                        </table>
-                                    </div> <!-- /.col-md-12-->
-                                </div> <!-- /.row-->
-                            </div><!--tab history-->
+                                    </table>
+                                </div> <!-- /.col-md-12-->
+                            </div> <!-- /.row-->
                      </div>
 
 

--- a/resources/views/account/accept/index.blade.php
+++ b/resources/views/account/accept/index.blade.php
@@ -15,7 +15,6 @@
       <div class="box-body">
         <!-- checked out Accessories table -->
 
-        <div class="table-responsive">
           <table
                   data-cookie-id-table="pendingAcceptances"
                   data-id-table="pendingAcceptances"
@@ -55,8 +54,6 @@
             </tbody>
           </table>
         </div>
-
-       </div> <!-- .box-body-->
     </div><!--.box.box-default-->
   </div> <!-- .col-md-12-->
 </div> <!-- .row-->

--- a/resources/views/account/requestable-assets.blade.php
+++ b/resources/views/account/requestable-assets.blade.php
@@ -49,47 +49,45 @@
                 <div class="tab-pane fade in active" id="assets">
                     <div class="row">
                         <div class="col-md-12">
-                                <div class="table-responsive">
-                                    <table
-                                        data-cookie-id-table="requestableAssetsListingTable"
-                                        data-id-table="requestableAssetsListingTable"
-                                        data-side-pagination="server"
-                                        data-show-export="false"
-                                        data-show-footer="false"
-                                        data-sort-order="asc"
-                                        data-sort-name="name"
-                                        data-toolbar="#assetsBulkEditToolbar"
-                                        data-bulk-button-id="#bulkAssetEditButton"
-                                        data-bulk-form-id="#assetsBulkForm"
-                                        id="assetsListingTable"
-                                        class="table table-striped snipe-table"
-                                        data-url="{{ route('api.assets.requestable', ['requestable' => true]) }}">
+                            <table
+                                data-cookie-id-table="requestableAssetsListingTable"
+                                data-id-table="requestableAssetsListingTable"
+                                data-side-pagination="server"
+                                data-show-export="false"
+                                data-show-footer="false"
+                                data-sort-order="asc"
+                                data-sort-name="name"
+                                data-toolbar="#assetsBulkEditToolbar"
+                                data-bulk-button-id="#bulkAssetEditButton"
+                                data-bulk-form-id="#assetsBulkForm"
+                                id="assetsListingTable"
+                                class="table table-striped snipe-table"
+                                data-url="{{ route('api.assets.requestable', ['requestable' => true]) }}">
 
-                                        <thead>
-                                            <tr>
-                                                <th class="col-md-1" data-field="image" data-formatter="imageFormatter" data-sortable="true">{{ trans('general.image') }}</th>
-                                                <th class="col-md-2" data-field="asset_tag" data-sortable="true" >{{ trans('general.asset_tag') }}</th>                                                
-                                                <th class="col-md-2" data-field="model" data-sortable="true">{{ trans('admin/hardware/table.asset_model') }}</th>
-                                                <th class="col-md-2" data-field="model_number" data-sortable="true">{{ trans('admin/models/table.modelnumber') }}</th>
-                                                <th class="col-md-2" data-field="name" data-sortable="true">{{ trans('admin/hardware/form.name') }}</th>
-                                                <th class="col-md-3" data-field="serial" data-sortable="true">{{ trans('admin/hardware/table.serial') }}</th>
-                                                <th class="col-md-2" data-field="location" data-sortable="true">{{ trans('admin/hardware/table.location') }}</th>
-                                                <th class="col-md-2" data-field="status" data-sortable="true">{{ trans('admin/hardware/table.status') }}</th>
-                                                <th class="col-md-2" data-field="expected_checkin" data-formatter="dateDisplayFormatter" data-sortable="true">{{ trans('admin/hardware/form.expected_checkin') }}</th>
+                                <thead>
+                                    <tr>
+                                        <th class="col-md-1" data-field="image" data-formatter="imageFormatter" data-sortable="true">{{ trans('general.image') }}</th>
+                                        <th class="col-md-2" data-field="asset_tag" data-sortable="true" >{{ trans('general.asset_tag') }}</th>
+                                        <th class="col-md-2" data-field="model" data-sortable="true">{{ trans('admin/hardware/table.asset_model') }}</th>
+                                        <th class="col-md-2" data-field="model_number" data-sortable="true">{{ trans('admin/models/table.modelnumber') }}</th>
+                                        <th class="col-md-2" data-field="name" data-sortable="true">{{ trans('admin/hardware/form.name') }}</th>
+                                        <th class="col-md-3" data-field="serial" data-sortable="true">{{ trans('admin/hardware/table.serial') }}</th>
+                                        <th class="col-md-2" data-field="location" data-sortable="true">{{ trans('admin/hardware/table.location') }}</th>
+                                        <th class="col-md-2" data-field="status" data-sortable="true">{{ trans('admin/hardware/table.status') }}</th>
+                                        <th class="col-md-2" data-field="expected_checkin" data-formatter="dateDisplayFormatter" data-sortable="true">{{ trans('admin/hardware/form.expected_checkin') }}</th>
 
-                                                @foreach(\App\Models\CustomField::get() as $field)
-                                                    @if (($field->field_encrypted=='0') && ($field->show_in_requestable_list=='1'))
-                                                        <th class="col-md-2" data-field="custom_fields.{{ $field->db_column }}" data-sortable="true">{{ $field->name }}</th>
-                                                    @endif
-                                                @endforeach
-                                                <th class="col-md-1" data-formatter="assetRequestActionsFormatter" data-field="actions" data-sortable="false">{{ trans('table.actions') }}</th>
-                                            </tr>
-                                        </thead>
-                                    </table>
-                                </div>
-                            </div>
+                                        @foreach(\App\Models\CustomField::get() as $field)
+                                            @if (($field->field_encrypted=='0') && ($field->show_in_requestable_list=='1'))
+                                                <th class="col-md-2" data-field="custom_fields.{{ $field->db_column }}" data-sortable="true">{{ $field->name }}</th>
+                                            @endif
+                                        @endforeach
+                                        <th class="col-md-1" data-formatter="assetRequestActionsFormatter" data-field="actions" data-sortable="false">{{ trans('table.actions') }}</th>
+                                    </tr>
+                                </thead>
+                            </table>
                         </div>
                     </div>
+                </div>
                 @endif
 
                 @if ($models->count() > 0)
@@ -97,7 +95,6 @@
                     <div class="row">
                         <div class="col-md-12">
                                 <table
-                                        name="requested-assets"
                                         data-toolbar="#toolbar"
                                         class="table table-striped snipe-table"
                                         id="table"

--- a/resources/views/blade/filestable.blade.php
+++ b/resources/views/blade/filestable.blade.php
@@ -5,7 +5,7 @@
 ])
 
 <!-- begin non-ajaxed file listing table -->
-<div class="table-responsive">
+
     <table
             data-columns="{{ \App\Presenters\UploadedFilesPresenter::dataTableLayout() }}"
             data-cookie-id-table="{{ $object_type }}-FileUploadsTable"
@@ -28,7 +28,6 @@
 
     <x-gallery-card />
 
-</div>
 
 
 

--- a/resources/views/categories/view.blade.php
+++ b/resources/views/categories/view.blade.php
@@ -52,7 +52,7 @@
                     <div class="tab-pane fade in active" id="items">
                         <div class="row">
                             <div class="col-md-12">
-                                <div class="table-responsive">
+
                                     @if ($category->category_type=='asset')
                                         @include('partials.asset-bulk-actions')
                                     @endif
@@ -121,7 +121,6 @@
                                             data-url="{{ route('api.'.$category_type_route.'.index',['category_id'=> $category->id]) }}">
 
                                     </table>
-                                </div>
                             </div>
                         </div>
                     </div>

--- a/resources/views/companies/view.blade.php
+++ b/resources/views/companies/view.blade.php
@@ -86,7 +86,6 @@
 
                     <div class="tab-pane fade in active" id="asset_tab">
                         <!-- checked out assets table -->
-                        <div class="table table-responsive">
                             @include('partials.asset-bulk-actions')
 
                             <table
@@ -107,11 +106,9 @@
                               "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                               }'>
                             </table>
-                        </div>
                     </div><!-- /asset_tab -->
 
                     <div class="tab-pane" id="licenses_tab">
-                        <div class="table-responsive">
 
                             <table
                                     data-columns="{{ \App\Presenters\LicensePresenter::dataTableLayout() }}"
@@ -128,11 +125,9 @@
                               }'>
                             </table>
 
-                        </div>
                     </div><!-- /licenses-tab -->
 
                     <div class="tab-pane" id="accessories_tab">
-                        <div class="table-responsive">
 
                             <table
                                     data-columns="{{ \App\Presenters\AccessoryPresenter::dataTableLayout() }}"
@@ -149,11 +144,9 @@
                               }'>
                             </table>
 
-                        </div>
                     </div><!-- /accessories-tab -->
 
                     <div class="tab-pane" id="consumables_tab">
-                        <div class="table-responsive">
 
                             <table
                                     data-columns="{{ \App\Presenters\ConsumablePresenter::dataTableLayout() }}"
@@ -170,11 +163,9 @@
                               }'>
                             </table>
 
-                        </div>
                     </div><!-- /consumables-tab -->
 
                     <div class="tab-pane" id="components_tab">
-                        <div class="table-responsive">
 
                             <table
                                     data-columns="{{ \App\Presenters\ComponentPresenter::dataTableLayout() }}"
@@ -191,12 +182,10 @@
                               }'>
 
                             </table>
-                        </div>
+
                     </div><!-- /consumables-tab -->
 
                     <div class="tab-pane" id="users_tab">
-                        <div class="table-responsive">
-
                             <table
                                     data-columns="{{ \App\Presenters\UserPresenter::dataTableLayout() }}"
                                     data-cookie-id-table="usersTable"
@@ -210,9 +199,7 @@
                               "fileName": "export-companies-{{ str_slug($company->name) }}-users-{{ date('Y-m-d') }}",
                               "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                               }'>
-
                             </table>
-                        </div>
                     </div><!-- /consumables-tab -->
 
 

--- a/resources/views/components/view.blade.php
+++ b/resources/views/components/view.blade.php
@@ -102,7 +102,7 @@
       <div class="tab-content">
 
         <div class="tab-pane active" id="checkedout">
-          <div class="table table-responsive">
+
 
             <table
                     data-cookie-id-table="componentsCheckedoutTable"
@@ -139,12 +139,9 @@
               </thead>
             </table>
 
-          </div>
         </div> <!-- close tab-pane div -->
 
         <div class="tab-pane" id="history">
-          <div class="table-responsive">
-
             <table
                     data-columns="{{ \App\Presenters\HistoryPresenter::dataTableLayout() }}"
                     class="table table-striped snipe-table"
@@ -161,7 +158,6 @@
                     data-cookie-id-table="componentHistory"
                     data-cookie="true">
             </table>
-          </div>
         </div><!-- /.tab-pane -->
 
 

--- a/resources/views/consumables/view.blade.php
+++ b/resources/views/consumables/view.blade.php
@@ -459,8 +459,6 @@
           </div><!--/FILES-->
 
           <div class="tab-pane" id="history">
-            <div class="table-responsive">
-
               <table
                       data-columns="{{ \App\Presenters\HistoryPresenter::dataTableLayout() }}"
                       class="table table-striped snipe-table"
@@ -473,12 +471,10 @@
                          "fileName": "export-consumable-{{  $consumable->id }}-history",
                          "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                        }'
-
                       data-url="{{ route('api.activity.index', ['item_id' => $consumable->id, 'item_type' => 'consumable']) }}"
                       data-cookie-id-table="consumableHistory"
                       data-cookie="true">
               </table>
-            </div>
           </div><!-- /.tab-pane -->
       </div><!-- /.tab-content -->
     </div><!-- nav-tabs-custom -->

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -226,7 +226,6 @@
       <div class="box-body">
         <div class="row">
           <div class="col-md-12">
-            <div class="table-responsive">
 
                 <table
                     data-cookie-id-table="dashActivityReport"
@@ -251,10 +250,6 @@
                     </tr>
                     </thead>
                 </table>
-
-
-
-            </div><!-- /.responsive -->
           </div><!-- /.col -->
           <div class="text-center col-md-12" style="padding-top: 10px;">
             <a href="{{ route('reports.activity') }}" class="btn btn-theme btn-sm" style="width: 100%">{{ trans('general.viewall') }}</a>
@@ -309,7 +304,6 @@
 				<div class="box-body">
 					<div class="row">
 						<div class="col-md-12">
-							<div class="table-responsive">
 							<table
 									data-cookie-id-table="dashCompanySummary"
 									data-height="400"
@@ -352,7 +346,6 @@
 								</tr>
 								</thead>
 							</table>
-							</div>
 						</div> <!-- /.col -->
 						<div class="text-center col-md-12" style="padding-top: 10px;">
 							<a href="{{ route('companies.index') }}" class="btn btn-theme btn-sm" style="width: 100%">{{ trans('general.viewall') }}</a>
@@ -378,7 +371,7 @@
 				<div class="box-body">
 					<div class="row">
 						<div class="col-md-12">
-							<div class="table-responsive">
+
 							<table
 									data-cookie-id-table="dashLocationSummary"
 									data-height="400"
@@ -411,7 +404,6 @@
 								</tr>
 								</thead>
 							</table>
-							</div>
 						</div> <!-- /.col -->
 						<div class="text-center col-md-12" style="padding-top: 10px;">
 							<a href="{{ route('locations.index') }}" class="btn btn-theme btn-sm" style="width: 100%">{{ trans('general.viewall') }}</a>
@@ -441,7 +433,7 @@
             <div class="box-body">
                 <div class="row">
                     <div class="col-md-12">
-                        <div class="table-responsive">
+
                         <table
                                 data-cookie-id-table="dashCategorySummary"
                                 data-height="400"
@@ -482,7 +474,7 @@
                             </tr>
                             </thead>
                         </table>
-                        </div>
+
                     </div> <!-- /.col -->
                     <div class="text-center col-md-12" style="padding-top: 10px;">
                         <a href="{{ route('categories.index') }}" class="btn btn-theme btn-sm" style="width: 100%">{{ trans('general.viewall') }}</a>

--- a/resources/views/departments/view.blade.php
+++ b/resources/views/departments/view.blade.php
@@ -21,26 +21,22 @@
                 <div class="box-body">
                     <div class="row">
                         <div class="col-md-12">
-                            <div class="table table-responsive">
+                            <table
+                                    data-columns="{{ \App\Presenters\UserPresenter::dataTableLayout() }}"
+                                    data-cookie-id-table="departmentsUsersTable"
+                                    data-id-table="departmentsUsersTable"
+                                    data-show-footer="true"
+                                    data-side-pagination="server"
+                                    data-sort-order="asc"
+                                    id="departmentsUsersTable"
+                                    class="table table-striped snipe-table"
+                                    data-url="{{ route('api.users.index',['department_id'=> $department->id]) }}"
+                                    data-export-options='{
+                          "fileName": "export-departments-{{ str_slug($department->name) }}-{{ date('Y-m-d') }}",
+                          "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
+                          }'>
 
-                                <table
-                                        data-columns="{{ \App\Presenters\UserPresenter::dataTableLayout() }}"
-                                        data-cookie-id-table="departmentsUsersTable"
-                                        data-id-table="departmentsUsersTable"
-                                        data-show-footer="true"
-                                        data-side-pagination="server"
-                                        data-sort-order="asc"
-                                        id="departmentsUsersTable"
-                                        class="table table-striped snipe-table"
-                                        data-url="{{ route('api.users.index',['department_id'=> $department->id]) }}"
-                                        data-export-options='{
-                              "fileName": "export-departments-{{ str_slug($department->name) }}-{{ date('Y-m-d') }}",
-                              "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
-                              }'>
-
-
-                                </table>
-                            </div>
+                            </table>
                         </div>
                     </div>
                 </div>

--- a/resources/views/depreciations/view.blade.php
+++ b/resources/views/depreciations/view.blade.php
@@ -30,6 +30,7 @@
             <!-- Custom Tabs -->
             <div class="nav-tabs-custom">
                 <ul class="nav nav-tabs">
+                    @can('view', \App\Models\Asset::class)
                     <li class="active">
                         <a href="#assets" data-toggle="tab">
                             {{ trans('general.assets') }}
@@ -37,6 +38,8 @@
                             {!! ($depreciation->assets()->AssetsForShow()->count() > 0 ) ? '<span class="badge badge-secondary">'.number_format($depreciation->assets()->AssetsForShow()->count()).'</span>' : '' !!}
                         </a>
                     </li>
+                    @endcan
+                    @can('view', \App\Models\License::class)
                     <li>
                         <a href="#licenses" data-toggle="tab">
                             {{ trans('general.licenses') }}
@@ -44,6 +47,8 @@
                             {!! ($depreciation->licenses_count > 0 ) ? '<span class="badge badge-secondary">'.number_format($depreciation->licenses_count).'</span>' : '' !!}
                         </a>
                     </li>
+                    @endcan
+                    @can('view', \App\Models\AssetModel::class)
                     <li>
                         <a href="#models" data-toggle="tab">
                             {{ trans('general.asset_models') }}
@@ -51,6 +56,7 @@
                             {!! ($depreciation->models_count > 0 ) ? '<span class="badge badge-secondary">'.number_format($depreciation->models_count).'</span>' : '' !!}
                         </a>
                     </li>
+                    @endcan
                 </ul>
 
                 <div class="tab-content">
@@ -89,9 +95,6 @@
                     <div class="tab-pane" id="licenses">
                         <div class="row">
                             <div class="col-md-12">
-
-                                <div class="table-responsive">
-
                                     <table
                                             data-columns="{{ \App\Presenters\LicensePresenter::dataTableLayout() }}"
                                             data-cookie-id-table="depreciationsLicenseTable"
@@ -107,9 +110,6 @@
                         "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                         }'>
                                     </table>
-
-                                </div>
-
                             </div>
 
                         </div> <!--/.row-->
@@ -122,16 +122,13 @@
                             <form method="POST" action="{{ route('models.bulkedit.index') }}" accept-charset="UTF-8" class="form-inline" id="bulkForm">
                             @csrf
                             <div class="col-md-12">
-                                <div id="toolbar">
-                                    <label for="bulk_actions" class="sr-only">{{ trans('general.bulk_actions') }}</label>
-                                    <select name="bulk_actions" class="form-control select2" aria-label="bulk_actions" style="width: 300px;">
-                                        <option value="edit">{{ trans('general.bulk_edit') }}</option>
-                                        <option value="delete">{{ trans('general.bulk_delete') }}</option>
-                                    </select>
-                                    <button class="btn btn-primary" id="AssetModelsBulkEditButton" disabled>{{ trans('button.go') }}</button>
-                                </div>
 
-                                <div class="table-responsive">
+                                @include('partials.models-bulk-actions', [
+                               'id_divname' => 'assetModelsBulkEditToolbar',
+                               'id_formname' => 'assetModelsBulkForm',
+                               'id_button' => 'AssetModelsBulkEditButton'
+                               ])
+
                                     <table
                                             data-columns="{{ \App\Presenters\AssetModelPresenter::dataTableLayout() }}"
                                             data-cookie-id-table="depreciationsModelsTable"
@@ -150,11 +147,7 @@
                         "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                         }'>
                                     </table>
-
-
                                 </div>
-
-                            </div>
                             </form>
 
                         </div> <!--/.row-->

--- a/resources/views/groups/index.blade.php
+++ b/resources/views/groups/index.blade.php
@@ -18,8 +18,6 @@
   <div class="col-md-12">
     <div class="box box-default">
       <div class="box-body">
-        <div class="table-responsive">
-
             <table
                 data-cookie-id-table="groupsTable"
                 data-side-pagination="server"
@@ -49,7 +47,6 @@
               </tr>
             </thead>
           </table>
-        </div>
       </div> <!--.box-body-->
     </div> <!-- /.box.box-default-->
   </div> <!-- .col-md-12-->

--- a/resources/views/hardware/audit-due.blade.php
+++ b/resources/views/hardware/audit-due.blade.php
@@ -45,10 +45,9 @@
                                 'id_formname' => 'dueAssetEditForm',
                                 'id_button'   => 'dueAssetEditButton'])
 
-                    <div class="row">
-                            <div class="table table-responsive">
-                        <div class="col-md-12">
-                            <table
+                        <div class="row">
+                            <div class="col-md-12">
+                                <table
 
                                     data-columns="{{ \App\Presenters\AssetAuditPresenter::dataTableLayout() }}"
                                     data-cookie-id-table="dueAssetAuditListing"
@@ -64,12 +63,11 @@
                                     class="table table-striped snipe-table"
                                     data-url="{{ route('api.assets.list-upcoming', ['action' => 'audits', 'upcoming_status' => 'due']) }}"
                                     data-export-options='{
-                "fileName": "export-assets-due-audit-{{ date('Y-m-d') }}",
-                "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
-                }'>
-                            </table>
-                                </div> <!-- end col-md-12 -->
-                            </div><!-- end table-responsive -->
+                                        "fileName": "export-assets-due-audit-{{ date('Y-m-d') }}",
+                                        "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
+                                        }'>
+                                </table>
+                            </div> <!-- end col-md-12 -->
                         </div><!-- end row -->
                     </div><!-- end tab-pane -->
 
@@ -82,7 +80,6 @@
                                     'id_button'   => 'overdueAssetEditButton'])
 
                         <div class="row">
-                            <div class="table table-responsive">
                                 <div class="col-md-12">
                                     <table
                                         data-columns="{{ \App\Presenters\AssetAuditPresenter::dataTableLayout() }}"
@@ -104,7 +101,6 @@
             }'>
                                     </table>
                                 </div> <!-- end col-md-12 -->
-                            </div><!-- end table-responsive -->
                         </div><!-- end row -->
                     </div><!-- end tab-pane -->
                 </div><!-- end tab-content -->

--- a/resources/views/hardware/checkin-due.blade.php
+++ b/resources/views/hardware/checkin-due.blade.php
@@ -44,31 +44,28 @@
                                 'id_button'   => 'dueAssetEditButton'])
 
                         <div class="row">
-                            <div class="table table-responsive">
                                 <div class="col-md-12">
                                     <table
-
-                                            data-columns="{{ \App\Presenters\AssetPresenter::dataTableLayout() }}"
-                                            data-show-columns-search="true"
-                                            data-cookie-id-table="dueAssetcheckinListing"
-                                            data-id-table="dueAssetcheckinListing"
-                                            data-side-pagination="server"
-                                            data-show-footer="true"
-                                            data-sort-order="asc"
-                                            data-sort-name="name"
-                                            data-toolbar="#dueAssetEditToolbar"
-                                            data-bulk-button-id="#dueAssetEditButton"
-                                            data-bulk-form-id="#dueAssetEditForm"
-                                            id="#dueAssetcheckinListing"
-                                            class="table table-striped snipe-table"
-                                            data-url="{{ route('api.assets.list-upcoming', ['action' => 'checkins', 'upcoming_status' => 'due']) }}"
-                                            data-export-options='{
-            "fileName": "export-assets-due-checkin-{{ date('Y-m-d') }}",
-            "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
-            }'>
+                                        data-columns="{{ \App\Presenters\AssetPresenter::dataTableLayout() }}"
+                                        data-show-columns-search="true"
+                                        data-cookie-id-table="dueAssetcheckinListing"
+                                        data-id-table="dueAssetcheckinListing"
+                                        data-side-pagination="server"
+                                        data-show-footer="true"
+                                        data-sort-order="asc"
+                                        data-sort-name="name"
+                                        data-toolbar="#dueAssetEditToolbar"
+                                        data-bulk-button-id="#dueAssetEditButton"
+                                        data-bulk-form-id="#dueAssetEditForm"
+                                        id="#dueAssetcheckinListing"
+                                        class="table table-striped snipe-table"
+                                        data-url="{{ route('api.assets.list-upcoming', ['action' => 'checkins', 'upcoming_status' => 'due']) }}"
+                                        data-export-options='{
+                                            "fileName": "export-assets-due-checkin-{{ date('Y-m-d') }}",
+                                            "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
+                                            }'>
                                     </table>
                                 </div> <!-- end col-md-12 -->
-                            </div><!-- end table-responsive -->
                         </div><!-- end row -->
                     </div><!-- end tab-pane -->
 
@@ -81,30 +78,27 @@
                                     'id_button'   => 'overdueAssetEditButton'])
 
                         <div class="row">
-                            <div class="table table-responsive">
-                                <div class="col-md-12">
-                                    <table
-
-                                            data-columns="{{ \App\Presenters\AssetPresenter::dataTableLayout() }}"
-                                            data-cookie-id-table="overdueAssetcheckinListing"
-                                            data-id-table="overdueAssetcheckinListing"
-                                            data-side-pagination="server"
-                                            data-show-footer="true"
-                                            data-sort-order="asc"
-                                            data-sort-name="name"
-                                            data-toolbar="#overdueAssetEditToolbar"
-                                            data-bulk-button-id="#overdueAssetEditButton"
-                                            data-bulk-form-id="#overdueAssetEditForm"
-                                            id="#overdueAssetcheckinListing"
-                                            class="table table-striped snipe-table"
-                                            data-url="{{ route('api.assets.list-upcoming', ['action' => 'checkins', 'upcoming_status' => 'overdue']) }}"
-                                            data-export-options='{
-            "fileName": "export-assets-overdue-checkin-{{ date('Y-m-d') }}",
-            "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
-            }'>
-                                    </table>
-                                </div> <!-- end col-md-12 -->
-                            </div><!-- end table-responsive -->
+                            <div class="col-md-12">
+                                <table
+                                    data-columns="{{ \App\Presenters\AssetPresenter::dataTableLayout() }}"
+                                    data-cookie-id-table="overdueAssetcheckinListing"
+                                    data-id-table="overdueAssetcheckinListing"
+                                    data-side-pagination="server"
+                                    data-show-footer="true"
+                                    data-sort-order="asc"
+                                    data-sort-name="name"
+                                    data-toolbar="#overdueAssetEditToolbar"
+                                    data-bulk-button-id="#overdueAssetEditButton"
+                                    data-bulk-form-id="#overdueAssetEditForm"
+                                    id="#overdueAssetcheckinListing"
+                                    class="table table-striped snipe-table"
+                                    data-url="{{ route('api.assets.list-upcoming', ['action' => 'checkins', 'upcoming_status' => 'overdue']) }}"
+                                    data-export-options='{
+                                        "fileName": "export-assets-overdue-checkin-{{ date('Y-m-d') }}",
+                                        "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
+                                        }'>
+                                </table>
+                            </div> <!-- end col-md-12 -->
                         </div><!-- end row -->
                     </div><!-- end tab-pane -->
                 </div><!-- end tab-content -->

--- a/resources/views/hardware/requested.blade.php
+++ b/resources/views/hardware/requested.blade.php
@@ -20,9 +20,7 @@
                     <div class="row">
                         <div class="col-md-12">
 
-        <div class="table-responsive">
             <table
-                    name="requestedAssets"
                     data-toolbar="#toolbar"
                     class="table table-striped snipe-table"
                     id="requestedAssets"
@@ -129,7 +127,6 @@
 
 
                         </div>
-                    </div>
                 </div>
             </div>
         </div>

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -1262,39 +1262,30 @@
                                     @include('partials.asset-bulk-actions')
 
                                         <!-- checked out assets table -->
-                                        <div class="table-responsive">
-
                                             <table
-                                                    data-columns="{{ \App\Presenters\AssetPresenter::dataTableLayout() }}"
-                                                    data-show-columns-search="true"
-                                                    data-cookie-id-table="assetsTable"
-                                                    data-id-table="assetsTable"
-                                                    data-side-pagination="server"
-                                                    data-sort-order="asc"
-                                                    data-toolbar="#assetsBulkEditToolbar"
-                                                    data-bulk-button-id="#bulkAssetEditButton"
-                                                    data-bulk-form-id="#assetsBulkForm"
-                                                    id="assetsListingTable"
-                                                    class="table table-striped snipe-table"
-                                                    data-url="{{route('api.assets.index',['assigned_to' => $asset->id, 'assigned_type' => 'App\Models\Asset']) }}"
-                                                    data-export-options='{
-                                  "fileName": "export-assets-{{ str_slug($asset->name) }}-assets-{{ date('Y-m-d') }}",
-                                  "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
-                                  }'>
-
+                                                data-columns="{{ \App\Presenters\AssetPresenter::dataTableLayout() }}"
+                                                data-show-columns-search="true"
+                                                data-cookie-id-table="assetsTable"
+                                                data-id-table="assetsTable"
+                                                data-side-pagination="server"
+                                                data-sort-order="asc"
+                                                data-toolbar="#assetsBulkEditToolbar"
+                                                data-bulk-button-id="#bulkAssetEditButton"
+                                                data-bulk-form-id="#assetsBulkForm"
+                                                id="assetsListingTable"
+                                                class="table table-striped snipe-table"
+                                                data-url="{{route('api.assets.index',['assigned_to' => $asset->id, 'assigned_type' => 'App\Models\Asset']) }}"
+                                                data-export-options='{
+                                                  "fileName": "export-assets-{{ str_slug($asset->name) }}-assets-{{ date('Y-m-d') }}",
+                                                  "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
+                                                  }'>
                                             </table>
-                                        </div>
-
-
                                 </div><!-- /col -->
                             </div> <!-- row -->
                         </div> <!-- /.tab-pane software -->
 
 
                     <div class="tab-pane" id="accessories_assigned">
-
-
-                        <div class="table table-responsive">
 
                             <h2 class="box-title" style="float:left">
                                 {{ trans('general.accessories_assigned') }}
@@ -1315,7 +1306,6 @@
                                   }'>
                             </table>
 
-                        </div><!-- /.table-responsive -->
                     </div><!-- /.tab-pane -->
 
 

--- a/resources/views/kits/edit.blade.php
+++ b/resources/views/kits/edit.blade.php
@@ -32,7 +32,7 @@
                 </div>
             </div>
             <div class="box-body">
-                <div class="table-responsive">
+
                 <table
                 data-cookie-id-table="kitModelsTable"
                 data-columns="{{ \App\Presenters\PredefinedKitPresenter::dataTableModels() }}"
@@ -48,7 +48,6 @@
                 }'>
                 </table>
 
-                </div>
             </div> <!--.box-body-->
         </div> <!-- /.box.box-default-->
     </div> <!-- .col-md-12-->
@@ -73,7 +72,7 @@
 
 {{--                </div>--}}
 {{--                <div class="box-body">--}}
-{{--                    <div class="table-responsive">--}}
+{{--                    --}}
 {{--                    <table--}}
 {{--                    data-cookie-id-table="kitLicensesTable"--}}
 {{--                    data-columns="{{ \App\Presenters\PredefinedKitPresenter::dataTableLicenses() }}"--}}
@@ -88,7 +87,6 @@
 {{--                    "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]--}}
 {{--                    }'>--}}
 {{--                    </table>--}}
-{{--                    </div>--}}
 {{--                </div> <!--.box-body-->--}}
 {{--            </div> <!-- /.box.box-default-->--}}
 {{--        </div> <!-- .col-md-12-->--}}
@@ -111,7 +109,7 @@
 {{--                    </div>--}}
 {{--                </div>--}}
 {{--                <div class="box-body">--}}
-{{--                    <div class="table-responsive">--}}
+{{--                    --}}
 {{--                    <table--}}
 {{--                    data-cookie-id-table="kitConsumablesTable"--}}
 {{--                    data-columns="{{ \App\Presenters\PredefinedKitPresenter::dataTableConsumables() }}"--}}
@@ -126,7 +124,6 @@
 {{--                    "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]--}}
 {{--                    }'>--}}
 {{--                    </table>--}}
-{{--                    </div>--}}
 {{--                </div> <!--.box-body-->--}}
 {{--            </div> <!-- /.box.box-default-->--}}
 {{--        </div> <!-- .col-md-12-->--}}
@@ -149,7 +146,7 @@
 
 {{--                </div>--}}
 {{--                <div class="box-body">--}}
-{{--                    <div class="table-responsive">--}}
+{{--                    --}}
 {{--                    <table--}}
 {{--                    data-cookie-id-table="kitAccessoriesTable"--}}
 {{--                    data-columns="{{ \App\Presenters\PredefinedKitPresenter::dataTableAccessories() }}"--}}
@@ -164,7 +161,6 @@
 {{--                    "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]--}}
 {{--                    }'>--}}
 {{--                    </table>--}}
-{{--                    </div>--}}
 {{--                </div> <!--.box-body-->--}}
 {{--            </div> <!-- /.box.box-default-->--}}
 {{--        </div> <!-- .col-md-12-->--}}

--- a/resources/views/licenses/view.blade.php
+++ b/resources/views/licenses/view.blade.php
@@ -441,9 +441,6 @@
           <div class="tab-pane" id="seats">
             <div class="row">
               <div class="col-md-12">
-
-                <div class="table-responsive">
-
                   <table
                           data-columns="{{ \App\Presenters\LicensePresenter::dataTableLayoutSeats() }}"
                           data-cookie-id-table="seatsTable"
@@ -460,9 +457,6 @@
                         "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                         }'>
                   </table>
-
-                </div>
-
               </div>
 
             </div> <!--/.row-->
@@ -471,8 +465,6 @@
           <div class="tab-pane" id="available-seats">
             <div class="row">
               <div class="col-md-12">
-                <div class="table-responsive">
-
                   <table
                           data-columns="{{ \App\Presenters\LicensePresenter::dataTableLayoutSeats() }}"
                           data-cookie-id-table="availableSeatsTable"
@@ -490,8 +482,6 @@
                         }'>
                   </table>
 
-                </div>
-
               </div>
 
             </div> <!--/.row-->
@@ -506,7 +496,7 @@
           <div class="tab-pane" id="history">
             <div class="row">
               <div class="col-md-12">
-                <div class="table-responsive">
+
                   <table
                           data-columns="{{ \App\Presenters\HistoryPresenter::dataTableLayout() }}"
                           class="table table-striped snipe-table"
@@ -521,7 +511,6 @@
                      }'
                           data-url="{{ route('api.activity.index', ['item_id' => $license->id, 'item_type' => 'license']) }}">
                   </table>
-                </div>
               </div> <!-- /.col-md-12-->
 
 

--- a/resources/views/manufacturers/view.blade.php
+++ b/resources/views/manufacturers/view.blade.php
@@ -101,7 +101,7 @@
         <div class="tab-pane fade in active" id="assets">
 
           @include('partials.asset-bulk-actions')
-          <div class="table table-responsive">
+
           <table
                   data-columns="{{ \App\Presenters\AssetPresenter::dataTableLayout() }}"
                   data-show-columns-search="true"
@@ -120,7 +120,6 @@
               "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
               }'>
           </table>
-          </div>
 
         </div> <!-- /.tab-pane assets -->
 

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -87,7 +87,7 @@
                     'fullscreen',
                     'advancedSearch',
                 ],
-                classes: 'table table-striped snipe-table table-no-bordered',
+                classes: 'table table-responsive table-striped snipe-table table-no-bordered',
                 clickToSelect: data_with_default('click-to-select', true),
                 cookie: true,
                 cookieExpire: '2y',

--- a/resources/views/reports/asset.blade.php
+++ b/resources/views/reports/asset.blade.php
@@ -18,7 +18,6 @@
     <div class="col-md-12">
         <div class="box box-default">
             <div class="box-body">
-                <div class="table-responsive">
 
                     <table
                     name="assetsReport"
@@ -70,7 +69,6 @@
                             </tr>
                         </thead>
                     </table>
-                </div> <!-- .table-responsive -->
             </div>
         </div>
     </div>

--- a/resources/views/reports/index.blade.php
+++ b/resources/views/reports/index.blade.php
@@ -18,7 +18,7 @@
 </div>
 
 <div class="row">
-    <div class="table-responsive">
+
         <table id="example">
             <thead>
                 <tr role="row">
@@ -85,7 +85,6 @@
                 @endforeach
             </tbody>
         </table>
-    </div>
 </div>
 
 @stop

--- a/resources/views/suppliers/view.blade.php
+++ b/resources/views/suppliers/view.blade.php
@@ -129,7 +129,7 @@
           <div class="tab-pane active" id="assets">
             <h2 class="box-title">{{ trans('general.assets') }}</h2>
 
-            <div class="table table-responsive">
+
               @include('partials.asset-bulk-actions')
               <table
                       data-cookie-id-table="suppliersAssetsTable"
@@ -158,7 +158,6 @@
 
           <div class="tab-pane" id="accessories">
             <h2 class="box-title">{{ trans('general.accessories') }}</h2>
-            <div class="table table-responsive">
               <table
                       data-columns="{{ \App\Presenters\AccessoryPresenter::dataTableLayout() }}"
                       data-cookie-id-table="accessoriesListingTable"
@@ -173,14 +172,12 @@
                               "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                               }'>
               </table>
-            </div><!-- /.table-responsive -->
           </div><!-- /.tab-pane -->
 
 
           <div class="tab-pane" id="licenses">
             <h2 class="box-title">{{ trans('general.licenses') }}</h2>
 
-            <div class="table table-responsive">
               <table
                       data-columns="{{ \App\Presenters\LicensePresenter::dataTableLayout() }}"
                       data-cookie-id-table="licensesListingTable"
@@ -196,12 +193,11 @@
                               }'>
               </table>
 
-            </div><!-- /.table-responsive -->
           </div><!-- /.tab-pane -->
 
             <div class="tab-pane" id="components">
                 <h2 class="box-title">{{ trans('general.components') }}</h2>
-                <div class="table table-responsive">
+
                     <table
                             data-columns="{{ \App\Presenters\ComponentPresenter::dataTableLayout() }}"
                             data-cookie-id-table="componentsListingTable"
@@ -216,12 +212,11 @@
                               "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                               }'>
                     </table>
-                </div><!-- /.table-responsive -->
             </div><!-- /.tab-pane -->
 
             <div class="tab-pane" id="consumables">
             <h2 class="box-title">{{ trans('general.consumables') }}</h2>
-            <div class="table table-responsive">
+
                 <table
                         data-columns="{{ \App\Presenters\ConsumablePresenter::dataTableLayout() }}"
                         data-cookie-id-table="consumablesListingTable"
@@ -236,13 +231,11 @@
                               "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                               }'>
                 </table>
-            </div><!-- /.table-responsive -->
         </div><!-- /.tab-pane -->
 
 
           <div class="tab-pane" id="maintenances">
             <h2 class="box-title">{{ trans('admin/maintenances/general.maintenances') }}</h2>
-            <div class="table table-responsive">
 
               <table
                       data-columns="{{ \App\Presenters\MaintenancesPresenter::dataTableLayout() }}"
@@ -260,7 +253,6 @@
                               }'>
 
               </table>
-            </div><!-- /.table-responsive -->
           </div><!-- /.tab-pane -->
 
             <div class="tab-pane fade" id="files">

--- a/resources/views/suppliers/view.blade.php
+++ b/resources/views/suppliers/view.blade.php
@@ -150,8 +150,6 @@
                               "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                               }'>
               </table>
-
-            </div><!-- /.table-responsive -->
           </div><!-- /.tab-pane -->
 
 

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -1080,7 +1080,7 @@
           <div class="tab-pane" id="managed-users">
 
               @include('partials.users-bulk-actions')
-              
+
               <table
                       data-columns="{{ \App\Presenters\UserPresenter::dataTableLayout() }}"
                       data-cookie-id-table="managedUsersTable"

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -835,8 +835,6 @@
 
             @include('partials.asset-bulk-actions')
 
-            <div class="table table-responsive">
-
             <table
                     data-columns="{{ \App\Presenters\AssetPresenter::dataTableLayout() }}"
                     data-show-columns-search="true"
@@ -857,13 +855,10 @@
                 "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                 }'>
             </table>
-          </div>
         </div><!-- /asset -->
 
         <div class="tab-pane" id="licenses">
 
-
-          <div class="table-responsive">
             <table
                     data-cookie-id-table="userLicenseTable"
                     data-id-table="userLicenseTable"
@@ -919,11 +914,9 @@
                 @endforeach
               </tbody>
           </table>
-          </div>
         </div><!-- /licenses-tab -->
 
         <div class="tab-pane" id="accessories">
-          <div class="table-responsive">
             <table
                     data-cookie-id-table="userAccessoryTable"
                     data-id-table="userAccessoryTable"
@@ -965,11 +958,9 @@
                   @endforeach
               </tbody>
             </table>
-          </div>
         </div><!-- /accessories-tab -->
 
         <div class="tab-pane" id="consumables">
-          <div class="table-responsive">
             <table
                     data-cookie-id-table="userConsumableTable"
                     data-id-table="userConsumableTable"
@@ -1004,7 +995,6 @@
                 @endforeach
               </tbody>
           </table>
-          </div>
         </div><!-- /consumables-tab -->
 
         <div class="tab-pane" id="files">
@@ -1046,9 +1036,6 @@
           </div><!-- /eulas-tab -->
 
         <div class="tab-pane" id="history">
-          <div class="table-responsive">
-
-
               <table
                       data-columns="{{ \App\Presenters\HistoryPresenter::dataTableLayout() }}"
                       class="table table-striped snipe-table"
@@ -1063,8 +1050,6 @@
                      }'
                       data-url="{{ route('api.activity.index', ['item_id' => $user->id, 'item_type' => User::class]) }}">
               </table>
-
-          </div>
         </div><!-- /.tab-pane -->
 
         <div class="tab-pane" id="managed-locations">
@@ -1095,8 +1080,7 @@
           <div class="tab-pane" id="managed-users">
 
               @include('partials.users-bulk-actions')
-
-
+              
               <table
                       data-columns="{{ \App\Presenters\UserPresenter::dataTableLayout() }}"
                       data-cookie-id-table="managedUsersTable"


### PR DESCRIPTION
This removes the wrapped of `<div class="table table-responsive">` and  `<div class="table-responsive">` that we had around some bootstrap tables, which was causing a double scrollbar in chrome. 

I was hoping the previous fix to just remove the extra `table-responsive` from the bootstrap table partial would have worked, but seems not. Fixes #18317