### PR TITLE
Added fix-permissions script to composer to handle #18601

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -125,7 +125,8 @@
     "post-autoload-dump": [
       "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
       "@php artisan package:discover --ansi",
-      "@php artisan vendor:publish --force --tag=livewire:assets --ansi"
+      "@php artisan vendor:publish --force --tag=livewire:assets --ansi",
+      "@php fix-permissions.php"
     ],
     "post-create-project-cmd": [
       "php artisan key:generate"

--- a/fix-permissions.php
+++ b/fix-permissions.php
@@ -4,8 +4,8 @@
 
 $icon = '';
 $files = [
-    'storage/oauth-private.key' => '0600',
-    'storage/oauth-public.key' => '0660',
+    'storage/oauth-private.key' => '660',
+    'storage/oauth-public.key' => '660',
 ];
 
 echo "\n";

--- a/fix-permissions.php
+++ b/fix-permissions.php
@@ -1,0 +1,54 @@
+<?php
+(PHP_SAPI !== 'cli' || isset($_SERVER['HTTP_USER_AGENT'])) && die('Access denied.');
+
+
+$icon = '';
+$files = [
+    'storage/oauth-private.key' => '0600',
+    'storage/oauth-public.key' => '0660',
+];
+
+echo "\n";
+
+// Normalize key permissions for Passport 13 (covers both fresh installs and upgrades)
+if (PHP_OS_FAMILY !== 'Windows') {
+
+    foreach ($files as $file => $permission) {
+        if (file_exists($file)) {
+            try {
+                @chmod($file, $permission);
+                $messages[]['success'] = "Permissions updated to ".$permission." on ".$file." \n";
+            } catch (Exception $e) {
+                $messages[]['error'] = "Could not change permissions for ".$file.". Please manually change the permissions on this file to ".$permission.". See the documentation: https://snipe-it.readme.io/docs/debugging-permissions#linuxosx \n";
+            }
+        } else {
+            $messages[]['info'] = "The file ".$file." was not found and may not have been created yet. \n";
+        }
+    }
+
+
+    if (count($messages) > 0) {
+
+        for($x = 0; $x < count($messages); $x++) {
+
+            foreach ($messages[$x] as $type => $message) {
+                if ($type === 'error') {
+                    echo " \e[0;97;41m ERROR \e[0m ";
+                } elseif ($type === 'info') {
+                    echo " \e[0;97;44m INFO \e[0m ";
+                } elseif ($type === 'success') {
+                    echo " \e[0;97;42m SUCCESS \e[0m ";
+                }
+                echo $message;
+            }
+        }
+
+    }
+
+    echo "\n";
+    exit();
+
+}
+
+echo " \e[0;97;44m INFO \e[0m Windows OS detected, so OAuth key permissions could not be set. If you have problems with API calls or tables loading in your Snipe-IT application, see the documentation on how to correct them: https://snipe-it.readme.io/docs/debugging-permissions#windows \n";
+exit();


### PR DESCRIPTION
This follows up with the PR #18601 (which I unfortunately had to revert). This will run the new `fix-permissions.php` script to make sure the oauth keys are set to the right permission. Unfortunately, this only works on Linux machines, since Windows machines handle permissions in an entirely different way, but hopefully the info text at the bottom will be enough.

<img width="1389" height="898" alt="Screenshot 2026-03-08 at 2 50 45 PM" src="https://github.com/user-attachments/assets/e03cef6b-a0c6-4094-9af5-8546c004bac7" />


@joelpittet - I think something like this might help?

