### PR TITLE
Careful upgrade to minimize too many version changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6816,11 +6816,11 @@
             }
         },
         "node_modules/jspdf-autotable": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/jspdf-autotable/-/jspdf-autotable-5.0.2.tgz",
-            "integrity": "sha512-YNKeB7qmx3pxOLcNeoqAv3qTS7KuvVwkFe5AduCawpop3NOkBUtqDToxNc225MlNecxT4kP2Zy3z/y/yvGdXUQ==",
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/jspdf-autotable/-/jspdf-autotable-5.0.7.tgz",
+            "integrity": "sha512-2wr7H6liNDBYNwt25hMQwXkEWFOEopgKIvR1Eukuw6Zmprm/ZcnmLTQEjW7Xx3FCbD3v7pflLcnMAv/h1jFDQw==",
             "peerDependencies": {
-                "jspdf": "^2 || ^3"
+                "jspdf": "^2 || ^3 || ^4"
             }
         },
         "node_modules/jspdf/node_modules/core-js": {


### PR DESCRIPTION
While it was pretty tempting to try and just run `npm upgrade` and let it upgrade *everything* - that ended up making a *TON* of changes which made me nervous. So instead I just did `npm upgrade jspdf-autotable` which seemed to bump just that one package's version, without any other versions getting tweaked.

I was able to do `npm install` and `npm run prod` after that, so I think this is good.