### PR TITLE
Add SCIM url to admin settings

### DIFF
--- a/resources/lang/en-US/admin/settings/general.php
+++ b/resources/lang/en-US/admin/settings/general.php
@@ -78,6 +78,8 @@ return [
     'footer_text_help'          => 'This text will appear in the right-side footer. Links are allowed using <a href="https://help.github.com/articles/github-flavored-markdown/">Github flavored markdown</a>. Line breaks, headers, images, etc may result in unpredictable results.',
     'footer_text_placeholder'   => 'Optional footer text',
     'general_settings'			=> 'General Settings',
+    'api_url'			        => 'API Base URL',
+    'scim_url'			        => 'SCIM Base URL',
     'general_settings_help'     => 'Default EULA and more',
     'generate_backup'			=> 'Generate Backup',
     'google_workspaces'         => 'Google Workspaces',

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -163,6 +163,7 @@ return [
     'image_filetypes_help'  => 'Accepted Filetypes are jpg, webp, png, gif, svg, and avif. The maximum upload size allowed is :size.',
     'unaccepted_image_type'  => 'This image file was not readable. Accepted filetypes are jpg, webp, png, gif, and svg. The mimetype of this file is: :mimetype.',
     'import'         	    => 'Import',
+    'documentation'         => 'Open documentation in a new link',
     'import_this_file'      => 'Map fields and process this file',
     'importing'         	=> 'Importing',
     'importing_help'        => 'The CSV should be comma-delimited and formatted with headers that match the ones in the <a href="https://snipe-it.readme.io/docs/importing" target="_new">sample CSVs in the documentation <i class="fa fa-external-link"></i></a>.',

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -497,11 +497,13 @@
         .dropdown-menu > li,
         .navbar,
         .navbar-nav,
-        .label-default
+        .label-default,
+        .label-default:hover
         {
             background-color: var(--main-theme-color);
             color: var(--nav-primary-text-color) !important;
         }
+
 
         .dropdown-menu > li > a:link,
         .dropdown-menu > li > a:visited,

--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -343,86 +343,109 @@
         <h2 class="box-title">{{ trans('admin/settings/general.system') }}</h2>
       </div>
       <div class="box-body">
-        <div class="col-md-12" style="margin-right:4px;">
-        <div class="row row-new-striped" style="line-height: 23px;">
+        <div class="row-new-striped">
 
           <!-- row -->
           <div class="row">
-            <div class="col-md-2" style="padding-top: 3px; padding-bottom: 3px;">
+            <div class="col-md-2">
               <strong>{{ trans('admin/settings/general.snipe_version') }}:</strong>
             </div>
-            <div class="col-md-4" style="padding-top: 3px; padding-bottom: 3px;">
+            <div class="col-md-4">
               {{ config('version.app_version') }}  build {{ config('version.build_version') }} ({{ config('version.hash_version') }})
             </div>
 
-            <div class="col-md-2" style="padding-top: 3px; padding-bottom: 3px;">
+            <div class="col-md-2">
               <strong>{{ trans('admin/settings/general.license') }}:</strong>
             </div>
-            <div class="col-md-4" style="padding-top: 3px; padding-bottom: 3px;">
-              <a href="https://www.gnu.org/licenses/agpl-3.0.en.html" rel="noopener">AGPL3</a>
+            <div class="col-md-4">
+                AGPL3
+                <a href="https://www.gnu.org/licenses/agpl-3.0.en.html" target="_blank" data-tooltip="true" title="{{ trans('general.documentation') }}"><x-icon type="external-link" /></a>
            </div>
           </div>
           <!-- / row -->
 
+
           <!-- row -->
           <div class="row">
-            <div class="col-md-2" style="padding-top: 3px; padding-bottom: 3px;">
+            <div class="col-md-2">
               <strong>{{ trans('admin/settings/general.php') }}:</strong>
             </div>
-            <div class="col-md-4" style="padding-top: 3px; padding-bottom: 3px;">
+            <div class="col-md-4">
               {{ phpversion() }}
             </div>
 
-            <div class="col-md-2" style="padding-top: 3px; padding-bottom: 3px;">
+            <div class="col-md-2">
               <strong>{{ trans('admin/settings/general.laravel') }}:</strong>
             </div>
-            <div class="col-md-4" style="padding-top: 3px; padding-bottom: 3px;">
+            <div class="col-md-4">
               {{ $snipeSettings->lar_ver() }}
             </div>
           </div>
 
           <!-- row -->
           <div class="row">
-              <div class="col-md-2" style="padding-top: 3px; padding-bottom: 3px;">
+              <div class="col-md-2">
                 <strong>{{ trans('admin/settings/general.timezone') }}:</strong>
               </div>
-              <div class="col-md-4" style="padding-top: 3px; padding-bottom: 3px;">
+              <div class="col-md-4">
                 {{ config('app.timezone') }}
               </div>
 
-              <div class="col-md-2" style="padding-top: 3px; padding-bottom: 3px;">
+              <div class="col-md-2">
                 <strong>{{ trans('admin/settings/general.database_driver') }}:</strong>
               </div>
-              <div class="col-md-4" style="padding-top: 3px; padding-bottom: 3px;">
+              <div class="col-md-4">
                 {{ config('database.default') }}
               </div>
           </div>
 
           <!-- row -->
           <div class="row">
-            <div class="col-md-2" style="padding-top: 3px; padding-bottom: 3px;">
+            <div class="col-md-2">
               <strong>{{ trans('admin/settings/general.mail_from') }}:</strong>
             </div>
-            <div class="col-md-4" style="padding-top: 3px; padding-bottom: 3px;">
+            <div class="col-md-4">
               {{ config('mail.from.name') }}
               <code>&lt;{{ config('mail.from.address') }}&gt;</code>
             </div>
 
-            <div class="col-md-2" style="padding-top: 3px; padding-bottom: 3px;">
+            <div class="col-md-2">
               <strong>{{ trans('admin/settings/general.mail_reply_to') }}:</strong>
             </div>
-            <div class="col-md-4" style="padding-top: 3px; padding-bottom: 3px;">
+            <div class="col-md-4">
               {{ config('mail.reply_to.name') }}
               <code>&lt;{{ config('mail.reply_to.address') }}&gt;</code>
             </div>
           </div>
 
+            <!-- row -->
+            <div class="row">
+                <div class="col-md-2">
+                    <strong>{{ trans('admin/settings/general.api_url') }}:</strong>
+                </div>
+                <div class="col-md-4">
+                    <code>{{ url('/api/v1') }}{!! trans('account/general.api_base_url_endpoint') !!}</code>
+                    <a href="https://snipe-it.readme.io/docs/scim" target="_blank" data-tooltip="true" title="{{ trans('general.documentation') }}"><x-icon type="external-link" /></a>
+
+                </div>
+
+                <div class="col-md-2">
+                    <strong>{{ trans('admin/settings/general.scim_url') }}:</strong>
+                </div>
+                <div class="col-md-4">
+                    <code>{{ config('app.url') }}/scim/v2/</code>
+                    <a href="https://snipe-it.readme.io/docs/scim" target="_blank" data-tooltip="true" title="{{ trans('general.documentation') }}"><x-icon type="external-link" /></a>
+
+                </div>
+            </div>
+            <!-- / row -->
+
           <!-- row -->
           <div class="row">
-            <div class="col-md-2" style="padding-top: 3px; padding-bottom: 3px;">
+            <div class="col-md-2">
               <strong>{{ trans('admin/settings/general.bs_table_storage') }}:</strong>
             </div>
-            <div class="col-md-4" style="padding-top: 3px; padding-bottom: 3px;">
+            <div class="col-md-4">
               {{ config('session.bs_table_storage') }}
             </div>
             <div class="col-md-2">
@@ -434,7 +457,7 @@
         </div>
           </div>
           <!--/ row -->
-        </div>
+
       </div> <!-- /box-body-->
     </div> <!--/box-default-->
 


### PR DESCRIPTION
We run into situations where users are having a hard time understanding the docs for what the SCIM and API base URLs should be, so this clarifies that in the `admin` section. 

<img width="1443" height="285" alt="Screenshot 2025-12-16 at 8 02 31 PM" src="https://github.com/user-attachments/assets/78565b7b-3d20-4cea-89ca-296c277ec510" />
