### PR TITLE
Replaced deprecated Symfony `Request::get()` usage

### DIFF
--- a/app/Http/Controllers/Accessories/AccessoriesController.php
+++ b/app/Http/Controllers/Accessories/AccessoriesController.php
@@ -90,10 +90,10 @@ class AccessoriesController extends Controller
             $accessory = $request->handleImages($accessory);
         }
 
-        if($request->get('redirect_option') === 'back'){
+        if($request->input('redirect_option') === 'back'){
             session()->put(['redirect_option' => 'index']);
         } else {
-            session()->put(['redirect_option' => $request->get('redirect_option')]);
+            session()->put(['redirect_option' => $request->input('redirect_option')]);
         }
 
         // Was the accessory created?
@@ -182,10 +182,10 @@ class AccessoriesController extends Controller
 
             $accessory = $request->handleImages($accessory);
 
-            if($request->get('redirect_option') === 'back'){
+            if($request->input('redirect_option') === 'back'){
                 session()->put(['redirect_option' => 'index']);
             } else {
-                session()->put(['redirect_option' => $request->get('redirect_option')]);
+                session()->put(['redirect_option' => $request->input('redirect_option')]);
             }
 
             if ($accessory->save()) {

--- a/app/Http/Controllers/Accessories/AccessoryCheckinController.php
+++ b/app/Http/Controllers/Accessories/AccessoryCheckinController.php
@@ -76,7 +76,7 @@ class AccessoryCheckinController extends Controller
         if ($accessory_checkout->delete()) {
             event(new CheckoutableCheckedIn($accessory, $accessory_checkout->assignedTo, auth()->user(), $request->input('note'), $checkin_at));
 
-            session()->put(['redirect_option' => $request->get('redirect_option')]);
+            session()->put(['redirect_option' => $request->input('redirect_option')]);
 
             return Helper::getRedirectOption($request, $accessory->id, 'Accessories')
                 ->with('success', trans('admin/accessories/message.checkin.success'));

--- a/app/Http/Controllers/Accessories/AccessoryCheckoutController.php
+++ b/app/Http/Controllers/Accessories/AccessoryCheckoutController.php
@@ -94,7 +94,7 @@ class AccessoryCheckoutController extends Controller
         $request->request->add(['checkout_to_type' => request('checkout_to_type')]);
         $request->request->add(['assigned_to' => $target->id]);
 
-        session()->put(['redirect_option' => $request->get('redirect_option'), 'checkout_to_type' => $request->get('checkout_to_type')]);
+        session()->put(['redirect_option' => $request->input('redirect_option'), 'checkout_to_type' => $request->input('checkout_to_type')]);
 
 
         // Redirect to the new accessory page

--- a/app/Http/Controllers/Api/AccessoriesController.php
+++ b/app/Http/Controllers/Api/AccessoriesController.php
@@ -389,7 +389,7 @@ class AccessoriesController extends Controller
         ]);
 
         if ($request->filled('search')) {
-            $accessories = $accessories->where('accessories.name', 'LIKE', '%'.$request->get('search').'%');
+            $accessories = $accessories->where('accessories.name', 'LIKE', '%'.$request->input('search').'%');
         }
 
         $accessories = $accessories->orderBy('name', 'ASC')->paginate(50);

--- a/app/Http/Controllers/Api/AssetModelsController.php
+++ b/app/Http/Controllers/Api/AssetModelsController.php
@@ -249,7 +249,7 @@ class AssetModelsController extends Controller
          * it, but I'll be damned if I can think of one. - snipe
          */
         if ($request->filled('custom_fieldset_id')) {
-            $assetmodel->fieldset_id = $request->get('custom_fieldset_id');
+            $assetmodel->fieldset_id = $request->input('custom_fieldset_id');
         }
 
 

--- a/app/Http/Controllers/Api/CategoriesController.php
+++ b/app/Http/Controllers/Api/CategoriesController.php
@@ -265,7 +265,7 @@ class CategoriesController extends Controller
         ]);
 
         if ($request->filled('search')) {
-            $categories = $categories->where('name', 'LIKE', '%'.$request->get('search').'%');
+            $categories = $categories->where('name', 'LIKE', '%'.$request->input('search').'%');
         }
 
         $categories = $categories->where('category_type', $category_type)->orderBy('name', 'ASC')->paginate(50);

--- a/app/Http/Controllers/Api/CompaniesController.php
+++ b/app/Http/Controllers/Api/CompaniesController.php
@@ -202,7 +202,7 @@ class CompaniesController extends Controller
 
 
         if ($request->filled('search')) {
-            $companies = $companies->where('companies.name', 'LIKE', '%'.$request->get('search').'%');
+            $companies = $companies->where('companies.name', 'LIKE', '%'.$request->input('search').'%');
         }
 
         $companies = $companies->orderBy('name', 'ASC')->paginate(50);

--- a/app/Http/Controllers/Api/ComponentsController.php
+++ b/app/Http/Controllers/Api/ComponentsController.php
@@ -303,11 +303,11 @@ class ComponentsController extends Controller
         }
 
         // Make sure there is at least one available to checkout
-        if ($component->numRemaining() < $request->get('assigned_qty')) {
-            return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/components/message.checkout.unavailable', ['remaining' => $component->numRemaining(), 'requested' => $request->get('assigned_qty')])));
+        if ($component->numRemaining() < $request->input('assigned_qty')) {
+            return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/components/message.checkout.unavailable', ['remaining' => $component->numRemaining(), 'requested' => $request->input('assigned_qty')])));
         }
 
-        if ($component->numRemaining() >= $request->get('assigned_qty')) {
+        if ($component->numRemaining() >= $request->input('assigned_qty')) {
 
             $asset = Asset::find($request->input('assigned_to'));
             $component->assigned_to = $request->input('assigned_to');
@@ -315,10 +315,10 @@ class ComponentsController extends Controller
             $component->assets()->attach($component->id, [
                 'component_id' => $component->id,
                 'created_at' => Carbon::now(),
-                'assigned_qty' => $request->get('assigned_qty', 1),
+                'assigned_qty' => $request->input('assigned_qty', 1),
                 'created_by' => auth()->id(),
-                'asset_id' => $request->get('assigned_to'),
-                'note' => $request->get('note'),
+                'asset_id' => $request->input('assigned_to'),
+                'note' => $request->input('note'),
             ]);
 
             $component->logCheckout($request->input('note'), $asset);
@@ -326,7 +326,7 @@ class ComponentsController extends Controller
             return response()->json(Helper::formatStandardApiResponse('success', null,  trans('admin/components/message.checkout.success')));
         }
 
-        return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/components/message.checkout.unavailable', ['remaining' => $component->numRemaining(), 'requested' => $request->get('assigned_qty')])));
+        return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/components/message.checkout.unavailable', ['remaining' => $component->numRemaining(), 'requested' => $request->input('assigned_qty')])));
     }
 
     /**

--- a/app/Http/Controllers/Api/ConsumablesController.php
+++ b/app/Http/Controllers/Api/ConsumablesController.php
@@ -346,7 +346,7 @@ class ConsumablesController extends Controller
         ]);
 
         if ($request->filled('search')) {
-            $consumables = $consumables->where('consumables.name', 'LIKE', '%'.$request->get('search').'%');
+            $consumables = $consumables->where('consumables.name', 'LIKE', '%'.$request->input('search').'%');
         }
 
         $consumables = $consumables->orderBy('name', 'ASC')->paginate(50);

--- a/app/Http/Controllers/Api/DepartmentsController.php
+++ b/app/Http/Controllers/Api/DepartmentsController.php
@@ -195,7 +195,7 @@ class DepartmentsController extends Controller
         ]);
 
         if ($request->filled('search')) {
-            $departments = $departments->where('name', 'LIKE', '%'.$request->get('search').'%');
+            $departments = $departments->where('name', 'LIKE', '%'.$request->input('search').'%');
         }
 
         $departments = $departments->orderBy('name', 'ASC')->paginate(50);

--- a/app/Http/Controllers/Api/ImportController.php
+++ b/app/Http/Controllers/Api/ImportController.php
@@ -196,7 +196,7 @@ class ImportController extends Controller
         $this->authorize('import');
 
         // Run a backup immediately before processing
-        if ($request->get('run-backup')) {
+        if ($request->input('run-backup')) {
             Log::debug('Backup manually requested via importer');
             Artisan::call('snipeit:backup', ['--filename' => 'pre-import-backup-'.date('Y-m-d-H-i-s')]);
         } else {
@@ -212,7 +212,7 @@ class ImportController extends Controller
 
         $errors = $request->import($import);
         $redirectTo = 'hardware.index';
-        switch ($request->get('import-type')) {
+        switch ($request->input('import-type')) {
             case 'asset':
                 $model_perms = 'App\Models\Asset';
                 $redirectTo = 'hardware.index';

--- a/app/Http/Controllers/Api/LabelsController.php
+++ b/app/Http/Controllers/Api/LabelsController.php
@@ -24,7 +24,7 @@ class LabelsController extends Controller
         $labels = Label::find();
 
         if ($request->filled('search')) {
-            $search = $request->get('search');
+            $search = $request->input('search');
             $labels = $labels->filter(function ($label, $index) use ($search) {
                 return stripos($label->getName(), $search) !== false;
             });
@@ -32,11 +32,11 @@ class LabelsController extends Controller
 
         $total = $labels->count();
 
-        $offset = $request->get('offset', 0);
+        $offset = $request->input('offset', 0);
         $offset = ($offset > $total) ? $total : $offset;
 
         $maxLimit = config('app.max_results');
-        $limit = $request->get('limit', $maxLimit);
+        $limit = $request->input('limit', $maxLimit);
         $limit = ($limit > $maxLimit) ? $maxLimit : $limit;
         
         $labels = $labels->skip($offset)->take($limit);

--- a/app/Http/Controllers/Api/LicensesController.php
+++ b/app/Http/Controllers/Api/LicensesController.php
@@ -265,7 +265,7 @@ class LicensesController extends Controller
         ]);
 
         if ($request->filled('search')) {
-            $licenses = $licenses->where('licenses.name', 'LIKE', '%'.$request->get('search').'%');
+            $licenses = $licenses->where('licenses.name', 'LIKE', '%'.$request->input('search').'%');
         }
 
         $licenses = $licenses->orderBy('name', 'ASC')->paginate(50);

--- a/app/Http/Controllers/Api/LocationsController.php
+++ b/app/Http/Controllers/Api/LocationsController.php
@@ -200,7 +200,7 @@ class LocationsController extends Controller
 
         // Only scope location if the setting is enabled
         if (Setting::getSettings()->scope_locations_fmcs) {
-            $location->company_id = Company::getIdForCurrentUser($request->get('company_id'));
+            $location->company_id = Company::getIdForCurrentUser($request->input('company_id'));
             // check if parent is set and has a different company
             if ($location->parent_id && Location::find($location->parent_id)->company_id != $location->company_id) {
                 response()->json(Helper::formatStandardApiResponse('error', null, 'different company than parent'));
@@ -278,13 +278,13 @@ class LocationsController extends Controller
         if ($request->filled('company_id')) {
             // Only scope location if the setting is enabled
             if (Setting::getSettings()->scope_locations_fmcs) {
-                $location->company_id = Company::getIdForCurrentUser($request->get('company_id'));
+                $location->company_id = Company::getIdForCurrentUser($request->input('company_id'));
                 // check if there are related objects with different company
                 if (Helper::test_locations_fmcs(false, $id, $location->company_id)) {
                     return response()->json(Helper::formatStandardApiResponse('error', null, 'error scoped locations'));
                 }                
             } else {
-                $location->company_id = $request->get('company_id');
+                $location->company_id = $request->input('company_id');
             }
         }
 

--- a/app/Http/Controllers/Api/ManufacturersController.php
+++ b/app/Http/Controllers/Api/ManufacturersController.php
@@ -274,7 +274,7 @@ class ManufacturersController extends Controller
         ]);
 
         if ($request->filled('search')) {
-            $manufacturers = $manufacturers->where('name', 'LIKE', '%'.$request->get('search').'%');
+            $manufacturers = $manufacturers->where('name', 'LIKE', '%'.$request->input('search').'%');
         }
 
         $manufacturers = $manufacturers->orderBy('name', 'ASC')->paginate(50);

--- a/app/Http/Controllers/Api/PredefinedKitsController.php
+++ b/app/Http/Controllers/Api/PredefinedKitsController.php
@@ -145,7 +145,7 @@ class PredefinedKitsController extends Controller
         ]);
 
         if ($request->filled('search')) {
-            $kits = $kits->where('name', 'LIKE', '%'.$request->get('search').'%');
+            $kits = $kits->where('name', 'LIKE', '%'.$request->input('search').'%');
         }
 
         $kits = $kits->orderBy('name', 'ASC')->paginate(50);
@@ -184,7 +184,7 @@ class PredefinedKitsController extends Controller
             $quantity = 1;
         }
 
-        $license_id = $request->get('license');
+        $license_id = $request->input('license');
         $relation = $kit->licenses();
         if ($relation->find($license_id)) {
             return response()->json(Helper::formatStandardApiResponse('error', null, ['license' => trans('admin/kits/general.license_error')]));
@@ -254,7 +254,7 @@ class PredefinedKitsController extends Controller
 
         $kit = PredefinedKit::findOrFail($kit_id);
 
-        $model_id = $request->get('model');
+        $model_id = $request->input('model');
         $quantity = $request->input('quantity', 1);
         if ($quantity < 1) {
             $quantity = 1;
@@ -332,7 +332,7 @@ class PredefinedKitsController extends Controller
             $quantity = 1;
         }
 
-        $consumable_id = $request->get('consumable');
+        $consumable_id = $request->input('consumable');
         $relation = $kit->consumables();
         if ($relation->find($consumable_id)) {
             return response()->json(Helper::formatStandardApiResponse('error', null, ['consumable' => trans('admin/kits/general.consumable_error')]));
@@ -406,7 +406,7 @@ class PredefinedKitsController extends Controller
             $quantity = 1;
         }
 
-        $accessory_id = $request->get('accessory');
+        $accessory_id = $request->input('accessory');
         $relation = $kit->accessories();
         if ($relation->find($accessory_id)) {
             return response()->json(Helper::formatStandardApiResponse('error', null, ['accessory' => trans('admin/kits/general.accessory_error')]));

--- a/app/Http/Controllers/Api/SettingsController.php
+++ b/app/Http/Controllers/Api/SettingsController.php
@@ -226,7 +226,7 @@ class SettingsController extends Controller
 
         $login_attempts = DB::table('login_attempts');
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
-        $sort = in_array($request->get('sort'), $allowed_columns) ? $request->get('sort') : 'created_at';
+        $sort = in_array($request->input('sort'), $allowed_columns) ? $request->input('sort') : 'created_at';
 
         $total = $login_attempts->count();
         $login_attempts->orderBy($sort, $order);

--- a/app/Http/Controllers/Api/StatuslabelsController.php
+++ b/app/Http/Controllers/Api/StatuslabelsController.php
@@ -324,7 +324,7 @@ class StatuslabelsController extends Controller
         $statuslabels = Statuslabel::orderBy('default_label', 'desc')->orderBy('name', 'asc')->orderBy('deployable', 'desc');
 
         if ($request->filled('search')) {
-            $statuslabels = $statuslabels->where('name', 'LIKE', '%'.$request->get('search').'%');
+            $statuslabels = $statuslabels->where('name', 'LIKE', '%'.$request->input('search').'%');
         }
 
         if ($request->filled('deployable')) {

--- a/app/Http/Controllers/Api/SuppliersController.php
+++ b/app/Http/Controllers/Api/SuppliersController.php
@@ -256,7 +256,7 @@ class SuppliersController extends Controller
         ]);
 
         if ($request->filled('search')) {
-            $suppliers = $suppliers->where('suppliers.name', 'LIKE', '%'.$request->get('search').'%');
+            $suppliers = $suppliers->where('suppliers.name', 'LIKE', '%'.$request->input('search').'%');
         }
 
         $suppliers = $suppliers->orderBy('name', 'ASC')->paginate(50);

--- a/app/Http/Controllers/Api/UploadedFilesController.php
+++ b/app/Http/Controllers/Api/UploadedFilesController.php
@@ -110,7 +110,7 @@ class UploadedFilesController extends Controller
             foreach ($request->file('file') as $file) {
                 $file_name = $request->handleFile(self::$map_storage_path[$object_type], self::$map_file_prefix[$object_type].'-'.$object->id, $file);
                 $files[] = $file_name;
-                $object->logUpload($file_name, $request->get('notes'));
+                $object->logUpload($file_name, $request->input('notes'));
             }
 
             $files = Actionlog::select('action_logs.*')->where('action_type', '=', 'uploaded')

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -253,7 +253,7 @@ class UsersController extends Controller
         }
 
         if ($request->filled('group_id')) {
-            $users = $users->ByGroup($request->get('group_id'));
+            $users = $users->ByGroup($request->input('group_id'));
         }
 
         if ($request->filled('department_id')) {
@@ -400,11 +400,11 @@ class UsersController extends Controller
 
         if ($request->filled('search')) {
             $users = $users->where(function ($query) use ($request) {
-                $query->SimpleNameSearch($request->get('search'))
-                    ->orWhere('username', 'LIKE', '%'.$request->get('search').'%')
-                    ->orWhere('display_name', 'LIKE', '%'.$request->get('search').'%')
-                    ->orWhere('email', 'LIKE', '%'.$request->get('search').'%')
-                    ->orWhere('employee_num', 'LIKE', '%'.$request->get('search').'%');
+                $query->SimpleNameSearch($request->input('search'))
+                    ->orWhere('username', 'LIKE', '%'.$request->input('search').'%')
+                    ->orWhere('display_name', 'LIKE', '%'.$request->input('search').'%')
+                    ->orWhere('email', 'LIKE', '%'.$request->input('search').'%')
+                    ->orWhere('employee_num', 'LIKE', '%'.$request->input('search').'%');
             });
         }
 
@@ -459,7 +459,7 @@ class UsersController extends Controller
 
         // 
         if ($request->filled('password')) {
-            $user->password = bcrypt($request->get('password'));
+            $user->password = bcrypt($request->input('password'));
         } else {
             $user->password = $user->noPassword();
         }
@@ -801,7 +801,7 @@ class UsersController extends Controller
 
         if ($request->filled('id')) {
             try {
-                $user = User::find($request->get('id'));
+                $user = User::find($request->input('id'));
                 $this->authorize('update', $user);
                 $user->two_factor_secret = null;
                 $user->two_factor_enrolled = 0;

--- a/app/Http/Controllers/Assets/AssetCheckinController.php
+++ b/app/Http/Controllers/Assets/AssetCheckinController.php
@@ -98,10 +98,10 @@ class AssetCheckinController extends Controller
         $asset->expected_checkin = null;
         $asset->assignedTo()->disassociate($asset);
         $asset->accepted = null;
-        $asset->name = $request->get('name');
+        $asset->name = $request->input('name');
 
         if ($request->filled('status_id')) {
-            $asset->status_id = e($request->get('status_id'));
+            $asset->status_id = e($request->input('status_id'));
         }
 
         // Add any custom fields that should be included in the checkout
@@ -112,11 +112,11 @@ class AssetCheckinController extends Controller
         $asset->location_id = $asset->rtd_location_id;
 
         if ($request->filled('location_id')) {
-            Log::debug('NEW Location ID: '.$request->get('location_id'));
-            $asset->location_id = $request->get('location_id');
+            Log::debug('NEW Location ID: '.$request->input('location_id'));
+            $asset->location_id = $request->input('location_id');
 
-            if ($request->get('update_default_location') == 0){
-                $asset->rtd_location_id = $request->get('location_id');
+            if ($request->input('update_default_location') == 0){
+                $asset->rtd_location_id = $request->input('location_id');
             }
         }
 
@@ -124,9 +124,9 @@ class AssetCheckinController extends Controller
 
         // Handle last checkin date
         $checkin_at = date('Y-m-d H:i:s');
-        if (($request->filled('checkin_at')) && ($request->get('checkin_at') != date('Y-m-d'))) {
+        if (($request->filled('checkin_at')) && ($request->input('checkin_at') != date('Y-m-d'))) {
             $originalValues['action_date'] = $checkin_at;
-            $checkin_at = $request->get('checkin_at');
+            $checkin_at = $request->input('checkin_at');
 
         }
         $asset->last_checkin = $checkin_at;
@@ -145,7 +145,7 @@ class AssetCheckinController extends Controller
             $acceptance->delete();
         });
 
-        session()->put('redirect_option', $request->get('redirect_option'));
+        session()->put('redirect_option', $request->input('redirect_option'));
 
         // Add any custom fields that should be included in the checkout
         $asset->customFieldsForCheckinCheckout('display_checkin');

--- a/app/Http/Controllers/Assets/AssetCheckoutController.php
+++ b/app/Http/Controllers/Assets/AssetCheckoutController.php
@@ -88,17 +88,17 @@ class AssetCheckoutController extends Controller
             $asset = $this->updateAssetLocation($asset, $target);
 
             $checkout_at = date('Y-m-d H:i:s');
-            if (($request->filled('checkout_at')) && ($request->get('checkout_at') != date('Y-m-d'))) {
-                $checkout_at = $request->get('checkout_at');
+            if (($request->filled('checkout_at')) && ($request->input('checkout_at') != date('Y-m-d'))) {
+                $checkout_at = $request->input('checkout_at');
             }
 
             $expected_checkin = '';
             if ($request->filled('expected_checkin')) {
-                $expected_checkin = $request->get('expected_checkin');
+                $expected_checkin = $request->input('expected_checkin');
             }
 
             if ($request->filled('status_id')) {
-                $asset->status_id = $request->get('status_id');
+                $asset->status_id = $request->input('status_id');
             }
 
 
@@ -123,9 +123,9 @@ class AssetCheckoutController extends Controller
                 }
             }
 
-            session()->put(['redirect_option' => $request->get('redirect_option'), 'checkout_to_type' => $request->get('checkout_to_type')]);
+            session()->put(['redirect_option' => $request->input('redirect_option'), 'checkout_to_type' => $request->input('checkout_to_type')]);
 
-            if ($asset->checkOut($target, $admin, $checkout_at, $expected_checkin, $request->get('note'), $request->get('name'))) {
+            if ($asset->checkOut($target, $admin, $checkout_at, $expected_checkin, $request->input('note'), $request->input('name'))) {
                 return Helper::getRedirectOption($request, $asset->id, 'Assets')
                     ->with('success', trans('admin/hardware/message.checkout.success'));
             }

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -249,7 +249,7 @@ class AssetsController extends Controller
                     }
 
                     if (isset($target)) {
-                        $asset->checkOut($target, auth()->user(), date('Y-m-d H:i:s'), $request->input('expected_checkin', null), 'Checked out on asset creation', $request->get('name'), $location);
+                        $asset->checkOut($target, auth()->user(), date('Y-m-d H:i:s'), $request->input('expected_checkin', null), 'Checked out on asset creation', $request->input('name'), $location);
                     }
 
                     $successes[] = "<a href='" . route('hardware.show', $asset) . "' style='color: white;'>" . e($asset->asset_tag) . "</a>";
@@ -266,13 +266,13 @@ class AssetsController extends Controller
         }
         DB::commit();
 
-        if($request->get('redirect_option') === 'back'){
+        if($request->input('redirect_option') === 'back'){
             session()->put(['redirect_option' => 'index']);
         } else {
-            session()->put(['redirect_option' => $request->get('redirect_option')]);
+            session()->put(['redirect_option' => $request->input('redirect_option')]);
         }
 
-        session()->put(['checkout_to_type' => $request->get('checkout_to_type'),
+        session()->put(['checkout_to_type' => $request->input('checkout_to_type'),
                        'other_redirect' =>  'model' ]);
 
 
@@ -454,7 +454,7 @@ class AssetsController extends Controller
         // Update custom fields in the database.
         // FIXME: No idea why this is returning a Builder error on db_column_name.
         // Need to investigate and fix. Using static method for now.
-        $model = AssetModel::find($request->get('model_id'));
+        $model = AssetModel::find($request->input('model_id'));
         if (($model) && ($model->fieldset)) {
             foreach ($model->fieldset->fields as $field) {
                 if ($field->element == 'checkbox' && !$request->has($field->db_column)) {
@@ -480,9 +480,9 @@ class AssetsController extends Controller
             }
         }
         session()->put([
-            'redirect_option' => $request->get('redirect_option'),
-            'checkout_to_type' => $request->get('checkout_to_type'),
-            'other_redirect' => $request->get('redirect_option') === 'other_redirect' ? 'model' : null,
+            'redirect_option' => $request->input('redirect_option'),
+            'checkout_to_type' => $request->input('checkout_to_type'),
+            'other_redirect' => $request->input('redirect_option') === 'other_redirect' ? 'model' : null,
         ]);
 
 
@@ -552,9 +552,9 @@ class AssetsController extends Controller
      */
     public function getAssetBySerial(Request $request) : RedirectResponse
     {
-        $topsearch = ($request->get('topsearch')=="true");
+        $topsearch = ($request->input('topsearch')=="true");
 
-        if (!$asset = Asset::where('serial', '=', $request->get('serial'))->first()) {
+        if (!$asset = Asset::where('serial', '=', $request->input('serial'))->first()) {
             return redirect()->route('hardware.index')->with('error', trans('admin/hardware/message.does_not_exist'));
         }
         $this->authorize('view', $asset);
@@ -570,8 +570,8 @@ class AssetsController extends Controller
      */
     public function getAssetByTag(Request $request, $tag=null) : RedirectResponse
     {
-        $tag = $tag ? $tag : $request->get('assetTag');
-        $topsearch = ($request->get('topsearch') == 'true');
+        $tag = $tag ? $tag : $request->input('assetTag');
+        $topsearch = ($request->input('topsearch') == 'true');
 
         // Search for an exact and unique asset tag match
         $assets = Asset::where('asset_tag', '=', $tag);
@@ -682,8 +682,8 @@ class AssetsController extends Controller
             return (new Label())
                 ->with('assets', collect([ $asset ]))
                 ->with('settings', Setting::getSettings())
-                ->with('template', request()->get('template'))
-                ->with('offset', request()->get('offset'))
+                ->with('template', request()->input('template'))
+                ->with('offset', request()->input('offset'))
                 ->with('bulkedit', false)
                 ->with('count', 0);
         }
@@ -982,7 +982,7 @@ class AssetsController extends Controller
 
         $this->authorize('audit', Asset::class);
 
-        session()->put('redirect_option', $request->get('redirect_option'));
+        session()->put('redirect_option', $request->input('redirect_option'));
         session()->put('other_redirect', 'audit');
 
 

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -588,7 +588,7 @@ class BulkAssetsController extends Controller
         if ($request->session()->has('bulk_back_url')) {
             $bulk_back_url = $request->session()->pull('bulk_back_url');
         }
-        $assetIds = $request->get('ids');
+        $assetIds = $request->input('ids');
 
         if(empty($assetIds)) {
             return redirect($bulk_back_url)->with('error', trans('admin/hardware/message.delete.nothing_updated'));
@@ -652,11 +652,11 @@ class BulkAssetsController extends Controller
             $target = $this->determineCheckoutTarget();
             session()->put(['checkout_to_type' => $target]);
 
-            if (! is_array($request->get('selected_assets'))) {
+            if (! is_array($request->input('selected_assets'))) {
                 return redirect()->route('hardware.bulkcheckout.show')->withInput()->with('error', trans('admin/hardware/message.checkout.no_assets_selected'));
             }
 
-            $asset_ids = array_filter($request->get('selected_assets'));
+            $asset_ids = array_filter($request->input('selected_assets'));
 
             $assets = Asset::findOrFail($asset_ids);
 
@@ -692,14 +692,14 @@ class BulkAssetsController extends Controller
                 }
             }
             $checkout_at = date('Y-m-d H:i:s');
-            if (($request->filled('checkout_at')) && ($request->get('checkout_at') != date('Y-m-d'))) {
-                $checkout_at = $request->get('checkout_at');
+            if (($request->filled('checkout_at')) && ($request->input('checkout_at') != date('Y-m-d'))) {
+                $checkout_at = $request->input('checkout_at');
             }
 
             $expected_checkin = '';
 
             if ($request->filled('expected_checkin')) {
-                $expected_checkin = $request->get('expected_checkin');
+                $expected_checkin = $request->input('expected_checkin');
             }
 
             $errors = [];
@@ -709,10 +709,10 @@ class BulkAssetsController extends Controller
 
                     // See if there is a status label passed
                     if ($request->filled('status_id')) {
-                        $asset->status_id = $request->get('status_id');
+                        $asset->status_id = $request->input('status_id');
                     }
 
-                    $checkout_success = $asset->checkOut($target, $admin, $checkout_at, $expected_checkin, e($request->get('note')), $asset->name, null);
+                    $checkout_success = $asset->checkOut($target, $admin, $checkout_at, $expected_checkin, e($request->input('note')), $asset->name, null);
 
                     //TODO - I think this logic is duplicated in the checkOut method?
                     if ($target->location_id != '') {
@@ -743,7 +743,7 @@ class BulkAssetsController extends Controller
     public function restore(Request $request) : RedirectResponse
     {
         $this->authorize('update', Asset::class);
-        $assetIds = $request->get('ids');
+        $assetIds = $request->input('ids');
 
         if (empty($assetIds)) {
             return redirect()->route('hardware.index')->with('error', trans('admin/hardware/message.restore.nothing_updated'));

--- a/app/Http/Controllers/Components/ComponentCheckinController.php
+++ b/app/Http/Controllers/Components/ComponentCheckinController.php
@@ -98,7 +98,7 @@ class ComponentCheckinController extends Controller
 
             event(new CheckoutableCheckedIn($component, $asset, auth()->user(), $request->input('note'), Carbon::now()));
 
-            session()->put(['redirect_option' => $request->get('redirect_option')]);
+            session()->put(['redirect_option' => $request->input('redirect_option')]);
 
             return Helper::getRedirectOption($request, $component->id, 'Components')
                 ->with('success', trans('admin/components/message.checkin.success'));

--- a/app/Http/Controllers/Components/ComponentCheckoutController.php
+++ b/app/Http/Controllers/Components/ComponentCheckoutController.php
@@ -80,8 +80,8 @@ class ComponentCheckoutController extends Controller
         $max_to_checkout = $component->numRemaining();
 
         // Make sure there are at least the requested number of components available to checkout
-        if ($max_to_checkout < $request->get('assigned_qty')) {
-            return redirect()->back()->withInput()->with('error', trans('admin/components/message.checkout.unavailable', ['remaining' => $max_to_checkout, 'requested' => $request->get('assigned_qty')]));
+        if ($max_to_checkout < $request->input('assigned_qty')) {
+            return redirect()->back()->withInput()->with('error', trans('admin/components/message.checkout.unavailable', ['remaining' => $max_to_checkout, 'requested' => $request->input('assigned_qty')]));
         }
 
         $validator = Validator::make($request->all(), [
@@ -120,7 +120,7 @@ class ComponentCheckoutController extends Controller
         $request->request->add(['checkout_to_type' => 'asset']);
         $request->request->add(['assigned_asset' => $asset->id]);
 
-        session()->put(['redirect_option' => $request->get('redirect_option'), 'checkout_to_type' => $request->get('checkout_to_type')]);
+        session()->put(['redirect_option' => $request->input('redirect_option'), 'checkout_to_type' => $request->input('checkout_to_type')]);
 
         return Helper::getRedirectOption($request, $component->id, 'Components')
             ->with('success', trans('admin/components/message.checkout.success'));

--- a/app/Http/Controllers/Components/ComponentsController.php
+++ b/app/Http/Controllers/Components/ComponentsController.php
@@ -88,10 +88,10 @@ class ComponentsController extends Controller
 
         $component = $request->handleImages($component);
 
-        if($request->get('redirect_option') === 'back'){
+        if($request->input('redirect_option') === 'back'){
             session()->put(['redirect_option' => 'index']);
         } else {
-            session()->put(['redirect_option' => $request->get('redirect_option')]);
+            session()->put(['redirect_option' => $request->input('redirect_option')]);
         }
 
 
@@ -168,7 +168,7 @@ class ComponentsController extends Controller
 
         $component = $request->handleImages($component);
 
-        session()->put(['redirect_option' => $request->get('redirect_option')]);
+        session()->put(['redirect_option' => $request->input('redirect_option')]);
 
         if ($component->save()) {
             return Helper::getRedirectOption($request, $component->id, 'Components')

--- a/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
+++ b/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
@@ -107,7 +107,7 @@ class ConsumableCheckoutController extends Controller
         $request->request->add(['checkout_to_type' => 'user']);
         $request->request->add(['assigned_user' => $user->id]);
 
-        session()->put(['redirect_option' => $request->get('redirect_option'), 'checkout_to_type' => $request->get('checkout_to_type')]);
+        session()->put(['redirect_option' => $request->input('redirect_option'), 'checkout_to_type' => $request->input('checkout_to_type')]);
 
 
         // Redirect to the new consumable page

--- a/app/Http/Controllers/Consumables/ConsumablesController.php
+++ b/app/Http/Controllers/Consumables/ConsumablesController.php
@@ -98,10 +98,10 @@ class ConsumablesController extends Controller
             $consumable = $request->handleImages($consumable);
         }
 
-        if($request->get('redirect_option') === 'back'){
+        if($request->input('redirect_option') === 'back'){
             session()->put(['redirect_option' => 'index']);
         } else {
-            session()->put(['redirect_option' => $request->get('redirect_option')]);
+            session()->put(['redirect_option' => $request->input('redirect_option')]);
         }
 
 
@@ -175,7 +175,7 @@ class ConsumablesController extends Controller
 
         $consumable = $request->handleImages($consumable);
 
-        session()->put(['redirect_option' => $request->get('redirect_option')]);
+        session()->put(['redirect_option' => $request->input('redirect_option')]);
 
         if ($consumable->save()) {
             return Helper::getRedirectOption($request, $consumable->id, 'Consumables')

--- a/app/Http/Controllers/CustomFieldsController.php
+++ b/app/Http/Controllers/CustomFieldsController.php
@@ -112,9 +112,9 @@ class CustomFieldsController extends Controller
 
 
         if ($request->filled('custom_format')) {
-            $field->format = $request->get('custom_format');
+            $field->format = $request->input('custom_format');
         } else {
-            $field->format = $request->get('format');
+            $field->format = $request->input('format');
         }
 
         if ($field->save()) {
@@ -225,34 +225,34 @@ class CustomFieldsController extends Controller
     public function update(CustomFieldRequest $request, CustomField $field) : RedirectResponse
     {
         $this->authorize('update', CustomField::class);
-        $show_in_email = $request->get("show_in_email", 0);
-        $display_in_user_view = $request->get("display_in_user_view", 0);
+        $show_in_email = $request->input("show_in_email", 0);
+        $display_in_user_view = $request->input("display_in_user_view", 0);
 
         // Override the display settings if the field is encrypted
-        if ($request->get("field_encrypted") == '1') {
+        if ($request->input("field_encrypted") == '1') {
             $show_in_email = '0';
             $display_in_user_view = '0';
         }
         
-        $field->name          = trim($request->get("name"));
-        $field->element       = $request->get("element");
-        $field->field_values  = $request->get("field_values");
+        $field->name          = trim($request->input("name"));
+        $field->element       = $request->input("element");
+        $field->field_values  = $request->input("field_values");
         $field->created_by       = auth()->id();
-        $field->help_text     = $request->get("help_text");
+        $field->help_text     = $request->input("help_text");
         $field->show_in_email = $show_in_email;
-        $field->is_unique     = $request->get("is_unique", 0);
+        $field->is_unique     = $request->input("is_unique", 0);
         $field->display_in_user_view = $display_in_user_view;
-        $field->auto_add_to_fieldsets = $request->get("auto_add_to_fieldsets", 0);
-        $field->show_in_listview = $request->get("show_in_listview", 0);
-        $field->show_in_requestable_list = $request->get("show_in_requestable_list", 0);
-        $field->display_checkin = $request->get("display_checkin", 0);
-        $field->display_checkout = $request->get("display_checkout", 0);
-        $field->display_audit = $request->get("display_audit", 0);
+        $field->auto_add_to_fieldsets = $request->input("auto_add_to_fieldsets", 0);
+        $field->show_in_listview = $request->input("show_in_listview", 0);
+        $field->show_in_requestable_list = $request->input("show_in_requestable_list", 0);
+        $field->display_checkin = $request->input("display_checkin", 0);
+        $field->display_checkout = $request->input("display_checkout", 0);
+        $field->display_audit = $request->input("display_audit", 0);
 
-        if ($request->get('format') == 'CUSTOM REGEX') {
-            $field->format = $request->get('custom_format');
+        if ($request->input('format') == 'CUSTOM REGEX') {
+            $field->format = $request->input('custom_format');
         } else {
-            $field->format = $request->get('format');
+            $field->format = $request->input('format');
         }
 
         if ($field->element == 'checkbox' || $field->element == 'radio'){

--- a/app/Http/Controllers/CustomFieldsetsController.php
+++ b/app/Http/Controllers/CustomFieldsetsController.php
@@ -91,7 +91,7 @@ class CustomFieldsetsController extends Controller
         $this->authorize('create', CustomField::class);
 
         $fieldset = new CustomFieldset([
-                'name' => $request->get('name'),
+                'name' => $request->input('name'),
                 'created_by' => auth()->id(),
         ]);
 

--- a/app/Http/Controllers/Kits/CheckoutKitController.php
+++ b/app/Http/Controllers/Kits/CheckoutKitController.php
@@ -47,7 +47,7 @@ class CheckoutKitController extends Controller
      */
     public function store(Request $request, $kit_id)
     {
-        $user_id = e($request->get('user_id'));
+        $user_id = e($request->input('user_id'));
         if (is_null($user = User::find($user_id))) {
             return redirect()->back()->with('error', trans('admin/users/message.user_not_found'));
         }

--- a/app/Http/Controllers/LabelsController.php
+++ b/app/Http/Controllers/LabelsController.php
@@ -81,7 +81,7 @@ class LabelsController extends Controller
 
         $settings = Setting::getSettings();
         if (request()->has('settings')) {
-            $overrides = request()->get('settings');
+            $overrides = request()->input('settings');
             foreach ($overrides as $key => $value) {
                 $settings->$key = $value;
             }

--- a/app/Http/Controllers/Licenses/LicenseCheckinController.php
+++ b/app/Http/Controllers/Licenses/LicenseCheckinController.php
@@ -97,8 +97,8 @@ class LicenseCheckinController extends Controller
             $licenseSeat->unreassignable_seat = true;
         }
 
-        session()->put(['redirect_option' => $request->get('redirect_option')]);
-        if ($request->get('redirect_option') === 'target'){
+        session()->put(['redirect_option' => $request->input('redirect_option')]);
+        if ($request->input('redirect_option') === 'target'){
             session()->put(['checkout_to_type' => 'user']);
         }
 

--- a/app/Http/Controllers/Licenses/LicenseCheckoutController.php
+++ b/app/Http/Controllers/Licenses/LicenseCheckoutController.php
@@ -96,13 +96,13 @@ class LicenseCheckoutController extends Controller
             session()->put(['checkout_to_type' => 'asset']);
             $checkoutTarget = $this->checkoutToAsset($licenseSeat);
             $request->request->add(['assigned_asset' => $checkoutTarget->id]);
-            session()->put(['redirect_option' => $request->get('redirect_option'), 'checkout_to_type' => 'asset']);
+            session()->put(['redirect_option' => $request->input('redirect_option'), 'checkout_to_type' => 'asset']);
 
         } elseif ($request->filled('assigned_to')) {
             session()->put(['checkout_to_type' => 'user']);
             $checkoutTarget = $this->checkoutToUser($licenseSeat);
             $request->request->add(['assigned_user' => $checkoutTarget->id]);
-            session()->put(['redirect_option' => $request->get('redirect_option'), 'checkout_to_type' => 'user']);
+            session()->put(['redirect_option' => $request->input('redirect_option'), 'checkout_to_type' => 'user']);
         }
 
 

--- a/app/Http/Controllers/Licenses/LicensesController.php
+++ b/app/Http/Controllers/Licenses/LicensesController.php
@@ -102,10 +102,10 @@ class LicensesController extends Controller
         $license->created_by           = auth()->id();
         $license->min_amt           = $request->input('min_amt');
 
-        if($request->get('redirect_option') === 'back'){
+        if($request->input('redirect_option') === 'back'){
             session()->put(['redirect_option' => 'index']);
         } else {
-            session()->put(['redirect_option' => $request->get('redirect_option')]);
+            session()->put(['redirect_option' => $request->input('redirect_option')]);
         }
 
         if ($license->save()) {
@@ -183,7 +183,7 @@ class LicensesController extends Controller
         $license->category_id       = $request->input('category_id');
         $license->min_amt           = $request->input('min_amt');
 
-        session()->put(['redirect_option' => $request->get('redirect_option')]);
+        session()->put(['redirect_option' => $request->input('redirect_option')]);
 
         if ($license->save()) {
             return Helper::getRedirectOption($request, $license->id, 'Licenses')

--- a/app/Http/Controllers/UploadedFilesController.php
+++ b/app/Http/Controllers/UploadedFilesController.php
@@ -56,7 +56,7 @@ class UploadedFilesController extends Controller
             foreach ($request->file('file') as $file) {
                 $file_name = $request->handleFile(self::$map_storage_path[$object_type], self::$map_file_prefix[$object_type].'-'.$object->id, $file);
                 $files[] = $file_name;
-                $object->logUpload($file_name, $request->get('notes'));
+                $object->logUpload($file_name, $request->input('notes'));
             }
 
             $files = Actionlog::select('action_logs.*')->where('action_type', '=', 'uploaded')

--- a/app/Http/Controllers/Users/UsersController.php
+++ b/app/Http/Controllers/Users/UsersController.php
@@ -130,10 +130,10 @@ class UsersController extends Controller
         // we have to invoke the form request here to handle image uploads
         app(ImageUploadRequest::class)->handleImages($user, 600, 'avatar', 'avatars', 'avatar');
 
-        if ($request->get('redirect_option') === 'back'){
+        if ($request->input('redirect_option') === 'back'){
             session()->put(['redirect_option' => 'index']);
         } else {
-            session()->put(['redirect_option' => $request->get('redirect_option')]);
+            session()->put(['redirect_option' => $request->input('redirect_option')]);
         }
 
 
@@ -325,7 +325,7 @@ class UsersController extends Controller
 
         // Handle uploaded avatar
         app(ImageUploadRequest::class)->handleImages($user, 600, 'avatar', 'avatars', 'avatar');
-        session()->put(['redirect_option' => $request->get('redirect_option')]);
+        session()->put(['redirect_option' => $request->input('redirect_option')]);
 
         if ($user->save()) {
             // Redirect to the user page

--- a/app/Http/Requests/ItemImportRequest.php
+++ b/app/Http/Requests/ItemImportRequest.php
@@ -62,8 +62,8 @@ class ItemImportRequest extends FormRequest
         }
         $importer->setCallbacks([$this, 'log'], [$this, 'progress'], [$this, 'errorCallback'])
                  ->setCreatedBy(auth()->id())
-                 ->setUpdating($this->get('import-update'))
-                 ->setShouldNotify($this->get('send-welcome'))
+                 ->setUpdating($this->input('import-update'))
+                 ->setShouldNotify($this->input('send-welcome'))
                  ->setUsernameFormat('firstname.lastname')
                  ->setFieldMappings($fieldMappings);
         $importer->import();

--- a/app/Http/Requests/SaveUserRequest.php
+++ b/app/Http/Requests/SaveUserRequest.php
@@ -44,7 +44,7 @@ class SaveUserRequest extends FormRequest
             case 'POST':
                 $rules['first_name'] = 'required|string|min:1';
                 $rules['username'] = 'required_unless:ldap_import,1|string|min:1';
-                if ($this->request->get('ldap_import') == false) {
+                if ($this->input('ldap_import') == false) {
                     $rules['password'] = Setting::passwordComplexityRulesSaving('store').'|confirmed';
                 }
                 break;

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -570,7 +570,7 @@ class Asset extends Depreciable
                             if (is_array(request()->input($field->db_column))) {
                                 $this->{$field->db_column} = Crypt::encrypt(implode(', ', request()->input($field->db_column)));
                             } else {
-                                $this->{$field->db_column} = Crypt::encrypt(request()->get($field->db_column));
+                                $this->{$field->db_column} = Crypt::encrypt(request()->input($field->db_column));
                             }
                         }
 

--- a/app/Services/PredefinedKitCheckoutService.php
+++ b/app/Services/PredefinedKitCheckoutService.php
@@ -45,18 +45,18 @@ class PredefinedKitCheckoutService
             }
 
             $checkout_at = date('Y-m-d H:i:s');
-            if (($request->filled('checkout_at')) && ($request->get('checkout_at') != date('Y-m-d'))) {
-                $checkout_at = $request->get('checkout_at');
+            if (($request->filled('checkout_at')) && ($request->input('checkout_at') != date('Y-m-d'))) {
+                $checkout_at = $request->input('checkout_at');
             }
 
             $expected_checkin = '';
             if ($request->filled('expected_checkin')) {
-                $expected_checkin = $request->get('expected_checkin');
+                $expected_checkin = $request->input('expected_checkin');
             }
 
             $admin = auth()->user();
 
-            $note = e($request->get('note'));
+            $note = e($request->input('note'));
 
             $errors = $this->saveToDb($user, $admin, $checkout_at, $expected_checkin, $errors, $assets_to_add, $license_seats_to_add, $consumables_to_add, $accessories_to_add, $note);
 

--- a/resources/views/hardware/index.blade.php
+++ b/resources/views/hardware/index.blade.php
@@ -2,30 +2,37 @@
 
 @section('title0')
 
-  @if ((Request::get('company_id')) && ($company))
+  @php
+    $requestStatus = request()->input('status');
+    $requestOrderNumber = request()->input('order_number');
+    $requestCompanyId = request()->input('company_id');
+    $requestStatusId = request()->input('status_id');
+  @endphp
+
+  @if (($requestCompanyId) && ($company))
     {{ $company->name }}
   @endif
 
 
 
-@if (Request::get('status'))
-  @if (Request::get('status')=='Pending')
+@if ($requestStatus)
+  @if ($requestStatus=='Pending')
     {{ trans('general.pending') }}
-  @elseif (Request::get('status')=='RTD')
+  @elseif ($requestStatus=='RTD')
     {{ trans('general.ready_to_deploy') }}
-  @elseif (Request::get('status')=='Deployed')
+  @elseif ($requestStatus=='Deployed')
     {{ trans('general.deployed') }}
-  @elseif (Request::get('status')=='Undeployable')
+  @elseif ($requestStatus=='Undeployable')
     {{ trans('general.undeployable') }}
-  @elseif (Request::get('status')=='Deployable')
+  @elseif ($requestStatus=='Deployable')
     {{ trans('general.deployed') }}
-  @elseif (Request::get('status')=='Requestable')
+  @elseif ($requestStatus=='Requestable')
     {{ trans('admin/hardware/general.requestable') }}
-  @elseif (Request::get('status')=='Archived')
+  @elseif ($requestStatus=='Archived')
     {{ trans('general.archived') }}
-  @elseif (Request::get('status')=='Deleted')
+  @elseif ($requestStatus=='Deleted')
     {{ ucfirst(trans('general.deleted')) }}
-  @elseif (Request::get('status')=='byod')
+  @elseif ($requestStatus=='byod')
     {{ strtoupper(trans('general.byod')) }}
   @endif
 @else
@@ -34,7 +41,7 @@
 {{ trans('general.assets') }}
 
   @if (Request::has('order_number'))
-    : Order #{{ strval(Request::get('order_number')) }}
+    : Order #{{ strval($requestOrderNumber) }}
   @endif
 @stop
 
@@ -57,7 +64,7 @@
           <div class="row">
             <div class="col-md-12">
 
-                @include('partials.asset-bulk-actions', ['status' => Request::get('status')])
+                @include('partials.asset-bulk-actions', ['status' => $requestStatus])
                    
               <table
                 data-columns="{{ \App\Presenters\AssetPresenter::dataTableLayout() }}"
@@ -76,12 +83,12 @@
                 id="{{ request()->has('status') ? e(request()->input('status')) : ''  }}assetsListingTable"
                 class="table table-striped snipe-table"
                 data-url="{{ route('api.assets.index',
-                    array('status' => e(Request::get('status')),
-                    'order_number'=>e(strval(Request::get('order_number'))),
-                    'company_id'=>e(Request::get('company_id')),
-                    'status_id'=>e(Request::get('status_id')))) }}"
+                    array('status' => e($requestStatus),
+                    'order_number'=>e(strval($requestOrderNumber)),
+                    'company_id'=>e($requestCompanyId),
+                    'status_id'=>e($requestStatusId))) }}"
                 data-export-options='{
-                "fileName": "export{{ (Request::has('status')) ? '-'.str_slug(Request::get('status')) : '' }}-assets-{{ date('Y-m-d') }}",
+                "fileName": "export{{ (Request::has('status')) ? '-'.str_slug($requestStatus) : '' }}-assets-{{ date('Y-m-d') }}",
                 "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                 }'>
               </table>

--- a/resources/views/models/index.blade.php
+++ b/resources/views/models/index.blade.php
@@ -3,7 +3,7 @@
 {{-- Page title --}}
 @section('title')
 
-  @if (Request::get('status')=='deleted')
+  @if (request()->input('status')=='deleted')
     {{ trans('admin/models/general.view_deleted') }}
     {{ trans('admin/models/table.title') }}
     @else

--- a/resources/views/reports/asset.blade.php
+++ b/resources/views/reports/asset.blade.php
@@ -14,6 +14,12 @@
 {{-- Page content --}}
 @section('content')
 
+@php
+    $requestStatus = request()->input('status');
+    $requestOrderNumber = request()->input('order_number');
+    $requestStatusId = request()->input('status_id');
+@endphp
+
 <div class="row">
     <div class="col-md-12">
         <div class="box box-default">
@@ -24,12 +30,12 @@
                     class="table table-striped snipe-table"
                     data-advanced-search="false"
                     id="table"
-                    data-url="{{route('api.assets.index', array(''=>e(Request::get('status')),'order_number'=>e(Request::get('order_number')), 'status_id'=>e(Request::get('status_id')), 'report'=>'true'))}}"
+                    data-url="{{route('api.assets.index', array(''=>e($requestStatus),'order_number'=>e($requestOrderNumber), 'status_id'=>e($requestStatusId), 'report'=>'true'))}}"
                     data-cookie="true"
-                    data-cookie-id-table="{{ e(Request::get('status')) }}assetTable-{{ config('version.hash_version') }}">
+                    data-cookie-id-table="{{ e($requestStatus) }}assetTable-{{ config('version.hash_version') }}">
                         <thead>
                             <tr>
-                                @if (Request::get('status')!='Deleted')
+                                @if ($requestStatus!='Deleted')
                                 <th data-class="hidden-xs" data-switchable="false" data-searchable="false" data-sortable="false" data-field="checkbox"><div class="text-center"><input type="checkbox" id="checkAll" style="padding-left: 0px;"></div></th>
                                 @endif
                                 <th data-sortable="true" data-field="id" data-visible="false">{{ trans('general.id') }}</th>


### PR DESCRIPTION


### Why
After upgrading dependencies, `deprecations.log` is flooded with:

> Since symfony/http-foundation 7.4: Request::get() is deprecated, use properties ->attributes, query or request directly instead. in .../vendor/symfony/deprecation-contracts/function.php on line 25
https://symfony.com/blog/new-in-symfony-7-4-request-class-improvements

Laravel still exposes `get()` through inheritance, but it now triggers Symfony’s deprecation path.
This PR switches to Laravel’s recommended request accessors. As per this discussion https://github.com/laravel/framework/discussions/57993 


### What changed

  - Replaced Blade `Request::get('key')` usage with `request()->input('key')` (and introduced small local variables in views to avoid repeated calls).
  - Replaced PHP `->get('key')` calls on request objects with `->input('key')`:
      - `$request->get(...)` → `$request->input(...)`
      - `request()->get(...)` → `request()->input(...)`
      - FormRequest `$this->get(...)` / `$this->request->get(...)` → `$this->input(...)`
  - Kept non-request ->get() calls intact (e.g., sessions/headers/response headers).

  ### Files touched (high level)

  - Blade: `resources/views/hardware/index.blade.php`, `resources/views/models/index.blade.php`, `resources/views/reports/asset.blade.php`
  - PHP (`controllers/requests/services`): multiple in `app/Http/...` plus `app/Services/PredefinedKitCheckoutService.php`

  ### Expected impact

  - Eliminates Symfony 7.4 `Request::get()` deprecation spam
  - No functional behaviour change intended (same input sources; Laravel’s input() is the
    preferred accessor)

