### PR TITLE
Added checkbox to determine if existing audit dates should be changed

### DIFF
--- a/resources/lang/en-US/admin/settings/general.php
+++ b/resources/lang/en-US/admin/settings/general.php
@@ -24,7 +24,7 @@ return [
     'allow_user_skin_help_text' => 'Checking this box will allow a user to override the UI skin with a different one.',
     'asset_ids'					=> 'Asset IDs',
     'audit_interval'            => 'Audit Interval',
-    'audit_interval_help'       => 'If you are required to regularly physically audit your assets, enter the interval in months that you use. If you update this value, all of the "next audit dates" for assets with an upcoming audit date will be updated.',
+    'audit_interval_help'       => 'If you are required to regularly physically audit your assets, enter the interval in months that you use. ',
     'audit_warning_days'        => 'Audit Warning Threshold',
     'audit_warning_days_help'   => 'How many days in advance should we warn you when assets are due for auditing?',
     'auto_increment_assets'		=> 'Generate auto-incrementing asset tags',
@@ -438,6 +438,7 @@ return [
     'client_secret' => 'Client Secret',
     'client_id' => 'Client ID',
     'too_many_users_to_show' => 'The number of users (:count) is larger than the unpaginated record limit (:max). Use the bulk user edit tool to manage group memberships.',
+    'update_existing_dates' => 'Also update all of the existing "next audit dates" for assets with an upcoming audit with the Audit Interval above. This is most commonly used when the internal policy for audit interval has changed.',
 
     'username_formats' => [
         'username_format'		=> 'Username Format',

--- a/resources/views/settings/alerts.blade.php
+++ b/resources/views/settings/alerts.blade.php
@@ -205,6 +205,16 @@
                                 </div>
                             </div>
 
+                            <!-- Alerts Enabled -->
+                            <div class="form-group {{ $errors->has('update_existing_dates') ? 'error' : '' }}">
+                                <div class="col-md-9 col-md-offset-3">
+                                    <label class="form-control">
+                                        <input type="checkbox" name="update_existing_dates" value="1" @checked(old('update_existing_dates'))>
+                                        {{  trans('admin/settings/general.update_existing_dates') }}
+                                    </label>
+                                </div>
+                            </div>
+
                         </fieldset>
 
                         </div>


### PR DESCRIPTION
This adds the ability to update all assets that currently have an audit date with the new interval date. (Previously it would do this automatically.)

<img width="1276" height="191" alt="Screenshot 2026-02-21 at 12 50 29 PM" src="https://github.com/user-attachments/assets/ba9d18a3-c597-4764-af20-63a70438a89e" />
