### PR TITLE
Fixed #17202: Replaced countries form macro

### DIFF
--- a/resources/macros/macros.php
+++ b/resources/macros/macros.php
@@ -4,42 +4,6 @@
 */
 
 /**
- * Country macro
- * Generates the dropdown menu of countries for the profile form
- */
-Form::macro('countries', function ($name = 'country', $selected = null, $class = null, $id = null) {
-
-    $idclause = (!is_null($id)) ? $id : '';
-
-    // Pull the autoglossonym array from the localizations translation file
-    $countries_array = trans('localizations.countries');
-
-    $select = '<select name="'.$name.'" class="'.$class.'" style="width:100%" '.$idclause.' aria-label="'.$name.'" data-placeholder="'.trans('localizations.select_country').'" data-allow-clear="true" data-tags="true">';
-    $select .= '<option value=""  role="option">'.trans('localizations.select_country').'</option>';
-
-    foreach ($countries_array as $abbr => $country) {
-
-        // We have to handle it this way to handle deprecation warnings since you can't strtoupper on null
-        if ($abbr!='') {
-            $abbr = strtoupper($abbr);
-        }
-
-        // Loop through the countries configured in the localization file
-        $select .= '<option value="' . $abbr . '" role="option" ' . (($selected == $abbr) ? ' selected="selected" aria-selected="true"' : ' aria-selected="false"') . '>' . $country . '</option> ';
-
-    }
-
-    // If the country value doesn't exist in the array, add it as a new option and select it so we don't drop that data
-    if (!array_key_exists($selected, $countries_array)) {
-        $select .= '<option value="' . e($selected) . '" selected="selected" role="option" aria-selected="true">' . e($selected) .' *</option> ';
-    }
-
-    $select .= '</select>';
-
-    return $select;
-});
-
-/**
  * Barcode macro
  * Generates the dropdown menu of available 1D barcodes
  */

--- a/resources/views/blade/input/country-select.blade.php
+++ b/resources/views/blade/input/country-select.blade.php
@@ -1,0 +1,35 @@
+@props([
+    'name' => 'country',
+    'selected' => null,
+])
+
+@php
+    $countries_array = trans('localizations.countries');
+@endphp
+
+<select
+    name="{{ $name }}"
+    {{ $attributes->merge(['class' => 'select2']) }}
+    aria-label="{{ $name }}"
+    data-placeholder="{{ trans('localizations.select_country') }}"
+    data-allow-clear="true"
+>
+    @foreach($countries_array as $abbreviation => $country)
+        @php
+            // We have to handle it this way to handle deprecation warnings since you can't strtoupper on null
+            if ($abbreviation!='') {
+                $abbreviation = strtoupper($abbreviation);
+            }
+        @endphp
+
+        <option value="{{ $abbreviation }}" {{ $selected === $abbreviation ? 'selected' : '' }}>
+            {{ $country }}
+        </option>
+    @endforeach
+
+    {{-- If the country value doesn't exist in the array, add it as a new option and select it so we don't drop that data --}}
+    @if (!array_key_exists($selected, $countries_array)) {
+        <option value="{{ e($selected) }}" selected="selected" role="option" aria-selected="true"> {{ e($selected) }} *</option> ';
+    @endif
+
+</select>

--- a/resources/views/modals/location.blade.php
+++ b/resources/views/modals/location.blade.php
@@ -32,7 +32,13 @@
 
                 <div class="dynamic-form-row">
                     <div class="col-md-3 col-xs-12 country"><label for="modal-country">{{ trans('general.country') }}:</label></div>
-                    <div class="col-md-9 col-xs-12">{!! Form::countries('country', old('country'), 'select2 country',"modal-country") !!}</div>
+                    <div class="col-md-9 col-xs-12">
+                        <x-input.country-select
+                            name="country"
+                            :selected="old('country')"
+                            id="modal-country"
+                        />
+                    </div>
                 </div>
             </form>
         </div>

--- a/resources/views/partials/forms/edit/address.blade.php
+++ b/resources/views/partials/forms/edit/address.blade.php
@@ -34,7 +34,10 @@
 <div class="form-group {{ $errors->has('country') ? ' has-error' : '' }}">
     <label for="country" class="col-md-3 control-label">{{ trans('general.country') }}</label>
     <div class="col-md-7">
-    {!! Form::countries('country', old('country', $item->country), 'select2') !!}
+        <x-input.country-select
+            name="country"
+            :selected="old('country', $item->country)"
+        />
         <p class="help-block">{{ trans('general.countries_manually_entered_help') }}</p>
         {!! $errors->first('country', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -502,7 +502,11 @@
                               <div class="form-group{{ $errors->has('country') ? ' has-error' : '' }}">
                                   <label class="col-md-3 control-label" for="country">{{ trans('general.country') }}</label>
                                   <div class="col-md-6">
-                                      {!! Form::countries('country', old('country', $user->country), 'col-md-12 select2') !!}
+                                      <x-input.country-select
+                                        name="country"
+                                        :selected="old('country', $user->country)"
+                                        class="col-md-12"
+                                      />
 
                                       <p class="help-block">{{ trans('general.countries_manually_entered_help') }}</p>
                                       {!! $errors->first('country', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}


### PR DESCRIPTION
This PR replaces the countries macro that is used on the user edit page and address partial.

<img width="950" height="162" alt="image" src="https://github.com/user-attachments/assets/bba84f72-e1ff-4092-9e8a-6b5cbdd4e13c" />


---

Fixes #17202