### PR TITLE
Fixed #18384: Remove backticks in bulk-actions.blade.php to avoid unintentional shell_exec() call

### DIFF
--- a/resources/views/components/tables/bulk-actions.blade.php
+++ b/resources/views/components/tables/bulk-actions.blade.php
@@ -18,7 +18,7 @@
         @csrf
 
         {{--        The sort and order will only be used if the cookie is actually empty (like on first-use)--}}
-        <input name="sort" type="hidden" value="{{`$model_name.id`}}">
+        <input name="sort" type="hidden" value="{{ "{$model_name}.id" }}">
         <input name="order" type="hidden" value="asc">
         <label for="bulk_actions">
             <span class="sr-only">


### PR DESCRIPTION
Fixes #18384.

`shell_exec()` is being called unintentionally in bulk-actions.blade.php via the use of backticks in the hidden sort input on line 21:

```php
<input name="sort" type="hidden" value="{{`$model_name.id`}}">
```

Since [backticks are an execution operator in PHP](https://www.php.net/manual/en/language.operators.execution.php), `shell_exec()` is being called using the value of $model_name.id when the Blade template is rendered, which fails. This may cause a runtime error depending on the user's environment configuration or it may fail silently, but the `value` attribute for the input isn't set properly regardless.

I've replaced the backticks and instead use string interpolation here:

```php
<input name="sort" type="hidden" value="{{ "{$model_name}.id" }}">
```

This now outputs the intended string (e.g. `category.id`).