### PR TITLE
Fixed #18017 - show status on bulk audit

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -1149,6 +1149,8 @@ class AssetsController extends Controller
                 'id' => $asset->id,
                 'asset_tag' => $asset->asset_tag,
                 'note' => $request->input('note'),
+                'status_label' => $asset->assetstatus->display_name,
+                'status_type' => $asset->assetstatus->getStatuslabelType(),
                 'next_audit_date' => Helper::getFormattedDateObject($asset->next_audit_date),
             ];
 

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -1148,8 +1148,8 @@ class AssetsController extends Controller
             $payload = [
                 'id' => $asset->id,
                 'asset_tag' => $asset->asset_tag,
-                'note' => $request->input('note'),
-                'status_label' => $asset->assetstatus->display_name,
+                'note' => e($request->input('note')),
+                'status_label' => e($asset->assetstatus->display_name),
                 'status_type' => $asset->assetstatus->getStatuslabelType(),
                 'next_audit_date' => Helper::getFormattedDateObject($asset->next_audit_date),
             ];

--- a/resources/views/hardware/quickscan.blade.php
+++ b/resources/views/hardware/quickscan.blade.php
@@ -107,6 +107,7 @@
                         <tr>
                             <th>{{ trans('general.asset_tag') }}</th>
                             <th>{{ trans('general.bulkaudit_status') }}</th>
+                            <th>{{ trans('general.status') }}</th>
                             <th></th>
                         </tr>
                         <tr id="audit-loader" style="display: none;">
@@ -154,7 +155,7 @@
                 success : function (data) {
 
                     if (data.status == 'success') {
-                        $('#audited tbody').prepend("<tr class='success'><td>" + data.payload.asset_tag + "</td><td>" + data.messages + "</td><td><i class='fas fa-check text-success' style='font-size:18px;'></i></td></tr>");
+                        $('#audited tbody').prepend("<tr class='success'><td>" + data.payload.asset_tag + "</td><td>" + data.messages + "</td><td>" + data.payload.status_label + " (" + data.payload.status_type + ")</td><td><i class='fas fa-check text-success' style='font-size:18px;'></i></td></tr>");
 
                         @if ($user->enable_sounds)
                         var audio = new Audio('{{ config('app.url') }}/sounds/success.mp3');

--- a/resources/views/hardware/quickscan.blade.php
+++ b/resources/views/hardware/quickscan.blade.php
@@ -108,6 +108,7 @@
                             <th>{{ trans('general.asset_tag') }}</th>
                             <th>{{ trans('general.bulkaudit_status') }}</th>
                             <th>{{ trans('general.status') }}</th>
+                            <th>{{ trans('general.notes') }}</th>
                             <th></th>
                         </tr>
                         <tr id="audit-loader" style="display: none;">
@@ -155,7 +156,7 @@
                 success : function (data) {
 
                     if (data.status == 'success') {
-                        $('#audited tbody').prepend("<tr class='success'><td>" + data.payload.asset_tag + "</td><td>" + data.messages + "</td><td>" + data.payload.status_label + " (" + data.payload.status_type + ")</td><td><i class='fas fa-check text-success' style='font-size:18px;'></i></td></tr>");
+                        $('#audited tbody').prepend("<tr class='success'><td>" + data.payload.asset_tag + "</td><td>" + data.messages + "</td><td>" + data.payload.status_label + " (" + data.payload.status_type + ")</td><td>" + data.payload.note + "</td><td><i class='fas fa-check text-success' style='font-size:18px;'></i></td></tr>");
 
                         @if ($user->enable_sounds)
                         var audio = new Audio('{{ config('app.url') }}/sounds/success.mp3');
@@ -202,7 +203,7 @@
                 }
             }
 
-            $('#audited tbody').prepend("<tr class='danger'><td>" + asset_tag + "</td><td>" + messages + "</td><td><i class='fas fa-times text-danger' style='font-size:18px;'></i></td></tr>");
+            $('#audited tbody').prepend("<tr class='danger'><td>" + asset_tag + "</td><td>" + messages + "</td><td></td><td></td><td><i class='fas fa-times text-danger' style='font-size:18px;'></i></td></tr>");
         }
 
         function incrementOnSuccess() {


### PR DESCRIPTION
This adds the status label to the bulk audit UI. The original request was to allow people to change it, but I don't think that's really feasible given how much room and logic that might take, since assets might not be able to be updated to a different status if they are checked out, etc. 

<img width="2385" height="990" alt="Screenshot 2026-02-21 at 1 11 11 PM" src="https://github.com/user-attachments/assets/0875b01d-d914-42e7-b501-bdc38b1de2b2" />



Sort of fixes #18017

