### PR TITLE
fixed: Prefer display name of user on table UI

### DIFF
--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -210,6 +210,7 @@ class AssetsTransformer
             return $asset->assigned ? [
                     'id' => (int) $asset->assigned->id,
                     'username' => e($asset->assigned->username),
+                    'display_name' => e($asset->assigned->display_name),
                     'name' => e($asset->assigned->getFullNameAttribute()),
                     'first_name'=> e($asset->assigned->first_name),
                     'last_name'=> ($asset->assigned->last_name) ? e($asset->assigned->last_name) : null,

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -1163,7 +1163,7 @@
 
             // display the username if it's checked out to a user, but don't do it if the username's there already
             if (value.username && !value.name.match('\\(') && !value.name.match('\\)')) {
-                value.name = value.name + ' (' + value.username + ')';
+                value.name = value.display_name + ' (' + value.username + ')';
             }
 
             return '<nobr><a href="{{ config('app.url') }}/' + item_destination +'/' + value.id + '" data-tooltip="true" title="' + value.type + '"><i class="' + item_icon + ' fa-fw"></i> ' + value.name + '</a></nobr>';


### PR DESCRIPTION
In #18404, I've updated the name displayed in the UI, but I overlooked the parts rendered by JavaScript.

Therefore, in this change, I’ve ensured that elements rendered by JavaScript also prioritize the display name.