### PR TITLE
Improved loading speeds on group create and edit page

### DIFF
--- a/app/Http/Controllers/GroupsController.php
+++ b/app/Http/Controllers/GroupsController.php
@@ -44,7 +44,11 @@ class GroupsController extends Controller
         $permissions = config('permissions');
         $groupPermissions = Helper::selectedPermissionsArray($permissions, $permissions);
         $selectedPermissions = $request->old('permissions', $groupPermissions);
-        $users_query = User::where('show_in_list', 1)->whereNull('deleted_at');
+        $users_query = User::query()
+            ->select(['users.id', 'users.first_name', 'users.last_name', 'users.username'])
+            ->where('show_in_list', 1)
+            ->whereNull('deleted_at');
+
         $users_count = $users_query->count();
 
         $users = collect();
@@ -114,8 +118,11 @@ class GroupsController extends Controller
 
         $selected_array = Helper::selectedPermissionsArray($permissions, $groupPermissions);
 
+        $users_query = User::query()
+            ->select(['users.id', 'users.first_name', 'users.last_name', 'users.username'])
+            ->where('show_in_list', 1)
+            ->whereNull('deleted_at');
 
-        $users_query = User::where('show_in_list', 1)->whereNull('deleted_at');
         $users_count = $users_query->count();
 
         $associated_users = collect();
@@ -124,7 +131,13 @@ class GroupsController extends Controller
         if ($users_count <= config('app.max_unpaginated_records')) {
             $associated_users = $group->users()->where('show_in_list', 1)->orderBy('first_name', 'asc')->orderBy('last_name', 'asc')->get();
             // Get the unselected users
-            $unselected_users = User::where('show_in_list', 1)->whereNotIn('id', $associated_users->pluck('id')->toArray())->orderBy('first_name', 'asc')->orderBy('last_name', 'asc')->get();
+            $unselected_users = User::query()
+                ->select(['users.id', 'users.first_name', 'users.last_name', 'users.username'])
+                ->where('show_in_list', 1)
+                ->whereNotIn('id', $associated_users->pluck('id')->toArray())
+                ->orderBy('first_name', 'asc')
+                ->orderBy('last_name', 'asc')
+                ->get();
         }
 
         return view('groups.edit', compact('group', 'permissions', 'selected_array', 'groupPermissions'))


### PR DESCRIPTION
I noticed that loading the group create and edit page was slow. Locally, I have ~2000 users and it was taking ~8000ms.

This improves loading times (to around ~500ms) by selecting only the required fields from the users table. 
