### PR TITLE
Fixed #17208: Replace username_format macro

### DIFF
--- a/resources/macros/macros.php
+++ b/resources/macros/macros.php
@@ -85,29 +85,3 @@ Form::macro('barcode_types', function ($name = 'barcode_type', $selected = null,
 
     return $select;
 });
-
-Form::macro('username_format', function ($name = 'username_format', $selected = null, $class = null) {
-    $formats = [
-        'firstname.lastname' => trans('admin/settings/general.username_formats.firstname_lastname_format'),
-        'firstname' => trans('admin/settings/general.username_formats.first_name_format'),
-        'lastname' => trans('admin/settings/general.username_formats.last_name_format'),
-        'filastname' => trans('admin/settings/general.username_formats.filastname_format'),
-        'lastnamefirstinitial' => trans('admin/settings/general.username_formats.lastnamefirstinitial_format'),
-        'firstname_lastname' => trans('admin/settings/general.username_formats.firstname_lastname_underscore_format'),
-        'firstinitial.lastname' => trans('admin/settings/general.username_formats.firstinitial_lastname'),
-        'lastname_firstinitial' => trans('admin/settings/general.username_formats.lastname_firstinitial'),
-        'lastname.firstinitial' => trans('admin/settings/general.username_formats.lastname_dot_firstinitial_format'),
-        'firstnamelastname' => trans('admin/settings/general.username_formats.firstnamelastname'),
-        'firstnamelastinitial' => trans('admin/settings/general.username_formats.firstnamelastinitial'),
-        'lastname.firstname' => trans('admin/settings/general.username_formats.lastnamefirstname'),
-    ];
-
-    $select = '<select name="'.$name.'" class="'.$class.'" style="width: 100%" aria-label="'.$name.'">';
-    foreach ($formats as $format => $label) {
-        $select .= '<option value="'.$format.'"'.($selected == $format ? ' selected="selected" role="option" aria-selected="true"' : ' aria-selected="false"').'>'.$label.'</option> '."\n";
-    }
-
-    $select .= '</select>';
-
-    return $select;
-});

--- a/resources/views/blade/input/username-select.blade.php
+++ b/resources/views/blade/input/username-select.blade.php
@@ -1,0 +1,27 @@
+@php
+    $formats = [
+        'firstname.lastname' => trans('admin/settings/general.username_formats.firstname_lastname_format'),
+        'firstname' => trans('admin/settings/general.username_formats.first_name_format'),
+        'lastname' => trans('admin/settings/general.username_formats.last_name_format'),
+        'filastname' => trans('admin/settings/general.username_formats.filastname_format'),
+        'lastnamefirstinitial' => trans('admin/settings/general.username_formats.lastnamefirstinitial_format'),
+        'firstname_lastname' => trans('admin/settings/general.username_formats.firstname_lastname_underscore_format'),
+        'firstinitial.lastname' => trans('admin/settings/general.username_formats.firstinitial_lastname'),
+        'lastname_firstinitial' => trans('admin/settings/general.username_formats.lastname_firstinitial'),
+        'lastname.firstinitial' => trans('admin/settings/general.username_formats.lastname_dot_firstinitial_format'),
+        'firstnamelastname' => trans('admin/settings/general.username_formats.firstnamelastname'),
+        'firstnamelastinitial' => trans('admin/settings/general.username_formats.firstnamelastinitial'),
+        'lastname.firstname' => trans('admin/settings/general.username_formats.lastnamefirstname'),
+    ];
+@endphp
+
+<x-input.select {{ $attributes }}>
+    @foreach($formats as $format => $label)
+        <option
+            value="{{ $format }}"
+            @selected($selected == $format)
+        >
+            {{ $label }}
+        </option>
+    @endforeach
+</x-input.select>

--- a/resources/views/settings/general.blade.php
+++ b/resources/views/settings/general.blade.php
@@ -102,7 +102,12 @@
                                <label for="username_format" class="col-md-3 control-label">{{ trans('admin/settings/general.username_formats.username_format') }}</label>
 
                                <div class="col-md-8">
-                                   {!! Form::username_format('username_format', old('username_format', $setting->username_format), 'select2') !!}
+                                   <x-input.username-select
+                                       name="username_format"
+                                       :selected="old('username_format', $setting->username_format)"
+                                       style="width: 100%"
+                                       aria-label="username_format"
+                                   />
                                    {!! $errors->first('username_format', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
 
                                    <p class="help-block">


### PR DESCRIPTION
On the general settings page (`/admin/settings`):

<img width="1296" height="496" alt="image" src="https://github.com/user-attachments/assets/803404dd-b441-4122-93cd-fc9be511eb67" />

---

Fixes #17208