### PR TITLE
Fixed RB-20713: Improved validation of license seat update api endpoint

### DIFF
--- a/app/Http/Controllers/Api/LicenseSeatsController.php
+++ b/app/Http/Controllers/Api/LicenseSeatsController.php
@@ -121,7 +121,7 @@ class LicenseSeatsController extends Controller
                     if (!is_null($value) && !Asset::where('id', $value)->whereNull('deleted_at')->exists()) {
                         $fail('The selected asset_id is invalid.');
                     }
-                }
+                },
             ],
             'notes' => 'sometimes|string|nullable',
         ]);

--- a/app/Http/Controllers/Api/LicenseSeatsController.php
+++ b/app/Http/Controllers/Api/LicenseSeatsController.php
@@ -174,7 +174,11 @@ class LicenseSeatsController extends Controller
         }
 
         if ($assignmentTouched && is_null($target)){
-            return response()->json(Helper::formatStandardApiResponse('error', null, 'Target not found'));
+            // if both asset_id and assigned_to are null then we are "checking-in"
+            // a related model that does not exist (possible purged or bad data).
+            if (!is_null($request->input('asset_id')) || !is_null($request->input('assigned_to'))) {
+                return response()->json(Helper::formatStandardApiResponse('error', null, 'Target not found'));
+            }
         }
 
         if ($licenseSeat->save()) {

--- a/app/Http/Controllers/Api/LicenseSeatsController.php
+++ b/app/Http/Controllers/Api/LicenseSeatsController.php
@@ -98,6 +98,8 @@ class LicenseSeatsController extends Controller
      */
     public function update(Request $request, $licenseId, $seatId) : JsonResponse | array
     {
+        $this->validate($request, ['assigned_to' => 'int']);
+
         $this->authorize('checkout', License::class);
 
 

--- a/app/Http/Controllers/Api/LicenseSeatsController.php
+++ b/app/Http/Controllers/Api/LicenseSeatsController.php
@@ -98,7 +98,18 @@ class LicenseSeatsController extends Controller
      */
     public function update(Request $request, $licenseId, $seatId) : JsonResponse | array
     {
-        $this->validate($request, ['assigned_to' => 'int']);
+        $this->validate($request, [
+            'assigned_to' => [
+                'sometimes',
+                'int',
+                // must be a valid user or null to unassign
+                function ($attribute, $value, $fail) {
+                    if (!is_null($value) && !User::find($value)) {
+                        $fail('The selected assigned_to is invalid.');
+                    }
+                },
+            ],
+        ]);
 
         $this->authorize('checkout', License::class);
 

--- a/app/Http/Controllers/Api/LicenseSeatsController.php
+++ b/app/Http/Controllers/Api/LicenseSeatsController.php
@@ -102,12 +102,24 @@ class LicenseSeatsController extends Controller
             'assigned_to' => [
                 'sometimes',
                 'int',
+                'prohibits:asset_id',
                 // must be a valid user or null to unassign
                 function ($attribute, $value, $fail) {
-                    if (!is_null($value) && !User::find($value)) {
+                    if (!is_null($value) && !User::where('id', $value)->whereNull('deleted_at')->exists()) {
                         $fail('The selected assigned_to is invalid.');
                     }
                 },
+            ],
+            'asset_id' => [
+                'sometimes',
+                'int',
+                'prohibits:assigned_to',
+                // must be a valid asset or null to unassign
+                function ($attribute, $value, $fail) {
+                    if (!is_null($value) && !Asset::where('id', $value)->whereNull('deleted_at')->exists()) {
+                        $fail('The selected asset_id is invalid.');
+                    }
+                }
             ],
         ]);
 

--- a/app/Http/Controllers/Api/LicenseSeatsController.php
+++ b/app/Http/Controllers/Api/LicenseSeatsController.php
@@ -121,6 +121,7 @@ class LicenseSeatsController extends Controller
                     }
                 }
             ],
+            'notes' => 'sometimes|string|nullable',
         ]);
 
         $this->authorize('checkout', License::class);
@@ -139,8 +140,7 @@ class LicenseSeatsController extends Controller
         $oldAsset = $licenseSeat->asset()->first();
 
         // attempt to update the license seat
-        $licenseSeat->fill($request->all());
-        $licenseSeat->created_by = auth()->id();
+        $licenseSeat->notes = $request->input('notes');
 
         // check if this update is a checkin operation
         // 1. are relevant fields touched at all?

--- a/app/Http/Controllers/Api/LicenseSeatsController.php
+++ b/app/Http/Controllers/Api/LicenseSeatsController.php
@@ -98,10 +98,11 @@ class LicenseSeatsController extends Controller
      */
     public function update(Request $request, $licenseId, $seatId) : JsonResponse | array
     {
-        $this->validate($request, [
+        $validated = $this->validate($request, [
             'assigned_to' => [
                 'sometimes',
                 'int',
+                'nullable',
                 'prohibits:asset_id',
                 // must be a valid user or null to unassign
                 function ($attribute, $value, $fail) {
@@ -113,6 +114,7 @@ class LicenseSeatsController extends Controller
             'asset_id' => [
                 'sometimes',
                 'int',
+                'nullable',
                 'prohibits:assigned_to',
                 // must be a valid asset or null to unassign
                 function ($attribute, $value, $fail) {
@@ -140,7 +142,7 @@ class LicenseSeatsController extends Controller
         $oldAsset = $licenseSeat->asset()->first();
 
         // attempt to update the license seat
-        $licenseSeat->notes = $request->input('notes');
+        $licenseSeat->fill($validated);
 
         // check if this update is a checkin operation
         // 1. are relevant fields touched at all?

--- a/database/factories/LicenseSeatFactory.php
+++ b/database/factories/LicenseSeatFactory.php
@@ -43,6 +43,13 @@ class LicenseSeatFactory extends Factory
         });
     }
 
+    public function unreassignable()
+    {
+        return $this->afterMaking(function (LicenseSeat $seat) {
+            $seat->license->update(['reassignable' => false]);
+        });
+    }
+
     public function notReassignable()
     {
         return $this->afterMaking(function (LicenseSeat $seat) {

--- a/tests/Feature/Checkouts/Api/LicenseCheckOutTest.php
+++ b/tests/Feature/Checkouts/Api/LicenseCheckOutTest.php
@@ -39,4 +39,29 @@ class LicenseCheckOutTest extends TestCase {
         $this->assertEquals('Checking out the seat to a user', $licenseSeat->notes);
         $this->assertHasTheseActionLogs($license, ['add seats', 'create', 'checkout']); //FIXME - backwards
     }
+
+    public function test_assigned_to_cannot_be_array()
+    {
+        $licenseSeat = LicenseSeat::factory()->create([
+            'assigned_to' => null,
+        ]);
+
+        $targets = User::factory()->count(2)->create();
+
+        $this->actingAsForApi(User::factory()->superuser()->create())
+            ->patchJson(
+                route('api.licenses.seats.update', [$licenseSeat->license->id, $licenseSeat->id]),
+                [
+                    'assigned_to' => [
+                        $targets[0]->id,
+                        $targets[1]->id,
+                    ],
+                    'notes' => '',
+                ]
+            )
+            ->assertStatus(200)
+            ->assertJsonFragment([
+                'status' => 'success',
+            ]);
+    }
 }

--- a/tests/Feature/Checkouts/Api/LicenseCheckOutTest.php
+++ b/tests/Feature/Checkouts/Api/LicenseCheckOutTest.php
@@ -19,9 +19,6 @@ class LicenseCheckOutTest extends TestCase {
 
     public function testLicenseCheckout()
     {
-        $authUser = User::factory()->superuser()->create();
-        $this->actingAsForApi($authUser);
-
         $license = License::factory()->create();
         $licenseSeat = LicenseSeat::factory()->for($license)->create([
             'assigned_to' => null,
@@ -34,9 +31,11 @@ class LicenseCheckOutTest extends TestCase {
             'notes' => 'Checking out the seat to a user',
         ];
 
-        $response = $this->patchJson(
-            route('api.licenses.seats.update', [$license->id, $licenseSeat->id]),
-            $payload);
+        $response = $this->actingAsForApi(User::factory()->superuser()->create())
+            ->patchJson(
+                $this->route($licenseSeat),
+                $payload
+            );
 
         $response->assertStatus(200)
             ->assertJsonFragment([

--- a/tests/Feature/Checkouts/Api/LicenseCheckOutTest.php
+++ b/tests/Feature/Checkouts/Api/LicenseCheckOutTest.php
@@ -60,8 +60,6 @@ class LicenseCheckOutTest extends TestCase {
                 ]
             )
             ->assertStatus(200)
-            ->assertJsonFragment([
-                'status' => 'success',
-            ]);
+            ->assertStatusMessageIs('error');
     }
 }

--- a/tests/Feature/Checkouts/Api/LicenseCheckOutTest.php
+++ b/tests/Feature/Checkouts/Api/LicenseCheckOutTest.php
@@ -7,6 +7,16 @@ use App\Models\User;
 use Tests\TestCase;
 
 class LicenseCheckOutTest extends TestCase {
+
+    public function test_requires_permission()
+    {
+        $licenseSeat = LicenseSeat::factory()->create();
+
+        $this->actingAsForApi(User::factory()->create())
+            ->patchJson($this->route($licenseSeat), [])
+            ->assertForbidden();
+    }
+
     public function testLicenseCheckout()
     {
         $authUser = User::factory()->superuser()->create();
@@ -111,5 +121,10 @@ class LicenseCheckOutTest extends TestCase {
     public function test_cannot_reassign_unreassignable_license_seat()
     {
         $this->markTestIncomplete();
+    }
+
+    private function route(LicenseSeat $licenseSeat)
+    {
+        return route('api.licenses.seats.update', [$licenseSeat->license->id, $licenseSeat->id]);
     }
 }

--- a/tests/Feature/LicenseSeats/Api/LicenseSeatUpdateTest.php
+++ b/tests/Feature/LicenseSeats/Api/LicenseSeatUpdateTest.php
@@ -1,13 +1,14 @@
 <?php
-namespace Tests\Feature\Checkouts\Api;
+
+namespace Tests\Feature\LicenseSeats\Api;
 
 use App\Models\License;
 use App\Models\LicenseSeat;
 use App\Models\User;
 use Tests\TestCase;
 
-class LicenseCheckOutTest extends TestCase {
-
+class LicenseSeatUpdateTest extends TestCase
+{
     public function test_requires_permission()
     {
         $licenseSeat = LicenseSeat::factory()->create();
@@ -17,8 +18,15 @@ class LicenseCheckOutTest extends TestCase {
             ->assertForbidden();
     }
 
-    public function testLicenseCheckout()
+    public function test_license_seat_can_be_updated()
     {
+        $this->markTestIncomplete();
+    }
+
+    public function test_license_seat_can_be_checked_out_when_updating()
+    {
+        $this->markTestIncomplete();
+
         $license = License::factory()->create();
         $licenseSeat = LicenseSeat::factory()->for($license)->create([
             'assigned_to' => null,
@@ -49,7 +57,29 @@ class LicenseCheckOutTest extends TestCase {
         $this->assertHasTheseActionLogs($license, ['add seats', 'create', 'checkout']); //FIXME - backwards
     }
 
-    public function test_license_update_without_checkout()
+    public function test_license_seat_can_be_checked_in_when_updating()
+    {
+        $this->markTestIncomplete();
+
+        $licenseSeat = LicenseSeat::factory()->reassignable()->assignedToUser()->create();
+
+        $this->actingAsForApi(User::factory()->superuser()->create())
+            ->patchJson(
+                route('api.licenses.seats.update', [$licenseSeat->license->id, $licenseSeat->id]),
+                [
+                    'assigned_to' => null,
+                    'notes' => '',
+                ]
+            )
+            ->assertStatus(200)
+            ->assertStatusMessageIs('error');
+
+        $licenseSeat->refresh();
+
+        $this->assertNull($licenseSeat->assigned_to);
+    }
+
+    public function test_cannot_reassign_unreassignable_license_seat()
     {
         $this->markTestIncomplete();
     }
@@ -93,33 +123,6 @@ class LicenseCheckOutTest extends TestCase {
             ->assertStatus(200)
             ->assertStatusMessageIs('error')
             ->assertMessagesContains('assigned_to');
-    }
-
-    public function test_null_assigned_to_checks_in_license_seat()
-    {
-        $this->markTestIncomplete();
-
-        $licenseSeat = LicenseSeat::factory()->reassignable()->assignedToUser()->create();
-
-        $this->actingAsForApi(User::factory()->superuser()->create())
-            ->patchJson(
-                route('api.licenses.seats.update', [$licenseSeat->license->id, $licenseSeat->id]),
-                [
-                    'assigned_to' => null,
-                    'notes' => '',
-                ]
-            )
-            ->assertStatus(200)
-            ->assertStatusMessageIs('error');
-
-        $licenseSeat->refresh();
-
-        $this->assertNull($licenseSeat->assigned_to);
-    }
-
-    public function test_cannot_reassign_unreassignable_license_seat()
-    {
-        $this->markTestIncomplete();
     }
 
     private function route(LicenseSeat $licenseSeat)

--- a/tests/Feature/LicenseSeats/Api/LicenseSeatUpdateTest.php
+++ b/tests/Feature/LicenseSeats/Api/LicenseSeatUpdateTest.php
@@ -190,9 +190,7 @@ class LicenseSeatUpdateTest extends TestCase
                 'notes' => 'Checking out the seat to a user',
             ])
             ->assertStatus(200)
-            ->assertJsonFragment([
-                'status' => 'success',
-            ]);
+            ->assertStatusMessageIs('success');
 
         $licenseSeat->refresh();
 
@@ -212,9 +210,7 @@ class LicenseSeatUpdateTest extends TestCase
                 'notes' => 'Checking out the seat to an asset',
             ])
             ->assertStatus(200)
-            ->assertJsonFragment([
-                'status' => 'success',
-            ]);
+            ->assertStatusMessageIs('success');
 
         $licenseSeat->refresh();
         $this->assertEquals($targetAsset->id, $licenseSeat->asset_id);
@@ -222,7 +218,28 @@ class LicenseSeatUpdateTest extends TestCase
         $this->assertHasTheseActionLogs($licenseSeat->license, ['add seats', 'create', 'checkout']); //FIXME - backwards
     }
 
-    public function test_license_seat_can_be_checked_in_when_updating()
+    public function test_license_seat_checked_out_to_asset_can_be_checked_in_when_updating()
+    {
+        $licenseSeat = LicenseSeat::factory()->unreassignable()->assignedToAsset()->create([
+            // this will be updated to true upon checkin...
+            'unreassignable_seat' => false,
+        ]);
+
+        $this->actingAsForApi(User::factory()->superuser()->create())
+            ->patchJson($this->route($licenseSeat), [
+                'asset_id' => null,
+                'notes' => 'Checking in the seat',
+            ])
+            ->assertStatus(200)
+            ->assertStatusMessageIs('success');
+
+        $licenseSeat->refresh();
+
+        $this->assertNull($licenseSeat->asset_id);
+        $this->assertTrue($licenseSeat->unreassignable_seat);
+    }
+
+    public function test_license_seat_checked_out_to_user_can_be_checked_in_when_updating()
     {
         $licenseSeat = LicenseSeat::factory()->unreassignable()->assignedToUser()->create([
             // this will be updated to true upon checkin...
@@ -241,6 +258,26 @@ class LicenseSeatUpdateTest extends TestCase
 
         $this->assertNull($licenseSeat->assigned_to);
         $this->assertTrue($licenseSeat->unreassignable_seat);
+    }
+
+    public function test_license_seat_checked_out_to_purged_asset_can_be_checked_in_when_updating()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function test_license_seat_checked_out_to_soft_deleted_asset_can_be_checked_in_when_updating()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function test_license_seat_checked_out_to_purged_user_can_be_checked_in_when_updating()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function test_license_seat_checked_out_to_soft_deleted_user_can_be_checked_in_when_updating()
+    {
+        $this->markTestIncomplete();
     }
 
     private function route(LicenseSeat $licenseSeat)

--- a/tests/Feature/LicenseSeats/Api/LicenseSeatUpdateTest.php
+++ b/tests/Feature/LicenseSeats/Api/LicenseSeatUpdateTest.php
@@ -128,6 +128,11 @@ class LicenseSeatUpdateTest extends TestCase
         $this->assertEquals($licenseId, $licenseSeat->license_id);
     }
 
+    public function test_reassignableness_is_not_updated()
+    {
+        $this->markTestIncomplete();
+    }
+
     public function test_created_by_and_timestamps_are_not_updated()
     {
         $licenseSeat = LicenseSeat::factory()->create();
@@ -153,7 +158,7 @@ class LicenseSeatUpdateTest extends TestCase
         $this->assertEquals($deleteAt, $licenseSeat->deleted_at);
     }
 
-    public function test_reassignableness_cannot_be_updated()
+    public function test_cannot_reassign_unreassignable_license_seat()
     {
         $this->markTestIncomplete();
     }
@@ -217,16 +222,6 @@ class LicenseSeatUpdateTest extends TestCase
         $licenseSeat->refresh();
 
         $this->assertNull($licenseSeat->assigned_to);
-    }
-
-    public function test_cannot_change_license_for_license_seat()
-    {
-        $this->markTestIncomplete();
-    }
-
-    public function test_cannot_reassign_unreassignable_license_seat()
-    {
-        $this->markTestIncomplete();
     }
 
     private function route(LicenseSeat $licenseSeat)

--- a/tests/Feature/LicenseSeats/Api/LicenseSeatUpdateTest.php
+++ b/tests/Feature/LicenseSeats/Api/LicenseSeatUpdateTest.php
@@ -18,72 +18,6 @@ class LicenseSeatUpdateTest extends TestCase
             ->assertForbidden();
     }
 
-    public function test_license_seat_can_be_updated()
-    {
-        $this->markTestIncomplete();
-    }
-
-    public function test_license_seat_can_be_checked_out_when_updating()
-    {
-        $this->markTestIncomplete();
-
-        $license = License::factory()->create();
-        $licenseSeat = LicenseSeat::factory()->for($license)->create([
-            'assigned_to' => null,
-        ]);
-
-        $targetUser = User::factory()->create();
-
-        $payload = [
-            'assigned_to' => $targetUser->id,
-            'notes' => 'Checking out the seat to a user',
-        ];
-
-        $response = $this->actingAsForApi(User::factory()->superuser()->create())
-            ->patchJson(
-                $this->route($licenseSeat),
-                $payload
-            );
-
-        $response->assertStatus(200)
-            ->assertJsonFragment([
-                'status' => 'success',
-            ]);
-
-        $licenseSeat->refresh();
-
-        $this->assertEquals($targetUser->id, $licenseSeat->assigned_to);
-        $this->assertEquals('Checking out the seat to a user', $licenseSeat->notes);
-        $this->assertHasTheseActionLogs($license, ['add seats', 'create', 'checkout']); //FIXME - backwards
-    }
-
-    public function test_license_seat_can_be_checked_in_when_updating()
-    {
-        $this->markTestIncomplete();
-
-        $licenseSeat = LicenseSeat::factory()->reassignable()->assignedToUser()->create();
-
-        $this->actingAsForApi(User::factory()->superuser()->create())
-            ->patchJson(
-                route('api.licenses.seats.update', [$licenseSeat->license->id, $licenseSeat->id]),
-                [
-                    'assigned_to' => null,
-                    'notes' => '',
-                ]
-            )
-            ->assertStatus(200)
-            ->assertStatusMessageIs('error');
-
-        $licenseSeat->refresh();
-
-        $this->assertNull($licenseSeat->assigned_to);
-    }
-
-    public function test_cannot_reassign_unreassignable_license_seat()
-    {
-        $this->markTestIncomplete();
-    }
-
     public function test_assigned_to_cannot_be_array()
     {
         $licenseSeat = LicenseSeat::factory()->create(['assigned_to' => null]);
@@ -123,6 +57,108 @@ class LicenseSeatUpdateTest extends TestCase
             ->assertStatus(200)
             ->assertStatusMessageIs('error')
             ->assertMessagesContains('assigned_to');
+    }
+
+    public function test_assigned_to_and_asset_id_cannot_be_provided_together()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function test_license_seat_can_be_updated()
+    {
+        $licenseSeat = LicenseSeat::factory()->create();
+
+        $this->actingAsForApi(User::factory()->superuser()->create())
+            ->patchJson($this->route($licenseSeat), [
+                'notes' => 'A new note is here',
+            ])
+            ->assertStatus(200)
+            ->assertStatusMessageIs('success');
+
+        $licenseSeat->refresh();
+
+        $this->assertEquals('A new note is here', $licenseSeat->notes);
+    }
+
+    public function test_created_by_and_timestamps_are_not_updated()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function test_reassignableness_cannot_be_updated()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function test_license_seat_can_be_checked_out_to_user_when_updating()
+    {
+        $this->markTestIncomplete();
+
+        $license = License::factory()->create();
+        $licenseSeat = LicenseSeat::factory()->for($license)->create([
+            'assigned_to' => null,
+        ]);
+
+        $targetUser = User::factory()->create();
+
+        $payload = [
+            'assigned_to' => $targetUser->id,
+            'notes' => 'Checking out the seat to a user',
+        ];
+
+        $response = $this->actingAsForApi(User::factory()->superuser()->create())
+            ->patchJson(
+                $this->route($licenseSeat),
+                $payload
+            );
+
+        $response->assertStatus(200)
+            ->assertJsonFragment([
+                'status' => 'success',
+            ]);
+
+        $licenseSeat->refresh();
+
+        $this->assertEquals($targetUser->id, $licenseSeat->assigned_to);
+        $this->assertEquals('Checking out the seat to a user', $licenseSeat->notes);
+        $this->assertHasTheseActionLogs($license, ['add seats', 'create', 'checkout']); //FIXME - backwards
+    }
+
+    public function test_license_seat_can_be_checked_out_to_asset_when_updating()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function test_license_seat_can_be_checked_in_when_updating()
+    {
+        $this->markTestIncomplete();
+
+        $licenseSeat = LicenseSeat::factory()->reassignable()->assignedToUser()->create();
+
+        $this->actingAsForApi(User::factory()->superuser()->create())
+            ->patchJson(
+                route('api.licenses.seats.update', [$licenseSeat->license->id, $licenseSeat->id]),
+                [
+                    'assigned_to' => null,
+                    'notes' => '',
+                ]
+            )
+            ->assertStatus(200)
+            ->assertStatusMessageIs('error');
+
+        $licenseSeat->refresh();
+
+        $this->assertNull($licenseSeat->assigned_to);
+    }
+
+    public function test_cannot_change_license_for_license_seat()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function test_cannot_reassign_unreassignable_license_seat()
+    {
+        $this->markTestIncomplete();
     }
 
     private function route(LicenseSeat $licenseSeat)

--- a/tests/Feature/LicenseSeats/Api/LicenseSeatUpdateTest.php
+++ b/tests/Feature/LicenseSeats/Api/LicenseSeatUpdateTest.php
@@ -224,7 +224,10 @@ class LicenseSeatUpdateTest extends TestCase
 
     public function test_license_seat_can_be_checked_in_when_updating()
     {
-        $licenseSeat = LicenseSeat::factory()->unreassignable()->assignedToUser()->create();
+        $licenseSeat = LicenseSeat::factory()->unreassignable()->assignedToUser()->create([
+            // this will be updated to true upon checkin...
+            'unreassignable_seat' => false,
+        ]);
 
         $this->actingAsForApi(User::factory()->superuser()->create())
             ->patchJson($this->route($licenseSeat), [

--- a/tests/Feature/LicenseSeats/Api/LicenseSeatUpdateTest.php
+++ b/tests/Feature/LicenseSeats/Api/LicenseSeatUpdateTest.php
@@ -19,6 +19,9 @@ class LicenseSeatUpdateTest extends TestCase
             ->assertForbidden();
     }
 
+    /**
+     * @link [rb-20713]
+     */
     public function test_assigned_to_cannot_be_array()
     {
         $licenseSeat = LicenseSeat::factory()->create(['assigned_to' => null]);

--- a/tests/Feature/LicenseSeats/Api/LicenseSeatUpdateTest.php
+++ b/tests/Feature/LicenseSeats/Api/LicenseSeatUpdateTest.php
@@ -28,7 +28,7 @@ class LicenseSeatUpdateTest extends TestCase
 
         $targets = User::factory()->count(2)->create();
 
-        $this->actingAsForApi(User::factory()->superuser()->create())
+        $this->actingAsForApi(User::factory()->checkoutLicenses()->create())
             ->patchJson($this->route($licenseSeat), [
                 'assigned_to' => [
                     $targets[0]->id,
@@ -47,7 +47,7 @@ class LicenseSeatUpdateTest extends TestCase
 
         $softDeletedUser = User::factory()->trashed()->create();
 
-        $this->actingAsForApi(User::factory()->superuser()->create())
+        $this->actingAsForApi(User::factory()->checkoutLicenses()->create())
             ->patchJson($this->route($licenseSeat), [
                 'assigned_to' => $softDeletedUser->id,
                 'notes' => '',
@@ -63,7 +63,7 @@ class LicenseSeatUpdateTest extends TestCase
 
         $softDeletedAsset = Asset::factory()->trashed()->create();
 
-        $this->actingAsForApi(User::factory()->superuser()->create())
+        $this->actingAsForApi(User::factory()->checkoutLicenses()->create())
             ->patchJson($this->route($licenseSeat), [
                 'asset_id' => $softDeletedAsset->id,
                 'notes' => '',
@@ -77,7 +77,7 @@ class LicenseSeatUpdateTest extends TestCase
     {
         $licenseSeat = LicenseSeat::factory()->create(['assigned_to' => null]);
 
-        $this->actingAsForApi(User::factory()->superuser()->create())
+        $this->actingAsForApi(User::factory()->checkoutLicenses()->create())
             ->patchJson($this->route($licenseSeat), [
                 'assigned_to' => User::factory()->create()->id,
                 'asset_id' => Asset::factory()->create()->id,
@@ -93,7 +93,7 @@ class LicenseSeatUpdateTest extends TestCase
     {
         $licenseSeat = LicenseSeat::factory()->create();
 
-        $this->actingAsForApi(User::factory()->superuser()->create())
+        $this->actingAsForApi(User::factory()->checkoutLicenses()->create())
             ->patchJson($this->route($licenseSeat), [
                 'notes' => 'A new note is here',
             ])
@@ -110,7 +110,7 @@ class LicenseSeatUpdateTest extends TestCase
         $licenseSeat = LicenseSeat::factory()->create();
         $licenseId = $licenseSeat->license_id;
 
-        $this->actingAsForApi(User::factory()->superuser()->create())
+        $this->actingAsForApi(User::factory()->checkoutLicenses()->create())
             ->patchJson($this->route($licenseSeat), [
                 'notes' => '',
                 'license_id' => License::factory()->create()->id,
@@ -126,7 +126,7 @@ class LicenseSeatUpdateTest extends TestCase
     {
         $licenseSeat = LicenseSeat::factory()->reassignable()->create(['unreassignable_seat' => false]);
 
-        $this->actingAsForApi(User::factory()->superuser()->create())
+        $this->actingAsForApi(User::factory()->checkoutLicenses()->create())
             ->patchJson($this->route($licenseSeat), [
                 'notes' => '',
                 'unreassignable_seat' => true,
@@ -146,7 +146,7 @@ class LicenseSeatUpdateTest extends TestCase
         $createdAt = $licenseSeat->created_at;
         $deleteAt = $licenseSeat->deleted_at;
 
-        $this->actingAsForApi(User::factory()->superuser()->create())
+        $this->actingAsForApi(User::factory()->checkoutLicenses()->create())
             ->patchJson($this->route($licenseSeat), [
                 'notes' => '',
                 'created_by' => User::factory()->create()->id,
@@ -167,7 +167,7 @@ class LicenseSeatUpdateTest extends TestCase
     {
         $licenseSeat = LicenseSeat::factory()->assignedToUser()->create(['unreassignable_seat' => true]);
 
-        $this->actingAsForApi(User::factory()->superuser()->create())
+        $this->actingAsForApi(User::factory()->checkoutLicenses()->create())
             ->patchJson($this->route($licenseSeat), [
                 'asset_id' => Asset::factory()->create()->id,
                 'notes' => 'Attempting to reassign an unreassignable seat',
@@ -184,7 +184,7 @@ class LicenseSeatUpdateTest extends TestCase
         $licenseSeat = LicenseSeat::factory()->create(['assigned_to' => null]);
         $targetUser = User::factory()->create();
 
-        $this->actingAsForApi(User::factory()->superuser()->create())
+        $this->actingAsForApi(User::factory()->checkoutLicenses()->create())
             ->patchJson($this->route($licenseSeat), [
                 'assigned_to' => $targetUser->id,
                 'notes' => 'Checking out the seat to a user',
@@ -204,7 +204,7 @@ class LicenseSeatUpdateTest extends TestCase
         $licenseSeat = LicenseSeat::factory()->create(['assigned_to' => null]);
         $targetAsset = Asset::factory()->create();
 
-        $this->actingAsForApi(User::factory()->superuser()->create())
+        $this->actingAsForApi(User::factory()->checkoutLicenses()->create())
             ->patchJson($this->route($licenseSeat), [
                 'asset_id' => $targetAsset->id,
                 'notes' => 'Checking out the seat to an asset',
@@ -225,7 +225,7 @@ class LicenseSeatUpdateTest extends TestCase
             'unreassignable_seat' => false,
         ]);
 
-        $this->actingAsForApi(User::factory()->superuser()->create())
+        $this->actingAsForApi(User::factory()->checkoutLicenses()->create())
             ->patchJson($this->route($licenseSeat), [
                 'asset_id' => null,
                 'notes' => 'Checking in the seat',
@@ -246,7 +246,7 @@ class LicenseSeatUpdateTest extends TestCase
             'unreassignable_seat' => false,
         ]);
 
-        $this->actingAsForApi(User::factory()->superuser()->create())
+        $this->actingAsForApi(User::factory()->checkoutLicenses()->create())
             ->patchJson($this->route($licenseSeat), [
                 'assigned_to' => null,
                 'notes' => 'Checking in the seat',
@@ -263,21 +263,75 @@ class LicenseSeatUpdateTest extends TestCase
     public function test_license_seat_checked_out_to_purged_asset_can_be_checked_in_when_updating()
     {
         $this->markTestIncomplete();
-    }
 
-    public function test_license_seat_checked_out_to_soft_deleted_asset_can_be_checked_in_when_updating()
-    {
-        $this->markTestIncomplete();
+        $licenseSeat = LicenseSeat::factory()->assignedToAsset()->create(['asset_id' => 100000]);
+
+        $this->actingAsForApi(User::factory()->checkoutLicenses()->create())
+            ->patchJson($this->route($licenseSeat), [
+                'asset_id' => null,
+                'notes' => 'Checking in the seat',
+            ])
+            ->assertStatus(200)
+            ->assertStatusMessageIs('success');
+
+        $licenseSeat->refresh();
+
+        $this->assertNull($licenseSeat->asset_id);
     }
 
     public function test_license_seat_checked_out_to_purged_user_can_be_checked_in_when_updating()
     {
         $this->markTestIncomplete();
+
+        $licenseSeat = LicenseSeat::factory()->unreassignable()->assignedToUser()->create(['assigned_to' => 100000]);
+
+        $this->actingAsForApi(User::factory()->checkoutLicenses()->create())
+            ->patchJson($this->route($licenseSeat), [
+                'assigned_to' => null,
+                'notes' => 'Checking in the seat',
+            ])
+            ->assertStatus(200)
+            ->assertStatusMessageIs('success');
+
+        $licenseSeat->refresh();
+
+        $this->assertNull($licenseSeat->assigned_to);
+    }
+
+    public function test_license_seat_checked_out_to_soft_deleted_asset_can_be_checked_in_when_updating()
+    {
+        $licenseSeat = LicenseSeat::factory()->assignedToAsset()->create();
+        $licenseSeat->asset->delete();
+
+        $this->actingAsForApi(User::factory()->checkoutLicenses()->create())
+            ->patchJson($this->route($licenseSeat), [
+                'asset_id' => null,
+                'notes' => 'Checking in the seat',
+            ])
+            ->assertStatus(200)
+            ->assertStatusMessageIs('success');
+
+        $licenseSeat->refresh();
+
+        $this->assertNull($licenseSeat->asset_id);
     }
 
     public function test_license_seat_checked_out_to_soft_deleted_user_can_be_checked_in_when_updating()
     {
-        $this->markTestIncomplete();
+        $licenseSeat = LicenseSeat::factory()->unreassignable()->assignedToUser()->create();
+        $licenseSeat->user->delete();
+
+        $this->actingAsForApi(User::factory()->checkoutLicenses()->create())
+            ->patchJson($this->route($licenseSeat), [
+                'assigned_to' => null,
+                'notes' => 'Checking in the seat',
+            ])
+            ->assertStatus(200)
+            ->assertStatusMessageIs('success');
+
+        $licenseSeat->refresh();
+
+        $this->assertNull($licenseSeat->assigned_to);
     }
 
     private function route(LicenseSeat $licenseSeat)

--- a/tests/Feature/LicenseSeats/Api/LicenseSeatUpdateTest.php
+++ b/tests/Feature/LicenseSeats/Api/LicenseSeatUpdateTest.php
@@ -89,6 +89,23 @@ class LicenseSeatUpdateTest extends TestCase
             ->assertMessagesContains('asset_id');
     }
 
+    public function test_assigned_to_and_asset_id_can_be_provided_together_if_they_are_both_null()
+    {
+        $licenseSeat = LicenseSeat::factory()->assignedToAsset()->create();
+
+        $this->actingAsForApi(User::factory()->checkoutLicenses()->create())
+            ->patchJson($this->route($licenseSeat), [
+                'assigned_to' => null,
+                'asset_id' => null,
+                'notes' => '',
+            ])
+            ->assertStatus(200)
+            ->assertStatusMessageIs('success');
+
+        $licenseSeat->refresh();
+        $this->assertNull($licenseSeat->assigned_to);
+    }
+
     public function test_license_seat_can_be_updated()
     {
         $licenseSeat = LicenseSeat::factory()->create();

--- a/tests/Support/CustomTestMacros.php
+++ b/tests/Support/CustomTestMacros.php
@@ -112,6 +112,8 @@ trait CustomTestMacros
             function (array|string $keys) {
                 Assert::assertArrayHasKey('messages', $this, 'Response did not contain any messages');
 
+                Assert::assertIsArray($this['messages'], '"messages" not an array so specific message existence cannot be checked.');
+
                 if (is_string($keys)) {
                     $keys = [$keys];
                 }

--- a/tests/Support/CustomTestMacros.php
+++ b/tests/Support/CustomTestMacros.php
@@ -112,8 +112,6 @@ trait CustomTestMacros
             function (array|string $keys) {
                 Assert::assertArrayHasKey('messages', $this, 'Response did not contain any messages');
 
-                Assert::assertIsArray($this['messages'], '"messages" not an array so specific message existence cannot be checked.');
-
                 if (is_string($keys)) {
                     $keys = [$keys];
                 }


### PR DESCRIPTION
This PR addresses a RB where a user hit the api for updating license seats while passing an array for `assigned_to` and caused a 500.

In the process:
- Moves the test class to an appropriate directory and backfill a bunch tests for existing behavior.
- Improves validation. Specifically adding `int` to `assigned_to` and `asset_id` to handle a RB.
- Stops using `fill` on the license seat to avoid overwriting timestamps, `license_id`, and `created_by`


@snipe let me know if
- [ ] I should move validation out of the controller into a dedicated form request. 

---

[RB-20712]
[RB-20713]