### PR TITLE
Do not delete asset name if update request does not have a name

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -810,7 +810,10 @@ class AssetsController extends Controller
             }
 
             if (isset($target)) {
-                $asset->checkOut($target, auth()->user(), date('Y-m-d H:i:s'), '', 'Checked out on asset update', e($request->input('name')), $location);
+                // Using `->has` preserves the asset name if the name parameter was not included in request.
+                $asset_name = request()->has('name') ? request('name') : $asset->name;
+
+                $asset->checkOut($target, auth()->user(), date('Y-m-d H:i:s'), '', 'Checked out on asset update', $asset_name, $location);
             }
 
             if ($asset->image) {


### PR DESCRIPTION
Fixes https://github.com/grokability/snipe-it/issues/17770 which still exists.

Upon update of an asset, if the request does not have a 'name', the old name is deleted.
Perform the same check as in checkout()

https://github.com/bilias/snipe-it/blob/2a8ebd2212de9023ec8296b929276a02b0dac9fd/app/Http/Controllers/Api/AssetsController.php#L970-L984