### PR TITLE
Use non-privileged port for Apache

### DIFF
--- a/docker/000-default.conf
+++ b/docker/000-default.conf
@@ -1,4 +1,4 @@
-<VirtualHost *:80>
+<VirtualHost *:8080>
 	# The ServerName directive sets the request scheme, hostname and port that
 	# the server uses to identify itself. This is used when creating
 	# redirection URLs. In the context of virtual hosts, the ServerName


### PR DESCRIPTION
Since the container runs with a non-root security context (runAsNonRoot: true), Apache cannot bind to port 80.

On Linux systems, ports below 1024 are privileged and require root (or the NET_BIND_SERVICE capability).

This change updates Apache to listen on a non-privileged port instead, ensuring the container runs securely without requiring additional capabilities.

Right now I'm getting this error when running the container

(13)Permission denied: AH00072: make_sock: could not bind to address [::]:80 (13)Permission denied: AH00072: make_sock: could not bind to address 0.0.0.0:80 no listening sockets available, shutting down
AH00015: Unable to open logs

I'm using AKS.