### PR TITLE
Fixed #18600 - add filesystem check on health checker

### DIFF
--- a/app/Http/Controllers/HealthController.php
+++ b/app/Http/Controllers/HealthController.php
@@ -29,10 +29,17 @@ class HealthController extends BaseController
     public function get()
     {
 
-        if (DB::select('select 2 + 2')) {
-            $db_status = 'ok';
-        } else {
-            $db_status = 'could not connect to database';
+        try {
+
+            if (DB::select('select 2 + 2')) {
+                $db_status = 'ok';
+            } else {
+                $db_status = 'Could not connect to database';
+            }
+
+        } catch (\Exception $e) {
+            $db_status = 'Could not connect to database';
+
         }
 
 

--- a/app/Http/Controllers/HealthController.php
+++ b/app/Http/Controllers/HealthController.php
@@ -28,23 +28,34 @@ class HealthController extends BaseController
      */
     public function get()
     {
-        try {
 
-            if (DB::select('select 2 + 2')) {
-                return response()->json([
-                    'status' => 'ok',
-                ]);
-            }
-
-        } catch (\Exception $e) {
-            \Log::error('Could not connect to database');
-            return response()->json([
-                'status' => 'database connection failed',
-            ], 500);
-
+        if (DB::select('select 2 + 2')) {
+            $db_status = 'ok';
+        } else {
+            $db_status = 'could not connect to database';
         }
 
 
+        if (is_writable(storage_path('logs'))) {
+            $filesystem_status = 'ok';
+        } else {
+            $filesystem_status = 'Could not write to storage/logs';
+        }
+
+        if (($filesystem_status!='ok') || ($db_status!='ok')) {
+            return response()->json([
+                'status' =>
+                    [
+                        'database' => $db_status,
+                        'filesystem' => $filesystem_status,
+                    ]
+            ], 500);
+        }
+
+
+        return response()->json([
+            'status' => 'ok',
+        ]);
 
     }
 }


### PR DESCRIPTION
This is a possible fix for #18600, where the requesting user had a filesystem corruption issue and the health checker was showing "ok", since the database was alright. 

I didn't want to change the output in the case of an *ok* system, so as not to break other integrations that might rely on that particular response format, but will now return


```json
{
    "status": "ok"
}
``` 

on success, and 

```json
{
    "status": {
        "database": "Could not connect to database",
        "filesystem": "Could not write to storage/logs"
    }
}
```

if something fails (and that error response will still give a 500).