### PR TITLE
Correct user city and state translations in German

### DIFF
--- a/resources/lang/de-DE/admin/reports/general.php
+++ b/resources/lang/de-DE/admin/reports/general.php
@@ -10,8 +10,8 @@ return [
     'acceptance_request' => 'Akzeptierungsanfrage',
     'custom_export' => [
         'user_address' => 'Adressinformation',
-        'user_city' => 'Stadt des Benuzers',
-        'user_state' => 'Stadt des Benutzers',
+        'user_city' => 'Stadt des Benutzers',
+        'user_state' => 'Bundesland des Benutzers',
         'user_country' => 'Land des Benutzers',
         'user_zip' => 'Postleitzahl des Benutzers'
     ],


### PR DESCRIPTION
This pull request fixes issues in the German translation of the custom export labels.

### Changes
- Fixed typo: "Stadt des Benuzers" → "Stadt des Benutzers"
- Corrected translation of `user_state`:
  - Previously: "Stadt des Benutzers"
  - Now: "Bundesland des Benutzers"

### Reason
`user_state` represents the regional/state value (e.g. Bundesland) and was incorrectly translated as "Stadt".
This caused confusion in the custom asset export for German users.

This PR ensures accurate labeling and improves translation quality.