### PR TITLE
Added eager load to Expiring Alerts command

### DIFF
--- a/app/Console/Commands/SendExpirationAlerts.php
+++ b/app/Console/Commands/SendExpirationAlerts.php
@@ -55,6 +55,8 @@ class SendExpirationAlerts extends Command
             // Expiring Assets
             $assets = Asset::getExpiringWarrantyOrEol($alert_interval);
 
+            $assets->load(['assignedTo', 'supplier']);
+
             if ($assets->count() > 0) {
 
                 Mail::to($recipients)->send(new ExpiringAssetsMail($assets, $alert_interval));


### PR DESCRIPTION
This PR simply eager loads `assignedTo` and `supplier` within the `snipeit:expiring-alerts` command. 

Locally, for 16 assets with expiring warranties or that are reaching their end of life the query count dropped from 29 to 13 by eliminating the n+1.

| Before | After |
|--------|--------|
| <img width="1754" height="2508" alt="image" src="https://github.com/user-attachments/assets/9492a5ac-f1b4-4533-829f-d4173ba9778c" /> | <img width="1772" height="1280" alt="image" src="https://github.com/user-attachments/assets/4efd2f80-affe-4c77-a7e5-8278b8d9e52e" /> |

---

[RB-20665]
