### PR TITLE
Added some withCount() params to tweak the 'minimum number of assets' notification

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -778,7 +778,7 @@ class Helper
         $consumables = Consumable::withCount('consumableAssignments as consumable_assignments_count')->whereNotNull('min_amt')->get();
         $accessories = Accessory::withCount('checkouts as checkouts_count')->whereNotNull('min_amt')->get();
         $components = Component::whereNotNull('min_amt')->get();
-        $asset_models = AssetModel::where('min_amt', '>', 0)->get();
+        $asset_models = AssetModel::where('min_amt', '>', 0)->withCount(['availableAssets', 'assets'])->get();
         $licenses = License::where('min_amt', '>', 0)->get();
 
         $items_array = [];
@@ -844,8 +844,8 @@ class Helper
         foreach ($asset_models as $asset_model){
 
             $asset = new Asset();
-            $total_owned = $asset->where('model_id', '=', $asset_model->id)->count();
-            $avail = $asset->where('model_id', '=', $asset_model->id)->whereNull('assigned_to')->count();
+            $total_owned = $asset_model->assets_count; //requires the withCount() clause in the initial query!
+            $avail = $asset_model->available_assets_count; //requires the withCount() clause in the initial query!
 
             if ($avail <= ($asset_model->min_amt) + $alert_threshold) {
                 if ($avail > 0) {


### PR DESCRIPTION
We originally thought that we would only need the 'total number of _available_ assets' parameter in order to do this, but we also need the 'number of assets period' amount as well.

This fixes a 1,001 query problem where we fetched a list of models, then for each model fetched asset counts on them - for larger numbers of models, this would end up causing a lot of dependent queries.