### PR TITLE
Fixed #18574 - adds checked out field to maintenances

### DIFF
--- a/app/Http/Controllers/Api/MaintenancesController.php
+++ b/app/Http/Controllers/Api/MaintenancesController.php
@@ -36,7 +36,7 @@ class MaintenancesController extends Controller
         $this->authorize('view', Asset::class);
 
         $maintenances = Maintenance::select('maintenances.*')
-            ->with('asset', 'asset.model', 'asset.location', 'asset.defaultLoc', 'supplier', 'asset.company', 'asset.assetstatus', 'adminuser');
+            ->with('asset', 'asset.model', 'asset.location', 'asset.defaultLoc', 'supplier', 'asset.company', 'asset.assetstatus', 'adminuser', 'asset.assignedTo',);
 
         if ($request->filled('search')) {
             $maintenances = $maintenances->TextSearch($request->input('search'));

--- a/app/Http/Transformers/MaintenancesTransformer.php
+++ b/app/Http/Transformers/MaintenancesTransformer.php
@@ -46,6 +46,7 @@ class MaintenancesTransformer
                 'status_type' => e($assetmaintenance->asset->assetstatus->getStatuslabelType()),
                 'status_meta' => e($assetmaintenance->asset->present()->statusMeta),
             ] : null,
+            'assigned_to' => (new AssetsTransformer)->transformAssignedTo($assetmaintenance->asset),
             'company' => (($assetmaintenance->asset) && ($assetmaintenance->asset->company)) ? [
                 'id' => (int) $assetmaintenance->asset->company->id,
                 'name' => ($assetmaintenance->asset->company->name) ? e($assetmaintenance->asset->company->name) : null,

--- a/app/Presenters/MaintenancesPresenter.php
+++ b/app/Presenters/MaintenancesPresenter.php
@@ -88,6 +88,13 @@ class MaintenancesPresenter extends Presenter
                 'switchable' => true,
                 'title' => trans('general.model_no'),
                 'visible' => true,
+            ],[
+                'field' => 'assigned_to',
+                'searchable' => true,
+                'sortable' => true,
+                'title' => trans('admin/hardware/form.checkedout_to'),
+                'visible' => true,
+                'formatter' => 'polymorphicItemFormatter',
             ],
             [
                 'field' => 'supplier',

--- a/resources/views/maintenances/view.blade.php
+++ b/resources/views/maintenances/view.blade.php
@@ -65,6 +65,38 @@ use Carbon\Carbon;
                                     </div>
                                 </div> <!-- /row -->
 
+                                @if ($maintenance->asset->assignedTo)
+                                    <div class="row">
+                                        <div class="col-md-3">
+                                            {{ trans('admin/hardware/form.checkedout_to') }}
+                                        </div>
+                                        <div class="col-md-9">
+                                            @if (($maintenance->asset?->assignedTo) && ($maintenance->asset?->deleted_at==''))
+                                                <x-icon type="circle-solid" class="text-blue" />
+                                                {{ $maintenance->asset?->assetstatus->name }}
+                                                <label class="label label-default">{{ trans('general.deployed') }}</label>
+
+
+                                                <x-icon type="long-arrow-right" />
+                                                <x-icon type="{{ $maintenance->asset?->assignedType() }}" class="fa-fw" />
+                                                {!!  $maintenance->asset?->assignedTo->present()->nameUrl() !!}
+                                            @else
+                                                @if (($maintenance->asset?->assetstatus) && ($maintenance->asset?->assetstatus->deployable=='1'))
+                                                    <x-icon type="circle-solid" class="text-green" />
+                                                @elseif (($maintenance->asset?->assetstatus) && ($maintenance->asset?->assetstatus->pending=='1'))
+                                                    <x-icon type="circle-solid" class="text-orange" />
+                                                @else
+                                                    <x-icon type="x" class="text-red" />
+                                                @endif
+                                                <a href="{{ route('statuslabels.show', $maintenance->asset?->assetstatus->id) }}">
+                                                    {{ $maintenance->asset?->assetstatus->name }}</a>
+                                                <label class="label label-default">{{ $asset->present()->statusMeta }}</label>
+
+                                            @endif
+                                        </div>
+                                    </div> <!-- /row -->
+                                @endif
+
                                 @if ($maintenance->asset->model)
                                     <div class="row">
                                         <div class="col-md-3">


### PR DESCRIPTION
This adds the user/location/etc the asset is checked out to into the maintenances list.

<img width="1850" height="1123" alt="Screenshot 2026-03-16 at 7 55 03 PM" src="https://github.com/user-attachments/assets/2ea50ddd-be61-43b8-836a-b5c4660123fe" />

Fixes: #18574 