### PR TITLE
Fixed FD-54250: Display assigned entity in expiring assets mail

### DIFF
--- a/resources/views/notifications/markdown/report-expiring-assets.blade.php
+++ b/resources/views/notifications/markdown/report-expiring-assets.blade.php
@@ -21,8 +21,8 @@
 @if ($asset->supplier)
 | **{{ trans('mail.supplier') }}** | {{ ($asset->supplier ? e($asset->supplier->name) : '') }} |
 @endif
-@if ($asset->assignedTo)
-| **{{ trans('mail.assigned_to') }}** | {{ e($asset->assignedTo->present()->display_name) }} |
+@if ($asset->assigned)
+| **{{ trans('mail.assigned_to') }}** | {{ e($asset->assigned->present()->display_name) }} |
 @endif
 | <hr> | <hr> |
 @endforeach


### PR DESCRIPTION
This PR displays the entity that is assigned to the asset to be displayed in the expiring asset email that is sent when `snipeit:expiring-alerts` is run.

<img width="1610" height="1246" alt="image" src="https://github.com/user-attachments/assets/16a09913-ff1a-4ac9-b4b6-e116610e8bac" />

---

[FD-54250]
