### PR TITLE
fix: paragonie/sodium_compat - Missing check that a point is on the prime subgroup for Edwards25519

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5755,16 +5755,16 @@
         },
         {
             "name": "paragonie/sodium_compat",
-            "version": "v1.21.1",
+            "version": "v1.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/sodium_compat.git",
-                "reference": "bb312875dcdd20680419564fe42ba1d9564b9e37"
+                "reference": "2cb48f26130919f92f30650bdcc30e6f4ebe45ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/sodium_compat/zipball/bb312875dcdd20680419564fe42ba1d9564b9e37",
-                "reference": "bb312875dcdd20680419564fe42ba1d9564b9e37",
+                "url": "https://api.github.com/repos/paragonie/sodium_compat/zipball/2cb48f26130919f92f30650bdcc30e6f4ebe45ac",
+                "reference": "2cb48f26130919f92f30650bdcc30e6f4ebe45ac",
                 "shasum": ""
             },
             "require": {
@@ -5835,9 +5835,9 @@
             ],
             "support": {
                 "issues": "https://github.com/paragonie/sodium_compat/issues",
-                "source": "https://github.com/paragonie/sodium_compat/tree/v1.21.1"
+                "source": "https://github.com/paragonie/sodium_compat/tree/v1.24.0"
             },
-            "time": "2024-04-22T22:05:04+00:00"
+            "time": "2025-12-30T16:16:35+00:00"
         },
         {
             "name": "php-debugbar/php-debugbar",
@@ -16520,5 +16520,5 @@
         "ext-pdo": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
I saw some other PRs tackling the onelogin/php-saml https://github.com/grokability/snipe-it/pull/18380

This one only targets
```
+-------------------+----------------------------------------------------------------------------------+
| Package           | paragonie/sodium_compat                                                          |
| Severity          |                                                                                  |
| Advisory ID       | PKSA-8x19-j2j3-bn67                                                              |
| CVE               | NO CVE                                                                           |
| Title             | Missing check that a point is on the prime subgroup for Edwards25519             |
| URL               | https://00f.net/2025/12/30/libsodium-vulnerability                               |
| Affected versions | >=2,<2.5.0|<1.24.0                                                               |
| Reported at       | 2025-12-30T00:00:00+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
```

```
~/Contrib/snipe-it develop 6s                                                                                                                                       13:49:08
❯ composer audit
Found 4 security vulnerability advisories affecting 4 packages:
+-------------------+----------------------------------------------------------------------------------+
| Package           | aws/aws-sdk-php                                                                  |
| Severity          | medium                                                                           |
| Advisory ID       | PKSA-dxyf-6n16-t87m                                                              |
| CVE               | CVE-2025-14761                                                                   |
| Title             | Key Commitment Issues in S3 Encryption Clients                                   |
| URL               | https://aws.amazon.com/security/security-bulletins/AWS-2025-032/                 |
| Affected versions | >=3.0.0,<3.368.0                                                                 |
| Reported at       | 2025-12-17T20:15:00+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | onelogin/php-saml                                                                |
| Severity          | critical                                                                         |
| Advisory ID       | PKSA-67d7-mg8j-87zx                                                              |
| CVE               | NO CVE                                                                           |
| Title             |  SAML PHP Toolkit Vulnerability on xmlseclibs CVE-2025-66475                     |
| URL               | https://github.com/advisories/GHSA-5j8p-438x-rgg5                                |
| Affected versions | >=4.0.0,<4.3.1|>=3.0.0,<3.8.1|<2.21.1                                            |
| Reported at       | 2025-12-09T17:24:09+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | paragonie/sodium_compat                                                          |
| Severity          |                                                                                  |
| Advisory ID       | PKSA-8x19-j2j3-bn67                                                              |
| CVE               | NO CVE                                                                           |
| Title             | Missing check that a point is on the prime subgroup for Edwards25519             |
| URL               | https://00f.net/2025/12/30/libsodium-vulnerability                               |
| Affected versions | >=2,<2.5.0|<1.24.0                                                               |
| Reported at       | 2025-12-30T00:00:00+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | robrichards/xmlseclibs                                                           |
| Severity          | medium                                                                           |
| Advisory ID       | PKSA-pcdf-qvqm-w4tv                                                              |
| CVE               | CVE-2025-66578                                                                   |
| Title             | robrichards/xmlseclibs has an Libxml2 Canonicalization error which can bypass    |
|                   | Digest/Signature validation                                                      |
| URL               | https://github.com/advisories/GHSA-c4cc-x928-vjw9                                |
| Affected versions | <=3.1.3                                                                          |
| Reported at       | 2025-12-08T17:57:33+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
```
