### PR TITLE
Fixed #17816 - added quantity to activity reports

### DIFF
--- a/app/Console/Commands/MigrateLicenseSeatQuantitiesInActionLogs.php
+++ b/app/Console/Commands/MigrateLicenseSeatQuantitiesInActionLogs.php
@@ -35,7 +35,7 @@ class MigrateLicenseSeatQuantitiesInActionLogs extends Command
                 ActionType::AddSeats->value,
                 ActionType::DeleteSeats->value,
             ])
-            ->where('qty', '=', 1)
+            ->where('quantity', '=', 1)
             ->orderBy('id');
 
         $count = $query->count();
@@ -57,13 +57,13 @@ class MigrateLicenseSeatQuantitiesInActionLogs extends Command
                         $this->error('Could not parse quantity from ID: {id}', ['id' => $log->id]);
                     }
 
-                    if ($log->qty !== (int) $quantityFromNote) {
+                    if ($log->quantity !== (int) $quantityFromNote) {
                         $this->info(vsprintf('Updating id: %s to quantity %s', [
                             'id' => $log->id,
                             'new_quantity' => $quantityFromNote,
                         ]));
 
-                        DB::table('action_logs')->where('id', $log->id)->update(['qty' => (int) $quantityFromNote]);
+                        DB::table('action_logs')->where('id', $log->id)->update(['quantity' => (int) $quantityFromNote]);
                     }
                 });
             });

--- a/app/Console/Commands/MigrateLicenseSeatQuantitiesInActionLogs.php
+++ b/app/Console/Commands/MigrateLicenseSeatQuantitiesInActionLogs.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\ActionType;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+class MigrateLicenseSeatQuantitiesInActionLogs extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'snipeit:migrate-license-seat-quantities-in-action-logs
+                            {--no-interaction: Do not ask any interactive question}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Updates quantity field in action_logs table for license seats that were added or deleted.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $query = DB::table('action_logs')
+            ->whereIn('action_type', [
+                ActionType::AddSeats->value,
+                ActionType::DeleteSeats->value,
+            ])
+            ->where('qty', '=', 1)
+            ->orderBy('id');
+
+        $count = $query->count();
+
+        if ($count === 0) {
+            $this->info('Nothing to update');
+
+            return 0;
+        }
+
+        $this->info("{$count} logs to update");
+
+        if ($this->option('no-interaction') || $this->confirm('Update quantities in the action log?')) {
+            $query->chunk(50, function ($logs) {
+                $logs->each(function ($log) {
+                    $quantityFromNote = Str::between($log->note, "ed ", " seats");
+
+                    if (!is_numeric($quantityFromNote)) {
+                        $this->error('Could not parse quantity from ID: {id}', ['id' => $log->id]);
+                    }
+
+                    if ($log->qty !== (int) $quantityFromNote) {
+                        $this->info(vsprintf('Updating id: %s to quantity %s', [
+                            'id' => $log->id,
+                            'new_quantity' => $quantityFromNote,
+                        ]));
+
+                        DB::table('action_logs')->where('id', $log->id)->update(['qty' => (int) $quantityFromNote]);
+                    }
+                });
+            });
+        }
+
+        return 0;
+    }
+}

--- a/app/Events/CheckoutableCheckedOut.php
+++ b/app/Events/CheckoutableCheckedOut.php
@@ -15,20 +15,20 @@ class CheckoutableCheckedOut
     public $checkedOutBy;
     public $note;
     public $originalValues;
-    public int $qty;
+    public int $quantity;
 
     /**
      * Create a new event instance.
      *
      * @return void
      */
-    public function __construct($checkoutable, $checkedOutTo, User $checkedOutBy, $note, $originalValues = [], $qty = 1)
+    public function __construct($checkoutable, $checkedOutTo, User $checkedOutBy, $note, $originalValues = [], $quantity = 1)
     {
         $this->checkoutable = $checkoutable;
         $this->checkedOutTo = $checkedOutTo;
         $this->checkedOutBy = $checkedOutBy;
         $this->note = $note;
         $this->originalValues = $originalValues;
-        $this->qty = $qty;
+        $this->quantity = $quantity;
     }
 }

--- a/app/Events/CheckoutableCheckedOut.php
+++ b/app/Events/CheckoutableCheckedOut.php
@@ -15,18 +15,20 @@ class CheckoutableCheckedOut
     public $checkedOutBy;
     public $note;
     public $originalValues;
+    public int $qty;
 
     /**
      * Create a new event instance.
      *
      * @return void
      */
-    public function __construct($checkoutable, $checkedOutTo, User $checkedOutBy, $note, $originalValues = [])
+    public function __construct($checkoutable, $checkedOutTo, User $checkedOutBy, $note, $originalValues = [], $qty = 1)
     {
         $this->checkoutable = $checkoutable;
         $this->checkedOutTo = $checkedOutTo;
         $this->checkedOutBy = $checkedOutBy;
         $this->note = $note;
         $this->originalValues = $originalValues;
+        $this->qty = $qty;
     }
 }

--- a/app/Http/Controllers/Accessories/AccessoryCheckoutController.php
+++ b/app/Http/Controllers/Accessories/AccessoryCheckoutController.php
@@ -67,7 +67,7 @@ class AccessoryCheckoutController extends Controller
      */
     public function store(AccessoryCheckoutRequest $request, Accessory $accessory) : RedirectResponse
     {
-        
+
         $this->authorize('checkout', $accessory);
 
         $target = $this->determineCheckoutTarget();
@@ -89,7 +89,14 @@ class AccessoryCheckoutController extends Controller
             $accessory_checkout->save();
         }
 
-        event(new CheckoutableCheckedOut($accessory,  $target, auth()->user(), $request->input('note')));
+        event(new CheckoutableCheckedOut(
+            $accessory,
+            $target,
+            auth()->user(),
+            $request->input('note'),
+            [],
+            $accessory->checkout_qty,
+        ));
 
         $request->request->add(['checkout_to_type' => request('checkout_to_type')]);
         $request->request->add(['assigned_to' => $target->id]);

--- a/app/Http/Controllers/Api/AccessoriesController.php
+++ b/app/Http/Controllers/Api/AccessoriesController.php
@@ -325,7 +325,14 @@ class AccessoriesController extends Controller
         }
 
         // Set this value to be able to pass the qty through to the event
-        event(new CheckoutableCheckedOut($accessory, $target, auth()->user(), $request->input('note')));
+        event(new CheckoutableCheckedOut(
+            $accessory,
+            $target,
+            auth()->user(),
+            $request->input('note'),
+            [],
+            $accessory->checkout_qty,
+        ));
 
         return response()->json(Helper::formatStandardApiResponse('success', $payload, trans('admin/accessories/message.checkout.success')));
 

--- a/app/Http/Controllers/Api/ComponentsController.php
+++ b/app/Http/Controllers/Api/ComponentsController.php
@@ -321,7 +321,7 @@ class ComponentsController extends Controller
                 'note' => $request->get('note'),
             ]);
 
-            $component->logCheckout($request->input('note'), $asset);
+            $component->logCheckout($request->input('note'), $asset, null, [], $request->get('assigned_qty', 1));
 
             return response()->json(Helper::formatStandardApiResponse('success', null,  trans('admin/components/message.checkout.success')));
         }

--- a/app/Http/Controllers/Api/ConsumablesController.php
+++ b/app/Http/Controllers/Api/ConsumablesController.php
@@ -326,8 +326,14 @@ class ConsumablesController extends Controller
             );
         }
 
-
-        event(new CheckoutableCheckedOut($consumable, $user, auth()->user(), $request->input('note')));
+        event(new CheckoutableCheckedOut(
+            $consumable,
+            $user,
+            auth()->user(),
+            $request->input('note'),
+            [],
+            $consumable->checkout_qty,
+        ));
 
         return response()->json(Helper::formatStandardApiResponse('success', null, trans('admin/consumables/message.checkout.success')));
 

--- a/app/Http/Controllers/Components/ComponentCheckoutController.php
+++ b/app/Http/Controllers/Components/ComponentCheckoutController.php
@@ -115,7 +115,14 @@ class ComponentCheckoutController extends Controller
             'note' => $request->input('note'),
         ]);
 
-        event(new CheckoutableCheckedOut($component, $asset, auth()->user(), $request->input('note')));
+        event(new CheckoutableCheckedOut(
+            $component,
+            $asset,
+            auth()->user(),
+            $request->input('note'),
+            [],
+            $component->checkout_qty,
+        ));
 
         $request->request->add(['checkout_to_type' => 'asset']);
         $request->request->add(['assigned_asset' => $asset->id]);

--- a/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
+++ b/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
@@ -102,7 +102,15 @@ class ConsumableCheckoutController extends Controller
         }
 
         $consumable->checkout_qty = $quantity;
-        event(new CheckoutableCheckedOut($consumable, $user, auth()->user(), $request->input('note')));
+
+        event(new CheckoutableCheckedOut(
+            $consumable,
+            $user,
+            auth()->user(),
+            $request->input('note'),
+            [],
+            $consumable->checkout_qty,
+        ));
 
         $request->request->add(['checkout_to_type' => 'user']);
         $request->request->add(['assigned_user' => $user->id]);

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -80,7 +80,7 @@ class ActionlogsTransformer
 
                     // this is a custom field
                     if (str_starts_with($fieldname, '_snipeit_')) {
-                        
+
                         foreach ($custom_fields as $custom_field) {
 
                             if ($custom_field->db_column == $fieldname) {
@@ -185,7 +185,7 @@ class ActionlogsTransformer
                 'name' => e($actionlog->target->display_name) ?? null,
                 'type' => e($actionlog->targetType()),
             ] : null,
-
+            'qty' => $this->getQuantity($actionlog),
             'note'          => ($actionlog->note) ? Helper::parseEscapedMarkedownInline($actionlog->note): null,
             'signature_file'   => ($actionlog->accept_signature) ? route('log.signature.view', ['filename' => $actionlog->accept_signature ]) : null,
             'log_meta'          => ((isset($clean_meta)) && (is_array($clean_meta))) ? $clean_meta: null,
@@ -336,6 +336,19 @@ class ActionlogsTransformer
 
     }
 
+    private function getQuantity(Actionlog $actionlog): ?int
+    {
+        if (!$actionlog->qty) {
+            return null;
+        }
+
+        // only a few action types will have a quantity we are interested in.
+        if (!in_array($actionlog->action_type, ['checkout', 'accepted', 'declined', 'checkin from'])) {
+            return null;
+        }
+
+        return (int) $actionlog->qty;
+    }
 
 
 }

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -343,7 +343,7 @@ class ActionlogsTransformer
         }
 
         // only a few action types will have a quantity we are interested in.
-        if (!in_array($actionlog->action_type, ['checkout', 'accepted', 'declined', 'checkin from'])) {
+        if (!in_array($actionlog->action_type, ['checkout', 'accepted', 'declined', 'checkin from', 'add seats', 'delete seats'])) {
             return null;
         }
 

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -185,7 +185,7 @@ class ActionlogsTransformer
                 'name' => e($actionlog->target->display_name) ?? null,
                 'type' => e($actionlog->targetType()),
             ] : null,
-            'qty' => $this->getQuantity($actionlog),
+            'quantity' => $this->getQuantity($actionlog),
             'note'          => ($actionlog->note) ? Helper::parseEscapedMarkedownInline($actionlog->note): null,
             'signature_file'   => ($actionlog->accept_signature) ? route('log.signature.view', ['filename' => $actionlog->accept_signature ]) : null,
             'log_meta'          => ((isset($clean_meta)) && (is_array($clean_meta))) ? $clean_meta: null,
@@ -338,7 +338,7 @@ class ActionlogsTransformer
 
     private function getQuantity(Actionlog $actionlog): ?int
     {
-        if (!$actionlog->qty) {
+        if (!$actionlog->quantity) {
             return null;
         }
 
@@ -347,7 +347,7 @@ class ActionlogsTransformer
             return null;
         }
 
-        return (int) $actionlog->qty;
+        return (int) $actionlog->quantity;
     }
 
 

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -1,6 +1,7 @@
 <?php
 namespace App\Http\Transformers;
 
+use App\Enums\ActionType;
 use App\Helpers\Helper;
 use App\Helpers\StorageHelper;
 use App\Models\Actionlog;
@@ -343,7 +344,14 @@ class ActionlogsTransformer
         }
 
         // only a few action types will have a quantity we are interested in.
-        if (!in_array($actionlog->action_type, ['checkout', 'accepted', 'declined', 'checkin from', 'add seats', 'delete seats'])) {
+        if (!in_array($actionlog->action_type, [
+            ActionType::Checkout->value,
+            ActionType::Accepted->value,
+            ActionType::Declined->value,
+            ActionType::CheckinFrom->value,
+            ActionType::AddSeats->value,
+            ActionType::DeleteSeats->value,
+        ])) {
             return null;
         }
 

--- a/app/Listeners/LogListener.php
+++ b/app/Listeners/LogListener.php
@@ -47,7 +47,13 @@ class LogListener
      */
     public function onCheckoutableCheckedOut(CheckoutableCheckedOut $event)
     {
-        $event->checkoutable->logCheckout($event->note, $event->checkedOutTo, $event->checkoutable->last_checkout, $event->originalValues);
+        $event->checkoutable->logCheckout(
+            $event->note,
+            $event->checkedOutTo,
+            $event->checkoutable->last_checkout,
+            $event->originalValues,
+            $event->qty
+        );
     }
 
     /**

--- a/app/Listeners/LogListener.php
+++ b/app/Listeners/LogListener.php
@@ -72,6 +72,7 @@ class LogListener
         $logaction->note = $event->acceptance->note;
         $logaction->action_type = 'accepted';
         $logaction->action_date = $event->acceptance->accepted_at;
+        $logaction->qty = $event->acceptance->qty ?? 1;
 
         // TODO: log the actual license seat that was checked out
         if ($event->acceptance->checkoutable instanceof LicenseSeat) {
@@ -90,6 +91,7 @@ class LogListener
         $logaction->note = $event->acceptance->note;
         $logaction->action_type = 'declined';
         $logaction->action_date = $event->acceptance->declined_at;
+        $logaction->qty = $event->acceptance->qty ?? 1;
 
         // TODO: log the actual license seat that was checked out
         if ($event->acceptance->checkoutable instanceof LicenseSeat) {

--- a/app/Listeners/LogListener.php
+++ b/app/Listeners/LogListener.php
@@ -52,7 +52,7 @@ class LogListener
             $event->checkedOutTo,
             $event->checkoutable->last_checkout,
             $event->originalValues,
-            $event->qty
+            $event->quantity
         );
     }
 
@@ -72,7 +72,7 @@ class LogListener
         $logaction->note = $event->acceptance->note;
         $logaction->action_type = 'accepted';
         $logaction->action_date = $event->acceptance->accepted_at;
-        $logaction->qty = $event->acceptance->qty ?? 1;
+        $logaction->quantity = $event->acceptance->qty ?? 1;
 
         // TODO: log the actual license seat that was checked out
         if ($event->acceptance->checkoutable instanceof LicenseSeat) {
@@ -91,7 +91,7 @@ class LogListener
         $logaction->note = $event->acceptance->note;
         $logaction->action_type = 'declined';
         $logaction->action_date = $event->acceptance->declined_at;
-        $logaction->qty = $event->acceptance->qty ?? 1;
+        $logaction->quantity = $event->acceptance->qty ?? 1;
 
         // TODO: log the actual license seat that was checked out
         if ($event->acceptance->checkoutable instanceof LicenseSeat) {

--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -223,7 +223,7 @@ class License extends Depreciable
             $logAction->created_by = auth()->id() ?: 1; // We don't have an id while running the importer from CLI.
             $logAction->note = "deleted {$change} seats";
             $logAction->target_id = null;
-            $logAction->qty = $change;
+            $logAction->quantity = $change;
             $logAction->logaction('delete seats');
 
             return true;
@@ -260,7 +260,7 @@ class License extends Depreciable
             $logAction->created_by = auth()->id() ?: 1; // Importer.
             $logAction->note = "added {$change} seats";
             $logAction->target_id = null;
-            $logAction->qty = $change;
+            $logAction->quantity = $change;
             $logAction->logaction('add seats');
         }
 

--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -223,6 +223,7 @@ class License extends Depreciable
             $logAction->created_by = auth()->id() ?: 1; // We don't have an id while running the importer from CLI.
             $logAction->note = "deleted {$change} seats";
             $logAction->target_id = null;
+            $logAction->qty = $change;
             $logAction->logaction('delete seats');
 
             return true;
@@ -259,6 +260,7 @@ class License extends Depreciable
             $logAction->created_by = auth()->id() ?: 1; // Importer.
             $logAction->note = "added {$change} seats";
             $logAction->target_id = null;
+            $logAction->qty = $change;
             $logAction->logaction('add seats');
         }
 

--- a/app/Models/Traits/Loggable.php
+++ b/app/Models/Traits/Loggable.php
@@ -40,7 +40,7 @@ trait Loggable
      * @since  [v3.4]
      * @return \App\Models\Actionlog
      */
-    public function logCheckout($note, $target, $action_date = null, $originalValues = [])
+    public function logCheckout($note, $target, $action_date = null, $originalValues = [], $qty)
     {
 
         $log = new Actionlog;
@@ -94,7 +94,7 @@ trait Loggable
 
         $log->note = $note;
         $log->action_date = $action_date;
-
+        $log->qty = $qty;
 
         $changed = [];
         $array_to_flip = array_keys($fields_array);

--- a/app/Models/Traits/Loggable.php
+++ b/app/Models/Traits/Loggable.php
@@ -40,7 +40,7 @@ trait Loggable
      * @since  [v3.4]
      * @return \App\Models\Actionlog
      */
-    public function logCheckout($note, $target, $action_date = null, $originalValues = [], $qty)
+    public function logCheckout($note, $target, $action_date = null, $originalValues = [], $qty = 1)
     {
 
         $log = new Actionlog;

--- a/app/Models/Traits/Loggable.php
+++ b/app/Models/Traits/Loggable.php
@@ -40,7 +40,7 @@ trait Loggable
      * @since  [v3.4]
      * @return \App\Models\Actionlog
      */
-    public function logCheckout($note, $target, $action_date = null, $originalValues = [], $qty = 1)
+    public function logCheckout($note, $target, $action_date = null, $originalValues = [], $quantity = 1)
     {
 
         $log = new Actionlog;
@@ -94,7 +94,7 @@ trait Loggable
 
         $log->note = $note;
         $log->action_date = $action_date;
-        $log->qty = $qty;
+        $log->quantity = $quantity;
 
         $changed = [];
         $array_to_flip = array_keys($fields_array);

--- a/app/Presenters/HistoryPresenter.php
+++ b/app/Presenters/HistoryPresenter.php
@@ -118,7 +118,7 @@ class HistoryPresenter extends Presenter
                 'formatter' => 'fileDownloadButtonsFormatter',
             ],
             [
-                'field' => 'qty',
+                'field' => 'quantity',
                 'searchable' => false,
                 'sortable' => true,
                 'visible' => true,

--- a/app/Presenters/HistoryPresenter.php
+++ b/app/Presenters/HistoryPresenter.php
@@ -118,6 +118,13 @@ class HistoryPresenter extends Presenter
                 'formatter' => 'fileDownloadButtonsFormatter',
             ],
             [
+                'field' => 'qty',
+                'searchable' => false,
+                'sortable' => true,
+                'visible' => true,
+                'title' => trans('general.quantity'),
+            ],
+            [
                 'field' => 'note',
                 'searchable' => true,
                 'sortable' => true,

--- a/database/migrations/2025_12_10_211855_add_qty_to_action_logs_table.php
+++ b/database/migrations/2025_12_10_211855_add_qty_to_action_logs_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('action_logs', function (Blueprint $table) {
+            $table->integer('qty')->default(1)->after('expected_checkin');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('action_logs', function (Blueprint $table) {
+            $table->dropColumn('qty');
+        });
+    }
+};

--- a/database/migrations/2025_12_10_211855_add_quantity_to_action_logs_table.php
+++ b/database/migrations/2025_12_10_211855_add_quantity_to_action_logs_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('action_logs', function (Blueprint $table) {
-            $table->integer('qty')->default(1)->after('expected_checkin');
+            $table->integer('quantity')->default(1)->after('expected_checkin');
         });
     }
 
@@ -22,7 +22,7 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('action_logs', function (Blueprint $table) {
-            $table->dropColumn('qty');
+            $table->dropColumn('quantity');
         });
     }
 };

--- a/tests/Feature/CheckoutAcceptances/Ui/AccessoryAcceptanceTest.php
+++ b/tests/Feature/CheckoutAcceptances/Ui/AccessoryAcceptanceTest.php
@@ -43,7 +43,7 @@ class AccessoryAcceptanceTest extends TestCase
             'target_type' => User::class,
             'item_id' => $accessory->id,
             'item_type' => Accessory::class,
-            'qty' => 2,
+            'quantity' => 2,
         ]);
     }
 
@@ -76,7 +76,7 @@ class AccessoryAcceptanceTest extends TestCase
             'target_type' => User::class,
             'item_id' => $accessory->id,
             'item_type' => Accessory::class,
-            'qty' => 2,
+            'quantity' => 2,
         ]);
     }
 

--- a/tests/Feature/CheckoutAcceptances/Ui/AccessoryAcceptanceTest.php
+++ b/tests/Feature/CheckoutAcceptances/Ui/AccessoryAcceptanceTest.php
@@ -14,6 +14,72 @@ use Tests\TestCase;
 
 class AccessoryAcceptanceTest extends TestCase
 {
+    public function test_can_accept_accessory_checkout()
+    {
+        $assignee = User::factory()->create();
+        $accessory = Accessory::factory()->create();
+
+        $checkoutAcceptance = CheckoutAcceptance::factory()
+            ->pending()
+            ->for($assignee, 'assignedTo')
+            ->for($accessory, 'checkoutable')
+            ->create(['qty' => 2]);
+
+        $this->actingAs($assignee)
+            ->post(route('account.store-acceptance', $checkoutAcceptance), [
+                'asset_acceptance' => 'accepted',
+                'note' => 'A note here',
+            ])
+            ->assertRedirect();
+
+        $this->assertNotNull($checkoutAcceptance->refresh()->accepted_at);
+        $this->assertEquals('A note here', $checkoutAcceptance->note);
+
+        $assignee->accessories->contains($accessory);
+
+        $this->assertDatabaseHas('action_logs', [
+            'action_type' => 'accepted',
+            'target_id' => $assignee->id,
+            'target_type' => User::class,
+            'item_id' => $accessory->id,
+            'item_type' => Accessory::class,
+            'qty' => 2,
+        ]);
+    }
+
+    public function test_can_decline_accessory_checkout()
+    {
+        $assignee = User::factory()->create();
+        $accessory = Accessory::factory()->create();
+
+        $checkoutAcceptance = CheckoutAcceptance::factory()
+            ->pending()
+            ->for($assignee, 'assignedTo')
+            ->for($accessory, 'checkoutable')
+            ->create(['qty' => 2]);
+
+        $this->actingAs($assignee)
+            ->post(route('account.store-acceptance', $checkoutAcceptance), [
+                'asset_acceptance' => 'declined',
+                'note' => 'A note here',
+            ])
+            ->assertRedirect();
+
+        $this->assertNotNull($checkoutAcceptance->refresh()->declined_at);
+        $this->assertEquals('A note here', $checkoutAcceptance->note);
+
+        $assignee->accessories->doesntContain($accessory);
+
+        $this->assertDatabaseHas('action_logs', [
+            'action_type' => 'declined',
+            'target_id' => $assignee->id,
+            'target_type' => User::class,
+            'item_id' => $accessory->id,
+            'item_type' => Accessory::class,
+            'qty' => 2,
+        ]);
+    }
+
     /**
      * This can be absorbed into a bigger test
      */

--- a/tests/Feature/CheckoutAcceptances/Ui/ConsumableAcceptanceTest.php
+++ b/tests/Feature/CheckoutAcceptances/Ui/ConsumableAcceptanceTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Feature\CheckoutAcceptances\Ui;
+
+use App\Models\CheckoutAcceptance;
+use App\Models\Consumable;
+use App\Models\User;
+use Tests\TestCase;
+
+class ConsumableAcceptanceTest extends TestCase
+{
+    public function test_can_accept_consumable_checkout()
+    {
+        $assignee = User::factory()->create();
+        $consumable = Consumable::factory()->create();
+
+        $checkoutAcceptance = CheckoutAcceptance::factory()
+            ->pending()
+            ->for($assignee, 'assignedTo')
+            ->for($consumable, 'checkoutable')
+            ->create(['qty' => 2]);
+
+        $this->actingAs($assignee)
+            ->post(route('account.store-acceptance', $checkoutAcceptance), [
+                'asset_acceptance' => 'accepted',
+                'note' => 'A note here',
+            ])
+            ->assertRedirect();
+
+        $this->assertNotNull($checkoutAcceptance->refresh()->accepted_at);
+        $this->assertEquals('A note here', $checkoutAcceptance->note);
+
+        $assignee->consumables->contains($consumable);
+
+        $this->assertDatabaseHas('action_logs', [
+            'action_type' => 'accepted',
+            'target_id' => $assignee->id,
+            'target_type' => User::class,
+            'item_id' => $consumable->id,
+            'item_type' => Consumable::class,
+            'qty' => 2,
+        ]);
+    }
+
+    public function test_can_decline_consumable_checkout()
+    {
+        $assignee = User::factory()->create();
+        $consumable = Consumable::factory()->create();
+
+        $checkoutAcceptance = CheckoutAcceptance::factory()
+            ->pending()
+            ->for($assignee, 'assignedTo')
+            ->for($consumable, 'checkoutable')
+            ->create(['qty' => 2]);
+
+        $this->actingAs($assignee)
+            ->post(route('account.store-acceptance', $checkoutAcceptance), [
+                'asset_acceptance' => 'declined',
+                'note' => 'A note here',
+            ])
+            ->assertRedirect();
+
+        $this->assertNotNull($checkoutAcceptance->refresh()->declined_at);
+        $this->assertEquals('A note here', $checkoutAcceptance->note);
+
+        $assignee->consumables->doesntContain($consumable);
+
+        $this->assertDatabaseHas('action_logs', [
+            'action_type' => 'declined',
+            'target_id' => $assignee->id,
+            'target_type' => User::class,
+            'item_id' => $consumable->id,
+            'item_type' => Consumable::class,
+            'qty' => 2,
+        ]);
+    }
+}

--- a/tests/Feature/CheckoutAcceptances/Ui/ConsumableAcceptanceTest.php
+++ b/tests/Feature/CheckoutAcceptances/Ui/ConsumableAcceptanceTest.php
@@ -38,7 +38,7 @@ class ConsumableAcceptanceTest extends TestCase
             'target_type' => User::class,
             'item_id' => $consumable->id,
             'item_type' => Consumable::class,
-            'qty' => 2,
+            'quantity' => 2,
         ]);
     }
 
@@ -71,7 +71,7 @@ class ConsumableAcceptanceTest extends TestCase
             'target_type' => User::class,
             'item_id' => $consumable->id,
             'item_type' => Consumable::class,
-            'qty' => 2,
+            'quantity' => 2,
         ]);
     }
 }

--- a/tests/Feature/Checkouts/Api/AccessoryCheckoutTest.php
+++ b/tests/Feature/Checkouts/Api/AccessoryCheckoutTest.php
@@ -115,21 +115,17 @@ class AccessoryCheckoutTest extends TestCase implements TestsPermissionsRequirem
 
         $this->assertTrue($accessory->checkouts()->where('assigned_type', User::class)->where('assigned_to', $user->id)->count() > 0);
 
-        $this->assertEquals(
-            1,
-            Actionlog::where([
-                'action_type' => 'checkout',
-                'target_id' => $user->id,
-                'target_type' => User::class,
-                'item_id' => $accessory->id,
-                'item_type' => Accessory::class,
-                'qty' => 2,
-                'created_by' => $admin->id,
-            ])->count(),
-            'Log entry either does not exist or there are more than expected'
-        );
-        $this->assertHasTheseActionLogs($accessory, ['create', 'checkout']);
+        $this->assertDatabaseHas('action_logs', [
+            'action_type' => 'checkout',
+            'target_id' => $user->id,
+            'target_type' => User::class,
+            'item_id' => $accessory->id,
+            'item_type' => Accessory::class,
+            'qty' => 2,
+            'created_by' => $admin->id,
+        ]);
 
+        $this->assertHasTheseActionLogs($accessory, ['create', 'checkout']);
     }
 
     public function testAccessoryCannotBeCheckedOutToInvalidUser()

--- a/tests/Feature/Checkouts/Api/AccessoryCheckoutTest.php
+++ b/tests/Feature/Checkouts/Api/AccessoryCheckoutTest.php
@@ -121,7 +121,7 @@ class AccessoryCheckoutTest extends TestCase implements TestsPermissionsRequirem
             'target_type' => User::class,
             'item_id' => $accessory->id,
             'item_type' => Accessory::class,
-            'qty' => 2,
+            'quantity' => 2,
             'created_by' => $admin->id,
         ]);
 

--- a/tests/Feature/Checkouts/Api/AccessoryCheckoutTest.php
+++ b/tests/Feature/Checkouts/Api/AccessoryCheckoutTest.php
@@ -123,6 +123,7 @@ class AccessoryCheckoutTest extends TestCase implements TestsPermissionsRequirem
                 'target_type' => User::class,
                 'item_id' => $accessory->id,
                 'item_type' => Accessory::class,
+                'qty' => 2,
                 'created_by' => $admin->id,
             ])->count(),
             'Log entry either does not exist or there are more than expected'

--- a/tests/Feature/Checkouts/Api/ComponentCheckoutTest.php
+++ b/tests/Feature/Checkouts/Api/ComponentCheckoutTest.php
@@ -109,7 +109,7 @@ class ComponentCheckoutTest extends TestCase implements TestsFullMultipleCompani
         $this->actingAsForApi($user)
             ->postJson(route('api.components.checkout', $component->id), [
                 'assigned_to' => $asset->id,
-                'assigned_qty' => 1,
+                'assigned_qty' => 2,
             ]);
 
         $this->assertDatabaseHas('action_logs', [
@@ -120,6 +120,7 @@ class ComponentCheckoutTest extends TestCase implements TestsFullMultipleCompani
             'location_id' => $location->id,
             'item_type' => Component::class,
             'item_id' => $component->id,
+            'qty' => 2,
         ]);
     }
 

--- a/tests/Feature/Checkouts/Api/ComponentCheckoutTest.php
+++ b/tests/Feature/Checkouts/Api/ComponentCheckoutTest.php
@@ -120,7 +120,7 @@ class ComponentCheckoutTest extends TestCase implements TestsFullMultipleCompani
             'location_id' => $location->id,
             'item_type' => Component::class,
             'item_id' => $component->id,
-            'qty' => 2,
+            'quantity' => 2,
         ]);
     }
 

--- a/tests/Feature/Checkouts/Api/ConsumableCheckoutTest.php
+++ b/tests/Feature/Checkouts/Api/ConsumableCheckoutTest.php
@@ -69,7 +69,7 @@ class ConsumableCheckoutTest extends TestCase
             'target_type' => User::class,
             'target_id' => $user->id,
             'action_type' => 'checkout',
-            'qty' => 2,
+            'quantity' => 2,
         ]);
     }
 

--- a/tests/Feature/Checkouts/Api/ConsumableCheckoutTest.php
+++ b/tests/Feature/Checkouts/Api/ConsumableCheckoutTest.php
@@ -52,6 +52,27 @@ class ConsumableCheckoutTest extends TestCase
         $this->assertHasTheseActionLogs($consumable, ['create', 'checkout']);
     }
 
+    public function testConsumableCanBeCheckedOutWithQuantity()
+    {
+        $consumable = Consumable::factory()->create();
+        $user = User::factory()->create();
+
+        $this->actingAsForApi(User::factory()->checkoutConsumables()->create())
+            ->postJson(route('api.consumables.checkout', $consumable), [
+                'assigned_to' => $user->id,
+                'checkout_qty' => 2,
+            ]);
+
+        $this->assertDatabaseHas('action_logs', [
+            'item_type' => Consumable::class,
+            'item_id' => $consumable->id,
+            'target_type' => User::class,
+            'target_id' => $user->id,
+            'action_type' => 'checkout',
+            'qty' => 2,
+        ]);
+    }
+
     public function testUserSentNotificationUponCheckout()
     {
         Mail::fake();

--- a/tests/Feature/Checkouts/Ui/AccessoryCheckoutTest.php
+++ b/tests/Feature/Checkouts/Ui/AccessoryCheckoutTest.php
@@ -81,7 +81,7 @@ class AccessoryCheckoutTest extends TestCase
             'target_type' => User::class,
             'item_id' => $accessory->id,
             'item_type' => Accessory::class,
-            'qty' => 1,
+            'quantity' => 1,
             'note' => 'oh hi there',
         ]);
         $this->assertHasTheseActionLogs($accessory, ['create', 'checkout']);
@@ -109,7 +109,7 @@ class AccessoryCheckoutTest extends TestCase
             'target_type' => User::class,
             'item_id' => $accessory->id,
             'item_type' => Accessory::class,
-            'qty' => 3,
+            'quantity' => 3,
             'note' => 'oh hi there',
         ]);
         $this->assertHasTheseActionLogs($accessory, ['create', 'checkout']);
@@ -137,7 +137,7 @@ class AccessoryCheckoutTest extends TestCase
             'target_type' => Location::class,
             'item_id' => $accessory->id,
             'item_type' => Accessory::class,
-            'qty' => 3,
+            'quantity' => 3,
             'note' => 'oh hi there',
         ]);
         $this->assertHasTheseActionLogs($accessory, ['create', 'checkout']);
@@ -165,7 +165,7 @@ class AccessoryCheckoutTest extends TestCase
             'target_type' => Asset::class,
             'item_id' => $accessory->id,
             'item_type' => Accessory::class,
-            'qty' => 3,
+            'quantity' => 3,
             'note' => 'oh hi there',
         ]);
         $this->assertHasTheseActionLogs($accessory, ['create', 'checkout']);

--- a/tests/Feature/Checkouts/Ui/AccessoryCheckoutTest.php
+++ b/tests/Feature/Checkouts/Ui/AccessoryCheckoutTest.php
@@ -81,6 +81,7 @@ class AccessoryCheckoutTest extends TestCase
             'target_type' => User::class,
             'item_id' => $accessory->id,
             'item_type' => Accessory::class,
+            'qty' => 1,
             'note' => 'oh hi there',
         ]);
         $this->assertHasTheseActionLogs($accessory, ['create', 'checkout']);
@@ -108,6 +109,7 @@ class AccessoryCheckoutTest extends TestCase
             'target_type' => User::class,
             'item_id' => $accessory->id,
             'item_type' => Accessory::class,
+            'qty' => 3,
             'note' => 'oh hi there',
         ]);
         $this->assertHasTheseActionLogs($accessory, ['create', 'checkout']);
@@ -135,6 +137,7 @@ class AccessoryCheckoutTest extends TestCase
             'target_type' => Location::class,
             'item_id' => $accessory->id,
             'item_type' => Accessory::class,
+            'qty' => 3,
             'note' => 'oh hi there',
         ]);
         $this->assertHasTheseActionLogs($accessory, ['create', 'checkout']);
@@ -162,6 +165,7 @@ class AccessoryCheckoutTest extends TestCase
             'target_type' => Asset::class,
             'item_id' => $accessory->id,
             'item_type' => Accessory::class,
+            'qty' => 3,
             'note' => 'oh hi there',
         ]);
         $this->assertHasTheseActionLogs($accessory, ['create', 'checkout']);

--- a/tests/Feature/Checkouts/Ui/ComponentsCheckoutTest.php
+++ b/tests/Feature/Checkouts/Ui/ComponentsCheckoutTest.php
@@ -119,7 +119,7 @@ class ComponentsCheckoutTest extends TestCase
             'target_type' => Asset::class,
             'item_id' => $component->id,
             'item_type' => Component::class,
-            'qty' => 2,
+            'quantity' => 2,
             'created_by' => $admin->id,
         ]);
     }

--- a/tests/Feature/Checkouts/Ui/ComponentsCheckoutTest.php
+++ b/tests/Feature/Checkouts/Ui/ComponentsCheckoutTest.php
@@ -97,4 +97,30 @@ class ComponentsCheckoutTest extends TestCase
             ->assertRedirect(route('hardware.show', $asset));
         $this->assertHasTheseActionLogs($component, ['create', 'checkout']);
     }
+
+    public function test_quantity_stored_in_action_log()
+    {
+        $component = Component::factory()->create();
+        $asset = Asset::factory()->create();
+
+        $admin = User::factory()->admin()->create();
+
+        $this->actingAs($admin)
+            ->from(route('components.index'))
+            ->post(route('components.checkout.store', $component), [
+                'asset_id' => $asset->id,
+                'redirect_option' => 'index',
+                'assigned_qty' => 2,
+            ]);
+
+        $this->assertDatabaseHas('action_logs', [
+            'action_type' => 'checkout',
+            'target_id' => $asset->id,
+            'target_type' => Asset::class,
+            'item_id' => $component->id,
+            'item_type' => Component::class,
+            'qty' => 2,
+            'created_by' => $admin->id,
+        ]);
+    }
 }

--- a/tests/Feature/Checkouts/Ui/ConsumableCheckoutTest.php
+++ b/tests/Feature/Checkouts/Ui/ConsumableCheckoutTest.php
@@ -171,7 +171,7 @@ class ConsumableCheckoutTest extends TestCase
             'target_type' => User::class,
             'item_id' => $consumable->id,
             'item_type' => Consumable::class,
-            'qty' => 2,
+            'quantity' => 2,
             'created_by' => $admin->id,
         ]);
     }

--- a/tests/Feature/Checkouts/Ui/ConsumableCheckoutTest.php
+++ b/tests/Feature/Checkouts/Ui/ConsumableCheckoutTest.php
@@ -152,7 +152,7 @@ class ConsumableCheckoutTest extends TestCase
 
     public function test_quantity_stored_in_action_log()
     {
-        $consumable = Consumable::factory()->create();
+        $consumable = Consumable::factory()->create(['qty' => 3]);
         $user = User::factory()->create();
 
         $admin = User::factory()->admin()->create();
@@ -162,7 +162,7 @@ class ConsumableCheckoutTest extends TestCase
             ->post(route('consumables.checkout.store', $consumable), [
                 'assigned_to' => $user->id,
                 'redirect_option' => 'target',
-                'assigned_qty' => 2,
+                'checkout_qty' => 2,
             ]);
 
         $this->assertDatabaseHas('action_logs', [

--- a/tests/Feature/Checkouts/Ui/ConsumableCheckoutTest.php
+++ b/tests/Feature/Checkouts/Ui/ConsumableCheckoutTest.php
@@ -150,4 +150,29 @@ class ConsumableCheckoutTest extends TestCase
             ->assertRedirect(route('users.show', $user));
     }
 
+    public function test_quantity_stored_in_action_log()
+    {
+        $consumable = Consumable::factory()->create();
+        $user = User::factory()->create();
+
+        $admin = User::factory()->admin()->create();
+
+        $this->actingAs($admin)
+            ->from(route('components.index'))
+            ->post(route('consumables.checkout.store', $consumable), [
+                'assigned_to' => $user->id,
+                'redirect_option' => 'target',
+                'assigned_qty' => 2,
+            ]);
+
+        $this->assertDatabaseHas('action_logs', [
+            'action_type' => 'checkout',
+            'target_id' => $user->id,
+            'target_type' => User::class,
+            'item_id' => $consumable->id,
+            'item_type' => Consumable::class,
+            'qty' => 2,
+            'created_by' => $admin->id,
+        ]);
+    }
 }

--- a/tests/Unit/Models/LicenseTest.php
+++ b/tests/Unit/Models/LicenseTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Enums\ActionType;
+use App\Models\License;
+use App\Models\User;
+use Tests\TestCase;
+
+class LicenseTest extends TestCase
+{
+    public function test_adding_seats_is_logged_when_updating()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $license = License::factory()->create(['seats' => 2]);
+
+        $license->update(['seats' => 6]);
+
+        $this->assertDatabaseHas('action_logs', [
+            'created_by' => $user->id,
+            'action_type' => ActionType::AddSeats,
+            'item_type' => License::class,
+            'item_id' => $license->id,
+            'deleted_at' => null,
+            // relevant for this test:
+            'qty' => 4,
+            'note' => 'added 4 seats',
+        ]);
+    }
+
+    public function test_removing_seats_is_logged_when_updating()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $license = License::factory()->create(['seats' => 6]);
+
+        $license->update(['seats' => 3]);
+
+        $this->assertDatabaseHas('action_logs', [
+            'created_by' => $user->id,
+            'action_type' => ActionType::DeleteSeats,
+            'item_type' => License::class,
+            'item_id' => $license->id,
+            'deleted_at' => null,
+            // relevant for this test:
+            'qty' => 3,
+            'note' => 'deleted 3 seats',
+        ]);
+    }
+}

--- a/tests/Unit/Models/LicenseTest.php
+++ b/tests/Unit/Models/LicenseTest.php
@@ -25,7 +25,7 @@ class LicenseTest extends TestCase
             'item_id' => $license->id,
             'deleted_at' => null,
             // relevant for this test:
-            'qty' => 4,
+            'quantity' => 4,
             'note' => 'added 4 seats',
         ]);
     }
@@ -46,7 +46,7 @@ class LicenseTest extends TestCase
             'item_id' => $license->id,
             'deleted_at' => null,
             // relevant for this test:
-            'qty' => 3,
+            'quantity' => 3,
             'note' => 'deleted 3 seats',
         ]);
     }


### PR DESCRIPTION
This PR adds a `quantity` column to the `action_logs` table and enables viewing the quantity checked out and the amount of seats where added/removed when updating a license.

---

## Screenshots

<details><summary>Activity Report</summary>
<p>
<img width="3162" height="1714" alt="image" src="https://github.com/user-attachments/assets/70f88c41-399d-4285-9ed6-7adbee653858" />
</p>
</details> 

<details><summary>Asset History</summary>
<p>
<img width="2796" height="888" alt="image" src="https://github.com/user-attachments/assets/37b3353d-1cd8-4dd8-ac20-0dbd0a87a504" />
</p>
</details> 

<details><summary>License History</summary>
<p>
<img width="1528" height="1218" alt="image" src="https://github.com/user-attachments/assets/cf3118ec-2281-4015-90ef-3c3596abba56" />
</p>
</details> 

<details><summary>Accessory History</summary>
<p>
<img width="1536" height="1000" alt="image" src="https://github.com/user-attachments/assets/e3d4e701-f083-4b25-8345-b4281a3682ae" />
</p>
</details> 

<details><summary>Consumable History</summary>
<p>
<img width="1610" height="1044" alt="image" src="https://github.com/user-attachments/assets/206ad373-a718-469d-8719-48e6dbea1108" />
</p>
</details> 

<details><summary>Component History</summary>
<p>
<img width="2108" height="798" alt="image" src="https://github.com/user-attachments/assets/16ce0d98-c67f-402d-8cb6-f79ec9a5af39" />
</p>
</details> 

---

## Migrating old data

When adding or removing seats from a license, the notes field is populated with `added x seats` or `deleted x seats` so it is possible to use that note field to update the newly created `quantity` column. 

This PR includes a command, `snipeit:migrate-license-seat-quantities-in-action-logs`, to do just that. I avoided including the logic in a migration in case I missed a detail that ended up screwing up action logs but if it looks good to everyone I can pull that logic into a new migration.

- [ ] ❓ Should I move the command logic to a migration

---

## Database details

In these screenshots of the action log, ID 1-17 were on the develop branch. I switched to this branch starting at ID 18. You'll see the quantity field starts being populated.

<img width="3486" height="2238" alt="image" src="https://github.com/user-attachments/assets/826a5d0c-9d16-4c8f-9396-7981906cbe02" />

This is the result after the command is run:
<img width="3486" height="2238" alt="image" src="https://github.com/user-attachments/assets/6e3d5a6b-d043-41fd-a5cc-d0fc9f966fc2" />

Here are `action_log` entries when items are checked out, accepted, and declined:
<img width="1082" height="322" alt="image" src="https://github.com/user-attachments/assets/ca36a435-0c11-4d0f-931b-2c2bcddc4afb" />

---

Semi-related to #17703

Fixes #17816