### PR TITLE
fixed: Prefer display name of user on UI

### DIFF
--- a/app/Presenters/ActionlogPresenter.php
+++ b/app/Presenters/ActionlogPresenter.php
@@ -14,7 +14,7 @@ class ActionlogPresenter extends Presenter
                 return $user->present()->nameUrl();
             }
             // The user was deleted
-            return '<del>'.$user->getFullNameAttribute().'</del> (deleted)';
+            return '<del>'.$user->display_name.'</del> (deleted)';
         }
 
         return '';

--- a/app/Presenters/UserPresenter.php
+++ b/app/Presenters/UserPresenter.php
@@ -524,7 +524,7 @@ class UserPresenter extends Presenter
      */
     public function nameUrl()
     {
-        return (string) link_to_route('users.show', $this->getFullNameAttribute(), $this->id);
+        return (string) link_to_route('users.show', $this->display_name, $this->id);
     }
 
     /**


### PR DESCRIPTION
Updated UI logic to prioritize the user's _display_ name when available.
Previously, some parts of the UI used the user's name directly.

This change ensures that wherever a name is shown, the display name is used if it has been set.


**appendix**

To identify where the relevant method was used in the UI helper, I ran the following command:

```sh
$ git grep getFullNameAttribute -- app/Presenters
app/Presenters/ActionlogPresenter.php:            return '<del>'.$user->getFullNameAttribute().'</del> (deleted)';
app/Presenters/UserPresenter.php:        return (string) link_to_route('users.show', $this->getFullNameAttribute(), $this->id);
```