### PR TITLE
Fixes title alignment to fit label L7163_A

### DIFF
--- a/app/Models/Labels/Sheets/Avery/L7163_A.php
+++ b/app/Models/Labels/Sheets/Avery/L7163_A.php
@@ -3,16 +3,18 @@
 namespace App\Models\Labels\Sheets\Avery;
 
 
+use App\Helpers\Helper;
+
 class L7163_A extends L7163
 {
     private const BARCODE_MARGIN =   1.80;
     private const TAG_SIZE       =   4.80;
     private const TITLE_SIZE     =   5.00;
-    private const TITLE_MARGIN   =   1.80;
-    private const LABEL_SIZE     =   2.35;
+    private const TITLE_MARGIN   =   .75;
+    private const LABEL_SIZE     =   3.35;
     private const LABEL_MARGIN   = - 0.30;
     private const FIELD_SIZE     =   4.80;
-    private const FIELD_MARGIN   =   0.30;
+    private const FIELD_MARGIN   =   0.20;
 
     public function getUnit()
     {
@@ -74,17 +76,7 @@ class L7163_A extends L7163
         $currentX = $pa->x1;
         $currentY = $pa->y1;
 
-        if ($record->has('title')) {
-            static::writeText(
-                $pdf, $record->get('title'),
-                $currentX, $currentY,
-                'freesans', '', self::TITLE_SIZE, 'C',
-                $usableWidth, self::TITLE_SIZE, true, 0
-            );
-            $currentY += self::TITLE_SIZE + self::TITLE_MARGIN;
-        }
-
-        $barcodeSize = $pa->h - self::TITLE_SIZE - self::TITLE_MARGIN - self::TAG_SIZE;
+        $barcodeSize = $pa->h - self::TAG_SIZE;
         
         if ($record->has('barcode2d')) {
             static::writeText(
@@ -108,25 +100,71 @@ class L7163_A extends L7163
                 $usableWidth, self::TAG_SIZE, true, 0
             );
         }
+        $title = $record->has('title') ? $record->get('title') : null;
+        $fields = $record->get('fields');
 
-        foreach ($record->get('fields') as $field) {
+        $field_layout = Helper::labelFieldLayoutScaling(
+            pdf: $pdf,
+            fields: $fields,
+            currentX: $currentX,
+            usableWidth: $usableWidth,
+            usableHeight: $usableHeight,
+            baseLabelSize: self::LABEL_SIZE,
+            baseFieldSize: self::FIELD_SIZE,
+            baseFieldMargin: self::FIELD_MARGIN,
+            title: $title,
+            baseTitleSize: self::TITLE_SIZE,
+            baseTitleMargin: self::TITLE_MARGIN,
+            baseLabelPadding: 1.5,
+            baseGap: 1.5,
+            maxScale: 1.8,
+            labelFont: 'freesans',
+        );
+
+        if ($field_layout['hasTitle']) {
             static::writeText(
-                $pdf, $field['label'],
+                $pdf, $title,
                 $currentX, $currentY,
-                'freesans', '', self::LABEL_SIZE, 'L',
-                $usableWidth, self::LABEL_SIZE, true, 0
+                'freesans', 'b', $field_layout['titleSize'], 'L',
+                $usableWidth, $field_layout['titleSize'], true, 0
             );
-            $currentY += self::LABEL_SIZE + self::LABEL_MARGIN;
+            $currentY += $field_layout['titleAdvance'];
+        }
+
+        foreach ($fields as $field) {
+            $rawLabel = $field['label'] ?? null;
+            $value    = (string)($field['value'] ?? '');
+
+            // No label: value takes the whole row
+            if (!is_string($rawLabel) || trim($rawLabel) === '') {
+                static::writeText(
+                    $pdf, $value,
+                    $currentX, $currentY,
+                    'freemono', 'B', $field_layout['fieldSize'], 'L',
+                    $usableWidth, $field_layout['rowAdvance'], true, 0, 0.01
+                );
+
+                $currentY += $field_layout['rowAdvance'];
+                continue;
+            }
+
+            $labelText = rtrim($field['label'], ':') . ':';
+
+            static::writeText(
+                $pdf, $labelText,
+                $currentX, $currentY,
+                'freesans', '', $field_layout['labelSize'], 'L',
+                $field_layout['labelWidth'], $field_layout['rowAdvance'], true,
+            );
 
             static::writeText(
                 $pdf, $field['value'],
-                $currentX, $currentY,
-                'freemono', 'B', self::FIELD_SIZE, 'L',
-                $usableWidth, self::FIELD_SIZE, true, 0, 0.5
+                $field_layout['valueX'], $currentY,
+                'freemono', 'B', $field_layout['fieldSize'], 'L',
+                $field_layout['valueWidth'], $field_layout['rowAdvance'], true, 0, 0.01
             );
-            $currentY += self::FIELD_SIZE + self::FIELD_MARGIN;
+            $currentY += $field_layout['rowAdvance'];;
         }
-
     }
 }
 


### PR DESCRIPTION
Fix title alignment to match 2D barcode and field layout
| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/90dc08f0-d225-48cf-b01a-03197c89fdac) | ![After](https://github.com/user-attachments/assets/388e82ed-88db-4b07-8f66-83bf9835c4ac) |
Fixes #18523