### PR TITLE
Re-add Location Observer with null-safe companyable check

### DIFF
--- a/app/Models/Traits/CompanyableTrait.php
+++ b/app/Models/Traits/CompanyableTrait.php
@@ -20,7 +20,7 @@ trait CompanyableTrait
         if (__CLASS__ != 'App\Models\Location') {
             static::addGlobalScope(new CompanyableScope);
         } else {
-            if (Setting::getSettings()->scope_locations_fmcs == 1) {
+            if (Setting::getSettings()?->scope_locations_fmcs == 1) {
                 static::addGlobalScope(new CompanyableScope);
             }
         }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -75,7 +75,7 @@ class AppServiceProvider extends ServiceProvider
         Component::observe(ComponentObserver::class);
         Consumable::observe(ConsumableObserver::class);
         License::observe(LicenseObserver::class);
-        // Location::observe(LocationObserver::class);
+        Location::observe(LocationObserver::class);
         Maintenance::observe(MaintenanceObserver::class);
         Setting::observe(SettingObserver::class);
         User::observe(UserObserver::class);


### PR DESCRIPTION
When you're doing a migration from 'scratch', you might not have a Settings record. So, a lot of the default scopes that fire on things like Locations might fail due to the record not even being there. This makes it hard to boot up an instance from scratch.

This adds the nullsafe operator `?->` to allow for that possibility so that the migrations can still fire OK.