### PR TITLE
Fixed storing image for accessory and consumable creation via api

### DIFF
--- a/app/Http/Requests/StoreAccessoryRequest.php
+++ b/app/Http/Requests/StoreAccessoryRequest.php
@@ -19,6 +19,7 @@ class StoreAccessoryRequest extends ImageUploadRequest
 
     public function prepareForValidation(): void
     {
+        parent::prepareForValidation();
 
         if ($this->category_id) {
             if ($category = Category::find($this->category_id)) {

--- a/app/Http/Requests/StoreConsumableRequest.php
+++ b/app/Http/Requests/StoreConsumableRequest.php
@@ -19,6 +19,7 @@ class StoreConsumableRequest extends ImageUploadRequest
 
     public function prepareForValidation(): void
     {
+        parent::prepareForValidation();
 
         if ($this->category_id) {
             if ($category = Category::find($this->category_id)) {


### PR DESCRIPTION
This PR addresses an issue where images could not be stored for Accessories or Consumables when creating them via the API. The fix, which we [already do for assets](https://github.com/grokability/snipe-it/blob/949f65b210ee848fa5b7de6f8cf461754be57a65/app/Http/Requests/StoreAssetRequest.php#L29), is to call `prepareForValidation()` on the parent `ImageUploadRequest`. 

---

[FD-53413]