### PR TITLE
Fixed #18394 - LDAP sync test table background in dark mode

### DIFF
--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -358,6 +358,22 @@
             border-right-color: var(--box-bg) !important;
         }
 
+        .table-bordered > tbody > tr > td,
+        .table-bordered > tbody > tr > th,
+        .table-bordered > tfoot > tr > td,
+        .table-bordered > tfoot > tr > th,
+        .table-bordered > thead > tr > td,
+        .table-bordered > thead > tr > td,
+        .table-bordered > thead > tr > th,
+        .table-bordered > thead > tr > th,
+        .table-bordered,
+        .well
+        {
+            border: 1px solid var(--box-header-top-border-color) !important;
+            border-left-color: var(--box-header-top-border-color) !important;
+            border-right-color: var(--box-header-top-border-color) !important;
+        }
+
         .box {
             border-top: 3px solid;
         }
@@ -398,7 +414,8 @@
         .nav-tabs-custom > .nav-tabs > li.active > a:link,
         .nav-tabs-custom > .nav-tabs > li.active > a:visited,
         .nav-tabs-custom > .nav-tabs > li.active > a:hover,
-        .bootstrap-table.fullscreen
+        .bootstrap-table.fullscreen,
+        .well
         {
 
             color: var(--color-fg);

--- a/resources/views/settings/ldap.blade.php
+++ b/resources/views/settings/ldap.blade.php
@@ -902,7 +902,7 @@
                                                 <input type="password" name="ldaptest_password" id="ldaptest_password" class="form-control" placeholder="{{trans('admin/settings/general.ldap_password_placeholder')}}" autocomplete="off" readonly onfocus="this.removeAttribute('readonly');">
                                             </div>
                                             <div class="col-md-3">
-                                                <a class="btn btn-default btn-sm" id="ldaptestlogin" style="margin-right: 10px;">{{ trans('admin/settings/general.ldap_test') }}</a>
+                                                <a class="btn btn-theme btn-sm" id="ldaptestlogin" style="margin-right: 10px;">{{ trans('admin/settings/general.ldap_test') }}</a>
                                             </div>
 
 
@@ -922,7 +922,7 @@
                                 <!-- LDAP test -->
                                 <div class="form-group">
                                     <div class="col-md-8 col-md-offset-3" id="ldaptestrow">
-                                        <a class="btn btn-default btn-sm" id="ldaptest" style="margin-right: 10px;">{{ trans('admin/settings/general.ldap_test_sync') }}</a>
+                                        <a class="btn btn-theme btn-sm" id="ldaptest" style="margin-right: 10px;">{{ trans('admin/settings/general.ldap_test_sync') }}</a>
                                         <p class="help-block">{{ trans('admin/settings/general.ldap_login_sync_help') }}</p>
                                     </div>
                                     <div class="col-md-12">
@@ -1137,11 +1137,11 @@
             html += '</ul>'
             html += '<div style="overflow:auto;">'
             html += '<div>{{ trans('admin/settings/message.ldap.sync_success') }}<br><br></div>'
-            html += '<div class="table-wrapper"><table class="table table-bordered table-condensed">'
+            html += '<table class="table table-striped snipe-table table-bordered table-condensed">'
             html += buildLdapResultsTableHeader()
             html += buildLdapResultsTableBody(results.user_sync.users)
             html += '</table></div>'
-            html += '</div>'
+            html += ''
             return html;
         }
 


### PR DESCRIPTION
This corrects the LDAP test sync background in dark mode, where the light text was making the results illegible (light on light text):

### Before
<img width="1294" height="554" alt="Screenshot 2026-01-05 at 2 57 24 PM" src="https://github.com/user-attachments/assets/241d1d16-400c-4cf0-aa1c-78d64d04c05d" />


### After (Dark)

<img width="1293" height="553" alt="Screenshot 2026-01-05 at 3 26 21 PM" src="https://github.com/user-attachments/assets/239e8144-68e7-4f50-9d1d-74c686ca106b" />

### After (Light)

<img width="1296" height="555" alt="Screenshot 2026-01-05 at 3 26 36 PM" src="https://github.com/user-attachments/assets/48e72484-231b-4368-863e-1f05b43f9563" />


Fixes #18394 