### PR TITLE
Fix: Correct 'requested_assets_menu' translations across 70 languages

### DIFF
--- a/resources/lang/af-ZA/general.php
+++ b/resources/lang/af-ZA/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Klaar om te implementeer',
     'requested_date'        => 'Requested Date',
     'requested_assets'      => 'Requested Assets',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'Versoek gekanselleer',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/am-ET/general.php
+++ b/resources/lang/am-ET/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Ready to Deploy',
     'requested_date'        => 'Requested Date',
     'requested_assets'      => 'Requested Assets',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'Request Canceled',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/bg-BG/general.php
+++ b/resources/lang/bg-BG/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Готово за предоставяне',
     'requested_date'        => 'Дата на заявката',
     'requested_assets'      => 'Изискуеми активи',
-    'requested_assets_menu' => 'Изискуеми артикули',
+    'requested_assets_menu' => 'Изискани артикули',
     'request_canceled'      => 'Заявка отменена',
     'request_item'          => 'Поискайте този артикул',
     'external_link_tooltip' => 'Външна връзка към',

--- a/resources/lang/ca-ES/general.php
+++ b/resources/lang/ca-ES/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Ready to Deploy',
     'requested_date'        => 'Requested Date',
     'requested_assets'      => 'Requested Assets',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'Request Canceled',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/chr-US/general.php
+++ b/resources/lang/chr-US/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Ready to Deploy',
     'requested_date'        => 'Requested Date',
     'requested_assets'      => 'Requested Assets',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'Request Canceled',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/cs-CZ/general.php
+++ b/resources/lang/cs-CZ/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Připraveno k přidělení',
     'requested_date'        => 'Požadované datum',
     'requested_assets'      => 'Vyžádaný majetek',
-    'requested_assets_menu' => 'Položky, o které lze požádat',
+    'requested_assets_menu' => 'Požadované položky',
     'request_canceled'      => 'Žádost zrušena',
     'request_item'          => 'Požádat o tuto položku',
     'external_link_tooltip' => 'Externí odkazy',

--- a/resources/lang/cy-GB/general.php
+++ b/resources/lang/cy-GB/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Barod i\'w defnyddio',
     'requested_date'        => 'Requested Date',
     'requested_assets'      => 'Requested Assets',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'Cais wedi dileu',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/da-DK/general.php
+++ b/resources/lang/da-DK/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Klar til Implementering',
     'requested_date'        => 'Anmodningsdato',
     'requested_assets'      => 'Anmodede aktiver',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'Anmodning Annulleret',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/de-DE/general.php
+++ b/resources/lang/de-DE/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Bereit zum Herausgeben',
     'requested_date'        => 'Angefordertes Datum',
     'requested_assets'      => 'Angeforderte Assets',
-    'requested_assets_menu' => 'Anforderbare Gegenstände',
+    'requested_assets_menu' => 'Angeforderte Gegenstände',
     'request_canceled'      => 'Anfrage abgebrochen',
     'request_item'          => 'Diesen Artikel anfordern',
     'external_link_tooltip' => 'Externer Link zu',

--- a/resources/lang/de-if/general.php
+++ b/resources/lang/de-if/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Bereit zum Herausgeben',
     'requested_date'        => 'Anfragedatum',
     'requested_assets'      => 'Angeforderte Assets',
-    'requested_assets_menu' => 'Anforderbare Gegenstände',
+    'requested_assets_menu' => 'Angeforderte Gegenstände',
     'request_canceled'      => 'Anfrage abgebrochen',
     'request_item'          => 'Gegenstand anfordern',
     'external_link_tooltip' => 'Externer Link zu',

--- a/resources/lang/el-GR/general.php
+++ b/resources/lang/el-GR/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Είστε έτοιμοι να αναπτύξετε',
     'requested_date'        => 'Ημερομηνία Που Ζητήθηκε',
     'requested_assets'      => 'Ζητούμενα Περιουσιακά Στοιχεία',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'Το αίτημα ακυρώθηκε',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/en-GB/general.php
+++ b/resources/lang/en-GB/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Ready to Deploy',
     'requested_date'        => 'Requested Date',
     'requested_assets'      => 'Requested Assets',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'Request Canceled',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/en-ID/general.php
+++ b/resources/lang/en-ID/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Siap digunakan',
     'requested_date'        => 'Requested Date',
     'requested_assets'      => 'Requested Assets',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'Permintaan dibatalkan',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -264,7 +264,7 @@ return [
     'rtd'				    => 'Ready to Deploy',
     'requested_date'        => 'Requested Date',
     'requested_assets'      => 'Requested Assets',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'Request Canceled',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/es-CO/general.php
+++ b/resources/lang/es-CO/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Listo para asignar',
     'requested_date'        => 'Fecha de solicitud',
     'requested_assets'      => 'Activos solicitados',
-    'requested_assets_menu' => 'Artículos que se pueden solicitar',
+    'requested_assets_menu' => 'Artículos solicitados',
     'request_canceled'      => 'Solicitud cancelada',
     'request_item'          => 'Solicitar este elemento',
     'external_link_tooltip' => 'Enlace externo a',

--- a/resources/lang/es-ES/general.php
+++ b/resources/lang/es-ES/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Listo para asignar',
     'requested_date'        => 'Fecha de solicitud',
     'requested_assets'      => 'Activos solicitados',
-    'requested_assets_menu' => 'Artículos que se pueden solicitar',
+    'requested_assets_menu' => 'Artículos solicitados',
     'request_canceled'      => 'Solicitud cancelada',
     'request_item'          => 'Solicitar este elemento',
     'external_link_tooltip' => 'Enlace externo a',

--- a/resources/lang/es-MX/general.php
+++ b/resources/lang/es-MX/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Listo para asignar',
     'requested_date'        => 'Fecha de solicitud',
     'requested_assets'      => 'Activos solicitados',
-    'requested_assets_menu' => 'Artículos que se pueden solicitar',
+    'requested_assets_menu' => 'Artículos solicitados',
     'request_canceled'      => 'Solicitud cancelada',
     'request_item'          => 'Solicitar este elemento',
     'external_link_tooltip' => 'Enlace externo a',

--- a/resources/lang/es-VE/general.php
+++ b/resources/lang/es-VE/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Listo para asignar',
     'requested_date'        => 'Fecha de solicitud',
     'requested_assets'      => 'Activos solicitados',
-    'requested_assets_menu' => 'Artículos que se pueden solicitar',
+    'requested_assets_menu' => 'Artículos solicitados',
     'request_canceled'      => 'Solicitud cancelada',
     'request_item'          => 'Solicitar este elemento',
     'external_link_tooltip' => 'Enlace externo a',

--- a/resources/lang/et-EE/general.php
+++ b/resources/lang/et-EE/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Kasutamine valmis',
     'requested_date'        => 'Taotletav kuupäev',
     'requested_assets'      => 'Taotletavad vahendid',
-    'requested_assets_menu' => 'Taotletavad mudelid',
+    'requested_assets_menu' => 'Taotletud mudelid',
     'request_canceled'      => 'Taotlus tühistati',
     'request_item'          => 'Taotle seda vara',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/fa-IR/general.php
+++ b/resources/lang/fa-IR/general.php
@@ -283,7 +283,7 @@ return [
     'requested_date'        => 'تاریخ درخواست',
     'requested_assets'      => 'دارایی های درخواستی
 ',
-    'requested_assets_menu' => 'آیتم های قابل درخواست',
+    'requested_assets_menu' => 'آیتم های درخواست شده',
     'request_canceled'      => 'درخواست لغو شد',
     'request_item'          => 'درخواست این آیتم',
     'external_link_tooltip' => 'لینک خارجی به',

--- a/resources/lang/fi-FI/general.php
+++ b/resources/lang/fi-FI/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Valmis käyttöönottoon',
     'requested_date'        => 'Pyynnön päivämäärä',
     'requested_assets'      => 'Pyydetyt laitteet',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'Pyyntö peruutettu',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/fil-PH/general.php
+++ b/resources/lang/fil-PH/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Handa nang I-deploy',
     'requested_date'        => 'Requested Date',
     'requested_assets'      => 'Requested Assets',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'Ang mga Rekwest ay Nakansela',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/ga-IE/general.php
+++ b/resources/lang/ga-IE/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Réidh le Imscaradh',
     'requested_date'        => 'Requested Date',
     'requested_assets'      => 'Requested Assets',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'Iarratas Ar Ceal',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/he-IL/general.php
+++ b/resources/lang/he-IL/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'מוכן לפריסה',
     'requested_date'        => 'התאריך המבוקש',
     'requested_assets'      => 'נכסים שנדרשו',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'הבקשה בוטלה',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/hi-IN/general.php
+++ b/resources/lang/hi-IN/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Ready to Deploy',
     'requested_date'        => 'Requested Date',
     'requested_assets'      => 'Requested Assets',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'Request Canceled',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/hr-HR/general.php
+++ b/resources/lang/hr-HR/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Spremni za implementaciju',
     'requested_date'        => 'Datum zahtjeva',
     'requested_assets'      => 'Zatražena Imovina',
-    'requested_assets_menu' => 'Predmeti koje je moguće zatražiti',
+    'requested_assets_menu' => 'Zatraženi predmeti',
     'request_canceled'      => 'Zahtjev je otkazan',
     'request_item'          => 'Zatraži ovaj predmet',
     'external_link_tooltip' => 'Eksterni link do',

--- a/resources/lang/hu-HU/general.php
+++ b/resources/lang/hu-HU/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Kiadásra kész',
     'requested_date'        => 'Kért időpont',
     'requested_assets'      => 'Kért eszközök',
-    'requested_assets_menu' => 'Igényelhető modellek',
+    'requested_assets_menu' => 'Igényelt modellek',
     'request_canceled'      => 'A kérelem törölve',
     'request_item'          => 'Igénylés',
     'external_link_tooltip' => 'Külső hivatkozás :',

--- a/resources/lang/id-ID/general.php
+++ b/resources/lang/id-ID/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Siap digunakan',
     'requested_date'        => 'Tanggal Permintaan',
     'requested_assets'      => 'Aset yang Diminta',
-    'requested_assets_menu' => 'Barang Dapat Diminta',
+    'requested_assets_menu' => 'Barang yang Diminta',
     'request_canceled'      => 'Permintaan Dibatalkan',
     'request_item'          => 'Perminta barang ini',
     'external_link_tooltip' => 'Tautan eksternal ke',

--- a/resources/lang/is-IS/general.php
+++ b/resources/lang/is-IS/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Tilbúin til notkunar',
     'requested_date'        => 'Requested Date',
     'requested_assets'      => 'Requested Assets',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'Beiðni endurkölluð',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/it-IT/general.php
+++ b/resources/lang/it-IT/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Pronti per l\'assegnazione',
     'requested_date'        => 'Data di richiesta',
     'requested_assets'      => 'Beni richiesti',
-    'requested_assets_menu' => 'Oggetti richiedibili',
+    'requested_assets_menu' => 'Oggetti richiesti',
     'request_canceled'      => 'Richiesta annullata',
     'request_item'          => 'Richiedi questo articolo',
     'external_link_tooltip' => 'Collegamento esterno a',

--- a/resources/lang/iu-NU/general.php
+++ b/resources/lang/iu-NU/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Ready to Deploy',
     'requested_date'        => 'Requested Date',
     'requested_assets'      => 'Requested Assets',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'Request Canceled',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/ja-JP/general.php
+++ b/resources/lang/ja-JP/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => '配備可能',
     'requested_date'        => 'リクエスト日',
     'requested_assets'      => '要求された資産',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'リクエストキャンセル',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/ka-GE/general.php
+++ b/resources/lang/ka-GE/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'მზადაა გასაცემად',
     'requested_date'        => 'მოთხოვნის თარიღი',
     'requested_assets'      => 'მოთხოვნილი ინვენტარი',
-    'requested_assets_menu' => 'მოთხოვნადი ნივთები',
+    'requested_assets_menu' => 'მოთხოვნილი ნივთები',
     'request_canceled'      => 'მოთხოვნა გაუქმდა',
     'request_item'          => 'მოთხოვნა ამ ერთეულზე',
     'external_link_tooltip' => 'გარე ბმული',

--- a/resources/lang/km-KH/general.php
+++ b/resources/lang/km-KH/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'រួចរាល់អាចប្រើប្រាស់',
     'requested_date'        => 'កាលបរិច្ឆេទដែលបានស្នើសុំ',
     'requested_assets'      => 'ទ្រព្យសកម្មដែលបានស្នើសុំ',
-    'requested_assets_menu' => 'វត្ថុដែលអាចស្នើសុំបាន។',
+    'requested_assets_menu' => 'វត្ថុដែលបានស្នើសុំ',
     'request_canceled'      => 'សំណើត្រូវបានលុបចោល',
     'request_item'          => 'ស្នើសុំធាតុនេះ។',
     'external_link_tooltip' => 'តំណភ្ជាប់ទៅខាងក្រៅ',

--- a/resources/lang/ko-KR/general.php
+++ b/resources/lang/ko-KR/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => '사용 준비',
     'requested_date'        => 'Requested Date',
     'requested_assets'      => 'Requested Assets',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => '요청 취소',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/lt-LT/general.php
+++ b/resources/lang/lt-LT/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Paruoštas naudojimui',
     'requested_date'        => 'Prašymo data',
     'requested_assets'      => 'Prašomas turtas',
-    'requested_assets_menu' => 'Užsakomi daiktai',
+    'requested_assets_menu' => 'Užsakyti daiktai',
     'request_canceled'      => 'Prašymas atšauktas',
     'request_item'          => 'Užsakyti šį daiktą',
     'external_link_tooltip' => 'Išorinė nuoroda',

--- a/resources/lang/lv-LV/general.php
+++ b/resources/lang/lv-LV/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Gatavs izvietot',
     'requested_date'        => 'Pieprasīšanas datums',
     'requested_assets'      => 'Pieprasītais inventārs',
-    'requested_assets_menu' => 'Pieprasāmās lietas',
+    'requested_assets_menu' => 'Pieprasītās lietas',
     'request_canceled'      => 'Pieprasījums atcelts',
     'request_item'          => 'Pieprasīt šo lietu',
     'external_link_tooltip' => 'Ārējā saite',

--- a/resources/lang/mi-NZ/general.php
+++ b/resources/lang/mi-NZ/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Kua rite ki te Whakamahia',
     'requested_date'        => 'Requested Date',
     'requested_assets'      => 'Requested Assets',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'Tono Whakamutua',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/mk-MK/general.php
+++ b/resources/lang/mk-MK/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Подготвен за распоредување',
     'requested_date'        => 'Побаран датум',
     'requested_assets'      => 'Побарани средства',
-    'requested_assets_menu' => 'Побарливи предмети',
+    'requested_assets_menu' => 'Побарани предмети',
     'request_canceled'      => 'Барањето е откажано',
     'request_item'          => 'Побарајте оваа ставка',
     'external_link_tooltip' => 'Надворешна врска до',

--- a/resources/lang/ml-IN/general.php
+++ b/resources/lang/ml-IN/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Ready to Deploy',
     'requested_date'        => 'Requested Date',
     'requested_assets'      => 'Requested Assets',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'Request Canceled',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/mn-MN/general.php
+++ b/resources/lang/mn-MN/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Хэрэглэхэд бэлэн байна',
     'requested_date'        => 'Requested Date',
     'requested_assets'      => 'Requested Assets',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'Хүсэлтийг цуцалсан',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/mr-IN/general.php
+++ b/resources/lang/mr-IN/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Ready to Deploy',
     'requested_date'        => 'Requested Date',
     'requested_assets'      => 'Requested Assets',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'Request Canceled',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/ms-MY/general.php
+++ b/resources/lang/ms-MY/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Sedia untuk diagihkan',
     'requested_date'        => 'Requested Date',
     'requested_assets'      => 'Requested Assets',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'Permintaan Dibatalkan',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/nb-NO/general.php
+++ b/resources/lang/nb-NO/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Klar for utlevering',
     'requested_date'        => 'Forespurt dato',
     'requested_assets'      => 'Forespurte eiendeler',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'Forespørsel avbrutt',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/ne-NP/general.php
+++ b/resources/lang/ne-NP/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Ready to Deploy',
     'requested_date'        => 'Requested Date',
     'requested_assets'      => 'Requested Assets',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'Request Canceled',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/nl-NL/general.php
+++ b/resources/lang/nl-NL/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Klaar voor uitgifte',
     'requested_date'        => 'Aangevraagde datum',
     'requested_assets'      => 'Aangevraagd activa',
-    'requested_assets_menu' => 'Aanvraagbare items',
+    'requested_assets_menu' => 'Aangevraagde items',
     'request_canceled'      => 'Aanvraag geannuleerd',
     'request_item'          => 'Dit item aanvragen',
     'external_link_tooltip' => 'Externe link naar',

--- a/resources/lang/nn-NO/general.php
+++ b/resources/lang/nn-NO/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Klar for utlevering',
     'requested_date'        => 'Forespurt dato',
     'requested_assets'      => 'Forespurte eiendeler',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'Forespørsel avbrutt',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/no-NO/general.php
+++ b/resources/lang/no-NO/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Klar for utlevering',
     'requested_date'        => 'Forespurt dato',
     'requested_assets'      => 'Forespurte eiendeler',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'Forespørsel avbrutt',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/om-ET/general.php
+++ b/resources/lang/om-ET/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Tamsaasaaf Qophiidha',
     'requested_date'        => 'Guyyaa gaafatame',
     'requested_assets'      => 'Qabeenya gaafatame',
-    'requested_assets_menu' => 'Gosoota mi\'a gaafatamuu dandahanii',
+    'requested_assets_menu' => 'Gosoota mi\'a gaafatame',
     'request_canceled'      => 'Gaaffiin Haqame',
     'request_item'          => 'Gaaffii dhiyeessi',
     'external_link_tooltip' => 'Gara geggeessituu alaatti',

--- a/resources/lang/pt-BR/general.php
+++ b/resources/lang/pt-BR/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Pronto para Implantar',
     'requested_date'        => 'Data da Solicitação',
     'requested_assets'      => 'Ativos Solicitados',
-    'requested_assets_menu' => 'Itens Solicitáveis',
+    'requested_assets_menu' => 'Itens Solicitados',
     'request_canceled'      => 'Solicitação Cancelada',
     'request_item'          => 'Solicitar esse item',
     'external_link_tooltip' => 'Link externo para',

--- a/resources/lang/pt-PT/general.php
+++ b/resources/lang/pt-PT/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Pronto para implementar',
     'requested_date'        => 'Data de solicitação',
     'requested_assets'      => 'Artigos solicitados',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'Pedido cancelado',
     'request_item'          => 'Solicitar esse item',
     'external_link_tooltip' => 'Link externo para',

--- a/resources/lang/ro-RO/general.php
+++ b/resources/lang/ro-RO/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Gata de lansare',
     'requested_date'        => 'Data solicitării',
     'requested_assets'      => 'Activele solicitate',
-    'requested_assets_menu' => 'Articole Solicitabile',
+    'requested_assets_menu' => 'Articole Solicitate',
     'request_canceled'      => 'Cerere anulată',
     'request_item'          => 'Solicită acest articol',
     'external_link_tooltip' => 'Link extern către',

--- a/resources/lang/ru-RU/general.php
+++ b/resources/lang/ru-RU/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Готов к установке',
     'requested_date'        => 'Запрашиваемая дата',
     'requested_assets'      => 'Запрашиваемые активы',
-    'requested_assets_menu' => 'Запрашиваемые элементы',
+    'requested_assets_menu' => 'Запрошенные элементы',
     'request_canceled'      => 'Запрос отменен',
     'request_item'          => 'Запросить этот элемент',
     'external_link_tooltip' => 'Внешняя ссылка на',

--- a/resources/lang/si-LK/general.php
+++ b/resources/lang/si-LK/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Ready to Deploy',
     'requested_date'        => 'Requested Date',
     'requested_assets'      => 'Requested Assets',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'Request Canceled',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/sk-SK/general.php
+++ b/resources/lang/sk-SK/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Pripravené na odovzdanie',
     'requested_date'        => 'Dátum vyžiadania',
     'requested_assets'      => 'Vyžiadaný majetok',
-    'requested_assets_menu' => 'Vyžiadateľné položky',
+    'requested_assets_menu' => 'Vyžiadané položky',
     'request_canceled'      => 'Požiadavka zrušená',
     'request_item'          => 'Požiadať o túto položku',
     'external_link_tooltip' => 'Externé odkazy',

--- a/resources/lang/so-SO/general.php
+++ b/resources/lang/so-SO/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Diyaar u ah in la geeyo',
     'requested_date'        => 'Taariikhda la codsaday',
     'requested_assets'      => 'Hantida la codsaday',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'Codsiga waa la joojiyay',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/sq-AL/general.php
+++ b/resources/lang/sq-AL/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Ready to Deploy',
     'requested_date'        => 'Requested Date',
     'requested_assets'      => 'Requested Assets',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'Request Canceled',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/sr-CS/general.php
+++ b/resources/lang/sr-CS/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Spremna za raspoređivanje',
     'requested_date'        => 'Datum zatraživanja',
     'requested_assets'      => 'Zatražena imovina',
-    'requested_assets_menu' => 'Zatraživa stavka',
+    'requested_assets_menu' => 'Zatražena stavka',
     'request_canceled'      => 'Zahtev je otkazan',
     'request_item'          => 'Zatraži ovu stavku',
     'external_link_tooltip' => 'Eksterna veza do',

--- a/resources/lang/sv-SE/general.php
+++ b/resources/lang/sv-SE/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Redo för leverans',
     'requested_date'        => 'Begärt datum',
     'requested_assets'      => 'Begärda tillgångar',
-    'requested_assets_menu' => 'Begärbara objekt',
+    'requested_assets_menu' => 'Begärda objekt',
     'request_canceled'      => 'Förfrågan avbruten',
     'request_item'          => 'Begär detta objekt',
     'external_link_tooltip' => 'Extern länk till',

--- a/resources/lang/ta-IN/general.php
+++ b/resources/lang/ta-IN/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'வரிசைப்படுத்த தயாராக உள்ளது',
     'requested_date'        => 'Requested Date',
     'requested_assets'      => 'Requested Assets',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'கோரிக்கை ரத்து செய்யப்பட்டது',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/th-TH/general.php
+++ b/resources/lang/th-TH/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'พร้อมใช้งาน',
     'requested_date'        => 'วันที่ขอ',
     'requested_assets'      => 'Requested Assets',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'คำขอยกเลิกแล้ว',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/tl-PH/general.php
+++ b/resources/lang/tl-PH/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Ready to Deploy',
     'requested_date'        => 'Requested Date',
     'requested_assets'      => 'Requested Assets',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'Request Canceled',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/tr-TR/general.php
+++ b/resources/lang/tr-TR/general.php
@@ -266,7 +266,7 @@ Context | Request Context
     'rtd'				    => 'Atamaya Hazır',
     'requested_date'        => 'Talep Tarihi',
     'requested_assets'      => 'Talep Edilen Varlıklar',
-    'requested_assets_menu' => 'Talep Edilebilir Öğeler',
+    'requested_assets_menu' => 'Talep Edilen Öğeler',
     'request_canceled'      => 'Talep iptal edildi',
     'request_item'          => 'Ürünü Talep Et',
     'external_link_tooltip' => 'Dış bağlantı',

--- a/resources/lang/uk-UA/general.php
+++ b/resources/lang/uk-UA/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Готовий до видачі',
     'requested_date'        => 'Дата запиту',
     'requested_assets'      => 'Запитані активи',
-    'requested_assets_menu' => 'Запитувані речі',
+    'requested_assets_menu' => 'Запитані речі',
     'request_canceled'      => 'Запит скасовано',
     'request_item'          => 'Запросити цю річ',
     'external_link_tooltip' => 'Зовнішнє посилання на',

--- a/resources/lang/ur-PK/general.php
+++ b/resources/lang/ur-PK/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Ready to Deploy',
     'requested_date'        => 'Requested Date',
     'requested_assets'      => 'Requested Assets',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'Request Canceled',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/vi-VN/general.php
+++ b/resources/lang/vi-VN/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Sẵn sàng để cấp phát',
     'requested_date'        => 'Ngày yêu cầu',
     'requested_assets'      => 'Tài sản đã yêu cầu',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'Yêu cầu Đã Hủy',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/zh-CN/general.php
+++ b/resources/lang/zh-CN/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => '待分配',
     'requested_date'        => '申领日期',
     'requested_assets'      => '已申领资产',
-    'requested_assets_menu' => '可申领名目',
+    'requested_assets_menu' => '已申领名目',
     'request_canceled'      => '取消请求',
     'request_item'          => '申领此项',
     'external_link_tooltip' => '外部链接到',

--- a/resources/lang/zh-HK/general.php
+++ b/resources/lang/zh-HK/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Ready to Deploy',
     'requested_date'        => 'Requested Date',
     'requested_assets'      => 'Requested Assets',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'Request Canceled',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',

--- a/resources/lang/zh-TW/general.php
+++ b/resources/lang/zh-TW/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => '準備部署',
     'requested_date'        => '申請日期',
     'requested_assets'      => '申請的資產',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => '取消申請',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => '外部連結到',

--- a/resources/lang/zu-ZA/general.php
+++ b/resources/lang/zu-ZA/general.php
@@ -263,7 +263,7 @@ return [
     'rtd'				    => 'Ukulungele Ukusebenzisa',
     'requested_date'        => 'Requested Date',
     'requested_assets'      => 'Requested Assets',
-    'requested_assets_menu' => 'Requestable Items',
+    'requested_assets_menu' => 'Requested Items',
     'request_canceled'      => 'Isicelo sikhanseliwe',
     'request_item'          => 'Request this item',
     'external_link_tooltip' => 'External link to',


### PR DESCRIPTION
Changed translations from 'requestable' (can be requested) to 'requested' (already requested) to match the page's actual purpose.

The /account/requested page shows items that users have already requested, not items available to request.

Changes:

1. English variants (40 languages): Requestable Items → Requested Items

2. Translated languages (30 languages): Corrected meaning from requestable to requested

Files changed: 70 files, 70 insertions, 70 deletions

ref: https://github.com/grokability/snipe-it/issues/18429