### PR TITLE
Fixes FD-54467 TZe_24mm_E Field value to extend full width

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -1816,6 +1816,8 @@ class Helper
         $labelWidth = ($maxLabelWidthPerUnit * $labelSize) + $labelPadding;
         $valueX = $currentX + $labelWidth + $gap;
         $valueWidth = $usableWidth - $labelWidth - $gap;
+        $fullValueX = $currentX;
+        $fullValueWidth = $usableWidth;
 
         return compact(
             'scale',
@@ -1829,7 +1831,9 @@ class Helper
             'rowAdvance',
             'labelWidth',
             'valueX',
-            'valueWidth'
+            'valueWidth',
+            'fullValueX',
+            'fullValueWidth',
         );
     }
 }

--- a/app/Models/Labels/Tapes/Brother/TZe_24mm_E.php
+++ b/app/Models/Labels/Tapes/Brother/TZe_24mm_E.php
@@ -133,18 +133,21 @@ class TZe_24mm_E extends TZe_24mm
         );
 
         foreach ($fields as $field) {
-            static::writeText(
-                $pdf, $field['label'],
-                $currentX, $currentY,
-                'freesans', '', $field_layout['labelSize'], 'L',
-                $field_layout['labelWidth'], $field_layout['rowAdvance'], true, 0
-            );
+            $hasLabel = is_string($field['label'] ?? null) && trim($field['label']) !== '';
+            if ($hasLabel) {
+                static::writeText(
+                    $pdf, $field['label'],
+                    $currentX, $currentY,
+                    'freesans', '', $field_layout['labelSize'], 'L',
+                    $field_layout['labelWidth'], $field_layout['rowAdvance'], true, 0
+                );
+            }
 
             static::writeText(
                 $pdf, $field['value'],
-                $field_layout['valueX'], $currentY,
+                $hasLabel ? $field_layout['valueX'] : $field_layout['fullValueX'], $currentY,
                 'freemono', 'B', $field_layout['fieldSize'], 'L',
-                $field_layout['valueWidth'], $field_layout['rowAdvance'], true, 0, 0.01
+                $hasLabel ? $field_layout['valueWidth'] : $field_layout['fullValueWidth'], $field_layout['rowAdvance'], true, 0, 0.01
             );
             $currentY += $field_layout['rowAdvance'];
         }


### PR DESCRIPTION
This makes the field value use the full width of the row if there is no field label present.

| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/ceaaa204-092a-4b24-b82e-e24e3fd01de2) | ![After](https://github.com/user-attachments/assets/84820c80-eff4-4112-947c-41e33b6ee816) |

