### PR TITLE
Fixed #17309 - include EOL date in custom asset report

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -818,7 +818,7 @@ class ReportsController extends Controller
                     }
 
                     if ($request->filled('eol')) {
-                        $row[] = ($asset->purchase_date != '') ? $asset->asset_eol_date : '';
+                        $row[] = ($asset->asset_eol_date != '') ? $asset->asset_eol_date : '';
                     }
 
                     if ($request->filled('warranty')) {


### PR DESCRIPTION
This PR address #17309 (EOL date not being included in custom asset report when asset does not have a purchase date) by always including the asset's eol date from the database.

---

Fixes #17309