### PR TITLE
Fixed #17652 - don't break company drop-down with modals

### DIFF
--- a/resources/views/partials/forms/edit/company-select.blade.php
+++ b/resources/views/partials/forms/edit/company-select.blade.php
@@ -4,7 +4,7 @@
     <div class="form-group">
         <label for="{{ $fieldname }}" class="col-md-3 control-label">{{ $translated_name }}</label>
         <div class="col-md-6">
-            <select class="js-data-ajax" disabled="true" data-endpoint="companies" data-placeholder="{{ trans('general.select_company') }}" name="{{ $fieldname }}" style="width: 100%" id="company_select" aria-label="{{ $fieldname }}"{{ (isset($multiple) && ($multiple=='true')) ? " multiple='multiple'" : '' }}>
+            <select class="js-data-ajax" disabled="true" data-endpoint="companies" data-placeholder="{{ trans('general.select_company') }}" name="{{ $fieldname }}" style="width: 100%" aria-label="{{ $fieldname }}"{{ (isset($multiple) && ($multiple=='true')) ? " multiple='multiple'" : '' }}>
                 @if ($company_id = old($fieldname, (isset($item)) ? $item->{$fieldname} : ''))
                     <option value="{{ $company_id }}" selected="selected" role="option" aria-selected="true"  role="option">
                         {{ (\App\Models\Company::find($company_id)) ? \App\Models\Company::find($company_id)->name : '' }}
@@ -21,7 +21,7 @@
     <div id="{{ $fieldname }}" class="form-group{{ $errors->has($fieldname) ? ' has-error' : '' }}">
         <label for="{{ $fieldname }}" class="col-md-3 control-label">{{ $translated_name }}</label>
         <div class="col-md-8">
-            <select class="js-data-ajax" data-endpoint="companies" data-placeholder="{{ trans('general.select_company') }}" name="{{ $fieldname }}" style="width: 100%" id="company_select"{{ (isset($multiple) && ($multiple=='true')) ? " multiple='multiple'" : '' }}>
+            <select class="js-data-ajax" data-endpoint="companies" data-placeholder="{{ trans('general.select_company') }}" name="{{ $fieldname }}" style="width: 100%"{{ (isset($multiple) && ($multiple=='true')) ? " multiple='multiple'" : '' }}>
                 @isset ($selected)
                     @foreach ($selected as $company_id)
                         <option value="{{ $company_id }}" selected="selected" role="option" aria-selected="true">


### PR DESCRIPTION
So the Company-select partial that we use is used not only in Create Asset, but *also* in the modal, for when you create either a user for the asset to be checked-out to, *or* if you create a default location for it to be assigned-to.

So, to fix that, I just removed ID from the company select in the partials. That seems like a bit of a 'harsh' fix, but I couldn't find anywhere in the code where we actually _used_ the ID of the company select for anything. So instead of writing some kind of weird stuff that would dynamically name the ID, with some kind of reasonable fallback - I just pulled it out completely.

Before this fix, opening up the 'create' modal for either creating a user _or_ for creating a default location would break the company drop-down in the 'parent' form. After the fix, both use cases no longer break the company drop-down.

I made sure to confirm that the modals javascript that we use just does a default "form-serialize" (which is based on element `name`, not based on `id`), so it should not be affected.

Fixes #17652 