### PR TITLE
Fixes Label text scaling 

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -1761,7 +1761,7 @@ class Helper
 
         $scale = min($scale, $maxScale);
 
-        $labelSize = $baseLabelSize * $scale;
+        $labelSize = $baseLabelSize;
         $fieldSize = $baseFieldSize * $scale;
         $fieldMargin = $baseFieldMargin * $scale;
 

--- a/app/Models/Labels/Sheets/Avery/L4736_A.php
+++ b/app/Models/Labels/Sheets/Avery/L4736_A.php
@@ -3,6 +3,8 @@
 namespace App\Models\Labels\Sheets\Avery;
 
 
+use App\Helpers\Helper;
+
 class L4736_A extends L4736
 {
     private const BARCODE_MARGIN =   1.80;
@@ -96,38 +98,38 @@ class L4736_A extends L4736
             $usableWidth -= $barcodeSize + self::BARCODE_MARGIN;
         }
         $fields = $record->get('fields');
-        $fieldCount = count($fields);
 
-        $perFieldHeight = (self::LABEL_SIZE + self::LABEL_MARGIN)
-                       + (self::FIELD_SIZE + self::FIELD_MARGIN);
+        $field_layout = Helper::labelFieldLayoutScaling(
+            pdf: $pdf,
+            fields: $fields,
+            currentX: $currentX,
+            usableWidth: $usableWidth,
+            usableHeight: $usableHeight,
+            baseLabelSize: self::LABEL_SIZE,
+            baseFieldSize: self::FIELD_SIZE,
+            baseFieldMargin: self::FIELD_MARGIN,
+            baseLabelPadding: 1.5,
+            baseGap: 1.5,
+            maxScale: 1.8,
+            labelFont: 'freesans',
+        );
 
-        $baseHeight = $fieldCount * $perFieldHeight;
-        $scale = 1.0;
-        if ($baseHeight > $usableHeight && $baseHeight > 0) {
-            $scale = $usableHeight / $baseHeight;
-        }
-
-        $labelSize   = self::LABEL_SIZE   * $scale;
-        $labelMargin = self::LABEL_MARGIN * $scale;
-        $fieldSize   = self::FIELD_SIZE   * $scale;
-        $fieldMargin = self::FIELD_MARGIN * $scale;
 
         foreach ($fields as $field) {
             static::writeText(
                 $pdf, $field['label'],
                 $currentX, $currentY,
-                'freesans', '', $labelSize, 'L',
-                $usableWidth, $labelSize, true, 0
+                'freesans', '', $field_layout['labelSize'], 'L',
+                $field_layout['labelWidth'], $field_layout['rowAdvance'], true, 0
             );
-            $currentY += $labelSize + $labelMargin;
 
             static::writeText(
                 $pdf, $field['value'],
-                $currentX, $currentY,
-                'freemono', 'B', $fieldSize, 'L',
-                $usableWidth, $fieldSize, true, 0, 0.01
+                $field_layout['valueX'], $currentY,
+                'freemono', 'B', $field_layout['fieldSize'], 'L',
+                $field_layout['valueWidth'], $field_layout['rowAdvance'], true, 0, 0.01
             );
-            $currentY += $fieldSize + $fieldMargin;
+            $currentY += $field_layout['rowAdvance'];
         }
 
     }

--- a/app/Models/Labels/Sheets/Avery/L6009_A.php
+++ b/app/Models/Labels/Sheets/Avery/L6009_A.php
@@ -2,6 +2,8 @@
 
 namespace App\Models\Labels\Sheets\Avery;
 
+use App\Helpers\Helper;
+
 class L6009_A extends L6009
 {
     private const BARCODE_MARGIN = 1.80;
@@ -60,43 +62,36 @@ class L6009_A extends L6009
             $usableWidth -= $barcodeSize + self::BARCODE_MARGIN;
         }
         $fields = $record->get('fields');
-        // Below rescales the size of the field box to fit, it feels like it could/should be abstracted one class above
-        // to be usable on other labels but im unsure of how to implement that, since it uses a lot of private
-        // constants.
 
-        // Figure out how tall the label fields wants to be
-        $fieldCount = count($fields);
-        $perFieldHeight = (self::LABEL_SIZE + self::LABEL_MARGIN)
-                        + (self::FIELD_SIZE + self::FIELD_MARGIN);
-
-        $baseHeight = $fieldCount * $perFieldHeight;
-        // If it doesn't fit in the available height, scale everything down
-        $scale = 1.0;
-        if ($baseHeight > $usableHeight && $baseHeight > 0) {
-            $scale = $usableHeight / $baseHeight;
-        }
-
-        $labelSize   = self::LABEL_SIZE   * $scale;
-        $labelMargin = self::LABEL_MARGIN * $scale;
-        $fieldSize   = self::FIELD_SIZE   * $scale;
-        $fieldMargin = self::FIELD_MARGIN * $scale;
-
+        $field_layout = Helper::labelFieldLayoutScaling(
+            pdf: $pdf,
+            fields: $fields,
+            currentX: $currentX,
+            usableWidth: $usableWidth,
+            usableHeight: $usableHeight,
+            baseLabelSize: self::LABEL_SIZE,
+            baseFieldSize: self::FIELD_SIZE,
+            baseFieldMargin: self::FIELD_MARGIN,
+            baseLabelPadding: 1.5,
+            baseGap: 1.5,
+            maxScale: 1.8,
+            labelFont: 'freesans',
+        );
         foreach ($fields as $field) {
             static::writeText(
                 $pdf, $field['label'],
                 $currentX, $currentY,
-                'freesans', '', $labelSize, 'L',
-                $usableWidth, $labelSize, true, 0
+                'freesans', '', $field_layout['labelSize'], 'L',
+                $field_layout['labelWidth'], $field_layout['rowAdvance'], true, 0
             );
-            $currentY += $labelSize + $labelMargin;
 
             static::writeText(
                 $pdf, $field['value'],
-                $currentX, $currentY,
-                'freemono', 'B', $fieldSize, 'L',
-                $usableWidth, $fieldSize, true, 0, 0.01
+                $field_layout['valueX'], $currentY,
+                'freemono', 'B', $field_layout['fieldSize'], 'L',
+                $field_layout['valueWidth'], $field_layout['rowAdvance'], true, 0, 0.01
             );
-            $currentY += $fieldSize + $fieldMargin;
+            $currentY += $field_layout['rowAdvance'];
         }
     }
 }

--- a/app/Models/Labels/Tapes/Brother/TZe_241.php
+++ b/app/Models/Labels/Tapes/Brother/TZe_241.php
@@ -57,8 +57,6 @@ class TZe_241 extends TZe_18mm
 
         $fields = $record->get('fields') ?? [];
 
-        $fieldCount = count($fields);
-
         $field_layout = Helper::labelFieldLayoutScaling(
             pdf: $pdf,
             fields: $fields,

--- a/app/Models/Labels/Tapes/Brother/TZe_241.php
+++ b/app/Models/Labels/Tapes/Brother/TZe_241.php
@@ -2,6 +2,8 @@
 
 namespace App\Models\Labels\Tapes\Brother;
 
+use App\Helpers\Helper;
+
 class TZe_241 extends TZe_18mm
 {
     private const LABEL_SIZE   = 5.0;
@@ -57,38 +59,36 @@ class TZe_241 extends TZe_18mm
 
         $fieldCount = count($fields);
 
-        $perFieldHeight = (self::LABEL_SIZE + self::LABEL_MARGIN)
-            + (self::FIELD_SIZE + self::FIELD_MARGIN);
-
-        $baseHeight = $fieldCount * $perFieldHeight;
-
-        // If it doesn't fit in the available height, scale everything down
-        $scale = 1.0;
-        if ($baseHeight > $usableHeight && $baseHeight > 0) {
-            $scale = $usableHeight / $baseHeight;
-        }
-
-        $labelSize   = self::LABEL_SIZE   * $scale;
-        $labelMargin = self::LABEL_MARGIN * $scale;
-        $fieldSize   = self::FIELD_SIZE   * $scale;
-        $fieldMargin = self::FIELD_MARGIN * $scale;
+        $field_layout = Helper::labelFieldLayoutScaling(
+            pdf: $pdf,
+            fields: $fields,
+            currentX: $currentX,
+            usableWidth: $usableWidth,
+            usableHeight: $usableHeight,
+            baseLabelSize: self::LABEL_SIZE,
+            baseFieldSize: self::FIELD_SIZE,
+            baseFieldMargin: self::FIELD_MARGIN,
+            baseLabelPadding: 1.5,
+            baseGap: 1.5,
+            maxScale: 1.8,
+            labelFont: 'freesans',
+        );
 
         foreach ($fields as $field) {
             static::writeText(
                 $pdf, $field['label'],
                 $currentX, $currentY,
-                'freesans', '', $labelSize, 'L',
-                $usableWidth, $labelSize, true, 0
+                'freesans', '', $field_layout['labelSize'], 'L',
+                $field_layout['labelWidth'], $field_layout['rowAdvance'], true, 0
             );
-            $currentY += $labelSize + $labelMargin;
 
             static::writeText(
                 $pdf, $field['value'],
-                $currentX, $currentY,
-                'freemono', 'B', $fieldSize, 'L',
-                $usableWidth, $fieldSize, true, 0, 0.01
+                $field_layout['valueX'], $currentY,
+                'freemono', 'B', $field_layout['fieldSize'], 'L',
+                $field_layout['valueWidth'], $field_layout['rowAdvance'], true, 0, 0.01
             );
-            $currentY += $fieldSize + $fieldMargin;
+            $currentY += $field_layout['rowAdvance'];
         }
     }
 }

--- a/app/Models/Labels/Tapes/Dymo/LabelWriter_11354.php
+++ b/app/Models/Labels/Tapes/Dymo/LabelWriter_11354.php
@@ -3,6 +3,8 @@
 namespace App\Models\Labels\Tapes\Dymo;
 
 
+use App\Helpers\Helper;
+
 class LabelWriter_11354 extends LabelWriter
 {
     private const BARCODE1D_HEIGHT =   3.00;
@@ -105,46 +107,37 @@ class LabelWriter_11354 extends LabelWriter
         }
 
         $fields = $record->get('fields');
-        // Below rescales the size of the field box to fit, it feels like it could/should be abstracted one class above
-        // to be usable on other labels but im unsure of how to implement that, since it uses a lot of private
-        // constants.
 
-        // Figure out how tall the label fields wants to be
-        $fieldCount = count($fields);
-        $perFieldHeight = (self::LABEL_SIZE + self::LABEL_MARGIN)
-            + (self::FIELD_SIZE + self::FIELD_MARGIN);
-        $usableHeight = $pa->h
-            - self::TAG_SIZE
-            - self::BARCODE_MARGIN;
-
-        $baseHeight = $fieldCount * $perFieldHeight;
-        // If it doesn't fit in the available height, scale everything down
-        $scale = 1.0;
-        if ($baseHeight > $usableHeight && $baseHeight > 0) {
-            $scale = $usableHeight / $baseHeight;
-        }
-
-        $labelSize   = self::LABEL_SIZE   * $scale;
-        $labelMargin = self::LABEL_MARGIN * $scale;
-        $fieldSize   = self::FIELD_SIZE   * $scale;
-        $fieldMargin = self::FIELD_MARGIN * $scale;
+        $field_layout = Helper::labelFieldLayoutScaling(
+            pdf: $pdf,
+            fields: $fields,
+            currentX: $currentX,
+            usableWidth: $usableWidth,
+            usableHeight: $usableHeight,
+            baseLabelSize: self::LABEL_SIZE,
+            baseFieldSize: self::FIELD_SIZE,
+            baseFieldMargin: self::FIELD_MARGIN,
+            baseLabelPadding: 1.5,
+            baseGap: 1.5,
+            maxScale: 1.8,
+            labelFont: 'freesans',
+        );
 
         foreach ($fields as $field) {
             static::writeText(
                 $pdf, $field['label'],
                 $currentX, $currentY,
-                'freesans', '', $labelSize, 'L',
-                $usableWidth, $labelSize, true, 0
+                'freesans', '', $field_layout['labelSize'], 'L',
+                $field_layout['labelWidth'], $field_layout['rowAdvance'], true, 0
             );
-            $currentY += $labelSize + $labelMargin;
 
             static::writeText(
                 $pdf, $field['value'],
-                $currentX, $currentY,
-                'freemono', 'B', $fieldSize, 'L',
-                $usableWidth, $fieldSize, true, 0, 0.01
+                $field_layout['valueX'], $currentY,
+                'freemono', 'B', $field_layout['fieldSize'], 'L',
+                $field_layout['valueWidth'], $field_layout['rowAdvance'], true, 0, 0.01
             );
-            $currentY += $fieldSize + $fieldMargin;
+            $currentY += $field_layout['rowAdvance'];
         }
     }
 

--- a/app/Models/Labels/Tapes/Dymo/LabelWriter_2112283.php
+++ b/app/Models/Labels/Tapes/Dymo/LabelWriter_2112283.php
@@ -3,6 +3,8 @@
 namespace App\Models\Labels\Tapes\Dymo;
 
 
+use App\Helpers\Helper;
+
 class LabelWriter_2112283 extends LabelWriter
 {
     private const BARCODE_MARGIN =   1.80;
@@ -98,40 +100,42 @@ class LabelWriter_2112283 extends LabelWriter
 
         // Figure out how tall the label fields wants to be
         $fieldCount = count($fields);
-        $perFieldHeight = (self::LABEL_SIZE + self::LABEL_MARGIN)
-            + (self::FIELD_SIZE + self::FIELD_MARGIN);
+
         $usableHeight = $pa->h
             - self::TAG_SIZE           // bottom tag text
             - self::BARCODE_MARGIN;    // gap between fields and 1D
-
-        $baseHeight = $fieldCount * $perFieldHeight;
-        // If it doesn't fit in the available height, scale everything down
-        $scale = 1.0;
-        if ($baseHeight > $usableHeight && $baseHeight > 0) {
-            $scale = $usableHeight / $baseHeight;
-        }
-
-        $labelSize   = self::LABEL_SIZE   * $scale;
-        $labelMargin = self::LABEL_MARGIN * $scale;
-        $fieldSize   = self::FIELD_SIZE   * $scale;
-        $fieldMargin = self::FIELD_MARGIN * $scale;
+        $field_layout = Helper::labelFieldLayoutScaling(
+            pdf: $pdf,
+            fields: $fields,
+            currentX: $currentX,
+            usableWidth: $usableWidth,
+            usableHeight: $usableHeight,
+            baseLabelSize: self::LABEL_SIZE,
+            baseFieldSize: self::FIELD_SIZE,
+            baseFieldMargin: self::FIELD_MARGIN,
+            baseLabelPadding: 1.5,
+            baseGap: 1.5,
+            maxScale: 1.8,
+            labelFont: 'freesans',
+        );
 
         foreach ($fields as $field) {
+            $labelText = rtrim($field['label'], ':') . ':';
+
             static::writeText(
-                $pdf, $field['label'],
+                $pdf, $labelText,
                 $currentX, $currentY,
-                'freesans', '', $labelSize, 'L',
-                $usableWidth, $labelSize, true, 0
+                'freesans', '', $field_layout['labelSize'], 'L',
+                $field_layout['labelWidth'], $field_layout['rowAdvance'], true, 0
             );
-            $currentY += $labelSize + $labelMargin;
 
             static::writeText(
                 $pdf, $field['value'],
-                $currentX, $currentY,
-                'freemono', 'B', $fieldSize, 'L',
-                $usableWidth, $fieldSize, true, 0, 0.01
+                $field_layout['valueX'], $currentY,
+                'freemono', 'B', $field_layout['fieldSize'], 'L',
+                $field_layout['valueWidth'], $field_layout['rowAdvance'], true, 0, 0.01
             );
-            $currentY += $fieldSize + $fieldMargin;
+            $currentY += $field_layout['rowAdvance'];
         }
         if ($record->has('barcode1d')) {
             static::write1DBarcode(


### PR DESCRIPTION
This adds a helper method that scales the text size of field/row values of a label. 
This should give the biggest size to fit the content on the label.
| Before | After |
|--------|-------|
| <img width="311" height="152" alt="Before" src="https://github.com/user-attachments/assets/0a119e86-e3b6-45ae-8431-7dab97241ca9" /> | <img width="430" height="248" alt="image" src="https://github.com/user-attachments/assets/3fd5ad90-2c01-4e6f-80c1-ca854e61109c" /> |


https://github.com/user-attachments/assets/756c1c19-b76c-4d6d-b215-c29f74dead86




