### PR TITLE
Fix Livewire and Passport routes for subpath hosting

### DIFF
--- a/app/Providers/LivewireServiceProvider.php
+++ b/app/Providers/LivewireServiceProvider.php
@@ -21,12 +21,18 @@ class LivewireServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        Livewire::setUpdateRoute(function ($handle) {
-            return Route::post('/' . config('livewire.url_prefix') . '/livewire/update', $handle);
+        $prefix = trim((string) config('livewire.url_prefix', ''), '/');
+        if ($prefix === '') {
+            $prefix = trim((string) parse_url(config('app.url'), PHP_URL_PATH), '/');
+        }
+        $prefix = $prefix === '' ? '' : '/' . $prefix;
+
+        Livewire::setUpdateRoute(function ($handle) use ($prefix) {
+            return Route::post($prefix . '/livewire/update', $handle);
         });
 
-        Livewire::setScriptRoute(function ($handle) {
-            return Route::get('/' . config('livewire.url_prefix') . '/livewire/livewire.js', $handle);
+        Livewire::setScriptRoute(function ($handle) use ($prefix) {
+            return Route::get($prefix . '/livewire/livewire.js', $handle);
         });
     }
 }

--- a/resources/views/vendor/passport/authorize.blade.php
+++ b/resources/views/vendor/passport/authorize.blade.php
@@ -64,7 +64,7 @@
 
                         <div class="buttons">
                             <!-- Authorize Button -->
-                            <form method="post" action="/oauth/authorize">
+                            <form method="post" action="{{ url('/oauth/authorize') }}">
                                 {{ csrf_field() }}
 
                                 <input type="hidden" name="state" value="{{ $request->state }}">
@@ -73,7 +73,7 @@
                             </form>
 
                             <!-- Cancel Button -->
-                            <form method="post" action="/oauth/authorize">
+                            <form method="post" action="{{ url('/oauth/authorize') }}">
                                 {{ csrf_field() }}
                                 {{ method_field('DELETE') }}
 


### PR DESCRIPTION
- Fix Livewire update/script route generation to honor subpath hosting, falling back to the path in `APP_URL`.
- Update Passport authorize form actions to use `url()` so they work under a subpath.

This resolves Livewire POSTs going to `/livewire/update` instead of the expected `/hardware-inventory/livewire/update` in our case.