### PR TITLE
Fixed #18557 - Tweak numRemaining to not re-query for un-checked-out components

### DIFF
--- a/app/Models/Component.php
+++ b/app/Models/Component.php
@@ -264,14 +264,21 @@ class Component extends SnipeModel
         // In case there are elements checked out to assets that belong to a different company
         // than this asset and full multiple company support is on we'll remove the global scope,
         // so they are included in the count.
-        if (is_null($this->sum_unconstrained_assets) || $recalculate) {
-            // This, in a components-listing context, is mostly important for when it sets a 'zero' which
-            // is *not* null - so we don't have to keep recalculating for un-checked-out components
+
+        // the 'sum' query returns NULL when there are zero checkouts - which can inadvertently re-trigger the following query
+        // for un-checked-out components. So we have to do this very careful process of fetching the 'attributes'
+        // of the component, then see if sum_unconstrained_assets exists as an attribute. If it doesn't, we run the
+        // query. But if it *does* exist as an attribute - even a null - we skip the query, because that means that this
+        // component was fetched using withCount() - and that count *is* accurate, even if null. We just do a quick
+        // null-coalesce at the end to zero for the null case.
+        $raw_attributes = $this->getAttributes();
+        if (!array_key_exists('sum_unconstrained_assets', $raw_attributes) || $recalculate) {
+            // This part should *only* run if the component was fetched *without* withCount() (or you've asked to recalculate)
             // NOTE: doing this will add a 'pseudo-attribute' to the component in question, so we need to _remove_ this
             // before we save - so that gets handled in the 'saving' callback defined in the 'booted' method, above.
             $this->sum_unconstrained_assets = $this->unconstrainedAssets()->sum('assigned_qty') ?? 0;
         }
-        return $this->sum_unconstrained_assets;
+        return $this->sum_unconstrained_assets ?? 0;
     }
 
 


### PR DESCRIPTION
In component listings, if a component was never checked out, it would trigger a re-query of component counts, even when we try to eagerly-load the counts using `withSum()`. This lead to a 1,001 query problem, in some cases (not always).

The problem was that `withSum()` will set the `sum_unconstrained_assets ` attribute to PHP's `null` when the count is zero. And we can't tell if `$this->sum_unconstrained_assets` is giving us `null` because it actually *is* a count of zero, versus it having been called up without the `withSum()` clause (which we only really do in the components index page).

So this uses a weird hack to fetch the attributes using `->getAttributes()` - which returns an array. And if the `sum_unconstrained_assets` attribute is set _there_ then that means, 100%, that this component was fetched with `withSum()`.