### PR TITLE
Fixed #18135 - only unset sensitive variables in the web UI importer

### DIFF
--- a/app/Importer/UserImporter.php
+++ b/app/Importer/UserImporter.php
@@ -10,6 +10,7 @@ use App\Notifications\WelcomeNotification;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Password;
+use Illuminate\Support\Facades\Auth;
 
 /**
  * This is ONLY used for the User Import. When we are importing users
@@ -102,8 +103,7 @@ class UserImporter extends ItemImporter
 
             $this->log('Updating User');
 
-            // Todo - check that this works
-            if (!Gate::allows('canEditAuthFields', $user)) {
+            if (Auth::check() && (!Gate::allows('canEditAuthFields', $user))) {
                 unset($user->username);
                 unset($user->email);
                 unset($user->password);


### PR DESCRIPTION
This should fix #18135, where cli user imports were failing because of the added security check to make sure the acting user can perform actions on other users that could compromise security (changing a superusers password or email, etc.)

This gets a little tricky because while the Web UI knows who the authenticated user is, the command line importer has no real way of knowing that (since a cli session is by nature unauthenticated - there is no session.)

This change checks to see if the user is authenticated (meaning it's being run via CLI) and then also uses the gate to check that the authenticated user can change those sensitive fields. 