### PR TITLE
Fixed #18571 - fix cross-company created_by in asset acceptance

### DIFF
--- a/app/Mail/CheckoutAssetMail.php
+++ b/app/Mail/CheckoutAssetMail.php
@@ -25,7 +25,7 @@ class CheckoutAssetMail extends BaseMailable
      * Create a new message instance.
      * @throws \Exception
      */
-    public function __construct(Asset $asset, $checkedOutTo, User $checkedOutBy, $acceptance, $note, bool $firstTimeSending = true)
+    public function __construct(Asset $asset, $checkedOutTo, ?User $checkedOutBy, $acceptance, $note, bool $firstTimeSending = true)
     {
         $this->item = $asset;
         $this->admin = $checkedOutBy;


### PR DESCRIPTION
In FMCS it's possible that the original admin who did a checkout isn't in the same company as the admin who might be trying to re-send the acceptance request. In this case, the 3rd parameter can come across as `null` - which violates the type constraint in the function definition.

This loosens that up to allow a `null`. The view part of the blade was already null-safe.

Fixes #18571 