### PR TITLE
Adds field_encrypted To Fields API Response

### DIFF
--- a/app/Http/Transformers/CustomFieldsTransformer.php
+++ b/app/Http/Transformers/CustomFieldsTransformer.php
@@ -44,6 +44,7 @@ class CustomFieldsTransformer
             'db_column_name' => e($field->db_column_name()),
             'format'   =>  e($field->format),
             'field_values'   => ($field->field_values) ? e($field->field_values) : null,
+            'field_encrypted' => $field->field_encrypted,
             'field_values_array'   => ($field->field_values) ? explode("\r\n", e($field->field_values)) : null,
             'type'   =>  e($field->element),
             'required'   =>  (($field->pivot) && ($field->pivot->required=='1')) ? true : false,


### PR DESCRIPTION
On the tin, adds `field_encrypted` to `/api/v1/fields` - realized it wasn't there while building out mobile custom field handling. 