### PR TITLE
Fixed #18402 - Clean up SAML readonly display

### DIFF
--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -278,8 +278,6 @@
         }
 
 
-
-
         input[type="text"]:focus,
         input[type="url"]:focus,
         input[type="date"]:focus,
@@ -289,6 +287,15 @@
         textarea:focus
         {
             border-color: hsl(from var(--main-theme-color) h s calc(l - 5)) !important;
+        }
+
+        *:disabled,
+        input[readonly],
+        textarea[readonly]
+        {
+            background-color: light-dark(rgb(234, 232, 232), rgb(117, 116, 117)) !important;
+            border: 1px solid light-dark(rgb(234, 232, 232), rgb(117, 116, 117)) !important;
+            cursor: not-allowed !important;
         }
 
 
@@ -629,7 +636,6 @@
             color: var(--nav-primary-text-color) !important;
         }
 
-
         .navbar-nav > .notifications-menu > .dropdown-menu > li.header,
         .navbar-nav > .messages-menu > .dropdown-menu > li.header,
         .navbar-nav > .tasks-menu > .dropdown-menu > li.header,
@@ -744,23 +750,23 @@
         }
 
         .text-warning {
-            color: var(--text-warning);
+            color: var(--text-warning) !important;
         }
 
         .text-info {
-            color: var(--text-info);
+            color: var(--text-info) !important;
         }
 
         .text-primary {
-            color: var(--main-theme-color);
+            color: var(--main-theme-color) !important;
         }
 
         .text-danger {
-            color: var(--text-danger);
+            color: var(--text-danger) !important;
         }
 
         .text-success {
-            color: var(--text-success);
+            color: var(--text-success) !important;
         }
 
         .dropdown-menu > .divider {
@@ -781,12 +787,6 @@
         }
 
 
-        input[type="checkbox"],
-        input[type="radio"],
-        label.form-control
-        {
-            cursor: pointer !important;
-        }
 
 
         .callout.callout-legend {

--- a/resources/views/settings/saml.blade.php
+++ b/resources/views/settings/saml.blade.php
@@ -14,12 +14,6 @@
 {{-- Page content --}}
 @section('content')
 
-    <style>
-        .checkbox label {
-            padding-right: 40px;
-        }
-    </style>
-
 
     <form method="POST" action="{{ route('settings.saml.save') }}" accept-charset="UTF-8" autocomplete="false"  role="form" class="form-horizontal">
     <!-- CSRF Token -->
@@ -49,8 +43,7 @@
                             <div class="control-label col-md-3">
                                 <strong>{{ trans('admin/settings/general.saml_integration') }}</strong>
                             </div>
-                            <div class="col-md-8">
-
+                            <div class="col-md-8" style="margin-left: -8px;">
                                 <label class="form-control{{ config('app.lock_passwords') === true ? ' form-control--disabled': '' }}">
                                     <input type="checkbox" name="saml_enabled" value="1" @checked(old('saml_enabled', $setting->saml_enabled)) @disabled(config('app.lock_passwords')) @class(['disabled' => config('app.lock_passwords')])/>
                                     {{ trans('admin/settings/general.saml_enabled') }}
@@ -64,42 +57,89 @@
 
 
 
-
+                            <div class="form-group{{ $errors->has('saml_sp_entitiyid') ? ' error' : '' }}">
                                 @if ($setting->saml_enabled)
-                                    <div class="col-md-9 col-md-offset-3">
-                                    <!-- SAML SP Details -->
-                                    <!-- SAML SP Entity ID -->
-                                    <label for="saml_sp_entitiyid" class="control-label col-md-3">{{ trans('admin/settings/general.saml_sp_entityid') }}</label>
-                                    <input class="form-control" readonly="" name="saml_sp_entitiyid" type="text" value="{{ config('app.url') }}" id="saml_sp_entitiyid">
-                                    <br>
-                                    <!-- SAML SP ACS -->
-                                    <label for="saml_sp_acs_url" class="control-label col-md-3">{{ trans('admin/settings/general.saml_sp_acs_url') }}</label>
-                                    <input class="form-control" readonly="" name="saml_sp_acs_url" type="text" value="{{ route('saml.acs') }}" id="saml_sp_acs_url">
-                                    <br>
-                                    <!-- SAML SP SLS -->
-                                    <label for="saml_sp_sls_url" class="control-label col-md-3">{{ trans('admin/settings/general.saml_sp_sls_url') }}</label>
-                                    <input class="form-control" readonly="" name="saml_sp_sls_url" type="text" value="{{ route('saml.sls') }}" id="saml_sp_sls_url">
-                                    <br>
+                                <label for="saml_sp_entitiyid" class="control-label col-md-3">
+                                    {{ trans('admin/settings/general.saml_sp_entityid') }}
+                                </label>
+
+                                <div class="col-md-8">
+                                <!-- SAML SP Details -->
+                                <!-- SAML SP Entity ID -->
+                                <input class="form-control" readonly name="saml_sp_entitiyid" type="text" value="{{ config('app.url') }}" id="saml_sp_entitiyid">
+                                    @if (config('app.lock_passwords') === true)
+                                        <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
+                                    @endif
+                                </div>
+                            </div>
+
+                            <div class="form-group{{ $errors->has('saml_sp_acs_url') ? ' error' : '' }}">
+                                <!-- SAML SP ACS -->
+                                <label for="saml_sp_acs_url" class="control-label col-md-3">
+                                    {{ trans('admin/settings/general.saml_sp_acs_url') }}
+                                </label>
+
+                                <div class="col-md-8">
+                                    <input class="form-control" readonly name="saml_sp_acs_url" type="text" value="{{ route('saml.acs') }}" id="saml_sp_acs_url">
+                                    @if (config('app.lock_passwords') === true)
+                                        <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
+                                    @endif
+                                </div>
+                            </div>
+
+                            <div class="form-group{{ $errors->has('saml_sp_sls_url') ? ' error' : '' }}">
+                                <!-- SAML SP SLS -->
+                                <label for="saml_sp_sls_url" class="control-label col-md-3">
+                                    {{ trans('admin/settings/general.saml_sp_sls_url') }}
+                                </label>
+                                <div class="col-md-8">
+                                    <input class="form-control" readonly name="saml_sp_sls_url" type="text" value="{{ route('saml.sls') }}" id="saml_sp_sls_url">
+                                    @if (config('app.lock_passwords') === true)
+                                        <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
+                                    @endif
+                                </div>
+                            </div>
+
+                            <div class="form-group{{ $errors->has('saml_sp_x509cert') ? ' error' : '' }}">
                                     <!-- SAML SP Certificate -->
                                     @if (!empty($setting->saml_sp_x509cert))
                                          <label for="saml_sp_x509cert" class="control-label col-md-3">{{ trans('admin/settings/general.saml_sp_x509cert') }}</label>
+
+                                    <div class="col-md-8">
                                             <x-input.textarea
                                                 name="saml_sp_x509cert"
                                                 id="saml_sp_x509cert"
+                                                rows="20"
                                                 :value="$setting->saml_sp_x509cert"
                                                 wrap="off"
                                                 readonly
                                             />
-                                        <br>
-                                    @endif
-                                    <!-- SAML SP Metadata URL -->
-                                    <label for="saml_sp_metadata_url" class="control-label col-md-3">{{ trans('admin/settings/general.saml_sp_metadata_url') }}</label>
-                                    <input class="form-control" readonly="" name="saml_sp_metadata_url" type="text" value="{{ route('saml.metadata') }}" id="saml_sp_metadata_url">
-                                    <br>
-                                    <p class="help-block">
-                                        <a href="{{ route('saml.metadata') }}" target="_blank" class="btn btn-default" style="margin-right: 5px;">{{ trans('admin/settings/general.saml_download') }}</a>
-                                    </p>
+
+                                        @if (config('app.lock_passwords') === true)
+                                            <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
+                                        @endif
+
                                     </div>
+                                    @endif
+                            </div>
+
+                            <div class="form-group{{ $errors->has('saml_sp_metadata_url') ? ' error' : '' }}">
+                                <!-- SAML SP Metadata URL -->
+                                <label for="saml_sp_metadata_url" class="control-label col-md-3">
+                                    {{ trans('admin/settings/general.saml_sp_metadata_url') }}
+                                </label>
+
+                                <div class="col-md-8">
+                                    <input class="form-control" readonly name="saml_sp_metadata_url" type="text" value="{{ route('saml.metadata') }}" id="saml_sp_metadata_url">
+                                    <p class="help-block">
+                                        <a href="{{ route('saml.metadata') }}" target="_blank" class="btn btn-theme" style="margin-right: 5px;">{{ trans('admin/settings/general.saml_download') }}</a>
+                                    </p>
+
+                                    @if (config('app.lock_passwords') === true)
+                                        <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
+                                    @endif
+
+                                </div>
                                 @endif
                                 {!! $errors->first('saml_enabled', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
 
@@ -108,25 +148,32 @@
 
                         <!-- SAML IdP Metadata -->
                         <div class="form-group {{ $errors->has('saml_idp_metadata') ? 'error' : '' }}">
+                            <label for="saml_idp_metadata" class="control-label col-md-3">
+                                {{ trans('admin/settings/general.saml_idp_metadata') }}
+                            </label>
 
-                            <label for="saml_idp_metadata" class="control-label col-md-3">{{ trans('admin/settings/general.saml_idp_metadata') }}</label>
+                            <div class="col-md-8">
+                                <x-input.textarea
+                                    name="saml_idp_metadata"
+                                    id="saml_idp_metadata"
+                                    :value="old('saml_idp_metadata', $setting->saml_idp_metadata)"
+                                    placeholder="https://example.com/idp/metadata"
+                                    wrap="off"
+                                    @disabled(config('app.lock_passwords'))
+                                />
+                                {!! $errors->first('saml_idp_metadata', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}<br>
+                                <button type="button" class="btn btn-theme" id="saml_idp_metadata_upload_btn" {{ $setting->demoMode }}>{{ trans('button.select_file') }}</button>
+                                <input type="file" class="js-uploadFile" id="saml_idp_metadata_upload" @disabled(config('app.lock_passwords'))
+                                    data-maxsize="{{ Helper::file_upload_max_size() }}"
+                                       @disabled(config('app.lock_passwords'))
+                                    accept="text/xml,application/xml" style="display:none; max-width: 90%" {{ $setting->demoMode }}>
 
-                        <div class="col-md-8">
-                            <x-input.textarea
-                                name="saml_idp_metadata"
-                                id="saml_idp_metadata"
-                                :value="old('saml_idp_metadata', $setting->saml_idp_metadata)"
-                                placeholder="https://example.com/idp/metadata"
-                                wrap="off"
-                            />
-                            {!! $errors->first('saml_idp_metadata', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}<br>
-                            <button type="button" class="btn btn-default" id="saml_idp_metadata_upload_btn" {{ $setting->demoMode }}>{{ trans('button.select_file') }}</button>
-                            <input type="file" class="js-uploadFile" id="saml_idp_metadata_upload"
-                                data-maxsize="{{ Helper::file_upload_max_size() }}"
-                                accept="text/xml,application/xml" style="display:none; max-width: 90%" {{ $setting->demoMode }}>
-                            
-                            <p class="help-block">{{ trans('admin/settings/general.saml_idp_metadata_help') }}</p>
-                        </div>
+                                <p class="help-block">{{ trans('admin/settings/general.saml_idp_metadata_help') }}</p>
+
+                                @if (config('app.lock_passwords') === true)
+                                    <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
+                                @endif
+                            </div>
                         </div>
 
                         <!-- SAML Attribute Mapping Username -->
@@ -134,10 +181,15 @@
 
                             <label for="saml_attr_mapping_username" class="control-label col-md-3">{{ trans('admin/settings/general.saml_attr_mapping_username') }}</label>
 
-                            <div class="col-md-9">
-                                <input class="form-control" name="saml_attr_mapping_username" type="text" id="saml_attr_mapping_username" value="{{ old('saml_attr_mapping_username', $setting->saml_attr_mapping_username) }}">
+                            <div class="col-md-8">
+                                <input class="form-control" name="saml_attr_mapping_username" type="text" id="saml_attr_mapping_username" value="{{ old('saml_attr_mapping_username', $setting->saml_attr_mapping_username) }}" @disabled(config('app.lock_passwords'))>
                                 <p class="help-block">{{ trans('admin/settings/general.saml_attr_mapping_username_help') }}</p>
                                 {!! $errors->first('saml_attr_mapping_username', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+
+                                @if (config('app.lock_passwords') === true)
+                                    <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
+                                @endif
+
                             </div>
                         </div>
 
@@ -146,14 +198,18 @@
                             <div class="control-label col-md-3">
                                 <strong>{{  trans('admin/settings/general.saml_forcelogin_label') }}</strong>
                             </div>
-                            <div class="col-md-9">
+                            <div class="col-md-8">
                                 <label class="form-control{{ config('app.lock_passwords') === true ? ' form-control--disabled': '' }}">
                                     <input type="checkbox" name="saml_forcelogin" value="1" @checked(old('saml_forcelogin', $setting->saml_forcelogin)) @disabled(config('app.lock_passwords')) @class(['disabled' => config('app.lock_passwords')]) />
                                     {{ trans('admin/settings/general.saml_forcelogin') }}
                                 </label>
                                 <p class="help-block">{{ trans('admin/settings/general.saml_forcelogin_help') }}</p>
-                                <p class="help-block">{{ route('login', ['nosaml']) }}</p>
                                 {!! $errors->first('saml_forcelogin', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+
+                                @if (config('app.lock_passwords') === true)
+                                    <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
+                                @endif
+
                             </div>
                         </div>
 
@@ -169,6 +225,11 @@
                                 </label>
                                 <p class="help-block">{{ trans('admin/settings/general.saml_slo_help') }}</p>
                                 {!! $errors->first('saml_slo', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+
+                                @if (config('app.lock_passwords') === true)
+                                    <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
+                                @endif
+
                             </div>
                         </div>
 
@@ -176,7 +237,7 @@
                         <div class="form-group {{ $errors->has('saml_custom_settings') ? 'error' : '' }}">
                         <label for="saml_custom_settings" class="control-label col-md-3">{{ trans('admin/settings/general.saml_custom_settings') }}</label>
 
-                        <div class="col-md-9">
+                        <div class="col-md-8">
                             <x-input.textarea
                                 name="saml_custom_settings"
                                 :value="old('saml_custom_settings', $setting->saml_custom_settings)"
@@ -185,6 +246,11 @@
                             />
                             <p class="help-block">{{ trans('admin/settings/general.saml_custom_settings_help') }}</p>
                             {!! $errors->first('saml_custom_settings', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+
+                            @if (config('app.lock_passwords') === true)
+                                <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
+                            @endif
+
                         </div>
                     </div>
 
@@ -194,13 +260,13 @@
                         <a class="btn btn-link text-left" href="{{ route('settings.index') }}">{{ trans('button.cancel') }}</a>
                     </div>
                     <div class="text-right col-md-6">
-                        <button type="submit" class="btn btn-primary"{{ config('app.lock_passwords') === true ? ' disabled': '' }}><x-icon type="checkmark" /> {{ trans('general.save') }}</button>
+                        <button type="submit" class="btn btn-theme"{{ config('app.lock_passwords') === true ? ' disabled': '' }}><x-icon type="checkmark" /> {{ trans('general.save') }}</button>
                     </div>
 
                 </div>
             </div> <!-- /box -->
 
-        </div> <!-- /.col-md-8-->
+        </div> <!-- /.col-md-7-->
     </div> <!-- /.row-->
 
     </form>

--- a/resources/views/settings/saml.blade.php
+++ b/resources/views/settings/saml.blade.php
@@ -159,7 +159,6 @@
                                     :value="old('saml_idp_metadata', $setting->saml_idp_metadata)"
                                     placeholder="https://example.com/idp/metadata"
                                     wrap="off"
-                                    @disabled(config('app.lock_passwords'))
                                 />
                                 {!! $errors->first('saml_idp_metadata', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}<br>
                                 <button type="button" class="btn btn-theme" id="saml_idp_metadata_upload_btn" {{ $setting->demoMode }}>{{ trans('button.select_file') }}</button>

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -20,12 +20,22 @@
       padding-top: 0px;
     }
 
-    input[type='text'][disabled], input[disabled], textarea[disabled], input[readonly], textarea[readonly], .form-control[disabled], .form-control[readonly], fieldset[disabled] .form-control {
-      background-color: white;
-      color: #555555;
-      cursor:text;
+    input[type='text'][disabled],
+    input[disabled],
+    textarea[disabled],
+    input[readonly],
+    textarea[readonly],
+    .form-control[disabled],
+    .form-control[readonly],
+    fieldset[disabled]
+     {
+        cursor:text !important;
+        background-color: var(--table-stripe-bg) !important;
+        color: var(--color-fg) !important;
     }
-
+    input:required, select:required {
+        border-right: 5px solid orange !important;
+    }
 
 </style>
 


### PR DESCRIPTION
This makes the disabled/read-only fields clearer

### Light Normal
<img width="4170" height="3170" alt="FireShot_Capture_092_-_Update_SAML_settings____Snipe-IT_Demo_-__snipe-it_test_" src="https://github.com/user-attachments/assets/32ab59f2-d1b0-45ab-9e95-006d726faf17" />


### Dark Normal
<img width="4170" height="3170" alt="FireShot_Capture_091_-_Update_SAML_settings____Snipe-IT_Demo_-__snipe-it_test_" src="https://github.com/user-attachments/assets/cea1a75e-8abb-420e-beb1-022e340072b1" />


### Light Demo Mode
<img width="4170" height="3922" alt="FireShot_Capture_089_-_Update_SAML_settings____Snipe-IT_Demo_-__snipe-it_test_" src="https://github.com/user-attachments/assets/68aaad74-5efa-4103-be2e-0abe0fcd18bd" />

### Dark Demo Mode
<img width="4170" height="3922" alt="FireShot_Capture_090_-_Update_SAML_settings____Snipe-IT_Demo_-__snipe-it_test_" src="https://github.com/user-attachments/assets/b4165f59-d7a7-4530-87d0-e349feedc296" />

This also addresses read-only/disabled for other sections for example demo mode on the admin account.

<img width="1350" height="574" alt="Screenshot 2026-01-07 at 3 33 23 PM" src="https://github.com/user-attachments/assets/30e94270-9d41-41d9-beb8-6f847d3ec2d6" />


Fixes #18402