### PR TITLE
Fixed #18435 - correct option value for currency format selector

### DIFF
--- a/resources/views/settings/localization.blade.php
+++ b/resources/views/settings/localization.blade.php
@@ -142,7 +142,7 @@
 
                                 <x-input.select
                                     name="digit_separator"
-                                    :options="['1,234.56', '1.234,56']"
+                                    :options="['1,234.56' => '1,234.56', '1.234,56'=> '1.234,56']"
                                     :selected="old('digit_separator', $setting->digit_separator)"
                                     style="min-width:120px"
                                 />


### PR DESCRIPTION
This is a small fix for a regression in how currency is displayed. The problem was not the currency format helper, but instead the select box which stores that data.

<img width="1080" height="53" alt="Screenshot 2026-02-19 at 11 57 59 AM" src="https://github.com/user-attachments/assets/19e0d61e-e7da-4116-b791-bfa83c1473d4" />

Given no inherent option value, it was defaulting to a zero-sorted array.

This restores the previous functionality of storing the actual value we're looking for. 

Fixed #18435
