### PR TITLE
Use Blah::class instead of new Blah in form requests

### DIFF
--- a/app/Http/Requests/AccessoryCheckoutRequest.php
+++ b/app/Http/Requests/AccessoryCheckoutRequest.php
@@ -13,7 +13,7 @@ class AccessoryCheckoutRequest extends ImageUploadRequest
      */
     public function authorize(): bool
     {
-        return Gate::allows('checkout', new Accessory);
+        return Gate::allows('checkout', Accessory::class);
     }
 
     public function prepareForValidation(): void

--- a/app/Http/Requests/StoreAccessoryRequest.php
+++ b/app/Http/Requests/StoreAccessoryRequest.php
@@ -14,7 +14,7 @@ class StoreAccessoryRequest extends ImageUploadRequest
      */
     public function authorize(): bool
     {
-        return Gate::allows('create', new Accessory);
+        return Gate::allows('create', Accessory::class);
     }
 
     public function prepareForValidation(): void

--- a/app/Http/Requests/StoreAssetModelRequest.php
+++ b/app/Http/Requests/StoreAssetModelRequest.php
@@ -14,7 +14,7 @@ class StoreAssetModelRequest extends ImageUploadRequest
      */
     public function authorize(): bool
     {
-        return Gate::allows('create', new AssetModel);
+        return Gate::allows('create', AssetModel::class);
     }
 
     public function prepareForValidation(): void

--- a/app/Http/Requests/StoreAssetRequest.php
+++ b/app/Http/Requests/StoreAssetRequest.php
@@ -21,7 +21,7 @@ class StoreAssetRequest extends ImageUploadRequest
      */
     public function authorize(): bool
     {
-        return Gate::allows('create', new Asset);
+        return Gate::allows('create', Asset::class);
     }
 
     public function prepareForValidation(): void

--- a/app/Http/Requests/StoreConsumableRequest.php
+++ b/app/Http/Requests/StoreConsumableRequest.php
@@ -14,7 +14,7 @@ class StoreConsumableRequest extends ImageUploadRequest
      */
     public function authorize(): bool
     {
-        return Gate::allows('create', new Consumable);
+        return Gate::allows('create', Consumable::class);
     }
 
     public function prepareForValidation(): void

--- a/app/Http/Requests/StoreDepartmentRequest.php
+++ b/app/Http/Requests/StoreDepartmentRequest.php
@@ -13,7 +13,7 @@ class StoreDepartmentRequest extends ImageUploadRequest
      */
     public function authorize(): bool
     {
-        return Gate::allows('create', new Department);
+        return Gate::allows('create', Department::class);
     }
 
     /**


### PR DESCRIPTION
This just normalizes the authorize gates to be more laravel compliant. (This fixes some recently failing tests as well)