### PR TITLE
Fixed #18282 - added original notes to checkout target in custom report

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -598,6 +598,10 @@ class ReportsController extends Controller
                 $header[] = trans('admin/reports/general.custom_export.user_zip');
             }
 
+            if ($request->filled('target_notes')) {
+                $header[] = trans('admin/reports/general.custom_export.target_notes');
+            }
+            
             if ($request->filled('status')) {
                 $header[] = trans('general.status');
             }
@@ -987,6 +991,15 @@ class ReportsController extends Controller
                             $row[] = ''; // Empty string if unassigned
                         }
                     }
+
+                    if ($request->filled('target_notes')) {
+                        if ($asset->checkedOutToUser()) {
+                            $row[] = ($asset->assignedto) ? $asset->assignedto->notes : '';
+                        } else {
+                            $row[] = ''; // Empty string if unassigned
+                        }
+                    }
+
 
                     if ($request->filled('status')) {
                         $row[] = ($asset->assetstatus) ? $asset->assetstatus->name.' ('.$asset->present()->statusMeta.')' : '';

--- a/resources/lang/en-US/admin/reports/general.php
+++ b/resources/lang/en-US/admin/reports/general.php
@@ -14,7 +14,8 @@ return [
         'user_city' => 'User City',
         'user_state' => 'User State',
         'user_country' => 'User Country',
-        'user_zip' => 'User Zip'
+        'user_zip' => 'User Zip',
+        'target_notes' => 'Notes',
     ],
     'open_saved_template' => 'Open Saved Template',
     'save_template' =>  'Save Template',

--- a/resources/views/reports/custom.blade.php
+++ b/resources/views/reports/custom.blade.php
@@ -252,15 +252,16 @@
                 {{ trans('admin/licenses/table.assigned_to') }}
               </label>
 
-            <label class="form-control">
-                <input type="checkbox" name="user_company" value="1" @checked($template->checkmarkValue('user_company')) />
-                {{ trans('admin/reports/general.custom_export.user_company') }}
-            </label>
 
               <label class="form-control">
                   <input type="checkbox" name="username" value="1" @checked($template->checkmarkValue('username')) />
                 {{ trans('admin/users/table.username') }}
               </label>
+
+            <label class="form-control">
+                <input type="checkbox" name="user_company" value="1" @checked($template->checkmarkValue('user_company')) />
+                {{ trans('admin/reports/general.custom_export.user_company') }}
+            </label>
 
             <label class="form-control">
                 <input type="checkbox" name="email" value="1" @checked($template->checkmarkValue('email')) />
@@ -316,6 +317,11 @@
                   <input type="checkbox" name="user_zip" value="1" @checked($template->checkmarkValue('user_zip')) />
                   {{ trans('general.zip') }}
               </label>
+
+            <label class="form-control">
+                <input type="checkbox" name="target_notes" value="1" @checked($template->checkmarkValue('target_notes')) />
+                {{ trans('admin/reports/general.custom_export.target_notes') }}
+            </label>
 
 
 


### PR DESCRIPTION
This just adds the original notes for the user in the custom asset report