### PR TITLE
Fix CVE-2026-33347 and CVE-2026-30838 in league/commonmark

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3385,16 +3385,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.7.1",
+            "version": "2.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "10732241927d3971d28e7ea7b5712721fa2296ca"
+                "reference": "59fb075d2101740c337c7216e3f32b36c204218b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/10732241927d3971d28e7ea7b5712721fa2296ca",
-                "reference": "10732241927d3971d28e7ea7b5712721fa2296ca",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/59fb075d2101740c337c7216e3f32b36c204218b",
+                "reference": "59fb075d2101740c337c7216e3f32b36c204218b",
                 "shasum": ""
             },
             "require": {
@@ -3419,9 +3419,9 @@
                 "phpstan/phpstan": "^1.8.2",
                 "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0",
                 "scrutinizer/ocular": "^1.8.1",
-                "symfony/finder": "^5.3 | ^6.0 | ^7.0",
-                "symfony/process": "^5.4 | ^6.0 | ^7.0",
-                "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0 | ^6.0 | ^7.0",
+                "symfony/finder": "^5.3 | ^6.0 | ^7.0 || ^8.0",
+                "symfony/process": "^5.4 | ^6.0 | ^7.0 || ^8.0",
+                "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0 | ^6.0 | ^7.0 || ^8.0",
                 "unleashedtech/php-coding-standard": "^3.1.1",
                 "vimeo/psalm": "^4.24.0 || ^5.0.0 || ^6.0.0"
             },
@@ -3431,7 +3431,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.8-dev"
+                    "dev-main": "2.9-dev"
                 }
             },
             "autoload": {
@@ -3488,7 +3488,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-20T12:47:49+00:00"
+            "time": "2026-03-19T13:16:38+00:00"
         },
         {
             "name": "league/config",


### PR DESCRIPTION
  ## Summary
  - update `league/commonmark` from `2.7.1` to `2.8.2` in `composer.lock`
  - fix `CVE-2026-33347` / `GHSA-hh8v-hgvp-g3f5`
  - resolve the `composer audit` finding for the embed extension allowed_domains bypass

Cherry-picked the composer audit because the other stuff is regarding laravel/passport in a separate PR.
```
+-------------------+----------------------------------------------------------------------------------+
| Package           | league/commonmark                                                                |
| Severity          | medium                                                                           |
| Advisory ID       | PKSA-21fb-n1x5-5nf7                                                              |
| CVE               | CVE-2026-33347                                                                   |
| Title             | league/commonmark has an embed extension allowed_domains bypass                  |
| URL               | https://github.com/advisories/GHSA-hh8v-hgvp-g3f5                                |
| Affected versions | <=2.8.1                                                                          |
| Reported at       | 2026-03-19T19:04:24+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | league/commonmark                                                                |
| Severity          | medium                                                                           |
| Advisory ID       | PKSA-2cx9-ynrq-qdk3                                                              |
| CVE               | CVE-2026-30838                                                                   |
| Title             | CommonMark has DisallowedRawHtml extension bypass via whitespace in HTML tag     |
|                   | names                                                                            |
| URL               | https://github.com/advisories/GHSA-4v6x-c7xx-hw9f                                |
| Affected versions | <=2.8.0                                                                          |
| Reported at       | 2026-03-06T23:27:03+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
  ```