### PR TITLE
Fixes [FD-52267] Expected Checkin Notification Shows Overdue instead of Reminder

### DIFF
--- a/app/Notifications/ExpectedCheckinNotification.php
+++ b/app/Notifications/ExpectedCheckinNotification.php
@@ -50,7 +50,12 @@ class ExpectedCheckinNotification extends Notification
      */
     public function toMail()
     {
-        $today = Carbon::now();
+        $today    = Carbon::today();
+        $expected = Carbon::parse($this->params->expected_checkin)->startOfDay();
+
+        $subjectText = $today->greaterThan($expected)
+            ? trans('mail.Expected_Checkin_Notification_Pastdue', ['name' => $this->params->display_name])
+            : trans('mail.Expected_Checkin_Notification', ['name' => $this->params->display_name]);
 
         $message = (new MailMessage)->markdown('notifications.markdown.expected-checkin',
             [
@@ -60,7 +65,7 @@ class ExpectedCheckinNotification extends Notification
                 'serial' => $this->params->serial,
                 'asset_tag' => $this->params->asset_tag,
             ])
-            ->subject('⏰'. ($today > $this->params->expected_checkin) ? trans('mail.Expected_Checkin_Notification_Pastdue', ['name' => $this->params->display_name]) : trans('mail.Expected_Checkin_Notification', ['name' => $this->params->display_name]))
+            ->subject('⏰'. $subjectText)
             ->withSymfonyMessage(function (Email $message) {
                 $message->getHeaders()->addTextHeader(
                     'X-System-Sender', 'Snipe-IT'


### PR DESCRIPTION
The expected checkin reminder notification was defaulting to overdue. `$today` was being calculated using `now()`, and comparing a date vs a datetime which was throwing off the ternary choice for the subject line. did a bit of code clean up as well.