### PR TITLE
Fixed #18662 wire up search box in assigned license seats

### DIFF
--- a/app/Http/Controllers/Api/LicenseSeatsController.php
+++ b/app/Http/Controllers/Api/LicenseSeatsController.php
@@ -37,6 +37,9 @@ class LicenseSeatsController extends Controller
                 $seats->ByAssigned();
             }
 
+            if ($request->filled('search')) {
+                $seats->TextSearch($request->input('search'));
+            }
 
             $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
 

--- a/app/Models/LicenseSeat.php
+++ b/app/Models/LicenseSeat.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Models\Traits\Acceptable;
 use App\Models\Traits\CompanyableChildTrait;
 use App\Models\Traits\Loggable;
+use App\Models\Traits\Searchable;
 use App\Notifications\CheckinLicenseNotification;
 use App\Notifications\CheckoutLicenseNotification;
 use App\Presenters\Presentable;
@@ -14,13 +15,15 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 class LicenseSeat extends SnipeModel implements ICompanyableChild
 {
+    use Acceptable;
     use CompanyableChildTrait;
     use HasFactory;
     use Loggable;
+    use Presentable;
+    use Searchable;
     use SoftDeletes;
 
     protected $presenter = \App\Presenters\LicenseSeatPresenter::class;
-    use Presentable;
 
     protected $guarded = 'id';
     protected $table = 'license_seats';
@@ -39,7 +42,25 @@ class LicenseSeat extends SnipeModel implements ICompanyableChild
         'notes',
     ];
 
-    use Acceptable;
+    /**
+     * The attributes that should be included when searching the model.
+     *
+     * @var array
+     */
+    protected $searchableAttributes = [
+        'notes',
+    ];
+
+    /**
+     * The relations and their attributes that should be included when searching the model.
+     *
+     * @var array
+     */
+    protected $searchableRelations = [
+        'user' => ['first_name', 'last_name', 'display_name', 'username', 'email'],
+        'asset' => ['name', 'asset_tag'],
+    ];
+
 
     public function getCompanyableParents()
     {

--- a/resources/views/blade/table/index.blade.php
+++ b/resources/views/blade/table/index.blade.php
@@ -5,6 +5,7 @@
     'api_url' => null,
     'show_column_search' => false,
     'show_advanced_search' => false,
+    'show_search' => true,
     'fixed_number' => false,
     'fixed_right_number' => false,
     'sort_order' => 'asc',
@@ -26,6 +27,7 @@
     id="{{ $name }}ListingTable"
     data-show-columns-search="{{ $show_column_search }}"
     data-show-advanced-search="{{ $show_advanced_search }}"
+    data-search="{{ $show_search }}"
     data-footer-style="footerStyle"
     data-show-footer="true"
 

--- a/resources/views/licenses/view.blade.php
+++ b/resources/views/licenses/view.blade.php
@@ -79,6 +79,7 @@
                         <x-slot:content>
 
                             <x-table
+                                    show_search="false"
                                     api_url="{{ route('api.licenses.seats.index', [$license->id, 'status' => 'available']) }}"
                                     :presenter="\App\Presenters\LicensePresenter::dataTableLayoutSeats()"
                                     export_filename="export-{{ str_slug($license->name) }}-available-{{ date('Y-m-d') }}"

--- a/resources/views/licenses/view.blade.php
+++ b/resources/views/licenses/view.blade.php
@@ -129,7 +129,7 @@
 
 
                     <x-slot:buttons>
-                        <x-button.checkout permission="checkout" :item="$license" :route="route('licenses.freecheckout', $license->id)" />
+                        <x-button.checkout permission="checkout" :item="$license" :route="route('licenses.checkout', $license->id)" />
                         <x-button.edit :item="$license" :route="route('licenses.edit', $license->id)" />
                         <x-button.clone :item="$license" :route="route('clone/license', $license->id)" />
                         <x-button.delete :item="$license" />


### PR DESCRIPTION
This adds search functionality to the assigned  license seats tab of license views. The actual bug was that we shouldn't have had a search box there, but I've added the search functionality there now. 


https://github.com/user-attachments/assets/b4605c3b-45b0-4966-9b14-f59b6806c111

