### PR TITLE
Fixed - throw fewer exceptions on SCIM misconfigurations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "ext-mbstring": "*",
     "ext-pdo": "*",
     "alek13/slack": "^2.0",
-    "arietimmerman/laravel-scim-server": "dev-laravel_11_compatibility",
+    "arietimmerman/laravel-scim-server": "dev-master",
     "bacon/bacon-qr-code": "^2.0",
     "barryvdh/laravel-debugbar": "^3.13",
     "doctrine/cache": "^1.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "553ce69c21704905c568769de08fffe4",
+    "content-hash": "b1dfc90a20cecf851224ea8a5c71f26d",
     "packages": [
         {
             "name": "alek13/slack",
@@ -74,16 +74,16 @@
         },
         {
             "name": "arietimmerman/laravel-scim-server",
-            "version": "dev-laravel_11_compatibility",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/grokability/laravel-scim-server.git",
-                "reference": "6c771799090bfe04dcee94a1dc9f82870aed4dbe"
+                "reference": "ad77044af7c36291b69dc1a7dbfa86ba82362554"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/grokability/laravel-scim-server/zipball/6c771799090bfe04dcee94a1dc9f82870aed4dbe",
-                "reference": "6c771799090bfe04dcee94a1dc9f82870aed4dbe",
+                "url": "https://api.github.com/repos/grokability/laravel-scim-server/zipball/ad77044af7c36291b69dc1a7dbfa86ba82362554",
+                "reference": "ad77044af7c36291b69dc1a7dbfa86ba82362554",
                 "shasum": ""
             },
             "require": {
@@ -98,6 +98,7 @@
                 "laravel/legacy-factories": "*",
                 "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0|^8.0"
             },
+            "default-branch": true,
             "type": "library",
             "extra": {
                 "laravel": {
@@ -130,9 +131,9 @@
             ],
             "description": "Laravel Package for creating a SCIM server",
             "support": {
-                "source": "https://github.com/grokability/laravel-scim-server/tree/laravel_11_compatibility"
+                "source": "https://github.com/grokability/laravel-scim-server/tree/master"
             },
-            "time": "2025-01-20T14:49:28+00:00"
+            "time": "2026-01-14T14:30:06+00:00"
         },
         {
             "name": "aws/aws-crt-php",


### PR DESCRIPTION
We very heavily use Rollbar in our hosted server fleet. And we have plenty of customers who heavily use SCIM. And it's surprisingly easy to misconfigure SCIM from the Identity-Provider (IdP) side, which can force a lot of exceptions to bubble up, and eat into our Rollbar budget.

This change allows us to pull the latest version of our fork of the laravel-scim-server, which *should* give us some slightly better error messaging around some of these common misconfigurations. The change there is this one: https://github.com/grokability/laravel-scim-server/pull/9 

The _hope_ is that, instead of throwing a 500 at the server level, we can instead give back a 400-series status code which can at least let the user know that they're sending something that we can't handle. As mentioned in that PR, that's very likely an unknown-subnode of something that we actually *do* handle - the example I give there was "Fax Number" - we *do* handles the `phones` attribute, but we do *not* handle the Fax "type".