### PR TITLE
Updated subject line of acceptance reminder emails

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -1228,12 +1228,14 @@ class ReportsController extends Controller
         ];
         $mailable= $lookup[get_class($acceptance->checkoutable)];
 
-        return new $mailable($acceptance->checkoutable,
+        return new $mailable(
+            $acceptance->checkoutable,
             $acceptance->checkedOutTo ?? $acceptance->assignedTo,
             $logItem->adminuser,
             $acceptance,
-            $acceptance->note);
-
+            $acceptance->note,
+            firstTimeSending: false,
+        );
     }
     /**
      * sentAssetAcceptanceReminder

--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -1212,8 +1212,6 @@ class ReportsController extends Controller
         if (is_null($email) || $email === '') {
             return redirect()->route('reports/unaccepted_assets')->with('error', trans('general.no_email'));
         }
-
-        $acceptance->checkoutable->checkout_qty = 1;
         $mailable = $this->getCheckoutMailType($acceptance, $logItem);
         Mail::to($email)->send($mailable->locale($locale));
 

--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -1212,6 +1212,8 @@ class ReportsController extends Controller
         if (is_null($email) || $email === '') {
             return redirect()->route('reports/unaccepted_assets')->with('error', trans('general.no_email'));
         }
+
+        $acceptance->checkoutable->checkout_qty = 1;
         $mailable = $this->getCheckoutMailType($acceptance, $logItem);
         Mail::to($email)->send($mailable->locale($locale));
 

--- a/app/Mail/CheckoutAccessoryMail.php
+++ b/app/Mail/CheckoutAccessoryMail.php
@@ -18,10 +18,12 @@ class CheckoutAccessoryMail extends BaseMailable
 {
     use Queueable, SerializesModels;
 
+    private bool $firstTimeSending;
+
     /**
      * Create a new message instance.
      */
-    public function __construct(Accessory $accessory, $checkedOutTo, User $checkedOutBy, $acceptance, $note)
+    public function __construct(Accessory $accessory, $checkedOutTo, User $checkedOutBy, $acceptance, $note, bool $firstTimeSending = true)
     {
         $this->item = $accessory;
         $this->admin = $checkedOutBy;
@@ -29,6 +31,7 @@ class CheckoutAccessoryMail extends BaseMailable
         $this->checkout_qty = $accessory->checkout_qty;
         $this->target = $checkedOutTo;
         $this->acceptance = $acceptance;
+        $this->firstTimeSending = $firstTimeSending;
         $this->settings = Setting::getSettings();
     }
 
@@ -41,7 +44,7 @@ class CheckoutAccessoryMail extends BaseMailable
 
         return new Envelope(
             from: $from,
-            subject: trans_choice('mail.Accessory_Checkout_Notification', $this->checkout_qty),
+            subject: $this->getSubject(),
         );
     }
 
@@ -112,5 +115,14 @@ class CheckoutAccessoryMail extends BaseMailable
     public function attachments(): array
     {
         return [];
+    }
+
+    private function getSubject(): string
+    {
+        if ($this->firstTimeSending) {
+            return trans_choice('mail.Accessory_Checkout_Notification', $this->checkout_qty);
+        }
+
+        return trans('mail.unaccepted_asset_reminder');
     }
 }

--- a/app/Mail/CheckoutAccessoryMail.php
+++ b/app/Mail/CheckoutAccessoryMail.php
@@ -91,12 +91,16 @@ class CheckoutAccessoryMail extends BaseMailable
             return trans_choice('mail.new_item_checked_location', $this->checkout_qty, ['location' => $this->target->name]);
         }
 
-        if ($this->requiresAcceptance()) {
+        if ($this->firstTimeSending && $this->requiresAcceptance()) {
             return trans_choice('mail.new_item_checked_with_acceptance', $this->checkout_qty);
         }
 
-        if (!$this->requiresAcceptance()) {
+        if ($this->firstTimeSending && !$this->requiresAcceptance()) {
             return trans_choice('mail.new_item_checked', $this->checkout_qty);
+        }
+
+        if (!$this->firstTimeSending && $this->requiresAcceptance()) {
+            return trans('mail.recent_item_checked');
         }
 
         // we shouldn't get here but let's send a default message just in case

--- a/app/Mail/CheckoutConsumableMail.php
+++ b/app/Mail/CheckoutConsumableMail.php
@@ -68,6 +68,7 @@ class CheckoutConsumableMail extends BaseMailable
                 'req_accept'    => $req_accept,
                 'accept_url'    => $accept_url,
                 'qty'           => $this->qty,
+                'introduction_line' => $this->introductionLine(),
             ]
         );
     }
@@ -89,5 +90,28 @@ class CheckoutConsumableMail extends BaseMailable
         }
 
         return trans('mail.unaccepted_asset_reminder');
+    }
+
+    private function introductionLine()
+    {
+        if ($this->firstTimeSending && $this->requiresAcceptance()) {
+            return trans_choice('mail.new_item_checked_with_acceptance', $this->qty);
+        }
+
+        if ($this->firstTimeSending && !$this->requiresAcceptance()) {
+            return trans_choice('mail.new_item_checked', $this->qty);
+        }
+
+        if (!$this->firstTimeSending && $this->requiresAcceptance()) {
+            return trans('mail.recent_item_checked');
+        }
+
+        // we shouldn't get here but let's send a default message just in case
+        return trans('new_item_checked');
+    }
+
+    private function requiresAcceptance(): int|bool
+    {
+        return method_exists($this->item, 'requireAcceptance') ? $this->item->requireAcceptance() : 0;
     }
 }

--- a/app/Mail/CheckoutConsumableMail.php
+++ b/app/Mail/CheckoutConsumableMail.php
@@ -15,10 +15,12 @@ class CheckoutConsumableMail extends BaseMailable
 {
     use Queueable, SerializesModels;
 
+    private bool $firstTimeSending;
+
     /**
      * Create a new message instance.
      */
-    public function __construct(Consumable $consumable, $checkedOutTo, User $checkedOutBy, $acceptance, $note)
+    public function __construct(Consumable $consumable, $checkedOutTo, User $checkedOutBy, $acceptance, $note, bool $firstTimeSending = true)
     {
         $this->item = $consumable;
         $this->admin = $checkedOutBy;
@@ -26,6 +28,7 @@ class CheckoutConsumableMail extends BaseMailable
         $this->target = $checkedOutTo;
         $this->acceptance = $acceptance;
         $this->qty = $consumable->checkout_qty;
+        $this->firstTimeSending = $firstTimeSending;
 
         $this->settings = Setting::getSettings();
     }
@@ -39,7 +42,7 @@ class CheckoutConsumableMail extends BaseMailable
 
         return new Envelope(
             from: $from,
-            subject: trans('mail.Confirm_consumable_delivery'),
+            subject: $this->getSubject(),
         );
     }
 
@@ -77,5 +80,14 @@ class CheckoutConsumableMail extends BaseMailable
     public function attachments(): array
     {
         return [];
+    }
+
+    private function getSubject(): string
+    {
+        if ($this->firstTimeSending) {
+            return trans('mail.Confirm_consumable_delivery');
+        }
+
+        return trans('mail.unaccepted_asset_reminder');
     }
 }

--- a/app/Mail/CheckoutLicenseMail.php
+++ b/app/Mail/CheckoutLicenseMail.php
@@ -16,10 +16,12 @@ class CheckoutLicenseMail extends BaseMailable
 {
     use Queueable, SerializesModels;
 
+    private bool $firstTimeSending;
+
     /**
      * Create a new message instance.
      */
-    public function __construct(LicenseSeat $licenseSeat, $checkedOutTo, User $checkedOutBy, $acceptance, $note)
+    public function __construct(LicenseSeat $licenseSeat, $checkedOutTo, User $checkedOutBy, $acceptance, $note, bool $firstTimeSending = true)
     {
         $this->item = $licenseSeat;
         $this->admin = $checkedOutBy;
@@ -27,6 +29,7 @@ class CheckoutLicenseMail extends BaseMailable
         $this->acceptance = $acceptance;
         $this->settings = Setting::getSettings();
         $this->target = $checkedOutTo;
+        $this->firstTimeSending = $firstTimeSending;
 
         if($this->target instanceof User){
             $this->target = $this->target->display_name;
@@ -45,7 +48,7 @@ class CheckoutLicenseMail extends BaseMailable
 
         return new Envelope(
             from: $from,
-            subject: trans('mail.Confirm_license_delivery'),
+            subject: $this->getSubject(),
         );
     }
 
@@ -81,5 +84,14 @@ class CheckoutLicenseMail extends BaseMailable
     public function attachments(): array
     {
         return [];
+    }
+
+    private function getSubject(): string
+    {
+        if ($this->firstTimeSending) {
+            return trans('mail.Confirm_license_delivery');
+        }
+
+        return trans('mail.unaccepted_asset_reminder');
     }
 }

--- a/app/Mail/CheckoutLicenseMail.php
+++ b/app/Mail/CheckoutLicenseMail.php
@@ -72,6 +72,7 @@ class CheckoutLicenseMail extends BaseMailable
                 'eula'          => $eula,
                 'req_accept'    => $req_accept,
                 'accept_url'    => $accept_url,
+                'introduction_line' => $this->introductionLine(),
             ]
         );
     }
@@ -93,5 +94,28 @@ class CheckoutLicenseMail extends BaseMailable
         }
 
         return trans('mail.unaccepted_asset_reminder');
+    }
+
+    private function introductionLine(): string
+    {
+        if ($this->firstTimeSending && $this->requiresAcceptance()) {
+            return trans_choice('mail.new_item_checked_with_acceptance', 1);
+        }
+
+        if ($this->firstTimeSending && !$this->requiresAcceptance()) {
+            return trans_choice('mail.new_item_checked', 1);
+        }
+
+        if (!$this->firstTimeSending && $this->requiresAcceptance()) {
+            return trans('mail.recent_item_checked');
+        }
+
+        // we shouldn't get here but let's send a default message just in case
+        return trans('new_item_checked');
+    }
+
+    private function requiresAcceptance(): int|bool
+    {
+        return method_exists($this->item, 'requireAcceptance') ? $this->item->requireAcceptance() : 0;
     }
 }

--- a/app/Models/AccessoryCheckout.php
+++ b/app/Models/AccessoryCheckout.php
@@ -20,6 +20,7 @@ use Watson\Validating\ValidatingTrait;
  */
 class AccessoryCheckout extends Model
 {
+    use HasFactory;
     use Searchable;
 
     protected $fillable = [
@@ -41,7 +42,7 @@ class AccessoryCheckout extends Model
      */
     public function accessory()
     {
-        return $this->hasOne(Accessory::class, 'id', 'accessory_id');
+        return $this->belongsTo(Accessory::class);
     }
 
     public function accessories()
@@ -57,7 +58,7 @@ class AccessoryCheckout extends Model
      */
     public function adminuser()
     {
-        return $this->hasOne(\App\Models\User::class, 'id', 'created_by');
+        return $this->belongsTo(User::class, 'created_by');
     }
 
     /**

--- a/database/factories/AccessoryCheckoutFactory.php
+++ b/database/factories/AccessoryCheckoutFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Accessory;
+use App\Models\AccessoryCheckout;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class AccessoryCheckoutFactory extends Factory
+{
+    protected $model = AccessoryCheckout::class;
+
+    public function definition(): array
+    {
+        return [
+            'created_by' => User::factory(),
+            'accessory_id' => Accessory::factory(),
+            'assigned_to' => User::factory(),
+            'assigned_type' => User::class,
+        ];
+    }
+}

--- a/database/factories/LicenseSeatFactory.php
+++ b/database/factories/LicenseSeatFactory.php
@@ -49,4 +49,11 @@ class LicenseSeatFactory extends Factory
             $seat->license->update(['reassignable' => false]);
         });
     }
+
+    public function requiringAcceptance()
+    {
+        return $this->afterCreating(function ($seat) {
+            $seat->license->category->update(['require_acceptance' => 1]);
+        });
+    }
 }

--- a/resources/views/mail/markdown/checkout-consumable.blade.php
+++ b/resources/views/mail/markdown/checkout-consumable.blade.php
@@ -1,7 +1,7 @@
 @component('mail::message')
 # {{ trans('mail.hello') }} {{ $target->display_name }},
 
-{{ trans_choice('mail.new_item_checked', $qty) }}
+{{ $introduction_line }}
 
 
 @component('mail::table')

--- a/resources/views/mail/markdown/checkout-license.blade.php
+++ b/resources/views/mail/markdown/checkout-license.blade.php
@@ -1,7 +1,7 @@
 @component('mail::message')
 # {{ trans('mail.hello').' '.$target.','}}
 
-{{ trans_choice('mail.new_item_checked', 1) }}
+{{ $introduction_line }}
 
 @component('mail::table')
 |        |          |

--- a/tests/Feature/Notifications/Email/AcceptanceReminderTest.php
+++ b/tests/Feature/Notifications/Email/AcceptanceReminderTest.php
@@ -110,7 +110,7 @@ class AcceptanceReminderTest extends TestCase
 
     public function testReminderIsSentToUserForAccessory()
     {
-        $accessory = Accessory::factory()->create();
+        $accessory = Accessory::factory()->requiringAcceptance()->create();
 
         $acceptance = $this->createCheckoutAcceptance($accessory, $this->assignee);
 
@@ -137,11 +137,15 @@ class AcceptanceReminderTest extends TestCase
         Mail::assertSent(CheckoutAccessoryMail::class, function (CheckoutAccessoryMail $mail) {
             return $mail->hasSubject(trans('mail.unaccepted_asset_reminder'));
         });
+
+        Mail::assertSent(CheckoutAccessoryMail::class, function (CheckoutAccessoryMail $mail) {
+            return str_contains($mail->render(), trans('mail.recent_item_checked'));
+        });
     }
 
     public function testReminderIsSentToUserForAsset()
     {
-        $asset = Asset::factory()->create();
+        $asset = Asset::factory()->requiresAcceptance()->create();
 
         $acceptance = $this->createCheckoutAcceptance($asset, $this->assignee);
 
@@ -162,11 +166,15 @@ class AcceptanceReminderTest extends TestCase
         Mail::assertSent(CheckoutAssetMail::class, function (CheckoutAssetMail $mail) {
             return $mail->hasSubject(trans('mail.unaccepted_asset_reminder'));
         });
+
+        Mail::assertSent(CheckoutAssetMail::class, function (CheckoutAssetMail $mail) {
+            return str_contains($mail->render(), trans('mail.recent_item_checked'));
+        });
     }
 
     public function testReminderIsSentToUserForConsumable()
     {
-        $consumable = Consumable::factory()->create();
+        $consumable = Consumable::factory()->requiringAcceptance()->create();
 
         $acceptance = $this->createCheckoutAcceptance($consumable, $this->assignee);
 
@@ -187,11 +195,15 @@ class AcceptanceReminderTest extends TestCase
         Mail::assertSent(CheckoutConsumableMail::class, function (CheckoutConsumableMail $mail) {
             return $mail->hasSubject(trans('mail.unaccepted_asset_reminder'));
         });
+
+        Mail::assertSent(CheckoutConsumableMail::class, function (CheckoutConsumableMail $mail) {
+            return str_contains($mail->render(), trans('mail.recent_item_checked'));
+        });
     }
 
     public function testReminderIsSentToUserForLicenseSeat()
     {
-        $licenseSeat = LicenseSeat::factory()->create();
+        $licenseSeat = LicenseSeat::factory()->requiringAcceptance()->create();
 
         $acceptance = $this->createCheckoutAcceptance($licenseSeat, $this->assignee);
 
@@ -211,6 +223,10 @@ class AcceptanceReminderTest extends TestCase
 
         Mail::assertSent(CheckoutLicenseMail::class, function (CheckoutLicenseMail $mail) {
             return $mail->hasSubject(trans('mail.unaccepted_asset_reminder'));
+        });
+
+        Mail::assertSent(CheckoutLicenseMail::class, function (CheckoutLicenseMail $mail) {
+            return str_contains($mail->render(), trans('mail.recent_item_checked'));
         });
     }
 

--- a/tests/Feature/Notifications/Email/AcceptanceReminderTest.php
+++ b/tests/Feature/Notifications/Email/AcceptanceReminderTest.php
@@ -7,6 +7,7 @@ use App\Mail\CheckoutAssetMail;
 use App\Mail\CheckoutConsumableMail;
 use App\Mail\CheckoutLicenseMail;
 use App\Models\Accessory;
+use App\Models\AccessoryCheckout;
 use App\Models\Actionlog;
 use App\Models\Asset;
 use App\Models\CheckoutAcceptance;
@@ -114,6 +115,12 @@ class AcceptanceReminderTest extends TestCase
         $acceptance = $this->createCheckoutAcceptance($accessory, $this->assignee);
 
         $this->createActionLogEntry($accessory, $this->admin, $this->assignee, $acceptance);
+
+        AccessoryCheckout::factory()
+            ->for($this->admin, 'adminuser')
+            ->for($accessory)
+            ->for($this->assignee, 'assignedTo')
+            ->create();
 
         $this->actingAs($this->admin)
             ->post(route('reports/unaccepted_assets_sent_reminder', [

--- a/tests/Feature/Notifications/Email/AcceptanceReminderTest.php
+++ b/tests/Feature/Notifications/Email/AcceptanceReminderTest.php
@@ -129,8 +129,13 @@ class AcceptanceReminderTest extends TestCase
             ->assertRedirect(route('reports/unaccepted_assets'));
 
         Mail::assertSent(CheckoutAccessoryMail::class, 1);
+
         Mail::assertSent(CheckoutAccessoryMail::class, function (CheckoutAccessoryMail $mail) {
             return $mail->hasTo($this->assignee);
+        });
+
+        Mail::assertSent(CheckoutAccessoryMail::class, function (CheckoutAccessoryMail $mail) {
+            return $mail->hasSubject(trans('mail.unaccepted_asset_reminder'));
         });
     }
 
@@ -149,8 +154,13 @@ class AcceptanceReminderTest extends TestCase
             ->assertRedirect(route('reports/unaccepted_assets'));
 
         Mail::assertSent(CheckoutAssetMail::class, 1);
+
         Mail::assertSent(CheckoutAssetMail::class, function (CheckoutAssetMail $mail) {
             return $mail->hasTo($this->assignee);
+        });
+
+        Mail::assertSent(CheckoutAssetMail::class, function (CheckoutAssetMail $mail) {
+            return $mail->hasSubject(trans('mail.unaccepted_asset_reminder'));
         });
     }
 
@@ -169,8 +179,13 @@ class AcceptanceReminderTest extends TestCase
             ->assertRedirect(route('reports/unaccepted_assets'));
 
         Mail::assertSent(CheckoutConsumableMail::class, 1);
+
         Mail::assertSent(CheckoutConsumableMail::class, function (CheckoutConsumableMail $mail) {
             return $mail->hasTo($this->assignee);
+        });
+
+        Mail::assertSent(CheckoutConsumableMail::class, function (CheckoutConsumableMail $mail) {
+            return $mail->hasSubject(trans('mail.unaccepted_asset_reminder'));
         });
     }
 
@@ -189,8 +204,13 @@ class AcceptanceReminderTest extends TestCase
             ->assertRedirect(route('reports/unaccepted_assets'));
 
         Mail::assertSent(CheckoutLicenseMail::class, 1);
+
         Mail::assertSent(CheckoutLicenseMail::class, function (CheckoutLicenseMail $mail) {
             return $mail->hasTo($this->assignee);
+        });
+
+        Mail::assertSent(CheckoutLicenseMail::class, function (CheckoutLicenseMail $mail) {
+            return $mail->hasSubject(trans('mail.unaccepted_asset_reminder'));
         });
     }
 

--- a/tests/Feature/Notifications/Email/AcceptanceReminderTest.php
+++ b/tests/Feature/Notifications/Email/AcceptanceReminderTest.php
@@ -20,7 +20,7 @@ use Illuminate\Support\Facades\Mail;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
-class AssetAcceptanceReminderTest extends TestCase
+class AcceptanceReminderTest extends TestCase
 {
     private User $admin;
     private User $assignee;

--- a/tests/Feature/Notifications/Email/AssetAcceptanceReminderTest.php
+++ b/tests/Feature/Notifications/Email/AssetAcceptanceReminderTest.php
@@ -14,6 +14,7 @@ use App\Models\Consumable;
 use App\Models\License;
 use App\Models\LicenseSeat;
 use App\Models\User;
+use Generator;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Mail;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -50,7 +51,7 @@ class AssetAcceptanceReminderTest extends TestCase
 
     public function testReminderNotSentIfAcceptanceDoesNotExist()
     {
-        $this->actingAs(User::factory()->canViewReports()->create())
+        $this->actingAs($this->admin)
             ->post(route('reports/unaccepted_assets_sent_reminder', [
                 'acceptance_id' => 999999,
             ]));
@@ -62,7 +63,7 @@ class AssetAcceptanceReminderTest extends TestCase
     {
         $checkoutAcceptanceAlreadyAccepted = CheckoutAcceptance::factory()->accepted()->create();
 
-        $this->actingAs(User::factory()->canViewReports()->create())
+        $this->actingAs($this->admin)
             ->post(route('reports/unaccepted_assets_sent_reminder', [
                 'acceptance_id' => $checkoutAcceptanceAlreadyAccepted->id,
             ]));
@@ -70,7 +71,7 @@ class AssetAcceptanceReminderTest extends TestCase
         Mail::assertNotSent(CheckoutAssetMail::class);
     }
 
-    public static function CheckoutAcceptancesToUsersWithoutEmailAddresses()
+    public static function checkoutAcceptancesToUsersWithoutEmailAddresses(): Generator
     {
         yield 'User with null email address' => [
             function () {
@@ -91,12 +92,12 @@ class AssetAcceptanceReminderTest extends TestCase
         ];
     }
 
-    #[DataProvider('CheckoutAcceptancesToUsersWithoutEmailAddresses')]
+    #[DataProvider('checkoutAcceptancesToUsersWithoutEmailAddresses')]
     public function testUserWithoutEmailAddressHandledGracefully($callback)
     {
         $checkoutAcceptance = $callback();
 
-        $this->actingAs(User::factory()->canViewReports()->create())
+        $this->actingAs($this->admin)
             ->post(route('reports/unaccepted_assets_sent_reminder', [
                 'acceptance_id' => $checkoutAcceptance->id,
             ]))

--- a/tests/Feature/Notifications/Email/AssetAcceptanceReminderTest.php
+++ b/tests/Feature/Notifications/Email/AssetAcceptanceReminderTest.php
@@ -21,11 +21,17 @@ use Tests\TestCase;
 
 class AssetAcceptanceReminderTest extends TestCase
 {
+    private User $admin;
+    private User $assignee;
+
     protected function setUp(): void
     {
         parent::setUp();
 
         Mail::fake();
+
+        $this->admin = User::factory()->canViewReports()->create();
+        $this->assignee = User::factory()->create();
     }
 
     public function testMustHavePermissionToSendReminder()
@@ -102,97 +108,81 @@ class AssetAcceptanceReminderTest extends TestCase
 
     public function testReminderIsSentToUserForAccessory()
     {
-        $checkedOutBy = User::factory()->canViewReports()->create();
-
-        $assignee = User::factory()->create(['email' => 'test@example.com']);
-
         $accessory = Accessory::factory()->create();
 
-        $acceptance = $this->createCheckoutAcceptance($accessory, $assignee);
+        $acceptance = $this->createCheckoutAcceptance($accessory, $this->assignee);
 
-        $this->createActionLogEntry($accessory, $checkedOutBy, $assignee, $acceptance);
+        $this->createActionLogEntry($accessory, $this->admin, $this->assignee, $acceptance);
 
-        $this->actingAs($checkedOutBy)
+        $this->actingAs($this->admin)
             ->post(route('reports/unaccepted_assets_sent_reminder', [
                 'acceptance_id' => $acceptance->id,
             ]))
             ->assertRedirect(route('reports/unaccepted_assets'));
 
         Mail::assertSent(CheckoutAccessoryMail::class, 1);
-        Mail::assertSent(CheckoutAccessoryMail::class, function (CheckoutAccessoryMail $mail) use ($assignee) {
-            return $mail->hasTo($assignee->email);
+        Mail::assertSent(CheckoutAccessoryMail::class, function (CheckoutAccessoryMail $mail) {
+            return $mail->hasTo($this->assignee);
         });
     }
 
     public function testReminderIsSentToUserForAsset()
     {
-        $checkedOutBy = User::factory()->canViewReports()->create();
-
-        $assignee = User::factory()->create(['email' => 'test@example.com']);
-
         $asset = Asset::factory()->create();
 
-        $acceptance = $this->createCheckoutAcceptance($asset, $assignee);
+        $acceptance = $this->createCheckoutAcceptance($asset, $this->assignee);
 
-        $this->createActionLogEntry($asset, $checkedOutBy, $assignee, $acceptance);
+        $this->createActionLogEntry($asset, $this->admin, $this->assignee, $acceptance);
 
-        $this->actingAs($checkedOutBy)
+        $this->actingAs($this->admin)
             ->post(route('reports/unaccepted_assets_sent_reminder', [
                 'acceptance_id' => $acceptance->id,
             ]))
             ->assertRedirect(route('reports/unaccepted_assets'));
 
         Mail::assertSent(CheckoutAssetMail::class, 1);
-        Mail::assertSent(CheckoutAssetMail::class, function (CheckoutAssetMail $mail) use ($assignee) {
-            return $mail->hasTo($assignee->email);
+        Mail::assertSent(CheckoutAssetMail::class, function (CheckoutAssetMail $mail) {
+            return $mail->hasTo($this->assignee);
         });
     }
 
     public function testReminderIsSentToUserForConsumable()
     {
-        $checkedOutBy = User::factory()->canViewReports()->create();
-
-        $assignee = User::factory()->create(['email' => 'test@example.com']);
-
         $consumable = Consumable::factory()->create();
 
-        $acceptance = $this->createCheckoutAcceptance($consumable, $assignee);
+        $acceptance = $this->createCheckoutAcceptance($consumable, $this->assignee);
 
-        $this->createActionLogEntry($consumable, $checkedOutBy, $assignee, $acceptance);
+        $this->createActionLogEntry($consumable, $this->admin, $this->assignee, $acceptance);
 
-        $this->actingAs($checkedOutBy)
+        $this->actingAs($this->admin)
             ->post(route('reports/unaccepted_assets_sent_reminder', [
                 'acceptance_id' => $acceptance->id,
             ]))
             ->assertRedirect(route('reports/unaccepted_assets'));
 
         Mail::assertSent(CheckoutConsumableMail::class, 1);
-        Mail::assertSent(CheckoutConsumableMail::class, function (CheckoutConsumableMail $mail) use ($assignee) {
-            return $mail->hasTo($assignee->email);
+        Mail::assertSent(CheckoutConsumableMail::class, function (CheckoutConsumableMail $mail) {
+            return $mail->hasTo($this->assignee);
         });
     }
 
     public function testReminderIsSentToUserForLicenseSeat()
     {
-        $checkedOutBy = User::factory()->canViewReports()->create();
-
-        $assignee = User::factory()->create(['email' => 'test@example.com']);
-
         $licenseSeat = LicenseSeat::factory()->create();
 
-        $acceptance = $this->createCheckoutAcceptance($licenseSeat, $assignee);
+        $acceptance = $this->createCheckoutAcceptance($licenseSeat, $this->assignee);
 
-        $this->createActionLogEntry($licenseSeat, $checkedOutBy, $assignee, $acceptance);
+        $this->createActionLogEntry($licenseSeat, $this->admin, $this->assignee, $acceptance);
 
-        $this->actingAs($checkedOutBy)
+        $this->actingAs($this->admin)
             ->post(route('reports/unaccepted_assets_sent_reminder', [
                 'acceptance_id' => $acceptance->id,
             ]))
             ->assertRedirect(route('reports/unaccepted_assets'));
 
         Mail::assertSent(CheckoutLicenseMail::class, 1);
-        Mail::assertSent(CheckoutLicenseMail::class, function (CheckoutLicenseMail $mail) use ($assignee) {
-            return $mail->hasTo($assignee->email);
+        Mail::assertSent(CheckoutLicenseMail::class, function (CheckoutLicenseMail $mail) {
+            return $mail->hasTo($this->assignee);
         });
     }
 

--- a/tests/Feature/Notifications/Email/AssetAcceptanceReminderTest.php
+++ b/tests/Feature/Notifications/Email/AssetAcceptanceReminderTest.php
@@ -210,7 +210,6 @@ class AssetAcceptanceReminderTest extends TestCase
         return Actionlog::factory()
             ->for($admin, 'adminuser')
             ->for($assignee, 'target')
-            // ->for($item, 'item')
             ->create([
                 'action_type' => 'checkout',
                 'item_id' => $itemId,


### PR DESCRIPTION
Recently, we expanded the ability to send acceptance reminders from only assets to include accessories, consumables, and licenses. Along the way we lost the clarity in the subject line of those reminder emails. 

Currently, reminder emails reuse the subject line from the initial email ("Asset checked out", "Accessories checked out", "Consumable delivery confirmation", "License delivery confirmation"). This PR adjusts that to say "Reminder: You have Unaccepted Items".

<img width="1562" height="816" alt="image" src="https://github.com/user-attachments/assets/1338bb30-f9fa-413b-9928-aff2dc4d1cf9" />

---

In addition, the introduction line in accessory and consumable emails has been fixed:

| Before | After |
|--------|--------|
| <img width="1508" height="890" alt="image" src="https://github.com/user-attachments/assets/ff07afc5-7353-45e6-91ca-e623ada3717e" /> | <img width="1502" height="828" alt="image" src="https://github.com/user-attachments/assets/3acb8c98-78e1-4f7b-8803-0b4baf02c526" /> |

---

Some implementation details:

- I updated the `accessory` relationship on the `AccessoryCheckout` from a `hasOne` to a `belongsTo`.
- I renamed `AssetAcceptanceReminderTest` to `AcceptanceReminderTest` since it is testing more than just assets. 

---

[FD-53577]
