### PR TITLE
Use basic container+box for primary index pages with one column

### DIFF
--- a/resources/views/categories/index.blade.php
+++ b/resources/views/categories/index.blade.php
@@ -8,11 +8,8 @@
 
 {{-- Page content --}}
 @section('content')
-
-<div class="row">
-  <div class="col-md-12">
-    <div class="box box-default">
-      <div class="box-body">
+    <x-container>
+        <x-box>
 
           <x-tables.bulk-actions
                   id_divname='categoriesBulkEditToolbar'
@@ -46,10 +43,8 @@
               "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
               }'>
           </table>
-      </div><!-- /.box-body -->
-    </div><!-- /.box -->
-  </div>
-</div>
+        </x-box>
+    </x-container>
 
 @stop
 

--- a/resources/views/consumables/index.blade.php
+++ b/resources/views/consumables/index.blade.php
@@ -8,12 +8,9 @@
 
 {{-- Page content --}}
 @section('content')
+    <x-container>
+        <x-box>
 
-<div class="row">
-  <div class="col-md-12">
-
-    <div class="box box-default">
-      <div class="box-body">
         <table
                 data-columns="{{ \App\Presenters\ConsumablePresenter::dataTableLayout() }}"
                 data-cookie-id-table="consumablesTable"
@@ -34,11 +31,8 @@
                 }'>
         </table>
 
-      </div><!-- /.box-body -->
-    </div><!-- /.box -->
-
-  </div> <!-- /.col-md-12 -->
-</div> <!-- /.row -->
+        </x-box>
+    </x-container>
 @stop
 
 @section('moar_scripts')

--- a/resources/views/departments/index.blade.php
+++ b/resources/views/departments/index.blade.php
@@ -8,31 +8,28 @@
 
 {{-- Page content --}}
 @section('content')
-    <div class="row">
-        <div class="col-md-12">
-            <div class="box box-default">
-                <div class="box-body">
-                        <table
-                                data-columns="{{ \App\Presenters\DepartmentPresenter::dataTableLayout() }}"
-                                data-cookie-id-table="departmentsTable"
-                                data-id-table="departmentsTable"
-                                data-side-pagination="server"
-                                data-sort-order="asc"
-                                id="departmentsTable"
-                                data-advanced-search="false"
-                                data-buttons="departmentButtons"
-                                class="table table-striped snipe-table"
-                                data-url="{{ route('api.departments.index') }}"
-                                data-export-options='{
-                              "fileName": "export-departments-{{ date('Y-m-d') }}",
-                              "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
-                              }'>
+    <x-container>
+        <x-box>
 
-                        </table>
-                </div>
-            </div>
-        </div>
-    </div>
+            <table
+                    data-columns="{{ \App\Presenters\DepartmentPresenter::dataTableLayout() }}"
+                    data-cookie-id-table="departmentsTable"
+                    data-id-table="departmentsTable"
+                    data-side-pagination="server"
+                    data-sort-order="asc"
+                    id="departmentsTable"
+                    data-advanced-search="false"
+                    data-buttons="departmentButtons"
+                    class="table table-striped snipe-table"
+                    data-url="{{ route('api.departments.index') }}"
+                    data-export-options='{
+                  "fileName": "export-departments-{{ date('Y-m-d') }}",
+                  "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
+                  }'>
+            </table>
+
+        </x-box>
+    </x-container>
 
 @stop
 

--- a/resources/views/groups/index.blade.php
+++ b/resources/views/groups/index.blade.php
@@ -12,12 +12,10 @@
 @stop
 
 
-{{-- Content --}}
+{{-- Page content --}}
 @section('content')
-<div class="row">
-  <div class="col-md-12">
-    <div class="box box-default">
-      <div class="box-body">
+    <x-container>
+        <x-box>
             <table
                 data-cookie-id-table="groupsTable"
                 data-side-pagination="server"
@@ -47,10 +45,8 @@
               </tr>
             </thead>
           </table>
-      </div> <!--.box-body-->
-    </div> <!-- /.box.box-default-->
-  </div> <!-- .col-md-12-->
-</div>
+        </x-box>
+    </x-container>
 @stop
 @section('moar_scripts')
 @include ('partials.bootstrap-table', ['exportFile' => 'groups-export', 'search' => true])

--- a/resources/views/hardware/index.blade.php
+++ b/resources/views/hardware/index.blade.php
@@ -53,16 +53,8 @@
 
 {{-- Page content --}}
 @section('content')
-
-
-
-<div class="row">
-  <div class="col-md-12">
-    <div class="box box-default">
-      <div class="box-body">
-       
-          <div class="row">
-            <div class="col-md-12">
+    <x-container>
+        <x-box>
 
                 @include('partials.asset-bulk-actions', ['status' => $requestStatus])
                    
@@ -93,13 +85,8 @@
                 }'>
               </table>
 
-            </div><!-- /.col -->
-          </div><!-- /.row -->
-        
-      </div><!-- ./box-body -->
-    </div><!-- /.box -->
-  </div>
-</div>
+        </x-box>
+    </x-container>
 @stop
 
 @section('moar_scripts')

--- a/resources/views/licenses/index.blade.php
+++ b/resources/views/licenses/index.blade.php
@@ -9,12 +9,8 @@
 
 {{-- Page content --}}
 @section('content')
-
-
-<div class="row">
-  <div class="col-md-12">
-    <div class="box box-default">
-      <div class="box-body">
+    <x-container>
+        <x-box>
 
           <table
               data-columns="{{ \App\Presenters\LicensePresenter::dataTableLayout() }}"
@@ -34,13 +30,8 @@
             }'>
           </table>
 
-      </div><!-- /.box-body -->
-
-      <div class="box-footer clearfix">
-      </div>
-    </div><!-- /.box -->
-  </div>
-</div>
+        </x-box>
+    </x-container>
 @stop
 
 @section('moar_scripts')

--- a/resources/views/maintenances/index.blade.php
+++ b/resources/views/maintenances/index.blade.php
@@ -9,33 +9,27 @@
 
 {{-- Page content --}}
 @section('content')
+    <x-container>
+        <x-box>
 
-<div class="row">
-  <div class="col-md-12">
-    <div class="box box-default">
-      <div class="box-body">
+              <table
+                  data-columns="{{ \App\Presenters\MaintenancesPresenter::dataTableLayout() }}"
+                  data-cookie-id-table="maintenancesTable"
+                  data-side-pagination="server"
+                  data-show-footer="true"
+                  data-advanced-search="false"
+                  id="maintenancesTable"
+                  data-buttons="maintenanceButtons"
+                  class="table table-striped snipe-table"
+                  data-url="{{route('api.maintenances.index') }}"
+                  data-export-options='{
+                    "fileName": "export-maintenances-{{ date('Y-m-d') }}",
+                        "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
+                  }'>
+            </table>
 
-          <table
-              data-columns="{{ \App\Presenters\MaintenancesPresenter::dataTableLayout() }}"
-              data-cookie-id-table="maintenancesTable"
-              data-side-pagination="server"
-              data-show-footer="true"
-              data-advanced-search="false"
-              id="maintenancesTable"
-              data-buttons="maintenanceButtons"
-              class="table table-striped snipe-table"
-              data-url="{{route('api.maintenances.index') }}"
-              data-export-options='{
-                "fileName": "export-maintenances-{{ date('Y-m-d') }}",
-                    "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
-              }'>
-
-        </table>
-
-      </div>
-    </div>
-  </div>
-</div>
+        </x-box>
+    </x-container>
 @stop
 
 @section('moar_scripts')

--- a/resources/views/manufacturers/index.blade.php
+++ b/resources/views/manufacturers/index.blade.php
@@ -8,67 +8,61 @@
 
 {{-- Page content --}}
 @section('content')
+    <x-container>
+        <x-box>
 
-  <div class="row">
-    <div class="col-md-12">
+            @if ($manufacturer_count == 0)
 
-      <div class="box box-default">
-        <div class="box-body">
+                    <form action="{{ route('manufacturers.seed') }}" method="POST">
+                      {{ csrf_field() }}
+                    <div class="callout callout-info">
+                      <p>
+                          {{ trans('general.seeding.manufacturers.prompt') }}
+                        <button class="btn btn-sm btn-theme hidden-print" rel="noopener">
+                          {{ trans('general.seeding.manufacturers.button') }}
+                        </button>
+                      </p>
+                    </div>
+                    </form>
 
-    @if ($manufacturer_count == 0)
+              @else
+                        <x-tables.bulk-actions
+                                id_divname='manufacturersBulkEditToolbar'
+                                action_route="{{route('manufacturers.bulk.delete')}}"
+                                id_formname="manufacturersBulkForm"
+                                id_button="bulkManufacturerEditButton"
+                                model_name="manufacturer"
+                        >
+                            @can('delete', App\Models\Manufacturer::class)
+                                <option>{{trans('general.delete')}}</option>
+                            @endcan
+                        </x-tables.bulk-actions>
 
-            <form action="{{ route('manufacturers.seed') }}" method="POST">
-              {{ csrf_field() }}
-            <div class="callout callout-info">
-              <p>
-                  {{ trans('general.seeding.manufacturers.prompt') }}
-                <button class="btn btn-sm btn-theme hidden-print" rel="noopener">
-                  {{ trans('general.seeding.manufacturers.button') }}
-                </button>
-              </p>
-            </div>
-            </form>
+                    <table
+                      data-columns="{{ \App\Presenters\ManufacturerPresenter::dataTableLayout() }}"
+                      data-cookie-id-table="manufacturersTable"
+                      data-id-table="manufacturersTable"
+                      data-advanced-search="false"
+                      data-side-pagination="server"
+                      data-sort-order="asc"
+                      id="manufacturersTable"
+                      {{-- begin stuff for bulk dropdown --}}
+                      data-toolbar="#manufacturersBulkEditToolbar"
+                      data-bulk-button-id="#bulkManufacturerEditButton"
+                      data-bulk-form-id="#manufacturersBulkForm"
+                      {{-- end stuff for bulk dropdown --}}
+                      data-buttons="manufacturerButtons"
+                      class="table table-striped snipe-table"
+                      data-url="{{route('api.manufacturers.index', ['status' => e(request()->input('status')) ]) }}"
+                      data-export-options='{
+                        "fileName": "export-manufacturers-{{ date('Y-m-d') }}",
+                        "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
+                        }'>
+                    </table>
 
-      @else
-                <x-tables.bulk-actions
-                        id_divname='manufacturersBulkEditToolbar'
-                        action_route="{{route('manufacturers.bulk.delete')}}"
-                        id_formname="manufacturersBulkForm"
-                        id_button="bulkManufacturerEditButton"
-                        model_name="manufacturer"
-                >
-                    @can('delete', App\Models\Manufacturer::class)
-                        <option>{{trans('general.delete')}}</option>
-                    @endcan
-                </x-tables.bulk-actions>
-
-            <table
-              data-columns="{{ \App\Presenters\ManufacturerPresenter::dataTableLayout() }}"
-              data-cookie-id-table="manufacturersTable"
-              data-id-table="manufacturersTable"
-              data-advanced-search="false"
-              data-side-pagination="server"
-              data-sort-order="asc"
-              id="manufacturersTable"
-              {{-- begin stuff for bulk dropdown --}}
-              data-toolbar="#manufacturersBulkEditToolbar"
-              data-bulk-button-id="#bulkManufacturerEditButton"
-              data-bulk-form-id="#manufacturersBulkForm"
-              {{-- end stuff for bulk dropdown --}}
-              data-buttons="manufacturerButtons"
-              class="table table-striped snipe-table"
-              data-url="{{route('api.manufacturers.index', ['status' => e(request()->input('status')) ]) }}"
-              data-export-options='{
-                "fileName": "export-manufacturers-{{ date('Y-m-d') }}",
-                "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
-                }'>
-            </table>
-
-            @endif
-        </div><!-- /.box-body -->
-      </div><!-- /.box -->
-    </div>
-  </div>
+                    @endif
+        </x-box>
+    </x-container>
 @stop
 
 @section('moar_scripts')

--- a/resources/views/models/index.blade.php
+++ b/resources/views/models/index.blade.php
@@ -15,37 +15,32 @@
 {{-- Page content --}}
 @section('content')
 
+    <x-container>
+        <x-box>
 
-<div class="row">
-  <div class="col-md-12">
-    <div class="box box-default">
-      <div class="box-body">
-
-        @include('partials.models-bulk-actions')
-                <table
-                        data-columns="{{ \App\Presenters\AssetModelPresenter::dataTableLayout() }}"
-                        data-cookie-id-table="asssetModelsTable"
-                        data-id-table="asssetModelsTable"
-                        data-show-footer="true"
-                        data-side-pagination="server"
-                        data-footer-style="footerStyle"
-                        data-toolbar="#modelsBulkEditToolbar"
-                        data-bulk-button-id="#bulkModelsEditButton"
-                        data-bulk-form-id="#modelsBulkForm"
-                        data-sort-order="asc"
-                        id="asssetModelsTable"
-                        data-buttons="modelButtons"
-                        class="table table-striped snipe-table"
-                        data-url="{{ route('api.models.index', ['status' => e(request('status'))]) }}"
-                        data-export-options='{
-              "fileName": "export-models-{{ date('Y-m-d') }}",
-              "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
-              }'>
-              </table>
-      </div><!-- /.box-body -->
-    </div><!-- /.box -->
-  </div>
-</div>
+    @include('partials.models-bulk-actions')
+            <table
+                    data-columns="{{ \App\Presenters\AssetModelPresenter::dataTableLayout() }}"
+                    data-cookie-id-table="asssetModelsTable"
+                    data-id-table="asssetModelsTable"
+                    data-show-footer="true"
+                    data-side-pagination="server"
+                    data-footer-style="footerStyle"
+                    data-toolbar="#modelsBulkEditToolbar"
+                    data-bulk-button-id="#bulkModelsEditButton"
+                    data-bulk-form-id="#modelsBulkForm"
+                    data-sort-order="asc"
+                    id="asssetModelsTable"
+                    data-buttons="modelButtons"
+                    class="table table-striped snipe-table"
+                    data-url="{{ route('api.models.index', ['status' => e(request('status'))]) }}"
+                    data-export-options='{
+          "fileName": "export-models-{{ date('Y-m-d') }}",
+          "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
+          }'>
+          </table>
+        </x-box>
+    </x-container>
 
 @stop
 

--- a/resources/views/reports/activity.blade.php
+++ b/resources/views/reports/activity.blade.php
@@ -18,11 +18,8 @@
 
 {{-- Page content --}}
 @section('content')
-
-<div class="row">
-    <div class="col-md-12">
-        <div class="box box-default">
-            <div class="box-body">
+    <x-container>
+        <x-box>
 
                 <table
                         data-columns="{{ \App\Presenters\HistoryPresenter::dataTableLayout($serial = true) }}"
@@ -40,10 +37,8 @@
                         "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                         }'>
                 </table>
-            </div>
-        </div>
-    </div>
-</div>
+        </x-box>
+    </x-container>
 @stop
 
 

--- a/resources/views/reports/maintenances.blade.php
+++ b/resources/views/reports/maintenances.blade.php
@@ -8,10 +8,8 @@
 
 {{-- Page content --}}
 @section('content')
-<div class="row">
-  <div class="col-md-12">
-    <div class="box box-default">
-      <div class="box-body">
+    <x-container>
+        <x-box>
             <table
                     data-cookie-id-table="maintenancesReport"
                     data-show-footer="true"
@@ -47,10 +45,8 @@
                 </tr>
                 </thead>
             </table>
-      </div>
-    </div>
-  </div>
-</div>
+        </x-box>
+    </x-container>
 @stop
 
 @section('moar_scripts')

--- a/resources/views/suppliers/index.blade.php
+++ b/resources/views/suppliers/index.blade.php
@@ -8,15 +8,8 @@
 
 {{-- Page content --}}
 @section('content')
-
-
-<div class="row">
-  <div class="col-md-12">
-      <div class="box box-default">
-      <div class="box-body">
-
-        <div class="row">
-          <div class="col-md-12">
+    <x-container>
+        <x-box>
 
               <x-tables.bulk-actions
                       id_divname='suppliersBulkEditToolbar'
@@ -25,10 +18,11 @@
                       id_button="bulkSupplierEditButton"
                       model_name="supplier"
               >
-                  @can('delete', App\Models\Supplier::class)
-                      <option>Delete</option>
-                  @endcan
+              @can('delete', App\Models\Supplier::class)
+                  <option>Delete</option>
+              @endcan
               </x-tables.bulk-actions>
+
             <table
             data-columns="{{ \App\Presenters\SupplierPresenter::dataTableLayout() }}"
             data-cookie-id-table="suppliersTable"
@@ -50,12 +44,8 @@
             "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
             }'>
       </table>
-          </div>
-        </div>
-      </div>
-  </div>
-  </div>
-</div>
+        </x-box>
+    </x-container>
 @stop
 
 @section('moar_scripts')

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -27,11 +27,8 @@
 
 {{-- Page content --}}
 @section('content')
-
-<div class="row">
-  <div class="col-md-12">
-    <div class="box box-default">
-        <div class="box-body">
+    <x-container>
+        <x-box>
 
             @include('partials.users-bulk-actions')
 
@@ -62,10 +59,8 @@
                 "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                 }'>
                     </table>
-                </div><!-- /.box-body -->
-            </div><!-- /.box -->
-        </div>
-    </div>
+        </x-box>
+    </x-container>
 
 
 @stop


### PR DESCRIPTION
This starts to move the most basic index table pages over to use the new container+box blade components. This is one more step towards being able to more easily upgrade the CSS framework. This will also help ensure that we don't have stupid unclosed (or extra closing) divs in our blades which can mangle the formatting. 

Ideally, if this works as expected, nothing visually should change.

This will require more fiddling with the container blade component for scenarios where we have two primary columns on listing pages,  but this at least gets us started.