### PR TITLE
Fixed #18415 - LDAP sync improvements to allow null display_name and bulk editing display_name

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -245,26 +245,26 @@ class LdapSync extends Command
         // Assign the mapped LDAP attributes for each user to the Snipe-IT user fields
         for ($i = 0; $i < $results['count']; $i++) {
             $item = [];
-            $item['username'] = $results[$i][$ldap_map["username"]][0] ?? '';
-            $item['display_name'] = $results[$i][$ldap_map["display_name"]][0] ?? '';
-            $item['employee_number'] = $results[$i][$ldap_map["emp_num"]][0] ?? '';
-            $item['lastname'] = $results[$i][$ldap_map["last_name"]][0] ?? '';
-            $item['firstname'] = $results[$i][$ldap_map["first_name"]][0] ?? '';
-            $item['email'] = $results[$i][$ldap_map["email"]][0] ?? '';
-            $item['ldap_location_override'] = $results[$i]['ldap_location_override'] ?? '';
-            $item['location_id'] = $results[$i]['location_id'] ?? '';
-            $item['telephone'] = $results[$i][$ldap_map["phone"]][0] ?? '';
-            $item['mobile'] = $results[$i][$ldap_map["mobile"]][0] ?? '';
-            $item['jobtitle'] = $results[$i][$ldap_map["jobtitle"]][0] ?? '';
-            $item['address'] = $results[$i][$ldap_map["address"]][0] ?? '';
-            $item['city'] = $results[$i][$ldap_map["city"]][0] ?? '';
-            $item['state'] = $results[$i][$ldap_map["state"]][0] ?? '';
-            $item['country'] = $results[$i][$ldap_map["country"]][0] ?? '';
-            $item['zip'] = $results[$i][$ldap_map["zip"]][0] ?? '';
-            $item['department'] = $results[$i][$ldap_map["dept"]][0] ?? '';
-            $item['manager'] = $results[$i][$ldap_map["manager"]][0] ?? '';
-            $item['location'] = $results[$i][$ldap_map["location"]][0] ?? '';
-            $location = $default_location; //initially, set '$location' to the default_location (which may just be `null`)
+            $item['username'] = $results[$i][$ldap_map["username"]][0] ?? null;
+            $item['display_name'] = $results[$i][$ldap_map["display_name"]][0] ?? null;
+            $item['employee_number'] = $results[$i][$ldap_map["emp_num"]][0] ?? null;
+            $item['lastname'] = $results[$i][$ldap_map["last_name"]][0] ?? null;
+            $item['firstname'] = $results[$i][$ldap_map["first_name"]][0] ?? null;
+            $item['email'] = $results[$i][$ldap_map["email"]][0] ?? null;
+            $item['ldap_location_override'] = $results[$i]['ldap_location_override'] ?? null;
+            $item['location_id'] = $results[$i]['location_id'] ?? null;
+            $item['telephone'] = $results[$i][$ldap_map["phone"]][0] ?? null;
+            $item['mobile'] = $results[$i][$ldap_map["mobile"]][0] ?? null;
+            $item['jobtitle'] = $results[$i][$ldap_map["jobtitle"]][0] ?? null;
+            $item['address'] = $results[$i][$ldap_map["address"]][0] ?? null;
+            $item['city'] = $results[$i][$ldap_map["city"]][0] ?? null;
+            $item['state'] = $results[$i][$ldap_map["state"]][0] ?? null;
+            $item['country'] = $results[$i][$ldap_map["country"]][0] ?? null;
+            $item['zip'] = $results[$i][$ldap_map["zip"]][0] ?? null;
+            $item['department'] = $results[$i][$ldap_map["dept"]][0] ?? null;
+            $item['manager'] = $results[$i][$ldap_map["manager"]][0] ?? null;
+            $item['location'] = $results[$i][$ldap_map["location"]][0] ?? null;
+            $location = $default_location; //initially, set '$location' to the default_location (which may just be null)
 
             // ONLY if you are using the "ldap_location" option *AND* you have an actual result
             if ($ldap_map["location"] && $item['location']) {
@@ -464,6 +464,7 @@ class LdapSync extends Command
             $errors = '';
 
             if ($user->save()) {
+                $item['id'] = $user->id;
                 $item['note'] = $item['createorupdate'];
                 $item['status'] = 'success';
                 if ($item['createorupdate'] === 'created' && $ldap_default_group) {

--- a/app/Http/Controllers/Users/BulkUsersController.php
+++ b/app/Http/Controllers/Users/BulkUsersController.php
@@ -169,6 +169,7 @@ class BulkUsersController extends Controller
             ->conditionallyAddItem('remote')
             ->conditionallyAddItem('ldap_import')
             ->conditionallyAddItem('activated')
+            ->conditionallyAddItem('display_name')
             ->conditionallyAddItem('start_date')
             ->conditionallyAddItem('end_date')
             ->conditionallyAddItem('city')
@@ -212,6 +213,10 @@ class BulkUsersController extends Controller
 
         if ($request->input('null_locale')=='1') {
             $this->update_array['locale'] = null;
+        }
+
+        if ($request->input('null_display_name')=='1') {
+            $this->update_array['display_name'] = null;
         }
 
         if (! $manager_conflict) {

--- a/app/Presenters/UserPresenter.php
+++ b/app/Presenters/UserPresenter.php
@@ -79,9 +79,10 @@ class UserPresenter extends Presenter
                 'field' => 'display_name',
                 'searchable' => true,
                 'sortable' => true,
-                'switchable' => false,
+                'switchable' => true,
                 'title' => trans('admin/users/table.display_name'),
                 'visible' => false,
+                'formatter' => 'usersLinkFormatter',
             ], [
                 'field' => 'username',
                 'searchable' => true,

--- a/resources/views/users/bulk-edit.blade.php
+++ b/resources/views/users/bulk-edit.blade.php
@@ -214,7 +214,7 @@
                             <label class="col-md-3 control-label" for="groups"> {{ trans('general.groups') }}</label>
                             <div class="col-md-6">
                                 @if ((config('app.lock_passwords') || (!Auth::user()->isSuperUser())))
-                                    <span class="help-block">{{  trans('admin/users/general.group_memberships_helpblock') }}</p>
+                                    <p class="help-block">{{  trans('admin/users/general.group_memberships_helpblock') }}</p>
                                 @else
                                     <div class="controls">
                                         <select name="groups[]" id="groups[]" multiple="multiple" class="form-control" aria-label="groups">
@@ -232,6 +232,21 @@
                         @endif
                     </div> <!--/col-md-5-->
                     </div>
+
+                        <!-- Display Name -->
+                        <div class="form-group {{ $errors->has('display_name') ? ' has-error' : '' }}">
+                            <label for="display_name" class="col-md-3 control-label">{{ trans('admin/users/table.display_name') }}</label>
+                            <div class="col-md-4">
+                                    <input type="text" class="form-control" placeholder="{{ trans('admin/users/table.display_name') }}" name="display_name" id="display_name" value="{{ old('display_name') }}">
+                                {!! $errors->first('display_name', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}
+                            </div>
+                            <div class="col-md-5">
+                                <label class="form-control">
+                                    <input type="checkbox" name="null_display_name" value="1" />
+                                    {{ trans_choice('general.set_to_null', count($users),['selection_count' => count($users)]) }}
+                                </label>
+                            </div>
+                        </div>
 
 
                         <!-- Start Date -->

--- a/resources/views/users/ldap.blade.php
+++ b/resources/views/users/ldap.blade.php
@@ -16,7 +16,7 @@
 @section('content')
 
 <div class="row">
-  <div class="col-md-12">
+    <div class="col-md-8 col-md-offset-2">
     @if ($snipeSettings->ldap_enabled == 0)
       {{ trans('admin/users/message.ldap_not_configured') }}
     @else
@@ -26,19 +26,18 @@
         <div class="box-body">
 
                 <div class="callout callout-legend col-md-12">
-
                     <p>
                         <i class="fa-solid fa-lightbulb"></i>
                         <strong>{!!  trans('admin/users/general.ldap_sync_intro', ['link' => 'https://snipe-it.readme.io/docs/ldap-sync#/']) !!}</strong>
                     </p>
                 </div>
          
-          <!-- location_id-->
-          <div class="form-group {{ $errors->has('location_id') ? 'has-error' : '' }}">
-               <!-- Location -->
-              @include ('partials.forms.edit.location-select', ['translated_name' => trans('general.ldap_sync_location'), 'help_text' => trans('admin/users/general.ldap_config_text'), 'fieldname' => 'location_id[]', 'multiple' => true])
-          </div>
-
+              <!-- location_id-->
+              <div class="form-group {{ $errors->has('location_id') ? 'has-error' : '' }}">
+                   <!-- Location -->
+                  @include ('partials.forms.edit.location-select', ['translated_name' => trans('general.ldap_sync_location'), 'help_text' => trans('admin/users/general.ldap_config_text'), 'fieldname' => 'location_id[]', 'multiple' => true])
+              </div>
+            </div><!-- ./box-body -->
             <div class="box-footer">
                 <div class="text-left col-md-6">
                     <a class="btn btn-link" href="{{ route('users.index') }}">{{ trans('button.cancel') }}</a>
@@ -48,10 +47,8 @@
                         <i id="sync-button-icon" class="fas fa-sync-alt icon-white" aria-hidden="true"></i> <span id="sync-button-text">{{ trans('general.synchronize') }}</span>
                     </button>
                 </div>
+            </div> <!-- ./box-footer -->
 
-            </div>
-
-        </div>
       </div>
     </form>
   </div>
@@ -62,30 +59,52 @@
 
 @if (Session::get('summary'))
 <div class="row">
-  <div class="col-md-12">
+  <div class="col-md-8 col-md-offset-2">
 
     <div class="box box-default">
       <div class="box-header with-border">
         <h2 class="box-title">{{ trans('general.sync_results') }}</h2>
       </div><!-- /.box-header -->
       <div class="box-body">
-        <table class="table table-bordered">
+          <table
+                  data-cookie-id-table="ldapUserSync"
+                  data-id-table="ldapUserSyncTable"
+                  data-side-pagination="client"
+                  data-sort-order="asc"
+                  data-sort-name="username"
+                  data-show-refresh="false"
+                  id="customFieldsTable"
+                  data-advanced-search="false"
+                  class="table table-striped snipe-table"
+                  data-export-options='{
+                "fileName": "ldap-sync-results-{{ date('Y-m-d') }}"
+                }'>
+              <thead>
           <tr>
-              <th>{{ trans('general.username') }}</th><th>{{ trans('general.employee_number') }}</th>
-              <th>{{ trans('general.first_name') }}</th><th>{{ trans('general.last_name') }}</th>
-              <th>{{ trans('general.email') }}</th><th>{{ trans('general.notes') }}</th>
+              <th data-sortable="true" data-visible="false" data-searchable="true">{{ trans('general.id') }}</th>
+              <th data-sortable="true" data-visible="true" data-searchable="true">{{ trans('general.username') }}</th>
+              <th data-sortable="true" data-visible="true" data-searchable="true">{{ trans('admin/users/table.display_name') }}</th>
+              <th data-sortable="true" data-visible="true" data-searchable="true">{{ trans('general.employee_number') }}</th>
+              <th data-sortable="true" data-visible="true" data-searchable="true">{{ trans('general.first_name') }}</th>
+              <th data-sortable="true" data-visible="true" data-searchable="true">{{ trans('general.last_name') }}</th>
+              <th data-sortable="true" data-visible="true" data-searchable="true">{{ trans('general.email') }}</th>
+              <th data-sortable="true" data-visible="true" data-searchable="true">{{ trans('general.notes') }}</th>
           </tr>
+              </thead>
+              <tbody>
 
           @foreach (Session::get('summary') as $entry)
-          <tr {!! ($entry['status']=='success') ? 'class="success"' : 'class="danger"' !!}>
+          <tr>
+              <td>{{ $entry['id'] }}</td>
               <td>{{ $entry['username'] }}</td>
+              <td>{{ $entry['display_name'] }}</td>
               <td>{{ $entry['employee_number'] }}</td>
               <td>{{ $entry['firstname'] }}</td>
               <td>{{ $entry['lastname'] }}</td>
               <td>{{ $entry['email'] }}</td>
               <td>
                 @if ($entry['status']=='success')
-                  <i class="fas fa-check"></i> {!! $entry['note'] !!}
+                  <span class="text-success"><i class="fas fa-check"></i> {!! $entry['note'] !!}</span>
                 @else
                   <span class="alert-msg" aria-hidden="true">{!! $entry['note'] !!}</span>
                 @endif
@@ -93,6 +112,7 @@
                 </td>
               </tr>
           @endforeach
+              </tbody>
         </table>
       </div>
     </div>
@@ -106,7 +126,9 @@
 
 @section('moar_scripts')
 
-<script type="text/javascript">
+ @include ('partials.bootstrap-table')
+
+    <script type="text/javascript">
     $(document).ready(function () {
         $("#sync").click(function () {
             $("#sync").removeClass("btn-warning");


### PR DESCRIPTION
This updates the LDAP sync to correctly set nulls instead of blanks, adds an export option and sortable headers on the LDAP sync results, and adds the display name to the LDAP sync display results.

This also addresses unreadable text on the results in dark mode, and adds display name to the bulk user edit with the option to null out names. 

### Before
https://github.com/user-attachments/assets/4042e0ad-f788-4753-a2b3-e3b943623d6d


### After
https://github.com/user-attachments/assets/4b05bd6e-90b1-422c-a267-85494dad2d99

### Bulk Edit


https://github.com/user-attachments/assets/c5a64f6a-38e5-4bc9-ad30-de997acc6793





Fixes #18415