### PR TITLE
Fix deprecated string interpolation in controllers

### DIFF
--- a/app/Http/Controllers/ModalController.php
+++ b/app/Http/Controllers/ModalController.php
@@ -38,7 +38,7 @@ class ModalController extends Controller
 
 
         if (in_array($type, $allowed_types)) {
-        $view = view("modals.${type}");
+        $view = view("modals.{$type}");
 
             if ($type == "statuslabel") {
                 $view->with('statuslabel_types', Helper::statusTypeList());

--- a/app/Http/Controllers/ViewAssetsController.php
+++ b/app/Http/Controllers/ViewAssetsController.php
@@ -206,7 +206,7 @@ class ViewAssetsController extends Controller
         if ($fullItemType == Asset::class) {
             $data['item_url'] = route('hardware.show', $item->id);
         } else {
-            $data['item_url'] = route("view/${itemType}", $item->id);
+            $data['item_url'] = route("view/{$itemType}", $item->id);
         }
 
         $settings = Setting::getSettings();


### PR DESCRIPTION
While [experimenting with the API](https://snipe-it.readme.io/reference/api-overview) I spotted this "PHP Deprecated" message

```
❯ ddev artisan route:list | grep audit
PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/app/Http/Controllers/ModalController.php on line 41
PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/app/Http/Controllers/ViewAssetsController.php on line 209
  POST            api/v1/hardware/audit .............................................................................................................................................. api.asset.audit.legacy › Api\AssetsController@audit
  POST            api/v1/hardware/{asset}/audit ............................................................................................................................................. api.asset.audit › Api\AssetsController@audit
  GET|HEAD        hardware/audit/due .............................................................................................................................................. assets.audit.due › Assets\AssetsController@dueForAudit
  GET|HEAD        hardware/bulkaudit ................................................................................................................................................ assets.bulkaudit › Assets\AssetsController@quickScan
  GET|HEAD        hardware/{asset}/audit .............................................................................................................................................. asset.audit.create › Assets\AssetsController@audit
  POST            hardware/{asset}/audit .......................................................................................................................................... asset.audit.store › Assets\AssetsController@auditStore
  GET|HEAD        reports/audit .................................................................................................................................................................. reports.audit › ReportsController@audit
```