### PR TITLE
Fixes #18512 (first checkout) temporarily

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -154,15 +154,15 @@ class AssetsController extends Controller
         }
 
         $assets = Asset::select('assets.*')
-            ->addSelect([
-                'first_checkout_at' => Actionlog::query()
-                    ->select('created_at')
-                    ->whereColumn('item_id', 'assets.id')
-                    ->where('item_type', Asset::class)
-                    ->where('action_type', 'checkout')
-                    ->orderBy('created_at')
-                    ->limit(1),
-            ])
+//            ->addSelect([
+//                'first_checkout_at' => Actionlog::query()
+//                    ->select('created_at')
+//                    ->whereColumn('item_id', 'assets.id')
+//                    ->where('item_type', Asset::class)
+//                    ->where('action_type', 'checkout')
+//                    ->orderBy('created_at')
+//                    ->limit(1),
+//            ])
             ->with(
                 'model',
                 'location',

--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -104,7 +104,7 @@ class AssetsTransformer
             'next_audit_date' => Helper::getFormattedDateObject($asset->next_audit_date, 'date'),
             'deleted_at' => Helper::getFormattedDateObject($asset->deleted_at, 'datetime'),
             'purchase_date' => Helper::getFormattedDateObject($asset->purchase_date, 'date'),
-            'first_checkout' => Helper::getFormattedDateObject($asset->first_checkout_at, 'datetime'),
+//            'first_checkout' => Helper::getFormattedDateObject($asset->first_checkout_at, 'datetime'),
             'age' => $asset->purchase_date ? $asset->purchase_date->locale(app()->getLocale())->diffForHumans() : '',
             'last_checkout' => Helper::getFormattedDateObject($asset->last_checkout, 'datetime'),
             'last_checkin' => Helper::getFormattedDateObject($asset->last_checkin, 'datetime'),

--- a/app/Presenters/AssetPresenter.php
+++ b/app/Presenters/AssetPresenter.php
@@ -151,14 +151,15 @@ class AssetPresenter extends Presenter
                 'visible' => false,
                 'title' => trans('general.purchase_date'),
                 'formatter' => 'dateDisplayFormatter',
-            ], [
-                'field' => 'first_checkout',
-                'searchable' => true,
-                'sortable' => true,
-                'visible' => false,
-                'title' => trans('general.first_checkout'),
-                'formatter' => 'dateDisplayFormatter',
             ],
+//            [
+//                'field' => 'first_checkout',
+//                'searchable' => true,
+//                'sortable' => true,
+//                'visible' => false,
+//                'title' => trans('general.first_checkout'),
+//                'formatter' => 'dateDisplayFormatter',
+//            ],
             [
                 'field' => 'age',
                 'searchable' => false,

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -1105,16 +1105,16 @@
                                             </div>
                                         @endif
 
-                                        <div class="row">
-                                            <div class="col-md-3">
-                                                <strong>
-                                                    {!! trans('general.first_checkout') !!}
-                                                </strong>
-                                            </div>
-                                            <div class="col-md-9">
-                                                {{ Helper::getFormattedDateObject($asset->first_checkout_at, 'datetime')['formatted'] ?? '' }}
-                                            </div>
-                                        </div>
+{{--                                        <div class="row">--}}
+{{--                                            <div class="col-md-3">--}}
+{{--                                                <strong>--}}
+{{--                                                    {!! trans('general.first_checkout') !!}--}}
+{{--                                                </strong>--}}
+{{--                                            </div>--}}
+{{--                                            <div class="col-md-9">--}}
+{{--                                                {{ Helper::getFormattedDateObject($asset->first_checkout_at, 'datetime')['formatted'] ?? '' }}--}}
+{{--                                            </div>--}}
+{{--                                        </div>--}}
 
 
                                         @if ($asset->last_checkin!='')


### PR DESCRIPTION
This just comments out the `first_checkout` functionality for now, as the additional querying against the `action_logs` table is too heavy for databases with a lot of action logs. We're still working on de-norming, so the `first_checkout` field will return, but this at least removes the lag it created for right now. 