### PR TITLE
Fix CC Mail header for checkouts and check-ins

### DIFF
--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -39,7 +39,6 @@ use Exception;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Osama\LaravelTeamsNotification\TeamsNotification;
-use Symfony\Component\Mime\Email;
 class CheckoutableListener
 {
     private array $skipNotificationsFor = [

--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -39,7 +39,7 @@ use Exception;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Osama\LaravelTeamsNotification\TeamsNotification;
-
+use Symfony\Component\Mime\Email;
 class CheckoutableListener
 {
     private array $skipNotificationsFor = [
@@ -108,7 +108,7 @@ class CheckoutableListener
             if (!empty($cc)) {
                 try {
                     $ccMail = (clone $mailable)->locale(Setting::getSettings()->locale);
-                    Mail::to(array_flatten($cc))->send($ccMail);
+                    Mail::cc(array_flatten($cc))->send($ccMail);
                 } catch (ClientException $e) {
                     Log::debug("Exception caught during checkout email: " . $e->getMessage());
                 } catch (Exception $e) {
@@ -210,7 +210,7 @@ class CheckoutableListener
             if (!empty($cc)) {
                 try {
                     $ccMail = (clone $mailable)->locale(Setting::getSettings()->locale);
-                    Mail::to(array_flatten($cc))->send($ccMail);
+                    Mail::cc(array_flatten($cc))->send($ccMail);
                 } catch (ClientException $e) {
                     Log::debug("Exception caught during checkin email: " . $e->getMessage());
                 } catch (Exception $e) {

--- a/tests/Feature/Notifications/Email/EmailNotificationsToAdminAlertEmailUponCheckinTest.php
+++ b/tests/Feature/Notifications/Email/EmailNotificationsToAdminAlertEmailUponCheckinTest.php
@@ -56,7 +56,7 @@ class EmailNotificationsToAdminAlertEmailUponCheckinTest extends TestCase
             return $mail->hasTo($this->user->email);
         });
         Mail::assertSent(CheckinAssetMail::class, function ($mail) {
-            return $mail->hasTo('cc@example.com');
+            return $mail->hasCc('cc@example.com');
         });
     }
 

--- a/tests/Feature/Notifications/Email/EmailNotificationsToAdminAlertEmailUponCheckoutTest.php
+++ b/tests/Feature/Notifications/Email/EmailNotificationsToAdminAlertEmailUponCheckoutTest.php
@@ -48,7 +48,7 @@ class EmailNotificationsToAdminAlertEmailUponCheckoutTest extends TestCase
         $this->fireCheckoutEvent();
 
         Mail::assertSent(CheckoutAssetMail::class, function (CheckoutAssetMail $mail) {
-            return $mail->hasTo('cc@example.com');
+            return $mail->hasCc('cc@example.com');
         });
     }
 


### PR DESCRIPTION
This changes the mail header from `Mail::to()` to `Mail::cc()` for checkout and check in cc emails, 
The `cc` addresses may still replace a null or blank to field. Some mail clients may display the `cc` addresses in the `to` field if no addresses are provided for `To`.

Fixes #18365