### PR TITLE
Add translation and template name for Label Preview

### DIFF
--- a/resources/lang/en-US/admin/settings/general.php
+++ b/resources/lang/en-US/admin/settings/general.php
@@ -402,6 +402,7 @@ return [
     'select_template'         => 'Select a Template',
     'label2_fields'           => 'Field Definitions',
     'label2_fields_help'      => 'Fields can be added, removed, and reordered in the left column. For each field, multiple options for Label and DataSource can be added, removed, and reordered in the right column. Field changes made here will be reflected immediately in the preview below but must be saved for them to apply to new labels.',
+    "label2_label_preview"    => 'Label Preview',
     'purge_barcodes' => 'Purge Barcodes',
     'help_asterisk_bold'    => 'Text entered as <code>**text**</code> will be displayed as bold',
     'help_blank_to_use'     => 'Leave blank to use the value from <code>:setting_name</code>',

--- a/resources/views/settings/labels.blade.php
+++ b/resources/views/settings/labels.blade.php
@@ -382,7 +382,7 @@
 
                     <fieldset name="label-preview">
                         <x-form.legend>
-                            Label Preview
+                            {!! trans('admin/settings/general.label2_label_preview').': '.$setting->label2_template!!}
                         </x-form.legend>
                             <div class="col-md-12" style="margin-bottom: 10px;">
                                 @include('partials.label2-preview')

--- a/resources/views/settings/labels.blade.php
+++ b/resources/views/settings/labels.blade.php
@@ -382,7 +382,7 @@
 
                     <fieldset name="label-preview">
                         <x-form.legend>
-                            {!! trans('admin/settings/general.label2_label_preview').': '.$setting->label2_template!!}
+                            {{ trans('admin/settings/general.label2_label_preview') }}: <code>{{ $setting->label2_template}}</code>
                         </x-form.legend>
                             <div class="col-md-12" style="margin-bottom: 10px;">
                                 @include('partials.label2-preview')


### PR DESCRIPTION
Adds translation and the template name for the label preview area
| Before | After |
|--------|-------|
| <img width="479" height="320" alt="Before – labels overlapping vertically" src="https://github.com/user-attachments/assets/d12bd035-249b-48c1-adfe-3c5b19b64148" /> | <img width="494" height="324" alt="image" src="https://github.com/user-attachments/assets/fa3b9b3d-a924-4a5c-b176-6bbd00a7cd89" /> |

