### PR TITLE
Moved helper query, to eager load through Asset API index

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -1583,20 +1583,6 @@ class Helper
                 'he-IL'
             ]) ? 'rtl' : 'ltr';
     }
-    public static function getAssetFirstCheckout($assetId) {
-
-        if (!$assetId) {
-            return null;
-        }
-        $first_checkout = Actionlog::where('item_id', $assetId)
-            ->where('item_type', Asset::class)
-            ->where('action_type', 'checkout')
-            ->oldest('created_at')
-            ->first();
-
-        return self::getFormattedDateObject($first_checkout?->created_at, 'datetime');
-    }
-
 
     static public function getRedirectOption($request, $id, $table, $item_id = null) : RedirectResponse
     {

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -15,6 +15,7 @@ use App\Http\Transformers\ComponentsTransformer;
 use App\Http\Transformers\LicensesTransformer;
 use App\Http\Transformers\SelectlistTransformer;
 use App\Models\AccessoryCheckout;
+use App\Models\Actionlog;
 use App\Models\Asset;
 use App\Models\AssetModel;
 use App\Models\CheckoutAcceptance;
@@ -153,6 +154,15 @@ class AssetsController extends Controller
         }
 
         $assets = Asset::select('assets.*')
+            ->addSelect([
+                'first_checkout_at' => Actionlog::query()
+                    ->select('created_at')
+                    ->whereColumn('item_id', 'assets.id')
+                    ->where('item_type', Asset::class)
+                    ->where('action_type', 'checkout')
+                    ->orderBy('created_at')
+                    ->limit(1),
+            ])
             ->with(
                 'model',
                 'location',

--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -104,7 +104,7 @@ class AssetsTransformer
             'next_audit_date' => Helper::getFormattedDateObject($asset->next_audit_date, 'date'),
             'deleted_at' => Helper::getFormattedDateObject($asset->deleted_at, 'datetime'),
             'purchase_date' => Helper::getFormattedDateObject($asset->purchase_date, 'date'),
-            'first_checkout' => Helper::getAssetFirstCheckout($asset->id),
+            'first_checkout' => Helper::getFormattedDateObject($asset->first_checkout_at, 'datetime'),
             'age' => $asset->purchase_date ? $asset->purchase_date->locale(app()->getLocale())->diffForHumans() : '',
             'last_checkout' => Helper::getFormattedDateObject($asset->last_checkout, 'datetime'),
             'last_checkin' => Helper::getFormattedDateObject($asset->last_checkin, 'datetime'),

--- a/app/Presenters/AssetPresenter.php
+++ b/app/Presenters/AssetPresenter.php
@@ -158,7 +158,8 @@ class AssetPresenter extends Presenter
                 'visible' => false,
                 'title' => trans('general.first_checkout'),
                 'formatter' => 'dateDisplayFormatter',
-            ], [
+            ],
+            [
                 'field' => 'age',
                 'searchable' => false,
                 'sortable' => false,

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -1112,7 +1112,7 @@
                                                 </strong>
                                             </div>
                                             <div class="col-md-9">
-                                                {{ Helper::getAssetFirstCheckout($asset->id)['formatted'] ?? '' }}
+                                                {{ Helper::getFormattedDateObject($asset->first_checkout_at, 'datetime')['formatted'] ?? '' }}
                                             </div>
                                         </div>
 


### PR DESCRIPTION
This moves the 1st checkout query from the helper file to eager loading when selecting the assets through the API for the index. Bringing the query count down from 38~ to 18~
<img width="678" height="238" alt="image" src="https://github.com/user-attachments/assets/dc86c336-94ff-474c-8dfe-e66a07347b2b" />

<img width="678" height="238" alt="image" src="https://github.com/user-attachments/assets/9dd25a49-da1a-42a2-b1a4-8436ef319187" />
