### PR TITLE
Feature: Add options for enforcing asset name validation (Touches #11473)

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -129,6 +129,16 @@ class SettingsController extends Controller
         $setting->require_checkinout_notes = $request->input('require_checkinout_notes', 0);
         $setting->manager_view_enabled = $request->input('manager_view_enabled', 0);
 
+        $setting->validate_asset_name = $request->input('validate_asset_name', '0');
+        $setting->asset_name_regex = $request->input('asset_name_regex');
+        if ($setting->validate_asset_name == '1') {
+            if (empty($setting->asset_name_regex)) {
+                return redirect()->back()->withInput()->withErrors(['asset_name_regex' => trans('admin/settings/message.asset_name_regex.empty')]);
+            }
+        }
+        $setting->unique_asset_name = $request->input('unique_asset_name', '0');
+        $setting->ignore_blank_asset_name = $request->input('ignore_blank_asset_name', '0');
+
 
         if ($request->input('per_page') != '') {
             $setting->per_page = $request->input('per_page');

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -255,6 +255,19 @@ class Asset extends Depreciable
     }
 
 
+    public function nameFieldValidationRules()
+    {
+        $nameFieldValidationRules = ['string', 'max:255'];
+
+        $settings = \App\Models\Setting::getSettings();
+        if ($settings->validate_asset_name) { array_push($nameFieldValidationRules, $settings->asset_name_regex); }
+        if ($settings->unique_asset_name) { array_push($nameFieldValidationRules, 'unique_undeleted'); }
+        if ($settings->ignore_blank_asset_name) { array_push($nameFieldValidationRules, 'nullable'); }
+
+        return $nameFieldValidationRules;
+    }
+
+
 
     /**
      * This handles the custom field validation for assets
@@ -263,7 +276,12 @@ class Asset extends Depreciable
      */
     public function save(array $params = [])
     {
-        $this->rules += $this->customFieldValidationRules();
+        $this->rules = array_merge(
+            $this->rules,
+            $this->customFieldValidationRules(),
+            ['name' => $this->nameFieldValidationRules()]
+        );
+
         return parent::save($params);
     }
 

--- a/database/migrations/2025_12_29_000000_add_asset_name_settings.php
+++ b/database/migrations/2025_12_29_000000_add_asset_name_settings.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->boolean('validate_asset_name')->default('0');
+            $table->char('asset_name_regex')->nullable()->default(null);
+            $table->boolean('unique_asset_name')->default('0');
+            $table->boolean('ignore_blank_asset_name')->default('0');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('settings', function ($table) {
+            $table->dropColumn('validate_asset_name');
+            $table->dropColumn('asset_name_regex');
+            $table->dropColumn('unique_asset_name');
+            $table->dropColumn('ignore_blank_asset_name');
+        });
+    }
+};

--- a/resources/lang/en-US/admin/settings/general.php
+++ b/resources/lang/en-US/admin/settings/general.php
@@ -23,6 +23,14 @@ return [
     'allow_user_skin'           => 'Allow User Skin',
     'allow_user_skin_help_text' => 'Checking this box will allow a user to override the UI skin with a different one.',
     'asset_ids'					=> 'Asset IDs',
+    'asset_name_blank'          => 'Ignore Blank Asset Names',
+    'asset_name_blank_help'     => 'Checking this box will allow asset names to be blank, bypassing validation and uniqueness checks.',
+    'asset_name_regex'          => 'Asset Name Regex',
+    'asset_name_regex_help'     => 'This field allows you to use a regex expression for validation. It should start with "regex:". For example, to validate that the asset name conforms to the standard <code>AAAA-BBB-CCC000</code>, you would use <code>regex:/^[A-Z]{4}-[A-Z]{3}-[A-Z]{3}[0-9]{3}$/</code>.',
+    'asset_name_unique'         => 'Unique Asset Names',
+    'asset_name_unique_help'    => 'Checking this box will enforce a uniqueness constraint on asset names.',
+    'asset_name_validate'       => 'Validate Asset Names',
+    'asset_name_validate_help'  => 'Checking this box will enforce validation on asset names.',
     'audit_interval'            => 'Audit Interval',
     'audit_interval_help'       => 'If you are required to regularly physically audit your assets, enter the interval in months that you use. If you update this value, all of the "next audit dates" for assets with an upcoming audit date will be updated.',
     'audit_warning_days'        => 'Audit Warning Threshold',
@@ -492,6 +500,7 @@ return [
 
 
     'legends' => [
+        'asset_naming' => 'Asset Naming Preferences',
         'checkin' => 'Checkin Preferences',
         'colors' => 'Colors & Skins',
         'dashboard' => 'Login & Dashboard Preferences',

--- a/resources/lang/en-US/admin/settings/message.php
+++ b/resources/lang/en-US/admin/settings/message.php
@@ -2,6 +2,9 @@
 
 return [
 
+    'asset_name_regex' => [
+        'empty' => 'When validation is enabled, this value must be set. ',
+    ],
     'update' => [
         'error'                 => 'An error has occurred while updating. ',
         'success'               => 'Settings updated successfully.',

--- a/resources/views/settings/general.blade.php
+++ b/resources/views/settings/general.blade.php
@@ -373,6 +373,60 @@
                                </div>
                        </fieldset>
 
+                        <fieldset name="asset-naming">
+                            <x-form-legend>
+                                {{ trans('admin/settings/general.legends.asset_naming') }}
+                            </x-form-legend>
+
+                            <!-- Validate Asset Names -->
+                            <div class="form-group {{ $errors->has('validate_asset_name') ? 'error' : '' }}">
+                                <div class="col-md-8 col-md-offset-3">
+                                    <label class="form-control">
+                                        <input type="checkbox" name="validate_asset_name" id="validate_asset_name" value="1" @checked(old('validate_asset_name', $setting->validate_asset_name)) />
+                                        {{ trans('admin/settings/general.asset_name_validate') }}
+                                        {!! $errors->first('validate_asset_name', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                    </label>
+                                    <p class="help-block">{!! trans('admin/settings/general.asset_name_validate_help') !!}</p>
+                                </div>
+                            </div>
+
+                            <!-- Asset Name Regex -->
+                            <div class="form-group {{ $errors->has('asset_name_regex') ? 'error' : '' }}" id="asset_name_regex_container" style="display:none;">
+
+                                <label for="asset_name_regex" class="col-md-3 control-label">{{ trans('admin/settings/general.asset_name_regex') }}</label>
+
+                                <div class="col-md-8 required">
+                                    <input class="form-control" name="asset_name_regex" type="text" id="asset_name_regex" placeholder="regex:/^[A-Z]{4}-[A-Z]{3}-[A-Z]{3}[0-9]{3}$/" value="{{ old('asset_name_regex', $setting->asset_name_regex) }}" />
+                                    <p class="help-block">{!! trans('admin/settings/general.asset_name_regex_help') !!}</p>
+                                    {!! $errors->first('asset_name_regex', '<span class="alert-msg">:message</span>') !!}
+                                </div>
+                            </div>
+
+                            <!-- Unique Asset Names -->
+                            <div class="form-group {{ $errors->has('unique_asset_name') ? 'error' : '' }}">
+                                <div class="col-md-8 col-md-offset-3">
+                                    <label class="form-control">
+                                        <input type="checkbox" name="unique_asset_name" id="unique_asset_name" value="1" @checked(old('unique_asset_name', $setting->unique_asset_name)) />
+                                        {{ trans('admin/settings/general.asset_name_unique') }}
+                                        {!! $errors->first('unique_asset_name', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                    </label>
+                                    <p class="help-block">{!! trans('admin/settings/general.asset_name_unique_help') !!}</p>
+                                </div>
+                            </div>
+
+                            <!-- Ignore Blank Asset Names -->
+                            <div class="form-group {{ $errors->has('ignore_blank_asset_name') ? 'error' : '' }}">
+                                <div class="col-md-8 col-md-offset-3">
+                                    <label class="form-control">
+                                        <input type="checkbox" name="ignore_blank_asset_name" id="ignore_blank_asset_name" value="1" @checked(old('ignore_blank_asset_name', $setting->ignore_blank_asset_name)) />
+                                        {{ trans('admin/settings/general.asset_name_blank') }}
+                                        {!! $errors->first('ignore_blank_asset_name', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                    </label>
+                                    <p class="help-block">{!! trans('admin/settings/general.asset_name_blank_help') !!}</p>
+                                </div>
+                            </div>
+                        </fieldset>
+
 
                        <fieldset>
                            <x-form-legend>
@@ -545,6 +599,19 @@
 
 
             });
+        });
+
+        $(document).ready(function(){
+
+            // Only display the regex field if validation is checked
+            $("#validate_asset_name").change(function() {
+                if ($("#validate_asset_name").prop("checked")) {
+                    $("#asset_name_regex_container").show();
+                } else {
+                    $("#asset_name_regex_container").hide();
+                }
+            }).change();
+
         });
 
     </script>


### PR DESCRIPTION
Touches issue #11473
We (and several others apparently) use the Asset Name as the primary identifier for assets.
Therefore it's required to be mandatory, in a specific format, and unique forever.
We also do have some assets without a name, so null values are allowed.

I've put together this quick little commit to add those options into General Settings.
<img width="689" height="485" alt="image" src="https://github.com/user-attachments/assets/72c7f714-b8de-478c-98cf-cae191bf597e" />

**Validation** Checkbox - Enables the regex validation rule on asset names.
**Regex** Input - The regex rule itself.
**Unique** Checkbox - Enables the `unique_undeleted` rule on asset names.
**Ignore Blank** Checkbox - Enables the `nullable `rule on asset names.

For those in #11473 who are happy to just have it mandatory, enable **Validation**, set **Regex** to `regex:/^.+$/`, and disable **Ignore Blank**.