### PR TITLE
Bump php-saml to solve vulnerability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
     "nesbot/carbon": "^3.0",
     "nunomaduro/collision": "^8.1",
     "okvpn/clock-lts": "^1.0",
-    "onelogin/php-saml": "^3.4",
+    "onelogin/php-saml": "^3.8.1",
     "onnov/detect-encoding": "^2.0",
     "osa-eg/laravel-teams-notification": "^2.1",
     "paragonie/constant_time_encoding": "^2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "553ce69c21704905c568769de08fffe4",
+    "content-hash": "13bae1674df26af1c8a99adc229ebb46",
     "packages": [
         {
             "name": "alek13/slack",
@@ -5446,21 +5446,21 @@
         },
         {
             "name": "onelogin/php-saml",
-            "version": "3.8.0",
+            "version": "3.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/SAML-Toolkits/php-saml.git",
-                "reference": "03bd22f5e028a8aa3b5fec9864bb8984a55df899"
+                "reference": "3b6b661015c1d847a0e8cb82ca07636ccbb6cf18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SAML-Toolkits/php-saml/zipball/03bd22f5e028a8aa3b5fec9864bb8984a55df899",
-                "reference": "03bd22f5e028a8aa3b5fec9864bb8984a55df899",
+                "url": "https://api.github.com/repos/SAML-Toolkits/php-saml/zipball/3b6b661015c1d847a0e8cb82ca07636ccbb6cf18",
+                "reference": "3b6b661015c1d847a0e8cb82ca07636ccbb6cf18",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4",
-                "robrichards/xmlseclibs": ">=3.1.1"
+                "robrichards/xmlseclibs": ">=3.1.4"
             },
             "require-dev": {
                 "pdepend/pdepend": "^2.5.0",
@@ -5505,7 +5505,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-05-25T14:25:06+00:00"
+            "time": "2025-12-09T10:54:02+00:00"
         },
         {
             "name": "onnov/detect-encoding",
@@ -7317,16 +7317,16 @@
         },
         {
             "name": "robrichards/xmlseclibs",
-            "version": "3.1.3",
+            "version": "3.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/robrichards/xmlseclibs.git",
-                "reference": "2bdfd742624d739dfadbd415f00181b4a77aaf07"
+                "reference": "bc87389224c6de95802b505e5265b0ec2c5bcdbd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/robrichards/xmlseclibs/zipball/2bdfd742624d739dfadbd415f00181b4a77aaf07",
-                "reference": "2bdfd742624d739dfadbd415f00181b4a77aaf07",
+                "url": "https://api.github.com/repos/robrichards/xmlseclibs/zipball/bc87389224c6de95802b505e5265b0ec2c5bcdbd",
+                "reference": "bc87389224c6de95802b505e5265b0ec2c5bcdbd",
                 "shasum": ""
             },
             "require": {
@@ -7353,9 +7353,9 @@
             ],
             "support": {
                 "issues": "https://github.com/robrichards/xmlseclibs/issues",
-                "source": "https://github.com/robrichards/xmlseclibs/tree/3.1.3"
+                "source": "https://github.com/robrichards/xmlseclibs/tree/3.1.4"
             },
-            "time": "2024-11-20T21:13:56+00:00"
+            "time": "2025-12-08T11:57:53+00:00"
         },
         {
             "name": "rollbar/rollbar",
@@ -16519,6 +16519,6 @@
         "ext-mbstring": "*",
         "ext-pdo": "*"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
Bumping php-saml to 3.8.1 due to https://github.com/advisories/GHSA-5j8p-438x-rgg5.

I took a look at your implementation and I've found no breaking change in the [php-saml CHANGELOG](https://github.com/SAML-Toolkits/php-saml/blob/3.8.1/CHANGELOG).