### PR TITLE
Fixed #17348 - show deleted assets for deleted models

### DIFF
--- a/resources/views/blade/button/clone.blade.php
+++ b/resources/views/blade/button/clone.blade.php
@@ -6,7 +6,7 @@
 
 @can('create', $item)
     <!-- start clone button component -->
-    <a href="{{ $route }}" class="btn btn-sm btn-info hidden-print{{ ($wide=='true') ?? ' btn-block btn-social'  }}">
+    <a href="{{ $route }}" class="btn btn-sm btn-info hidden-print{{ ($wide=='true') ?? ' btn-block btn-social'  }}" data-tooltip="true"  data-placement="top" data-title="{{ trans('general.clone') }}">
     <x-icon type="clone" class="fa-fw"  />
         @if ($wide=='true')
             {{ trans('general.clone') }}

--- a/resources/views/blade/button/edit.blade.php
+++ b/resources/views/blade/button/edit.blade.php
@@ -7,13 +7,12 @@
 @can('update', $item)
 <!-- start update button component -->
 @if ($item->deleted_at=='')
-<a href="{{ ($item->deleted_at == '') ? $route: '#' }}" class="btn btn-sm btn-warning hidden-print {{ ($wide=='true') ?? ' btn-block btn-social'  }}{{ ($item->deleted_at!='') ? ' disabled' : '' }}">
+<a href="{{ ($item->deleted_at == '') ? $route: '#' }}" class="btn btn-sm btn-warning hidden-print {{ ($wide=='true') ?? ' btn-block btn-social'  }}{{ ($item->deleted_at!='') ? ' disabled' : '' }}" data-tooltip="true"  data-placement="top" data-title="{{ trans('general.update') }}">
     <x-icon type="edit" class="fa-fw" />
 
     @if ($wide=='true')
         {{ trans('general.update') }}
     @endif
-
 
 </a>
 @endif

--- a/resources/views/blade/button/restore.blade.php
+++ b/resources/views/blade/button/restore.blade.php
@@ -1,16 +1,19 @@
 @props([
     'item' => null,
     'route' => null,
+    'wide' => false,
 ])
 
 @can('update', $item)
     @if ($item->deleted_at!='')
     <!-- start restore button component -->
-    <form method="POST" action="{{ $route }}">
+    <form method="POST" action="{{ $route }}" class="inline">
     @csrf
-        <button class="btn btn-sm btn-block btn-warning btn-social hidden-print">
-        <x-icon type="restore" />
-        {{ trans('general.restore') }}
+        <button class="btn btn-sm btn-warning hidden-print{{ ($wide=='true') ?? ' btn-block btn-social'  }}" data-tooltip="true"  data-placement="top" data-title="{{ trans('general.restore') }}">
+        <x-icon type="restore" class="fa-fw" />
+            @if ($wide=='true')
+                {{ trans('general.restore') }}
+            @endif
         </button>
     </form>
     @endif

--- a/resources/views/models/view.blade.php
+++ b/resources/views/models/view.blade.php
@@ -38,7 +38,7 @@
 
                 <x-slot:tabpanes>
                     <x-tabs.pane name="assets" class="in active">
-                        <x-table.assets :route="route('api.assets.index', ['model_id' => $model->id])" />
+                        <x-table.assets :route="route('api.assets.index', ['model_id' => $model->id, 'status' => $model->deleted_at!='' ? 'Deleted' : ''])" />
                     </x-tabs.pane>
 
                     <x-tabs.pane name="files">
@@ -53,6 +53,7 @@
                 <x-box.info-panel :infoPanelObj="$model" img_path="{{ app('models_upload_url') }}">
                     <x-slot:buttons>
                         <x-button.edit :item="$model" :route="route('models.edit', $model->id)" />
+                        <x-button.restore :item="$model" :route="route('models.restore.store', $model->id)" />
                         <x-button.clone :item="$model" :route="route('models.clone.create', $model->id)" />
                         <x-button.delete :item="$model" />
                     </x-slot:buttons>


### PR DESCRIPTION
This adds an optional deleted_at parameter when fetching the assets list if the asset model is deleted.  

https://github.com/user-attachments/assets/a1ec4ce7-6c1a-4b74-93c4-0712132dcf58

Fixes #17348
