### PR TITLE
Fixes #18353 Label title scales with label fields. adjusted label row allotment. 

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -1794,6 +1794,12 @@ class Helper
 
         $maxLabelWidthPerUnit = 0;
         foreach ($fields as $field) {
+            $rawLabel = $field['label'] ?? null;
+
+            // If no label, do not include it in label-column sizing
+            if (!is_string($rawLabel) || trim($rawLabel) === '') {
+                continue;
+            }
             $label = rtrim($field['label'], ':') . ':';
             $width = $pdf->GetStringWidth($label);
             $maxLabelWidthPerUnit = max($maxLabelWidthPerUnit, $width / $baseLabelSize);

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -1757,18 +1757,26 @@ class Helper
         float $baseLabelSize,
         float $baseFieldSize,
         float $baseFieldMargin,
+        ?string $title            = null,
+        float $baseTitleSize      = 0.0,
+        float $baseTitleMargin    = 0.0,
         float $baseLabelPadding = 1.5,
         float $baseGap          = 1.5,
         float $maxScale         = 1.8,
         string $labelFont       = 'freesans',
+
     )  : array
     {
         $fieldCount = count($fields);
         $perFieldHeight = max($baseLabelSize, $baseFieldSize) + $baseFieldMargin;
-        $baseHeight = $fieldCount * $perFieldHeight;
+        $baseFieldsHeight = $fieldCount * $perFieldHeight;
+
+        $hasTitle = is_string($title) && trim($title) !== '';
+        $baseTitleHeight = $hasTitle ? ($baseTitleSize + $baseTitleMargin) : 0.0;
+        $baseTotalHeight = $baseTitleHeight + $baseFieldsHeight;
         $scale = 1.0;
-        if ($baseHeight > 0 && $usableHeight > 0) {
-            $scale = $usableHeight / $baseHeight;
+        if ($baseTotalHeight > 0 && $usableHeight > 0) {
+            $scale = $usableHeight / $baseTotalHeight;
         }
 
         $scale = min($scale, $maxScale);
@@ -1778,6 +1786,10 @@ class Helper
         $fieldMargin = $baseFieldMargin * $scale;
 
         $rowAdvance = max($labelSize, $fieldSize) + $fieldMargin;
+        $titleSize   = $hasTitle ? ($baseTitleSize   * $scale) : 0.0;
+        $titleMargin = $hasTitle ? ($baseTitleMargin * $scale) : 0.0;
+        $titleAdvance = $hasTitle ? ($titleSize + $titleMargin) : 0.0;
+
         $pdf->SetFont($labelFont, '', $baseLabelSize);
 
         $maxLabelWidthPerUnit = 0;
@@ -1796,6 +1808,11 @@ class Helper
 
         return compact(
             'scale',
+            'hasTitle',
+            'scale',
+            'titleSize',
+            'titleMargin',
+            'titleAdvance',
             'labelSize',
             'fieldSize',
             'fieldMargin',

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -1815,7 +1815,6 @@ class Helper
         return compact(
             'scale',
             'hasTitle',
-            'scale',
             'titleSize',
             'titleMargin',
             'titleAdvance',

--- a/app/Models/Labels/Tapes/Dymo/LabelWriter_11354.php
+++ b/app/Models/Labels/Tapes/Dymo/LabelWriter_11354.php
@@ -127,16 +127,15 @@ class LabelWriter_11354 extends LabelWriter
             maxScale: 1.8,
             labelFont: 'freesans',
         );
-        extract($field_layout);
 
-        if ($hasTitle) {
+        if ($field_layout['hasTitle']) {
             static::writeText(
                 $pdf, $title,
                 $currentX, $currentY,
-                'freesans', 'b', $titleSize, 'L',
-                $usableWidth, $titleSize, true, 0
+                'freesans', 'b', $field_layout['titleSize'], 'L',
+                $usableWidth, $field_layout['titleSize'], true, 0
             );
-            $currentY += $titleAdvance;
+            $currentY += $field_layout['titleAdvance'];
         }
         foreach ($fields as $field) {
             $rawLabel = $field['label'] ?? null;
@@ -147,11 +146,11 @@ class LabelWriter_11354 extends LabelWriter
                 static::writeText(
                     $pdf, $value,
                     $currentX, $currentY,
-                    'freemono', 'B', $fieldSize, 'L',
-                    $usableWidth, $rowAdvance, true, 0, 0.01
+                    'freemono', 'B', $field_layout['fieldSize'], 'L',
+                    $usableWidth, $field_layout['rowAdvance'], true, 0, 0.01
                 );
 
-                $currentY += $rowAdvance;
+                $currentY += $field_layout['rowAdvance'];
                 continue;
             }
 
@@ -160,17 +159,17 @@ class LabelWriter_11354 extends LabelWriter
             static::writeText(
                 $pdf, $labelText,
                 $currentX, $currentY,
-                'freesans', '', $labelSize, 'L',
-                $labelWidth, $rowAdvance, true, 0
+                'freesans', '', $field_layout['labelSize'], 'L',
+                $field_layout['labelWidth'], $field_layout['rowAdvance'], true,
             );
 
             static::writeText(
                 $pdf, $field['value'],
                 $field_layout['valueX'], $currentY,
-                'freemono', 'B', $fieldSize, 'L',
-                $valueWidth, $rowAdvance, true, 0, 0.01
+                'freemono', 'B', $field_layout['fieldSize'], 'L',
+                $field_layout['valueWidth'], $field_layout['rowAdvance'], true, 0, 0.01
             );
-            $currentY += $rowAdvance;
+            $currentY += $field_layout['rowAdvance'];;
         }
     }
 

--- a/app/Models/Labels/Tapes/Dymo/LabelWriter_11354.php
+++ b/app/Models/Labels/Tapes/Dymo/LabelWriter_11354.php
@@ -139,6 +139,22 @@ class LabelWriter_11354 extends LabelWriter
             $currentY += $titleAdvance;
         }
         foreach ($fields as $field) {
+            $rawLabel = $field['label'] ?? null;
+            $value    = (string)($field['value'] ?? '');
+
+            // No label: value takes the whole row
+            if (!is_string($rawLabel) || trim($rawLabel) === '') {
+                static::writeText(
+                    $pdf, $value,
+                    $currentX, $currentY,
+                    'freemono', 'B', $fieldSize, 'L',
+                    $usableWidth, $rowAdvance, true, 0, 0.01
+                );
+
+                $currentY += $rowAdvance;
+                continue;
+            }
+
             $labelText = rtrim($field['label'], ':') . ':';
 
             static::writeText(

--- a/app/Models/Labels/Tapes/Dymo/LabelWriter_1933081.php
+++ b/app/Models/Labels/Tapes/Dymo/LabelWriter_1933081.php
@@ -114,16 +114,15 @@ class LabelWriter_1933081 extends LabelWriter
             maxScale: 1.8,
             labelFont: 'freesans',
         );
-        extract($field_layout);
 
-        if ($hasTitle) {
+        if ($field_layout['hasTitle']) {
             static::writeText(
                 $pdf, $title,
                 $currentX, $currentY,
-                'freesans', 'b', $titleSize, 'L',
-                $usableWidth, $titleSize, true, 0
+                'freesans', 'b', $field_layout['titleSize'], 'L',
+                $usableWidth, $field_layout['titleSize'], true, 0
             );
-            $currentY += $titleAdvance;
+            $currentY += $field_layout['titleAdvance'];
         }
         foreach ($fields as $field) {
             $rawLabel = $field['label'] ?? null;
@@ -134,11 +133,11 @@ class LabelWriter_1933081 extends LabelWriter
                 static::writeText(
                     $pdf, $value,
                     $currentX, $currentY,
-                    'freemono', 'B', $fieldSize, 'L',
-                    $usableWidth, $rowAdvance, true, 0, 0.01
+                    'freemono', 'B', $field_layout['fieldSize'], 'L',
+                    $usableWidth, $field_layout['rowAdvance'], true, 0, 0.01
                 );
 
-                $currentY += $rowAdvance;
+                $currentY += $field_layout['rowAdvance'];
                 continue;
             }
 
@@ -147,17 +146,17 @@ class LabelWriter_1933081 extends LabelWriter
             static::writeText(
                 $pdf, $labelText,
                 $currentX, $currentY,
-                'freesans', '', $labelSize, 'L',
-                $labelWidth, $rowAdvance, true, 0
+                'freesans', '', $field_layout['labelSize'], 'L',
+                $field_layout['labelWidth'], $field_layout['rowAdvance'], true,
             );
 
             static::writeText(
                 $pdf, $field['value'],
                 $field_layout['valueX'], $currentY,
-                'freemono', 'B', $fieldSize, 'L',
-                $valueWidth, $rowAdvance, true, 0, 0.01
+                'freemono', 'B', $field_layout['fieldSize'], 'L',
+                $field_layout['valueWidth'], $field_layout['rowAdvance'], true, 0, 0.01
             );
-            $currentY += $rowAdvance;
+            $currentY += $field_layout['rowAdvance'];;
         }
 
         if ($record->has('barcode1d')) {

--- a/app/Models/Labels/Tapes/Dymo/LabelWriter_1933081.php
+++ b/app/Models/Labels/Tapes/Dymo/LabelWriter_1933081.php
@@ -126,6 +126,22 @@ class LabelWriter_1933081 extends LabelWriter
             $currentY += $titleAdvance;
         }
         foreach ($fields as $field) {
+            $rawLabel = $field['label'] ?? null;
+            $value    = (string)($field['value'] ?? '');
+
+            // No label: value takes the whole row
+            if (!is_string($rawLabel) || trim($rawLabel) === '') {
+                static::writeText(
+                    $pdf, $value,
+                    $currentX, $currentY,
+                    'freemono', 'B', $fieldSize, 'L',
+                    $usableWidth, $rowAdvance, true, 0, 0.01
+                );
+
+                $currentY += $rowAdvance;
+                continue;
+            }
+
             $labelText = rtrim($field['label'], ':') . ':';
 
             static::writeText(

--- a/app/Models/Labels/Tapes/Dymo/LabelWriter_1933081.php
+++ b/app/Models/Labels/Tapes/Dymo/LabelWriter_1933081.php
@@ -81,19 +81,18 @@ class LabelWriter_1933081 extends LabelWriter
             );
             $currentX += $barcodeSize + self::BARCODE_MARGIN;
             $usableWidth -= $barcodeSize + self::BARCODE_MARGIN;
-        } 
-
-        if ($record->has('title')) {
-            static::writeText(
-                $pdf, $record->get('title'),
-                $currentX, $currentY,
-                'freesans', 'b', self::TITLE_SIZE, 'L',
-                $usableWidth, self::TITLE_SIZE, true, 0
-            );
-            $currentY += self::TITLE_SIZE + self::TITLE_MARGIN;
         }
 
+        $title = $record->has('title') ? $record->get('title') : null;
         $fields = $record->get('fields');
+        $maxFields = $this->getSupportFields();
+        $fields = collect($fields);
+        if ($title) {
+            $maxFields = max(0, $maxFields - 1); // title consumes one row’s worth of space
+        }
+
+        $fields = $fields->take($maxFields)->values();
+
         $usableHeight = $pa->h
             - self::TAG_SIZE           // bottom tag text
             - self::BARCODE_MARGIN;    // gap between fields and 1D
@@ -107,29 +106,42 @@ class LabelWriter_1933081 extends LabelWriter
             baseLabelSize: self::LABEL_SIZE,
             baseFieldSize: self::FIELD_SIZE,
             baseFieldMargin: self::FIELD_MARGIN,
+            title: $title,
+            baseTitleSize: self::TITLE_SIZE,
+            baseTitleMargin: self::TITLE_MARGIN,
             baseLabelPadding: 1.5,
             baseGap: 1.5,
             maxScale: 1.8,
             labelFont: 'freesans',
         );
+        extract($field_layout);
 
+        if ($hasTitle) {
+            static::writeText(
+                $pdf, $title,
+                $currentX, $currentY,
+                'freesans', 'b', $titleSize, 'L',
+                $usableWidth, $titleSize, true, 0
+            );
+            $currentY += $titleAdvance;
+        }
         foreach ($fields as $field) {
             $labelText = rtrim($field['label'], ':') . ':';
 
             static::writeText(
                 $pdf, $labelText,
                 $currentX, $currentY,
-                'freesans', '', $field_layout['labelSize'], 'L',
-                $field_layout['labelWidth'], $field_layout['rowAdvance'], true, 0
+                'freesans', '', $labelSize, 'L',
+                $labelWidth, $rowAdvance, true, 0
             );
 
             static::writeText(
                 $pdf, $field['value'],
                 $field_layout['valueX'], $currentY,
-                'freemono', 'B', $field_layout['fieldSize'], 'L',
-                $field_layout['valueWidth'], $field_layout['rowAdvance'], true, 0, 0.01
+                'freemono', 'B', $fieldSize, 'L',
+                $valueWidth, $rowAdvance, true, 0, 0.01
             );
-            $currentY += $field_layout['rowAdvance'];
+            $currentY += $rowAdvance;
         }
 
         if ($record->has('barcode1d')) {

--- a/app/Models/Labels/Tapes/Dymo/LabelWriter_2112283.php
+++ b/app/Models/Labels/Tapes/Dymo/LabelWriter_2112283.php
@@ -126,6 +126,22 @@ class LabelWriter_2112283 extends LabelWriter
             $currentY += $titleAdvance;
         }
         foreach ($fields as $field) {
+            $rawLabel = $field['label'] ?? null;
+            $value    = (string)($field['value'] ?? '');
+
+            // No label: value takes the whole row
+            if (!is_string($rawLabel) || trim($rawLabel) === '') {
+                static::writeText(
+                    $pdf, $value,
+                    $currentX, $currentY,
+                    'freemono', 'B', $fieldSize, 'L',
+                    $usableWidth, $rowAdvance, true, 0, 0.01
+                );
+
+                $currentY += $rowAdvance;
+                continue;
+            }
+
             $labelText = rtrim($field['label'], ':') . ':';
 
             static::writeText(

--- a/app/Models/Labels/Tapes/Dymo/LabelWriter_2112283.php
+++ b/app/Models/Labels/Tapes/Dymo/LabelWriter_2112283.php
@@ -114,16 +114,15 @@ class LabelWriter_2112283 extends LabelWriter
             maxScale: 1.8,
             labelFont: 'freesans',
         );
-        extract($field_layout);
 
-        if ($hasTitle) {
+        if ($field_layout['hasTitle']) {
             static::writeText(
                 $pdf, $title,
                 $currentX, $currentY,
-                'freesans', 'b', $titleSize, 'L',
-                $usableWidth, $titleSize, true, 0
+                'freesans', 'b', $field_layout['titleSize'], 'L',
+                $usableWidth, $field_layout['titleSize'], true, 0
             );
-            $currentY += $titleAdvance;
+            $currentY += $field_layout['titleAdvance'];
         }
         foreach ($fields as $field) {
             $rawLabel = $field['label'] ?? null;
@@ -134,11 +133,11 @@ class LabelWriter_2112283 extends LabelWriter
                 static::writeText(
                     $pdf, $value,
                     $currentX, $currentY,
-                    'freemono', 'B', $fieldSize, 'L',
-                    $usableWidth, $rowAdvance, true, 0, 0.01
+                    'freemono', 'B', $field_layout['fieldSize'], 'L',
+                    $usableWidth, $field_layout['rowAdvance'], true, 0, 0.01
                 );
 
-                $currentY += $rowAdvance;
+                $currentY += $field_layout['rowAdvance'];
                 continue;
             }
 
@@ -147,17 +146,17 @@ class LabelWriter_2112283 extends LabelWriter
             static::writeText(
                 $pdf, $labelText,
                 $currentX, $currentY,
-                'freesans', '', $labelSize, 'L',
-                $labelWidth, $rowAdvance, true, 0
+                'freesans', '', $field_layout['labelSize'], 'L',
+                $field_layout['labelWidth'], $field_layout['rowAdvance'], true,
             );
 
             static::writeText(
                 $pdf, $field['value'],
                 $field_layout['valueX'], $currentY,
-                'freemono', 'B', $fieldSize, 'L',
-                $valueWidth, $rowAdvance, true, 0, 0.01
+                'freemono', 'B', $field_layout['fieldSize'], 'L',
+                $field_layout['valueWidth'], $field_layout['rowAdvance'], true, 0, 0.01
             );
-            $currentY += $rowAdvance;
+            $currentY += $field_layout['rowAdvance'];;
         }
         if ($record->has('barcode1d')) {
             static::write1DBarcode(

--- a/resources/lang/en-US/admin/settings/general.php
+++ b/resources/lang/en-US/admin/settings/general.php
@@ -387,7 +387,7 @@ return [
     'label2_template'         => 'Template',
     'label2_template_help'    => 'Select which template to use for label generation',
     'label2_title'            => 'Title',
-    'label2_title_help'       => 'The title to show on labels that support it',
+    'label2_title_help'       => 'The title to show on labels that support it. <br>This will occupy the first Label Field row.',
     'label2_title_help_phold' => 'The placeholder <code>{COMPANY}</code> will be replaced with the asset&apos;s company name',
     'label2_asset_logo'       => 'Use Asset Logo',
     'label2_asset_logo_help'  => 'Use the logo of the asset&apos;s assigned company, rather than the value at <code>:setting_name</code>',


### PR DESCRIPTION
This fixes the title trying to cram onto the label. Now, the title takes the place of the first label row.

This also corrects spacing when a label field doesnt have a 'label' to go with the value  ie `null`: John Smith. Now, the value will extend the whole row.
<img width="796" height="234" alt="image" src="https://github.com/user-attachments/assets/683c815f-d9b1-4ae4-aad3-ca0a152f30ca" />
<img width="642" height="363" alt="image" src="https://github.com/user-attachments/assets/706548db-280b-4ea7-be7b-69a55a2f502f" />

Title help text:
<img width="516" height="162" alt="image" src="https://github.com/user-attachments/assets/bc958aa4-0b86-4967-9218-014ffa4f800e" />

Fixes: #18353 
