### PR TITLE
Improved asset maintenance report

### DIFF
--- a/app/Http/Controllers/Api/MaintenancesController.php
+++ b/app/Http/Controllers/Api/MaintenancesController.php
@@ -126,6 +126,10 @@ class MaintenancesController extends Controller
         $total = $maintenances->count();
         $maintenances = $maintenances->skip($offset)->take($limit)->get();
 
+        if (request()->input('format') == 'flat') {
+            return (new MaintenancesTransformer)->transformMaintenancesFlat($maintenances, $total);
+        }
+        
         return (new MaintenancesTransformer)->transformMaintenances($maintenances, $total);
 
     }

--- a/app/Http/Transformers/MaintenancesTransformer.php
+++ b/app/Http/Transformers/MaintenancesTransformer.php
@@ -17,7 +17,6 @@ class MaintenancesTransformer
         foreach ($maintenances as $assetmaintenance) {
             $array[] = self::transformMaintenance($assetmaintenance);
         }
-
         return (new DatatablesTransformer)->transformDatatables($array, $total);
     }
 
@@ -72,7 +71,7 @@ class MaintenancesTransformer
             'cost' => Helper::formatCurrencyOutput($assetmaintenance->cost),
             'asset_maintenance_type' => e($assetmaintenance->asset_maintenance_type),
             'start_date' => Helper::getFormattedDateObject($assetmaintenance->start_date, 'date'),
-            'asset_maintenance_time' => $assetmaintenance->asset_maintenance_time,
+            'asset_maintenance_time' => (int) $assetmaintenance->asset_maintenance_time,
             'completion_date' => Helper::getFormattedDateObject($assetmaintenance->completion_date, 'date'),
             'user_id' => ($assetmaintenance->adminuser) ? [
                 'id' => $assetmaintenance->adminuser->id,
@@ -84,7 +83,57 @@ class MaintenancesTransformer
             ] : null,
             'created_at' => Helper::getFormattedDateObject($assetmaintenance->created_at, 'datetime'),
             'updated_at' => Helper::getFormattedDateObject($assetmaintenance->updated_at, 'datetime'),
-            'is_warranty' => $assetmaintenance->is_warranty,
+            'is_warranty' => (bool) $assetmaintenance->is_warranty,
+
+        ];
+
+        $permissions_array['available_actions'] = [
+            'update' => (Gate::allows('update', Asset::class) && ((($assetmaintenance->asset) && $assetmaintenance->asset->deleted_at == ''))) ? true : false,
+            'delete' => Gate::allows('delete', Asset::class),
+        ];
+
+        $array += $permissions_array;
+
+        return $array;
+    }
+
+    public function transformMaintenancesFlat(Collection $maintenances, $total)
+    {
+        $array = [];
+        foreach ($maintenances as $assetmaintenance) {
+            $array[] = self::transformMaintenanceForReport($assetmaintenance);
+        }
+        return (new DatatablesTransformer)->transformDatatables($array, $total);
+    }
+
+    public function transformMaintenanceForReport(Maintenance $assetmaintenance)
+    {
+        $array = [
+            'id' => (int) $assetmaintenance->id,
+            'asset_name' => ($assetmaintenance->asset->name) ? e($assetmaintenance->asset->name) : null,
+            'asset_tag' => ($assetmaintenance->asset->asset_tag) ? e($assetmaintenance->asset->asset_tag) : null,
+            'serial' => ($assetmaintenance->asset?->serial) ? e($assetmaintenance->asset->serial) : null,
+            'image' => ($assetmaintenance->image != '') ? Storage::disk('public')->url('maintenances/' . e($assetmaintenance->image)) : null,
+            'model' => ($assetmaintenance->asset?->model?->name) ? e($assetmaintenance->asset?->model?->name) : null,
+            'model_number' => ($assetmaintenance->asset?->model?->model_number) ? e($assetmaintenance->asset?->model?->model_number) : null,
+            'status_label' => ($assetmaintenance->asset?->assetstatus) ? e($assetmaintenance->asset?->assetstatus?->display_name) : null,
+            'assigned_to' => ($assetmaintenance->asset?->assigned) ? e($assetmaintenance->asset?->assigned?->display_name) : null,
+            'company' => ($assetmaintenance->asset?->company?->name) ? e($assetmaintenance->asset->company->name) : null,
+            'name' => ($assetmaintenance->name) ? e($assetmaintenance->name) : null,
+            'title' => ($assetmaintenance->name) ? e($assetmaintenance->name) : null, // legacy to not change the shape of the API
+            'location' => (($assetmaintenance->asset) && ($assetmaintenance->asset->location)) ? e($assetmaintenance->asset->location->name) : null,
+            'notes' => ($assetmaintenance->notes) ? Helper::parseEscapedMarkedownInline($assetmaintenance->notes) : null,
+            'supplier' => ($assetmaintenance->supplier) ? e($assetmaintenance->supplier?->name) : null,
+            'url' => ($assetmaintenance->url) ? e($assetmaintenance->url) : null,
+            'cost' => Helper::formatCurrencyOutput($assetmaintenance->cost),
+            'asset_maintenance_type' => e($assetmaintenance->asset_maintenance_type),
+            'start_date' => Helper::getFormattedDateObject($assetmaintenance->start_date, 'date'),
+            'asset_maintenance_time' => (int) $assetmaintenance->asset_maintenance_time,
+            'completion_date' => Helper::getFormattedDateObject($assetmaintenance->completion_date, 'date'),
+            'created_by' => ($assetmaintenance->adminuser) ? e($assetmaintenance->adminuser->display_name) : null,
+            'created_at' => Helper::getFormattedDateObject($assetmaintenance->created_at, 'datetime'),
+            'updated_at' => Helper::getFormattedDateObject($assetmaintenance->updated_at, 'datetime'),
+            'is_warranty' => (bool) $assetmaintenance->is_warranty,
 
         ];
 

--- a/app/Presenters/MaintenancesPresenter.php
+++ b/app/Presenters/MaintenancesPresenter.php
@@ -187,4 +187,161 @@ class MaintenancesPresenter extends Presenter
 
         return json_encode($layout);
     }
+
+    public static function reportLayout()
+    {
+        $layout = [
+            [
+                'field' => 'company',
+                'searchable' => true,
+                'sortable' => true,
+                'switchable' => true,
+                'title' => trans('admin/companies/table.title'),
+                'visible' => false,
+            ],
+            [
+                'field' => 'asset_tag',
+                'searchable' => true,
+                'sortable' => true,
+                'title' => trans('admin/hardware/table.asset_tag'),
+            ],
+            [
+                'field' => 'asset_name',
+                'searchable' => true,
+                'sortable' => true,
+                'title' => trans('admin/maintenances/table.asset_name'),
+            ],
+            [
+                'field' => 'name',
+                'searchable' => true,
+                'sortable' => true,
+                'switchable' => true,
+                'title' => trans('general.name'),
+                'visible' => true,
+            ],
+            [
+                'field' => 'image',
+                'searchable' => false,
+                'sortable' => true,
+                'switchable' => true,
+                'title' => trans('general.image'),
+                'visible' => true,
+                'formatter' => 'imageFormatter',
+            ],
+            [
+                'field' => 'serial',
+                'searchable' => true,
+                'sortable' => true,
+                'title' => trans('admin/hardware/table.serial'),
+            ], [
+                'field' => 'status_label',
+                'searchable' => true,
+                'sortable' => true,
+                'title' => trans('admin/hardware/table.status'),
+                'visible' => true,
+            ], [
+                'field' => 'model',
+                'searchable' => true,
+                'sortable' => true,
+                'switchable' => true,
+                'title' => trans('admin/hardware/form.model'),
+                'visible' => false,
+            ], [
+                'field' => 'model_number',
+                'searchable' => true,
+                'sortable' => true,
+                'switchable' => true,
+                'title' => trans('general.model_no'),
+                'visible' => true,
+            ], [
+                'field' => 'assigned_to',
+                'searchable' => true,
+                'sortable' => true,
+                'title' => trans('admin/hardware/form.checkedout_to'),
+                'visible' => true,
+            ],
+            [
+                'field' => 'supplier',
+                'searchable' => true,
+                'sortable' => true,
+                'switchable' => true,
+                'title' => trans('general.supplier'),
+                'visible' => false,
+            ], [
+                'field' => 'location',
+                'searchable' => true,
+                'sortable' => true,
+                'title' => trans('general.location'),
+            ], [
+                'field' => 'asset_maintenance_type',
+                'searchable' => true,
+                'sortable' => true,
+                'title' => trans('admin/maintenances/form.asset_maintenance_type'),
+            ], [
+                'field' => 'start_date',
+                'searchable' => true,
+                'sortable' => true,
+                'title' => trans('admin/maintenances/form.start_date'),
+                'formatter' => 'dateDisplayFormatter',
+            ], [
+                'field' => 'completion_date',
+                'searchable' => true,
+                'sortable' => true,
+                'title' => trans('admin/maintenances/form.completion_date'),
+                'formatter' => 'dateDisplayFormatter',
+            ], [
+                'field' => 'asset_maintenance_time',
+                'searchable' => true,
+                'sortable' => true,
+                'title' => trans('admin/maintenances/form.asset_maintenance_time'),
+            ], [
+                'field' => 'url',
+                'searchable' => true,
+                'sortable' => true,
+                'title' => trans('general.url'),
+                'formatter' => 'externalLinkFormatter',
+            ], [
+                'field' => 'notes',
+                'searchable' => true,
+                'sortable' => true,
+                'title' => trans('admin/maintenances/form.notes'),
+            ], [
+                'field' => 'is_warranty',
+                'searchable' => true,
+                'sortable' => true,
+                'title' => trans('admin/maintenances/table.is_warranty'),
+                'formatter' => 'trueFalseFormatter',
+            ], [
+                'field' => 'cost',
+                'searchable' => true,
+                'sortable' => true,
+                'title' => trans('admin/maintenances/form.cost'),
+                'class' => 'text-right',
+            ], [
+                'field' => 'created_by',
+                'searchable' => false,
+                'sortable' => true,
+                'title' => trans('general.created_by'),
+                'visible' => false,
+            ], [
+                'field' => 'created_at',
+                'searchable' => true,
+                'sortable' => true,
+                'switchable' => true,
+                'title' => trans('general.created_at'),
+                'visible' => false,
+                'formatter' => 'dateDisplayFormatter',
+            ], [
+                'field' => 'updated_at',
+                'searchable' => true,
+                'sortable' => true,
+                'switchable' => true,
+                'title' => trans('general.updated_at'),
+                'visible' => false,
+                'formatter' => 'dateDisplayFormatter',
+            ],
+        ];
+
+        return json_encode($layout);
+    }
 }

--- a/resources/views/reports/maintenances.blade.php
+++ b/resources/views/reports/maintenances.blade.php
@@ -12,38 +12,20 @@
         <x-box>
             <table
                     data-cookie-id-table="maintenancesReport"
+                    data-columns="{{ \App\Presenters\MaintenancesPresenter::reportLayout() }}"
                     data-show-footer="true"
                     data-id-table="maintenancesReport"
                     data-side-pagination="server"
                     data-sort-order="asc"
                     id="maintenancesReport"
                     data-advanced-search="false"
-                    data-url="{{route('api.maintenances.index') }}"
+                    data-url="{{route('api.maintenances.index', ['format' => 'flat']) }}"
                     class="table table-striped snipe-table"
                     data-export-options='{
                         "fileName": "maintenance-report-{{ date('Y-m-d') }}",
                         "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                         }'>
-                <thead>
-                <tr>
-                    <th data-field="company" data-sortable="false" data-visible="false" data-formatter="companiesLinkObjFormatter">{{ trans('admin/companies/table.title') }}</th>
-                    <th data-sortable="true" data-field="id" data-visible="false">{{ trans('general.id') }}</th>
-                    <th data-sortable="true" data-field="asset_tag" data-formatter="assetTagLinkFormatter" data-visible="false">{{ trans('general.asset_tag') }}</th>
-                    <th data-sortable="false" data-field="asset_name" data-formatter="assetNameLinkFormatter">{{ trans('admin/maintenances/table.asset_name') }}</th>
-                    <th data-sortable="false" data-field="supplier" data-formatter="suppliersLinkObjFormatter">{{ trans('general.supplier') }}</th>
-                    <th data-searchable="true" data-sortable="true" data-field="asset_maintenance_type">{{ trans('admin/maintenances/form.asset_maintenance_type') }}</th>
-                    <th data-searchable="true" data-sortable="true" data-field="title">{{ trans('admin/maintenances/form.title') }}</th>
-                    <th data-searchable="true" data-sortable="false" data-field="start_date" data-formatter="dateDisplayFormatter">{{ trans('admin/maintenances/form.start_date') }}</th>
-                    <th data-searchable="true" data-sortable="true" data-field="completion_date" data-formatter="dateDisplayFormatter">{{ trans('admin/maintenances/form.completion_date') }}</th>
-                    <th data-searchable="true" data-sortable="true" data-field="asset_maintenance_time">{{ trans('admin/maintenances/form.asset_maintenance_time') }}</th>
-                    <th data-searchable="true" data-sortable="true" data-field="cost" class="text-right" data-footer-formatter="sumFormatter">{{ trans('admin/maintenances/form.cost') }}</th>
-                    <th data-sortable="true" data-field="location" data-formatter="deployedLocationFormatter" data-visible="false">{{ trans('general.location') }}</th>
-                    <th data-sortable="true" data-field="rtd_location" data-formatter="deployedLocationFormatter" data-visible="false">{{ trans('admin/hardware/form.default_location') }}</th>
-                    <th data-searchable="true" data-sortable="true" data-field="is_warranty" data-formatter="trueFalseFormatter">{{ trans('admin/maintenances/table.is_warranty') }}</th>
-                    <th data-searchable="true" data-sortable="true" data-field="user_id" data-formatter="usersLinkObjFormatter">{{ trans('general.created_by') }}</th>
-                    <th data-searchable="true" data-sortable="true" data-field="notes" data-visible="false">{{ trans('admin/maintenances/form.notes') }}</th>
-                </tr>
-                </thead>
+
             </table>
         </x-box>
     </x-container>


### PR DESCRIPTION
This adds the checked out to field to the asset maintenance *report* (versus the asset maintenances page). It also unlinks fields, since we don't necessarily know whether or not the user has permissions if they click through on some of the linked things, which would result in a sad panda.