### PR TITLE
Adds [RB-20474] a try/catch to ms teams audit notification

### DIFF
--- a/app/Models/Traits/Loggable.php
+++ b/app/Models/Traits/Loggable.php
@@ -11,7 +11,6 @@ use App\Models\Setting;
 use App\Models\User;
 use App\Notifications\AuditNotification;
 use GuzzleHttp\Exception\ConnectException;
-use GuzzleHttp\Exception\RequestException;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;

--- a/app/Models/Traits/Loggable.php
+++ b/app/Models/Traits/Loggable.php
@@ -292,7 +292,6 @@ trait Loggable
             try {
                 $message = AuditNotification::toMicrosoftTeams($params);
                 $notification = new TeamsNotification($endpoint);
-
                 $notification->success()->sendMessage($message[0], $message[1]);
 
             } catch (ConnectException $e) {

--- a/app/Models/Traits/Loggable.php
+++ b/app/Models/Traits/Loggable.php
@@ -297,13 +297,13 @@ trait Loggable
 
             } catch (ConnectException $e) {
                 Log::warning('Teams webhook connection failed', [
-                    'endpoint' => Setting::getSettings()->webhook_endpoint,
+                    'endpoint' => $endpoint,
                     'error' => $e->getMessage(),
                 ]);
 
             } catch (Throwable $e) {
                 Log::error('Teams webhook failed unexpectedly', [
-                    'endpoint' => Setting::getSettings()->webhook_endpoint,
+                    'endpoint' => $endpoint,
                     'exception' => get_class($e),
                     'error' => $e->getMessage(),
                 ]);

--- a/app/Models/Traits/Loggable.php
+++ b/app/Models/Traits/Loggable.php
@@ -286,8 +286,10 @@ trait Loggable
         ];
 
         if(Setting::getSettings()->webhook_selected === 'microsoft' && Str::contains(Setting::getSettings()->webhook_endpoint, 'workflows')) {
-            try {
+
                 $endpoint = Setting::getSettings()->webhook_endpoint;
+
+            try {
                 $message = AuditNotification::toMicrosoftTeams($params);
                 $notification = new TeamsNotification($endpoint);
 


### PR DESCRIPTION
This adds a try/catch around the MS Teams audit notification to log connection errors and unexpected failures. This should prevent unnecessary roll bars.