### PR TITLE
Added barcode mailto as label option

### DIFF
--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -172,17 +172,34 @@ class Label implements View
                                     ? route('locations.show', $asset->location_id)
                                     : null;
                                 break;
-                            case 'hardware_id':
-                            default:
-                                $barcode2DTarget = route('hardware.show', $asset);
-                                break;
-                            }
-                            $assetData->put('barcode2d', (object)[
-                                'type' => $barcode2DType,
-                                'content' => $barcode2DTarget,
-                            ]);
-                        }
-                    }
+                            // Special case for mailto link
+                            case 'mailto':
+                                            // Get company email or fallback to default support email or from .env
+                                            $companyEmail = $asset->company->email ?? config('mail.from.address') ?? 'support@example.com';
+                                            $assetUrl = url("/ht/{$asset->asset_tag}");
+                                            $subject = rawurlencode("Lost Asset - " . $asset->asset_tag);
+                                            $bodyPlain = "Hello,\n\n"
+                                                . "I found this asset with tag: " . $asset->asset_tag . "\n\n"
+                                                . "Asset page: " . $assetUrl . "\n\n"
+                                                . "Please contact me for retrieval.\n\n"
+                                                . "Thank you!";
+                                            $body = rawurlencode($bodyPlain);
+                                            // Create mailto link
+                                            $barcode2DTarget = "mailto:{$companyEmail}?subject={$subject}";
+                                            // If you want to include the body as well, uncomment the line below and comment the line above
+                                            // $barcode2DTarget = "mailto:{$companyEmail}?subject={$subject}&body={$body}";
+                                            break;
+                                        case 'hardware_id':
+                                        default:
+                                            $barcode2DTarget = route('hardware.show', $asset);
+                                            break;
+                                        }
+                                        $assetData->put('barcode2d', (object)[
+                                            'type' => $barcode2DType,
+                                            'content' => $barcode2DTarget,
+                                        ]);
+                                    }
+                                }
 
                 $fields = $fieldDefinitions
                     ->map(fn($field) => $field->toArray($asset))

--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -174,26 +174,39 @@ class Label implements View
                                 break;
                             // Special case for mailto link
                             case 'mailto':
-                                            // Get company email or fallback to default support email or from .env
-                                            $companyEmail = $asset->company->email ?? env('MAIL_FROM_ADDR');
-                                            // Skip qrcode generation if no email found
-                                            if (empty($companyEmail)) {
-                                            $barcode2DTarget = null;
-                                            break;
-                                            }
-                                            $assetUrl = url("/ht/{$asset->asset_tag}");
-                                            $subject = rawurlencode("Lost Asset - " . $asset->asset_tag);
-                                            $bodyPlain = "Hello,\n\n"
-                                                . "I found this asset with tag: " . $asset->asset_tag . "\n\n"
-                                                . "Asset page: " . $assetUrl . "\n\n"
-                                                . "Please contact me for retrieval.\n\n"
-                                                . "Thank you!";
-                                            $body = rawurlencode($bodyPlain);
-                                            // Create mailto link
-                                            $barcode2DTarget = "mailto:{$companyEmail}?subject={$subject}";
-                                            // If you want to include the body as well, uncomment the line below and comment the line above
-                                            // $barcode2DTarget = "mailto:{$companyEmail}?subject={$subject}&body={$body}";
-                                            break;
+                                // Get from company email or fallback from .env
+                                $companyEmail = $asset->company->email ?? env('MAIL_FROM_ADDR');
+                            
+                                // Skip QR code if no email found
+                                if (empty($companyEmail)) {
+                                    $barcode2DTarget = null;
+                                    break;
+                                }
+                            
+                                // Get url Hardware Tag
+                                $assetUrl = url("/ht/{$asset->asset_tag}");
+                            
+                                // Get text from translation file
+                                $subjectText = trans('admin/settings/general.mailto_subject', [
+                                    'asset_tag' => $asset->asset_tag,
+                                ]);
+                            
+                                $bodyText = trans('admin/settings/general.mailto_body', [
+                                    'asset_tag' => $asset->asset_tag,
+                                    'asset_url' => $assetUrl,
+                                ]);
+                            
+                                // Encode for URL
+                                $subject = rawurlencode($subjectText);
+                                $body = rawurlencode($bodyText);
+                            
+                                // Create Mailto Link
+                                $barcode2DTarget = "mailto:{$companyEmail}?subject={$subject}";
+
+                                // If you want to include the body as well, uncomment the line below and comment the line above
+                                //$barcode2DTarget = "mailto:{$companyEmail}?subject={$subject}&body={$body}";
+                                
+                                break;
                                         case 'hardware_id':
                                         default:
                                             $barcode2DTarget = route('hardware.show', $asset);

--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -175,7 +175,12 @@ class Label implements View
                             // Special case for mailto link
                             case 'mailto':
                                             // Get company email or fallback to default support email or from .env
-                                            $companyEmail = $asset->company->email ?? config('mail.from.address');
+                                            $companyEmail = $asset->company->email ?? env('MAIL_FROM_ADDR');
+                                            // Skip qrcode generation if no email found
+                                            if (empty($companyEmail)) {
+                                            $barcode2DTarget = null;
+                                            break;
+                                            }
                                             $assetUrl = url("/ht/{$asset->asset_tag}");
                                             $subject = rawurlencode("Lost Asset - " . $asset->asset_tag);
                                             $bodyPlain = "Hello,\n\n"

--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -172,52 +172,40 @@ class Label implements View
                                     ? route('locations.show', $asset->location_id)
                                     : null;
                                 break;
-                            // Special case for mailto link
-                            case 'mailto':
-                                // Get from company email or fallback from .env
+			                case 'mailto':                                
                                 $companyEmail = $asset->company->email ?? env('MAIL_FROM_ADDR');
-                            
-                                // Skip QR code if no email found
                                 if (empty($companyEmail)) {
                                     $barcode2DTarget = null;
                                     break;
                                 }
-                            
-                                // Get url Hardware Tag
                                 $assetUrl = url("/ht/{$asset->asset_tag}");
-                            
-                                // Get text from translation file
                                 $subjectText = trans('admin/settings/general.mailto_subject', [
                                     'asset_tag' => $asset->asset_tag,
                                 ]);
-                            
+
                                 $bodyText = trans('admin/settings/general.mailto_body', [
                                     'asset_tag' => $asset->asset_tag,
                                     'asset_url' => $assetUrl,
                                 ]);
-                            
-                                // Encode for URL
+
                                 $subject = rawurlencode($subjectText);
                                 $body = rawurlencode($bodyText);
-                            
-                                // Create Mailto Link
-                                $barcode2DTarget = "mailto:{$companyEmail}?subject={$subject}";
 
+                                $barcode2DTarget = "mailto:{$companyEmail}?subject={$subject}";
                                 // If you want to include the body as well, uncomment the line below and comment the line above
-                                //$barcode2DTarget = "mailto:{$companyEmail}?subject={$subject}&body={$body}";
-                                
+                                // $barcode2DTarget = "mailto:{$companyEmail}?subject={$subject}&body={$body}";
                                 break;
-                                        case 'hardware_id':
-                                        default:
-                                            $barcode2DTarget = route('hardware.show', $asset);
-                                            break;
-                                        }
-                                        $assetData->put('barcode2d', (object)[
-                                            'type' => $barcode2DType,
-                                            'content' => $barcode2DTarget,
-                                        ]);
-                                    }
+                            case 'hardware_id':
+                                default:
+                                    $barcode2DTarget = route('hardware.show', $asset);
+                                    break;
                                 }
+                                    $assetData->put('barcode2d', (object)[
+                                    'type' => $barcode2DType,
+                                    'content' => $barcode2DTarget,
+                                    ]);
+                                }
+                            }
 
                 $fields = $fieldDefinitions
                     ->map(fn($field) => $field->toArray($asset))

--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -178,7 +178,6 @@ class Label implements View
                                     $barcode2DTarget = null;
                                     break;
                                 }
-                                $assetUrl = url("/ht/{$asset->asset_tag}");
                                 $subjectText = trans('admin/settings/general.mailto_subject', [
                                     'asset_tag' => $asset->asset_tag,
                                 ]);

--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -182,18 +182,9 @@ class Label implements View
                                 $subjectText = trans('admin/settings/general.mailto_subject', [
                                     'asset_tag' => $asset->asset_tag,
                                 ]);
-
-                                $bodyText = trans('admin/settings/general.mailto_body', [
-                                    'asset_tag' => $asset->asset_tag,
-                                    'asset_url' => $assetUrl,
-                                ]);
-
+							
                                 $subject = rawurlencode($subjectText);
-                                $body = rawurlencode($bodyText);
-
                                 $barcode2DTarget = "mailto:{$companyEmail}?subject={$subject}";
-                                // If you want to include the body as well, uncomment the line below and comment the line above
-                                // $barcode2DTarget = "mailto:{$companyEmail}?subject={$subject}&body={$body}";
                                 break;
                             case 'hardware_id':
                                 default:

--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -175,7 +175,7 @@ class Label implements View
                             // Special case for mailto link
                             case 'mailto':
                                             // Get company email or fallback to default support email or from .env
-                                            $companyEmail = $asset->company->email ?? config('mail.from.address') ?? 'support@example.com';
+                                            $companyEmail = $asset->company->email ?? config('mail.from.address');
                                             $assetUrl = url("/ht/{$asset->asset_tag}");
                                             $subject = rawurlencode("Lost Asset - " . $asset->asset_tag);
                                             $bodyPlain = "Hello,\n\n"

--- a/resources/lang/en-US/admin/settings/general.php
+++ b/resources/lang/en-US/admin/settings/general.php
@@ -399,14 +399,6 @@ return [
     'label2_2d_prefix_help'   => 'This text will be prepended to the 2D Barcode Target value selected below when the 2D code is scanned. This can be used to prepend an external URL or any other value that you might need.',
     'label2_2d_target'        => '2D Barcode Content',
     'label2_2d_target_help'   => 'The data that will be contained in the 2D barcode. This can link to the asset directly in Snipe-IT or can be one of the non-linked field values. If you use the prefix above, it will be prepended to this value.',
-    // Custom: Mailto barcode translation
-    'mailto_option' => 'Mailto (Send Email to Company)',
-    'mailto_subject' => 'Lost Asset - :asset_tag',
-    'mailto_body' => "Hello,\n\n"
-        . "I found this asset with tag: :asset_tag\n\n"
-        . "Asset page: :asset_url\n\n"
-        . "Please contact me for retrieval.\n\n"
-        . "Thank you!",
     'select_template'         => 'Select a Template',
     'label2_fields'           => 'Field Definitions',
     'label2_fields_help'      => 'Fields can be added, removed, and reordered in the left column. For each field, multiple options for Label and DataSource can be added, removed, and reordered in the right column. Field changes made here will be reflected immediately in the preview below but must be saved for them to apply to new labels.',

--- a/resources/lang/en-US/admin/settings/general.php
+++ b/resources/lang/en-US/admin/settings/general.php
@@ -399,6 +399,14 @@ return [
     'label2_2d_prefix_help'   => 'This text will be prepended to the 2D Barcode Target value selected below when the 2D code is scanned. This can be used to prepend an external URL or any other value that you might need.',
     'label2_2d_target'        => '2D Barcode Content',
     'label2_2d_target_help'   => 'The data that will be contained in the 2D barcode. This can link to the asset directly in Snipe-IT or can be one of the non-linked field values. If you use the prefix above, it will be prepended to this value.',
+    // Custom: Mailto barcode translation
+    'mailto_option' => 'Mailto (Send Email to Company)',
+    'mailto_subject' => 'Lost Asset - :asset_tag',
+    'mailto_body' => "Hello,\n\n"
+        . "I found this asset with tag: :asset_tag\n\n"
+        . "Asset page: :asset_url\n\n"
+        . "Please contact me for retrieval.\n\n"
+        . "Thank you!",
     'select_template'         => 'Select a Template',
     'label2_fields'           => 'Field Definitions',
     'label2_fields_help'      => 'Fields can be added, removed, and reordered in the left column. For each field, multiple options for Label and DataSource can be added, removed, and reordered in the right column. Field changes made here will be reflected immediately in the preview below but must be saved for them to apply to new labels.',

--- a/resources/views/settings/labels.blade.php
+++ b/resources/views/settings/labels.blade.php
@@ -323,6 +323,7 @@
                                         :options="[
                                                    'hardware_id'=> config('app.url').'/hardware/{id} ('.trans('admin/settings/general.default').')',
                                                    'ht_tag'=> config('app.url').'/ht/{asset_tag}',
+                                                   'mailto' => 'Mailto (Send Email to Company)',
                                                    'location' => config('app.url').'/locations/{location_id}',
                                                    'plain_asset_id'=> trans('admin/settings/general.asset_id'),
                                                    'plain_asset_tag'=> trans('general.asset_tag'),

--- a/resources/views/settings/labels.blade.php
+++ b/resources/views/settings/labels.blade.php
@@ -323,7 +323,7 @@
                                         :options="[
                                                    'hardware_id'=> config('app.url').'/hardware/{id} ('.trans('admin/settings/general.default').')',
                                                    'ht_tag'=> config('app.url').'/ht/{asset_tag}',
-                                                   'mailto' => 'Mailto (Send Email to Company)',
+                                                   'mailto' => trans('admin/settings/general.mailto_option'),
                                                    'location' => config('app.url').'/locations/{location_id}',
                                                    'plain_asset_id'=> trans('admin/settings/general.asset_id'),
                                                    'plain_asset_tag'=> trans('general.asset_tag'),


### PR DESCRIPTION
Hi Snipe,

It was nice to meet you again.

I am writing regarding my recent Pull Request, which introduces a new feature for barcode labels by adding a MAILTO function.

I developed this feature because my Snipe-IT instance is hosted on a private domain and is not publicly accessible. The MAILTO link is intended to simplify asset identification: users can simply scan the label, and it will automatically generate an email with the asset details.

The email address is determined by the following logic:

1. Company Specific: If a company is specified and an email address is entered for that company, the company email address will be used.
2. Default from .env: If a company is not specified, the system will use the address defined by the MAIL_FROM_ADDRESS variable in the .env file.
3. Fallback: If neither of the above is present, it will default to support@example.com.

I hope this feature can be implemented in the next version. Thank you for considering my contribution!


Label Settings:
<img width="2219" height="752" alt="image" src="https://github.com/user-attachments/assets/ad4d9e8f-fd2d-491e-afe9-3559cecddebd" />


This example

<img width="642" height="452" alt="Screenshot 2025-12-24 at 12 32 14" src="https://github.com/user-attachments/assets/66807011-d02a-41b8-ab9d-4ce34de374b4" />

