### PR TITLE
Fixed #18475 - reference the correct model when checking in an asset via import

### DIFF
--- a/app/Importer/AssetImporter.php
+++ b/app/Importer/AssetImporter.php
@@ -85,9 +85,9 @@ class AssetImporter extends ItemImporter
         if ($this->findCsvMatch($row, 'id')!='') {
             // Override asset if an ID was given
             \Log::debug('Finding asset by ID: '.$this->findCsvMatch($row, 'id'));
-            $asset = Asset::find($this->findCsvMatch($row, 'id'));
+            $asset = Asset::with('assignedTo')->find($this->findCsvMatch($row, 'id'));
         } else {
-            $asset = Asset::where(['asset_tag'=> (string) $asset_tag])->first();
+            $asset = Asset::with('assignedTo')->where(['asset_tag' => (string) $asset_tag])->first();
         }
         
         if ($asset) {
@@ -203,7 +203,7 @@ class AssetImporter extends ItemImporter
             if (isset($target) && ($target !== false)) {
                 if (!is_null($asset->assigned_to)){
                     if ($asset->assigned_to != $target->id) {
-                        event(new CheckoutableCheckedIn($asset, User::find($asset->assigned_to), auth()->user(), 'Checkin from CSV Importer', $checkin_date));
+                        event(new CheckoutableCheckedIn($asset, $asset->assigned, auth()->user(), 'Checkin from CSV Importer', $checkin_date));
                     }
                 }
 


### PR DESCRIPTION
As noted in #18475, when updating an asset that is checked out to a location via the importer and part of the update is re-assigning the asset to a different location then the action log would record the "check in" as coming from a User with the same id as the original location.

This is because we were always referencing a user by calling `User::find($asset->assigned_to)`. This has been changed so that we pass the model that is currently assigned to the `CheckoutableCheckedIn` event.

---

Fixes #18475