### PR TITLE
Adds withTrashed() to `adminuser` and updates presenter to show strikethrough

### DIFF
--- a/app/Models/Accessory.php
+++ b/app/Models/Accessory.php
@@ -271,7 +271,7 @@ class Accessory extends SnipeModel
      */
     public function adminuser()
     {
-        return $this->belongsTo(\App\Models\User::class, 'created_by');
+        return $this->belongsTo(\App\Models\User::class, 'created_by')->withTrashed();
     }
 
     /**

--- a/app/Models/AccessoryCheckout.php
+++ b/app/Models/AccessoryCheckout.php
@@ -58,7 +58,7 @@ class AccessoryCheckout extends Model
      */
     public function adminuser()
     {
-        return $this->belongsTo(User::class, 'created_by');
+        return $this->belongsTo(User::class, 'created_by')->withTrashed();
     }
 
     /**

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -907,7 +907,7 @@ class Asset extends Depreciable
      */
     public function adminuser()
     {
-        return $this->belongsTo(\App\Models\User::class, 'created_by');
+        return $this->belongsTo(\App\Models\User::class, 'created_by')->withTrashed();
     }
 
 

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -242,7 +242,7 @@ class Category extends SnipeModel
 
     public function adminuser()
     {
-        return $this->belongsTo(\App\Models\User::class, 'created_by');
+        return $this->belongsTo(\App\Models\User::class, 'created_by')->withTrashed();
     }
 
     /**

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -320,7 +320,7 @@ final class Company extends SnipeModel
 
     public function adminuser()
     {
-        return $this->belongsTo(\App\Models\User::class, 'created_by');
+        return $this->belongsTo(\App\Models\User::class, 'created_by')->withTrashed();
     }
 
 

--- a/app/Models/Component.php
+++ b/app/Models/Component.php
@@ -167,7 +167,7 @@ class Component extends SnipeModel
      */
     public function adminuser()
     {
-        return $this->belongsTo(\App\Models\User::class, 'created_by');
+        return $this->belongsTo(\App\Models\User::class, 'created_by')->withTrashed();
     }
 
     /**

--- a/app/Models/Consumable.php
+++ b/app/Models/Consumable.php
@@ -148,7 +148,7 @@ class Consumable extends SnipeModel
      */
     public function adminuser()
     {
-        return $this->belongsTo(User::class, 'created_by');
+        return $this->belongsTo(User::class, 'created_by')->withTrashed();
     }
 
     /**

--- a/app/Models/ConsumableAssignment.php
+++ b/app/Models/ConsumableAssignment.php
@@ -29,6 +29,6 @@ class ConsumableAssignment extends Model
 
     public function adminuser()
     {
-        return $this->belongsTo(\App\Models\User::class, 'created_by');
+        return $this->belongsTo(\App\Models\User::class, 'created_by')->withTrashed();
     }
 }

--- a/app/Models/Depreciation.php
+++ b/app/Models/Depreciation.php
@@ -108,7 +108,7 @@ class Depreciation extends SnipeModel
      */
     public function adminuser()
     {
-        return $this->belongsTo(\App\Models\User::class, 'created_by');
+        return $this->belongsTo(\App\Models\User::class, 'created_by')->withTrashed();
     }
 
 

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -68,7 +68,7 @@ class Group extends SnipeModel
      */
     public function adminuser()
     {
-        return $this->belongsTo(\App\Models\User::class, 'created_by');
+        return $this->belongsTo(\App\Models\User::class, 'created_by')->withTrashed();
     }
 
     /**

--- a/app/Models/Import.php
+++ b/app/Models/Import.php
@@ -24,6 +24,6 @@ class Import extends Model
      */
     public function adminuser()
     {
-        return $this->belongsTo(\App\Models\User::class, 'created_by');
+        return $this->belongsTo(\App\Models\User::class, 'created_by')->withTrashed();
     }
 }

--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -478,7 +478,7 @@ class License extends Depreciable
      */
     public function adminuser()
     {
-        return $this->belongsTo(\App\Models\User::class, 'created_by');
+        return $this->belongsTo(\App\Models\User::class, 'created_by')->withTrashed();
     }
 
     /**

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -149,7 +149,7 @@ class Location extends SnipeModel
      */
     public function adminuser()
     {
-        return $this->belongsTo(\App\Models\User::class, 'created_by');
+        return $this->belongsTo(\App\Models\User::class, 'created_by')->withTrashed();
     }
 
     /**

--- a/app/Models/Manufacturer.php
+++ b/app/Models/Manufacturer.php
@@ -116,7 +116,7 @@ class Manufacturer extends SnipeModel
 
     public function adminuser()
     {
-        return $this->belongsTo(\App\Models\User::class, 'created_by');
+        return $this->belongsTo(\App\Models\User::class, 'created_by')->withTrashed();
     }
 
 

--- a/app/Models/Statuslabel.php
+++ b/app/Models/Statuslabel.php
@@ -79,7 +79,7 @@ class Statuslabel extends SnipeModel
 
     public function adminuser()
     {
-        return $this->belongsTo(\App\Models\User::class, 'created_by');
+        return $this->belongsTo(\App\Models\User::class, 'created_by')->withTrashed();
     }
 
     /**

--- a/app/Models/Supplier.php
+++ b/app/Models/Supplier.php
@@ -158,7 +158,7 @@ class Supplier extends SnipeModel
      */
     public function adminuser()
     {
-        return $this->belongsTo(\App\Models\User::class, 'created_by');
+        return $this->belongsTo(\App\Models\User::class, 'created_by')->withTrashed();
     }
 
     /**

--- a/app/Presenters/UserPresenter.php
+++ b/app/Presenters/UserPresenter.php
@@ -551,9 +551,9 @@ class UserPresenter extends Presenter
     public function formattedNameLink() {
 
         if (auth()->user()->can('view', ['\App\Models\User', $this])) {
-            return ($this->tag_color ? "<i class='fa-solid fa-fw fa-square' style='color: ".e($this->tag_color)."' aria-hidden='true'></i>" : '').'<a href="'.route('users.show', e($this->id)).'">'.e($this->display_name).'</a>';
+            return '<a href="'.route('users.show', e($this->id)).'" class="'. (($this->deleted_at!='') ? 'deleted' : '').'">'.e($this->display_name).'</a>';
         }
 
-        return ($this->tag_color ? "<i class='fa-solid fa-fw fa-square' style='color: ".e($this->tag_color)."' aria-hidden='true'></i>" : '').e($this->display_name);
+        return '<span class="'. (($this->deleted_at!='') ? 'deleted' : '').'">'.e($this->display_name).'</span>';
     }
 }

--- a/resources/views/blade/box/info-panel.blade.php
+++ b/resources/views/blade/box/info-panel.blade.php
@@ -481,11 +481,7 @@
                 <span class="text-muted">
                     <x-icon type="user" class="fa-fw" title="{{ trans('general.created_by') }}" />
                         {{ trans('general.created_by') }}
-                    @can('view', $infoPanelObj->adminuser)
-                        <a href="{{ route('users.show', $infoPanelObj->adminuser) }}"> {{ $infoPanelObj->adminuser->display_name }}</a>
-                    @else
-                        {{ $infoPanelObj->adminuser->display_name }}
-                    @endcan
+                    {!!  $infoPanelObj->adminuser->present()->formattedNameLink !!}
 
                 </span>
             </x-info-element>


### PR DESCRIPTION
This continues down the path of letting the presenters handle a little more of the display logic (versus junking up the blades).

I've added `->withTrashed()` onto all of the `adminuser` methods, and then put the logic of whether the name should be linked with a strikethrough, displayed normally, or displayed with a strikethrough into the presenter.

### Cannot view user details, user is deleted but not purged

<img width="506" height="371" alt="Screenshot 2026-02-23 at 10 46 31 AM" src="https://github.com/user-attachments/assets/6e98955f-62e4-4a9e-b07f-9f8e15aa116f" />

### Can view user details, user is deleted but not purged
<img width="577" height="375" alt="Screenshot 2026-02-23 at 10 46 39 AM" src="https://github.com/user-attachments/assets/fa85a5cc-fc14-4214-a370-2f7c94755df0" />

### Can view user details, user is not deleted
<img width="573" height="367" alt="Screenshot 2026-02-23 at 10 47 03 AM" src="https://github.com/user-attachments/assets/d7302efa-2d94-4952-b594-b43c539e0128" />

### Cannot view user details, user is not deleted
<img width="501" height="375" alt="Screenshot 2026-02-23 at 10 47 12 AM" src="https://github.com/user-attachments/assets/9616404f-3f5f-4d92-95e6-389fb3d41f11" />

