### PR TITLE
Fixed Checkin All Seats button

### DIFF
--- a/resources/views/licenses/view.blade.php
+++ b/resources/views/licenses/view.blade.php
@@ -208,6 +208,16 @@
         </x-page-column>
     </x-container>
 
+@can('checkin', \App\Models\License::class)
+    @include ('modals.confirm-action',
+          [
+              'modal_name' => 'checkinFromAllModal',
+              'route' => route('licenses.bulkcheckin', $license->id),
+              'title' => trans('general.modal_confirm_generic'),
+              'body' => trans_choice('admin/licenses/general.bulk.checkin_all.modal', 2, ['checkedout_seats_count' => $checkedout_seats_count])
+          ])
+@endcan
+
 @can('checkout', \App\Models\License::class)
     @include ('modals.confirm-action',
           [


### PR DESCRIPTION
This PR fixes the "Checkin All Seats" button. 

<img width="2018" height="1310" alt="image" src="https://github.com/user-attachments/assets/f5b6e43b-4830-4050-bfb6-ba53b48c484b" />

Currently nothing happens when the button is clicked but this PR adds missing code so the modal is popped up and the user can check in all seats:

<img width="2056" height="518" alt="image" src="https://github.com/user-attachments/assets/8e009b28-41f3-45b0-ba89-007a409ab17e" />

---

One thing I noticed is that the button is still active for non-reassignable licenses even when all seats are already checked in. Since this is a hot fix I'm going to hold off on addressing that here.

<img width="2058" height="772" alt="image" src="https://github.com/user-attachments/assets/9ebf7d1e-91b8-402f-88a4-d4dbf8a44de3" />
> clicking the "Confirm" button is essentially a no-op.


---

[FD-54108]

