### PR TITLE
Converted consumables to new blade component

### DIFF
--- a/app/Models/Consumable.php
+++ b/app/Models/Consumable.php
@@ -13,6 +13,7 @@ use App\Presenters\Presentable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Storage;
 use Watson\Validating\ValidatingTrait;
 
@@ -129,6 +130,13 @@ class Consumable extends SnipeModel
             $value = null;
         }
         $this->attributes['requestable'] = filter_var($value, FILTER_VALIDATE_BOOLEAN);
+    }
+
+    public function isDeletable()
+    {
+        return Gate::allows('delete', $this)
+            && ($this->numCheckedOut() === 0)
+            && ($this->deleted_at == '');
     }
 
     /**

--- a/app/Presenters/ConsumablePresenter.php
+++ b/app/Presenters/ConsumablePresenter.php
@@ -187,6 +187,58 @@ class ConsumablePresenter extends Presenter
         return json_encode($layout);
     }
 
+    public static function checkedOut()
+    {
+        $layout = [
+
+            [
+                'field' => 'avatar',
+                'searchable' => false,
+                'sortable' => false,
+                'title' => trans('general.image'),
+                'visible' => true,
+                'formatter' => 'imageFormatter',
+            ],
+            [
+                'field' => 'user',
+                'searchable' => false,
+                'sortable' => false,
+                'title' => trans('general.name'),
+                'visible' => true,
+                'formatter' => 'usersLinkObjFormatter',
+            ],
+            [
+                'field' => 'created_at',
+                'searchable' => false,
+                'sortable' => false,
+                'title' => trans('general.date'),
+                'visible' => true,
+                'formatter' => 'dateDisplayFormatter',
+            ],
+
+            [
+                'field' => 'note',
+                'searchable' => false,
+                'sortable' => false,
+                'title' => trans('general.notes'),
+                'visible' => true,
+            ],
+
+            [
+                'field' => 'created_by',
+                'searchable' => false,
+                'sortable' => false,
+                'title' => trans('general.created_by'),
+                'visible' => true,
+                'formatter' => 'usersLinkObjFormatter',
+            ],
+
+
+        ];
+
+        return json_encode($layout);
+    }
+
     /**
      * Url to view this item.
      * @return string

--- a/resources/views/blade/box/info-panel.blade.php
+++ b/resources/views/blade/box/info-panel.blade.php
@@ -84,7 +84,19 @@
 
         @if ($infoPanelObj->model_number)
             <x-info-element icon_type="number" title="{{ trans('general.model_no') }}">
+                {{ trans('general.model_no') }}
+                <x-copy-to-clipboard copy_what="model_number" class="pull-right">
                 {{ $infoPanelObj->model_number }}
+                </x-copy-to-clipboard>
+            </x-info-element>
+        @endif
+
+        @if ($infoPanelObj->item_no)
+            <x-info-element icon_type="number" title="{{ trans('admin/consumables/general.item_no') }}">
+                {{ trans('admin/consumables/general.item_no') }}
+                <x-copy-to-clipboard copy_what="item_no" class="pull-right">
+                {{ $infoPanelObj->item_no }}
+                </x-copy-to-clipboard>
             </x-info-element>
         @endif
 
@@ -142,13 +154,17 @@
 
         @if ($infoPanelObj->order_number)
             <x-info-element icon_type="order" title="{{ trans('general.order_number') }}">
-                {{ $infoPanelObj->order_number }}
+                <x-copy-to-clipboard copy_what="order_number" class="pull-right">
+                    {{ $infoPanelObj->order_number }}
+                </x-copy-to-clipboard>
             </x-info-element>
         @endif
 
         @if ($infoPanelObj->purchase_order)
             <x-info-element icon_type="purchase_order" title="{{ trans('admin/licenses/form.purchase_order') }}">
+                <x-copy-to-clipboard copy_what="purchase_order" class="pull-right">
                 {{ $infoPanelObj->purchase_order }}
+                </x-copy-to-clipboard>
             </x-info-element>
         @endif
 

--- a/resources/views/blade/box/info-panel.blade.php
+++ b/resources/views/blade/box/info-panel.blade.php
@@ -83,7 +83,7 @@
         @endif
 
         @if ($infoPanelObj->model_number)
-            <x-info-element icon_type="number" title="{{ trans('general.model_number') }}">
+            <x-info-element icon_type="number" title="{{ trans('general.model_no') }}">
                 {{ $infoPanelObj->model_number }}
             </x-info-element>
         @endif

--- a/resources/views/blade/box/info-panel.blade.php
+++ b/resources/views/blade/box/info-panel.blade.php
@@ -1,10 +1,10 @@
 @props([
     'infoPanelObj' => null,
     'img_path' => null,
+    'snipeSettings' => \App\Models\Setting::getSettings()
 ])
 
-
-
+<!-- start side info-box -->
 <div class="box-header with-border" style="padding-top: 0;">
     <h3 class="box-title side-box-header" style="line-height: 20px">
         {{ $infoPanelObj->display_name }}
@@ -95,6 +95,51 @@
             </x-info-element>
         @endif
 
+        @if (method_exists($infoPanelObj, 'numCheckedOut'))
+            <x-info-element icon_type="checkedout" title="{{ trans('general.checked_out') }}">
+                {{ (int) $infoPanelObj->numCheckedOut() }}
+                {{ trans('general.checked_out') }}
+            </x-info-element>
+        @endif
+
+        @if (method_exists($infoPanelObj, 'numRemaining'))
+            <x-info-element icon_type="available" title="{{ trans('general.remaining') }}">
+                {{ $infoPanelObj->numRemaining() }}
+                {{ trans('general.remaining') }}
+            </x-info-element>
+        @endif
+
+        @if ($infoPanelObj->purchase_cost)
+            <x-info-element>
+                <x-icon type="cost" class="fa-fw" title="{{ trans('general.unit_cost') }}" />
+                {{ trans('general.unit_cost') }}
+
+                @if ((isset($infoPanelObj->location)) && ($infoPanelObj->location->currency!=''))
+                    {{ $infoPanelObj->location->currency }}
+                @else
+                    {{ $snipeSettings->default_currency }}
+                @endif
+
+                {{ Helper::formatCurrencyOutput($infoPanelObj->purchase_cost) }}
+            </x-info-element>
+
+            @if (isset($infoPanelObj->qty))
+                <x-info-element>
+                    <x-icon type="cost" class="fa-fw" title="{{ trans('general.total_cost') }}" />
+                    {{ trans('general.total_cost') }}
+
+                    @if ((isset($infoPanelObj->location)) && ($infoPanelObj->location->currency!=''))
+                        {{ $infoPanelObj->location->currency }}
+                    @else
+                        {{ $snipeSettings->default_currency }}
+                    @endif
+
+                    {{ Helper::formatCurrencyOutput($infoPanelObj->totalCostSum()) }}
+                </x-info-element>
+            @endif
+
+        @endif
+
         @if ($infoPanelObj->order_number)
             <x-info-element icon_type="order" title="{{ trans('general.order_number') }}">
                 {{ $infoPanelObj->order_number }}
@@ -104,18 +149,6 @@
         @if ($infoPanelObj->purchase_order)
             <x-info-element icon_type="purchase_order" title="{{ trans('admin/licenses/form.purchase_order') }}">
                 {{ $infoPanelObj->purchase_order }}
-            </x-info-element>
-        @endif
-
-        @if (function_exists('numRemaining'))
-            <x-info-element icon_type="available" title="{{ trans('general.remaining') }}">
-                {{ $infoPanelObj->numRemaining() }}
-                {{ trans('general.remaining') }}
-            </x-info-element>
-
-            <x-info-element icon_type="checkedout" title="{{ trans('general.available') }}">
-                {{ $infoPanelObj->checkouts_count }}
-                {{ trans('general.checked_out') }}
             </x-info-element>
         @endif
 
@@ -187,7 +220,7 @@
                 </x-info-element.url>
             </x-info-element>
 
-            <x-info-element icon_type="external-link" class="subitem" title="{{ trans('general.url') }}">
+            <x-info-element icon_type="external-link" class="subitem" title="{{ trans('admin/manufacturers/table.support_url') }}">
                 <x-info-element.url>
                     {{ $infoPanelObj->manufacturer->support_url }}
                 </x-info-element.url>
@@ -337,12 +370,6 @@
             </x-info-element>
         @endif
 
-        @if ($infoPanelObj->purchase_cost)
-            <x-info-element>
-                <x-icon type="cost" class="fa-fw" title="{{ trans('general.purchase_cost') }}" />
-                {{ Helper::formatCurrencyOutput($infoPanelObj->purchase_cost) }}
-            </x-info-element>
-        @endif
 
 
         @if ($infoPanelObj->purchase_date)
@@ -489,5 +516,5 @@
 
 </div>
 
-
+<!-- end side info-box -->
 

--- a/resources/views/blade/button/wide-checkout.blade.php
+++ b/resources/views/blade/button/wide-checkout.blade.php
@@ -1,11 +1,13 @@
 @props([
     'item' => null,
-    'route' => null,
+    'route',
 ])
 
 @can('checkout', $item)
-    <a href="{{ $route  }}" class="btn btn-sm bg-maroon btn-social btn-block hidden-print">
-        <x-icon type="checkout" />
-        {{ trans('general.checkout') }}
-    </a>
+    @if ((method_exists($item, 'numRemaining')) && ($item->numRemaining() > 0))
+        <a href="{{ $route  }}" class="btn btn-sm bg-maroon btn-social btn-block hidden-print">
+            <x-icon type="checkout" />
+            {{ trans('general.checkout') }}
+        </a>
+    @endif
 @endcan

--- a/resources/views/blade/copy-to-clipboard.blade.php
+++ b/resources/views/blade/copy-to-clipboard.blade.php
@@ -3,7 +3,7 @@
 ])
 
 <!-- copy to clipboard -->
-<i class="fa-regular fa-clipboard js-copy-link hidden-print fa-fw" data-clipboard-target=".js-copy-{{ $copy_what }}" aria-hidden="true" data-tooltip="true" data-placement="top" title="{{ trans('general.copy_to_clipboard') }}">
+<i {{ $attributes->merge(['class' => 'fa-regular fa-clipboard js-copy-link hidden-print fa-fw']) }} style="font-size: 16px;" data-clipboard-target=".js-copy-{{ $copy_what }}" aria-hidden="true" data-tooltip="true" data-placement="top" title="{{ trans('general.copy_to_clipboard') }}">
     <span class="sr-only">{{ trans('general.copy_to_clipboard') }}</span>
 </i>
 

--- a/resources/views/blade/tabs/accessory-tab.blade.php
+++ b/resources/views/blade/tabs/accessory-tab.blade.php
@@ -1,9 +1,11 @@
 @props([
     'count' => null,
 ])
+@aware(['class'])
 
 @can('view', \App\Models\Accessory::class)
     <x-tabs.nav-item
+            :$class
             name="accessories"
             icon_type="accessory"
             label="{{ trans('general.accessories') }}"

--- a/resources/views/blade/tabs/asset-tab.blade.php
+++ b/resources/views/blade/tabs/asset-tab.blade.php
@@ -1,11 +1,12 @@
 @props([
     'count' => null,
 ])
+@aware(['class'])
 
 @can('view', \App\Models\Asset::class)
     <x-tabs.nav-item
+            :$class
             name="assets"
-            class="active"
             icon_type="assets"
             label="{{ trans('general.assets') }}"
             count="{{ $count }}"

--- a/resources/views/blade/tabs/checkedout-tab.blade.php
+++ b/resources/views/blade/tabs/checkedout-tab.blade.php
@@ -3,6 +3,7 @@
     'model' => null,
     'class' => null,
 ])
+@aware(['class'])
 
 @can('view', $model)
     <x-tabs.nav-item

--- a/resources/views/blade/tabs/component-tab.blade.php
+++ b/resources/views/blade/tabs/component-tab.blade.php
@@ -1,6 +1,7 @@
 @props([
     'count' => null,
 ])
+@aware(['class'])
 
 @can('view', \App\Models\Component::class)
     <x-tabs.nav-item

--- a/resources/views/blade/tabs/consumable-tab.blade.php
+++ b/resources/views/blade/tabs/consumable-tab.blade.php
@@ -1,6 +1,7 @@
 @props([
     'count' => null,
 ])
+@aware(['class'])
 
 @can('view', \App\Models\Consumable::class)
     <x-tabs.nav-item

--- a/resources/views/blade/tabs/files-tab.blade.php
+++ b/resources/views/blade/tabs/files-tab.blade.php
@@ -1,6 +1,9 @@
 @props([
     'count' => null,
 ])
+
+@aware(['class'])
+
 <x-tabs.nav-item
         name="files"
         icon_type="files"

--- a/resources/views/blade/tabs/history-tab.blade.php
+++ b/resources/views/blade/tabs/history-tab.blade.php
@@ -3,6 +3,7 @@
     'model' => null,
 ])
 
+@aware(['class'])
 
 @can('view', $model)
     <x-tabs.nav-item

--- a/resources/views/blade/tabs/license-tab.blade.php
+++ b/resources/views/blade/tabs/license-tab.blade.php
@@ -1,9 +1,11 @@
 @props([
     'count' => null,
 ])
+@aware(['class'])
 
 @can('view', \App\Models\License::class)
     <x-tabs.nav-item
+            :$class
             name="licenses"
             icon_type="licenses"
             label="{{ trans('general.licenses') }}"

--- a/resources/views/blade/tabs/nav-item.blade.php
+++ b/resources/views/blade/tabs/nav-item.blade.php
@@ -7,6 +7,7 @@
     'tooltip' => null,
     'icon_type' => null,
 ])
+
 <!-- start tab nav item -->
 <li {{ $attributes->merge(['class' => '']) }}>
 

--- a/resources/views/blade/tabs/user-tab.blade.php
+++ b/resources/views/blade/tabs/user-tab.blade.php
@@ -1,9 +1,11 @@
 @props([
     'count' => null,
 ])
+@aware(['class'])
 
 @can('view', \App\Models\User::class)
     <x-tabs.nav-item
+            :$class
             name="users"
             icon_type="user"
             label="{{ trans('general.users') }}"

--- a/resources/views/components/view.blade.php
+++ b/resources/views/components/view.blade.php
@@ -81,15 +81,10 @@
 
                     <x-slot:before_list>
 
-                        @can('checkout', \App\Models\Component::class)
-                            <x-button.wide-checkout :item="$snipe_component" :route="route('components.checkout.show', $snipe_component->id)" />
-                        @endcan
-
+                        <x-button.wide-checkout :item="$snipe_component" :route="route('components.checkout.show', $snipe_component->id)" />
                         <x-button.wide-edit :item="$snipe_component" :route="route('components.edit', $snipe_component->id)" />
                         <x-button.wide-clone :item="$snipe_component" :route="route('components.clone.create', $snipe_component->id)" />
-
                         <x-button.wide-delete :item="$snipe_component" />
-
 
                     </x-slot:before_list>
 

--- a/resources/views/consumables/view.blade.php
+++ b/resources/views/consumables/view.blade.php
@@ -9,476 +9,98 @@
 @endsection
 
 @section('header_right')
-  <a href="{{ URL::previous() }}" class="btn btn-primary pull-right">
-    {{ trans('general.back') }}</a>
+    <i class="fa-regular fa-2x fa-square-caret-right pull-right" id="expand-info-panel-button" data-tooltip="true" title="{{ trans('button.show_hide_info') }}"></i>
 @endsection
 
 {{-- Page content --}}
 @section('content')
 
+    <x-container columns="2">
+        <x-page-column class="col-md-9 main-panel">
+            <x-tabs>
+                <x-slot:tabnav>
+
+                    <x-tabs.nav-item
+                            name="assigned"
+                            class="active"
+                            icon_type="checkedout"
+                            label="{{ trans('general.assigned') }}"
+                            count="{{ $consumable->numCheckedOut() }}"
+                    />
+
+                    <x-tabs.files-tab count="{{ $consumable->uploads()->count() }}" />
+
+                    <x-tabs.history-tab model="\App\Models\Consumable::class"/>
+
+                    @can('update', $consumable)
+                        <x-tabs.nav-item-upload />
+                    @endcan
+
+                </x-slot:tabnav>
+
+                <x-slot:tabpanes>
+
+                    <x-tabs.pane name="assigned" class="in active">
+
+                        <x-slot:content>
+                            <x-table
+                                    :presenter="\App\Presenters\ConsumablePresenter::checkedOut()"
+                                    :api_url="route('api.consumables.show.users', $consumable->id)"
+                            />
+                        </x-slot:content>
+
+                    </x-tabs.pane>
+
+                    <x-tabs.pane name="files">
+                        <x-slot:header>
+                            {{ trans('general.files') }}
+                        </x-slot:header>
+                        <x-slot:content>
+                            <x-filestable object_type="consumables" :object="$consumable" />
+                        </x-slot:content>
+                    </x-tabs.pane>
+
+                    <!-- start history tab pane -->
+                    <x-tabs.pane name="history">
+                        <x-slot:header>
+                            {{ trans('general.history') }}
+                        </x-slot:header>
+                        <x-slot:content>
+                            <x-table
+                                    name="consumableHistory"
+                                    api_url="{{ route('api.activity.index', ['item_id' => $consumable->id, 'item_type' => 'consumable']) }}"
+                                    :presenter="\App\Presenters\HistoryPresenter::dataTableLayout()"
+                                    export_filename="export-licenses-{{ str_slug($consumable->name) }}-{{ date('Y-m-d') }}"
+                            />
+                        </x-slot:content>
+                    </x-tabs.pane>
+                </x-slot:tabpanes>
+
+            </x-tabs>
+        </x-page-column>
+
+        <x-page-column class="col-md-3">
+            <x-box>
+                <x-box.info-panel :infoPanelObj="$consumable" img_path="{{ app('consumables_upload_url') }}">
+
+                    <x-slot:before_list>
+
+                        @can('checkout', \App\Models\Component::class)
+                            <x-button.wide-checkout :item="$consumable" :route="route('consumables.checkout.show', $consumable->id)" />
+                        @endcan
+
+                        <x-button.wide-edit :item="$consumable" :route="route('consumables.edit', $consumable->id)" />
+                        <x-button.wide-clone :item="$consumable" :route="route('consumables.clone.create', $consumable->id)" />
+
+                        <x-button.wide-delete :item="$consumable" />
 
 
+                    </x-slot:before_list>
 
-  <div class="row">
-    <div class="col-md-12">
-      <div class="nav-tabs-custom">
-        <!-- Custom Tabs -->
-        <div class="nav-tabs-custom">
-          <ul class="nav nav-tabs hidden-print">
-
-            <li class="active">
-              <a href="#details" data-toggle="tab">
-            <span class="hidden-lg hidden-md">
-            <i class="fas fa-info-circle fa-2x"></i>
-            </span>
-                <span class="hidden-xs hidden-sm">{{ trans('admin/users/general.info') }}</span>
-              </a>
-            </li>
-
-            <li>
-              <a href="#checkedout" data-toggle="tab">
-                <span class="hidden-lg hidden-md">
-                <x-icon type="users" class="fa-2x" />
-                </span>
-                    <span class="hidden-xs hidden-sm">{{ trans('general.assigned') }}
-                      {!! ($consumable->users_consumables > 0 ) ? '<span class="badge badge-secondary">'.number_format($consumable->users_consumables).'</span>' : '' !!}
-                    </span>
-                  </a>
-            </li>
-
-
-            @can('consumables.files', $consumable)
-              <li>
-                <a href="#files" data-toggle="tab">
-                <span class="hidden-lg hidden-md">
-                  <i class="far fa-file fa-2x" aria-hidden="true"></i>
-                </span>
-                <span class="hidden-xs hidden-sm">{{ trans('general.file_uploads') }}
-                    {!! ($consumable->uploads->count() > 0 ) ? '<span class="badge badge-secondary">'.number_format($consumable->uploads->count()).'</span>' : '' !!}
-                  </span>
-                </a>
-              </li>
-            @endcan
-
-            <li>
-              <a href="#history" data-toggle="tab">
-                <span class="hidden-lg hidden-md">
-                  <i class="fas fa-history fa-2x" aria-hidden="true"></i>
-                </span>
-                <span class="hidden-xs hidden-sm">
-                  {{ trans('general.history') }}
-                </span>
-              </a>
-            </li>
-
-            @can('update', $consumable)
-              <li class="pull-right">
-                <a href="#" data-toggle="modal" data-target="#uploadFileModal">
-                  <x-icon type="paperclip" /> {{ trans('button.upload') }}
-                </a>
-              </li>
-            @endcan
-
-          </ul>
-        <div class="tab-content">
-          <div class="tab-pane active" id="details">
-            <div class="row">
-              <div class="info-stack-container">
-              <!-- Start button column -->
-              <div class="col-md-3 col-xs-12 col-sm-push-9 info-stack">
-
-                @if ($consumable->image!='')
-                  <div class="col-md-12 text-center" style="padding-bottom: 20px;">
-                    <a href="{{ Storage::disk('public')->url('consumables/'.e($consumable->image)) }}" data-toggle="lightbox" data-type="image">
-                      <img src="{{ Storage::disk('public')->url('consumables/'.e($consumable->image)) }}" class="img-responsive img-thumbnail" alt="{{ $consumable->name }}"></a>
-                  </div>
-                @endif
-
-                
-                @can('update', $consumable)
-                  <div class="col-md-12">
-                    <a href="{{ route('consumables.edit', $consumable->id) }}" style="margin-bottom:5px;"  class="btn btn-sm btn-block btn-social btn-warning hidden-print">
-                      <x-icon type="edit" />
-                      {{ trans('button.edit') }}
-                    </a>
-                  </div>
-                @endcan
-
-                  @can('checkout', $consumable)
-                    @if ($consumable->numRemaining() > 0)
-                      <div class="col-md-12">
-                        <a href="{{ route('consumables.checkout.show', $consumable->id) }}" style="margin-bottom:5px;" class="btn btn-sm btn-block bg-maroon btn-social hidden-print">
-                          <x-icon type="checkout" />
-                          {{ trans('general.checkout') }}
-                        </a>
-                      </div>
-                    @else
-                      <div class="col-md-12">
-                        <button style="margin-bottom:10px;" class="btn btn-block bg-maroon btn-sm btn-social hidden-print disabled">
-                          <x-icon type="checkout" />
-                          {{ trans('general.checkout') }}
-                        </button>
-                      </div>
-                    @endif
-                  @endif
-
-
-                @can('create', Consumable::class)
-
-                    <div class="col-md-12">
-                      <a href="{{ route('consumables.clone.create', $consumable->id) }}" style="margin-bottom:5px;"  class="btn btn-sm btn-block btn-info btn-social hidden-print">
-                        <x-icon type="clone" />
-                        {{ trans('button.var.clone', ['item_type' => trans('general.consumable')]) }}
-                      </a>
-                    </div>
-
-                  @endcan
-
-
-
-                  @can('delete', $consumable)
-                    <div class="col-md-12" style="padding-top: 10px; padding-bottom: 20px">
-                      @if ($consumable->deleted_at=='')
-                        <button class="btn btn-sm btn-block btn-danger btn-social hidden-print delete-asset" data-icon="fa fa-trash" data-toggle="modal" data-title="{{ trans('general.delete') }}" data-content="{{ trans('general.sure_to_delete_var', ['item' => $consumable->name]) }}" data-target="#dataConfirmModal" onClick="return false;">
-                          <x-icon type="delete" />
-                          {{ trans('general.delete') }}
-                        </button>
-                        <span class="sr-only">{{ trans('general.delete') }}</span>
-                      @endif
-                    </div>
-                  @endcan
-              </div>
-
-              <!-- End button column -->
-
-              <div class="col-md-9 col-xs-12 col-sm-pull-3 info-stack">
-
-                <div class="row-new-striped" style="margin: 0px;">
-
-                  <div class="row row-new-striped">
-                    <!-- name -->
-                    <div class="col-md-3 col-sm-2">
-                      {{ trans('admin/users/table.name') }}
-                    </div>
-                    <div class="col-md-9 col-sm-2">
-                      {{ $consumable->name }}
-                    </div>
-                  </div>
-
-                  <!-- company -->
-                  @if ($consumable->company)
-                    <div class="row">
-                      <div class="col-md-3">
-                        {{ trans('general.company') }}
-                      </div>
-                      <div class="col-md-9">
-                          {!!  $consumable->company->present()->formattedNameLink !!}
-                      </div>
-                    </div>
-                  @endif
-
-                  <!-- category -->
-                  @if ($consumable->category)
-                    <div class="row">
-                      <div class="col-md-3">
-                        {{ trans('general.category') }}
-                      </div>
-                      <div class="col-md-9">
-                          {!!  $consumable->category->present()->formattedNameLink !!}
-                      </div>
-                    </div>
-                  @endif
-
-                  <!-- total -->
-                  @if ($consumable->qty)
-                    <div class="row">
-                      <div class="col-md-3">
-                        {{ trans('admin/components/general.total') }}
-                      </div>
-                      <div class="col-md-9">
-                        {{ $consumable->qty }}
-                      </div>
-                    </div>
-                  @endif
-
-                  <!-- remaining -->
-                  @if ($consumable->numRemaining())
-                    <div class="row">
-                      <div class="col-md-3">
-                        {{ trans('general.remaining') }}
-                      </div>
-                      <div class="col-md-9">
-                        @if ($consumable->numRemaining() < (int) $consumable->min_amt)
-                          <i class="fas fa-exclamation-triangle text-orange"
-                             aria-hidden="true"
-                             data-tooltip="true"
-                             data-placement="top"
-                             title="{{ trans('admin/consumables/general.inventory_warning', ['min_count' => (int) $consumable->min_amt]) }}">
-                          </i>
-                        @endif
-                        {{ $consumable->numRemaining() }}
-                      </div>
-                    </div>
-                  @endif
-
-                  <!-- min amt -->
-                  @if ($consumable->min_amt)
-                    <div class="row">
-                      <div class="col-md-3">
-                        {{ trans('general.min_amt') }}
-                      </div>
-                      <div class="col-md-9">
-                        {{ $consumable->min_amt }}
-                      </div>
-                    </div>
-                  @endif
-
-                  <!-- locationm -->
-                  @if ($consumable->location)
-                    <div class="row">
-                      <div class="col-md-3">
-                        {{ trans('general.location') }}
-                      </div>
-                      <div class="col-md-9">
-                          {!!  $consumable->location->present()->formattedNameLink !!}
-                      </div>
-                    </div>
-                  @endif
-
-                  <!-- supplier -->
-                  @if ($consumable->supplier)
-                    <div class="row">
-                      <div class="col-md-3">
-                        {{ trans('general.supplier') }}
-                      </div>
-                      <div class="col-md-9">
-                          {!!  $consumable->supplier->present()->formattedNameLink !!}
-                      </div>
-                    </div>
-                  @endif
-
-                  <!-- supplier -->
-                  @if ($consumable->manufacturer)
-                    <div class="row">
-                      <div class="col-md-3">
-                        {{ trans('general.manufacturer') }}
-                      </div>
-                      <div class="col-md-9">
-                          {!!  $consumable->manufacturer->present()->formattedNameLink !!}
-                      </div>
-                    </div>
-                  @endif
-
-                  @if ($consumable->purchase_cost)
-                    <div class="row">
-                      <div class="col-md-3">
-                        {{ trans('general.unit_cost') }}
-                      </div>
-                      <div class="col-md-9">
-                        {{ $snipeSettings->default_currency }}
-                        {{ Helper::formatCurrencyOutput($consumable->purchase_cost) }}
-                      </div>
-                    </div>
-                  @endif
-
-                  @if ($consumable->purchase_cost)
-                        <div class="row">
-                            <div class="col-md-3">
-                                {{ trans('general.total_cost') }}
-                            </div>
-                            <div class="col-md-9">
-                                {{ $snipeSettings->default_currency }}
-                                {{ Helper::formatCurrencyOutput($consumable->totalCostSum()) }}
-                            </div>
-                        </div>
-                  @endif
-
-                  @if ($consumable->order_number)
-                    <div class="row">
-                      <div class="col-md-3">
-                        {{ trans('general.order_number') }}
-                      </div>
-                      <div class="col-md-9">
-                        <span class="js-copy">{{ $consumable->order_number  }}</span>
-                        <i class="fa-regular fa-clipboard js-copy-link" data-clipboard-target=".js-copy" aria-hidden="true" data-tooltip="true" data-placement="top" title="{{ trans('general.copy_to_clipboard') }}">
-                          <span class="sr-only">{{ trans('general.copy_to_clipboard') }}</span>
-                        </i>
-
-                      </div>
-                    </div>
-                  @endif
-
-                  @if ($consumable->item_no)
-                    <div class="row">
-                      <div class="col-md-3">
-                        {{ trans('admin/consumables/general.item_no') }}
-                      </div>
-                      <div class="col-md-9">
-
-                        <span class="js-copy-item_no">{{ $consumable->item_no  }}</span>
-                        <i class="fa-regular fa-clipboard js-copy-link" data-clipboard-target=".js-copy-item_no"
-                           aria-hidden="true" data-tooltip="true" data-placement="top"
-                           title="{{ trans('general.copy_to_clipboard') }}">
-                          <span class="sr-only">{{ trans('general.copy_to_clipboard') }}</span>
-                        </i>
-
-                      </div>
-                    </div>
-                  @endif
-
-                  @if ($consumable->model_number)
-                    <div class="row">
-                      <div class="col-md-3">
-                        {{ trans('general.model_no') }}
-                      </div>
-                      <div class="col-md-9">
-
-                        <span class="js-copy-model_no">{{ $consumable->model_number  }}</span>
-                        <i class="fa-regular fa-clipboard js-copy-link" data-clipboard-target=".js-copy-model_no"
-                           aria-hidden="true" data-tooltip="true" data-placement="top"
-                           title="{{ trans('general.copy_to_clipboard') }}">
-                          <span class="sr-only">{{ trans('general.copy_to_clipboard') }}</span>
-                        </i>
-
-                      </div>
-                    </div>
-                  @endif
-
-                  <!-- purchase date -->
-                  @if ($consumable->purchase_date)
-                    <div class="row">
-                      <div class="col-md-3">
-                        {{ trans('general.purchase_date') }}
-                      </div>
-                      <div class="col-md-9">
-                        {{ \App\Helpers\Helper::getFormattedDateObject($consumable->purchase_date, 'datetime', false) }}
-                      </div>
-                    </div>
-                  @endif
-
-                  @if ($consumable->adminuser)
-                    <!-- created at -->
-                    <div class="row">
-                      <div class="col-md-3">
-                        {{ trans('general.created_by') }}
-                      </div>
-                      <div class="col-md-9">
-                        @if ($consumable->adminuser->deleted_at == '')
-                          <a href="{{ route('users.show', ['user' => $consumable->adminuser]) }}">{{ $consumable->adminuser->present()->fullName }}</a>
-                        @else
-                          <del>{{ $consumable->adminuser->present()->fullName }}</del>
-                        @endif
-                      </div>
-                    </div>
-                  @endif
-
-                  @if ($consumable->created_at)
-                    <!-- created at -->
-                    <div class="row">
-                      <div class="col-md-3">
-                        {{ trans('general.created_at') }}
-                      </div>
-                      <div class="col-md-9">
-                        {{ \App\Helpers\Helper::getFormattedDateObject($consumable->created_at, 'datetime')['formatted']}}
-                      </div>
-                    </div>
-                  @endif
-
-                  @if ($consumable->updated_at)
-                    <!-- created at -->
-                    <div class="row">
-                      <div class="col-md-3">
-                        {{ trans('general.updated_at') }}
-                      </div>
-                      <div class="col-md-9">
-                        {{ \App\Helpers\Helper::getFormattedDateObject($consumable->updated_at, 'datetime')['formatted']}}
-                      </div>
-                    </div>
-                  @endif
-
-                  @if ($consumable->notes)
-                    <!-- empty -->
-                    <div class="row">
-
-                      <div class="col-md-3">
-                        {{ trans('admin/users/table.notes') }}
-                      </div>
-                      <div class="col-md-9">
-                        {!! nl2br(Helper::parseEscapedMarkedownInline($consumable->notes)) !!}
-                      </div>
-
-                    </div>
-                  @endif
-                </div> <!--/end striped container-->
-              </div> <!-- end col-md-9 -->
-              </div><!-- end info-stack-container -->
-            </div> <!--/.row-->
-          </div><!-- /.tab-pane -->
-
-          <div class="tab-pane" id="checkedout">
-
-            <table
-                    data-cookie-id-table="consumablesCheckedoutTable"
-                    data-id-table="consumablesCheckedoutTable"
-                    data-search="false"
-                    data-side-pagination="server"
-                    data-show-footer="true"
-                    data-sort-order="asc"
-                    data-sort-name="name"
-                    id="consumablesCheckedoutTable"
-                    class="table table-striped snipe-table"
-                    data-url="{{route('api.consumables.show.users', $consumable->id)}}"
-                    data-export-options='{
-                "fileName": "export-consumables-{{ str_slug($consumable->name) }}-checkedout-{{ date('Y-m-d') }}",
-                "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
-                }'>
-              <thead>
-              <tr>
-                <th data-searchable="false" data-sortable="false" data-field="avatar" data-formatter="imageFormatter">{{ trans('general.image') }}</th>
-                <th data-searchable="false" data-sortable="false" data-field="user" data-formatter="usersLinkObjFormatter">{{ trans('general.user') }}</th>
-                <th data-searchable="false" data-sortable="false" data-field="created_at" data-formatter="dateDisplayFormatter">
-                  {{ trans('general.date') }}
-                </th>
-                <th data-searchable="false" data-sortable="false" data-field="note">{{ trans('general.notes') }}</th>
-                <th data-searchable="false" data-sortable="false" data-field="created_by" data-formatter="usersLinkObjFormatter">{{ trans('general.created_by') }}</th>
-              </tr>
-              </thead>
-            </table>
-
-          </div><!-- /checkedout -->
-
-
-          <div class="tab-pane" id="files">
-
-            <div class="row">
-              <div class="col-md-12">
-                <x-filestable object_type="consumables" :object="$consumable" />
-              </div>
-            </div>
-
-          </div><!--/FILES-->
-
-          <div class="tab-pane" id="history">
-              <table
-                      data-columns="{{ \App\Presenters\HistoryPresenter::dataTableLayout() }}"
-                      class="table table-striped snipe-table"
-                      id="consumableHistory"
-                      data-id-table="consumableHistory"
-                      data-side-pagination="server"
-                      data-sort-order="desc"
-                      data-sort-name="created_at"
-                      data-export-options='{
-                         "fileName": "export-consumable-{{  $consumable->id }}-history",
-                         "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
-                       }'
-                      data-url="{{ route('api.activity.index', ['item_id' => $consumable->id, 'item_type' => 'consumable']) }}"
-                      data-cookie-id-table="consumableHistory"
-                      data-cookie="true">
-              </table>
-          </div><!-- /.tab-pane -->
-      </div><!-- /.tab-content -->
-    </div><!-- nav-tabs-custom -->
-  </div>
+                </x-box.info-panel>
+            </x-box>
+        </x-page-column>
+    </x-container>
 
   @can('update', \App\Models\User::class)
     @include ('modals.upload-file', ['item_type' => 'consumable', 'item_id' => $consumable->id])
@@ -489,6 +111,5 @@
 @stop
 
 @section('moar_scripts')
-
   @include ('partials.bootstrap-table', ['simple_view' => true])
 @endsection

--- a/resources/views/consumables/view.blade.php
+++ b/resources/views/consumables/view.blade.php
@@ -85,15 +85,10 @@
 
                     <x-slot:before_list>
 
-                        @can('checkout', \App\Models\Component::class)
-                            <x-button.wide-checkout :item="$consumable" :route="route('consumables.checkout.show', $consumable->id)" />
-                        @endcan
-
+                        <x-button.wide-checkout :item="$consumable" :route="route('consumables.checkout.show', $consumable->id)" />
                         <x-button.wide-edit :item="$consumable" :route="route('consumables.edit', $consumable->id)" />
                         <x-button.wide-clone :item="$consumable" :route="route('consumables.clone.create', $consumable->id)" />
-
                         <x-button.wide-delete :item="$consumable" />
-
 
                     </x-slot:before_list>
 

--- a/resources/views/suppliers/view.blade.php
+++ b/resources/views/suppliers/view.blade.php
@@ -20,8 +20,8 @@
             <x-tabs>
                 <x-slot:tabnav>
 
-                    <x-tabs.asset-tab count="{{ $supplier->assets()->AssetsForShow()->count() }}" />
-                    <x-tabs.license-tab count="{{ $supplier->licenses->count() }}" />
+                    <x-tabs.asset-tab count="{{ $supplier->assets()->AssetsForShow()->count() }}" class="active" />
+                    <x-tabs.license-tab count="{{ $supplier->licenses->count() }}" class="active" />
                     <x-tabs.accessory-tab count="{{ $supplier->accessories->count() }}" />
                     <x-tabs.consumable-tab count="{{ $supplier->consumables->count() }}" />
                     <x-tabs.component-tab count="{{ $supplier->components->count() }}" />


### PR DESCRIPTION
This converts the consumables view into the new format, adds a copy+paste, and also fixes a few things with the tabs.

One place where this does get tricky tho is that we generally give the first tab on the screen the `active` class (same with its corresponding pane), however if a non-superuser doesn't have permission to view that type of FCO, we end up with weird looking tabs. Everything will still work, but you'll have to click off that first tab and then onto it again, which is kind of a crappy UX. 

I need to figure out how to handle that programmatically in a way that isn't awful.