### PR TITLE
Fixed #18573 - download URLs for S3, actually force the download

### DIFF
--- a/app/Helpers/StorageHelper.php
+++ b/app/Helpers/StorageHelper.php
@@ -2,7 +2,6 @@
 
 namespace App\Helpers;
 
-use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -20,7 +19,14 @@ class StorageHelper
                 return response()->download(Storage::disk($disk)->path($filename)); // works for PRIVATE or public?!
 
             case 's3':
-                return redirect()->away(Storage::disk($disk)->temporaryUrl($filename, now()->addMinutes(5))); // works for private or public, I guess?
+                Storage::disk($disk)->temporaryUrl(
+                    $filename,
+                    now()->addMinutes(5),
+                    [
+                        'ResponseContentType' => 'application/octet-stream',
+                        'ResponseContentDisposition' => 'attachment; filename=download-file',
+                    ]
+                );
 
             default:
                 return Storage::disk($disk)->download($filename);
@@ -119,5 +125,4 @@ class StorageHelper
         return null;
 
     }
-
 }

--- a/app/Http/Controllers/Api/UploadedFilesController.php
+++ b/app/Http/Controllers/Api/UploadedFilesController.php
@@ -153,7 +153,7 @@ class UploadedFilesController extends Controller
             return response()->json(Helper::formatStandardApiResponse('error', null, trans('general.file_upload_status.invalid_id')), 200);
         }
 
-        if (! Storage::exists(self::$map_storage_path[$object_type].'/'.$log->filename)) {
+        if (! Storage::exists(self::$map_storage_path[$object_type].$log->filename)) {
             return response()->json(Helper::formatStandardApiResponse('error', null, trans('general.file_upload_status.file_not_found'), 200));
         }
 
@@ -162,10 +162,10 @@ class UploadedFilesController extends Controller
                 'Content-Disposition' => 'inline',
             ];
 
-            return Storage::download(self::$map_storage_path[$object_type].'/'.$log->filename, $log->filename, $headers);
+            return Storage::download(self::$map_storage_path[$object_type].$log->filename, $log->filename, $headers);
         }
 
-        return StorageHelper::downloader(self::$map_storage_path[$object_type].'/'.$log->filename);
+        return StorageHelper::downloader(self::$map_storage_path[$object_type].$log->filename);
 
     }
 
@@ -202,8 +202,8 @@ class UploadedFilesController extends Controller
 
         if ($log) {
             // Check the file actually exists, and delete it
-            if (Storage::exists(self::$map_storage_path[$object_type].'/'.$log->filename)) {
-                Storage::delete(self::$map_storage_path[$object_type].'/'.$log->filename);
+            if (Storage::exists(self::$map_storage_path[$object_type].$log->filename)) {
+                Storage::delete(self::$map_storage_path[$object_type].$log->filename);
             }
             // Delete the record of the file
             if ($log->logUploadDelete($object, $log->filename)) {

--- a/app/Http/Controllers/UploadedFilesController.php
+++ b/app/Http/Controllers/UploadedFilesController.php
@@ -96,7 +96,7 @@ class UploadedFilesController extends Controller
             return redirect()->back()->withFragment('files')->with('error', trans('general.file_upload_status.invalid_id'));
         }
 
-        if (! Storage::exists(self::$map_storage_path[$object_type].'/'.$log->filename)) {
+        if (! Storage::exists(self::$map_storage_path[$object_type].$log->filename)) {
             return redirect()->back()->withFragment('files')->with('error', trans('general.file_upload_status.file_not_found'));
         }
 
@@ -105,10 +105,10 @@ class UploadedFilesController extends Controller
                 'Content-Disposition' => 'inline',
             ];
 
-            return Storage::download(self::$map_storage_path[$object_type].'/'.$log->filename, $log->filename, $headers);
+            return Storage::download(self::$map_storage_path[$object_type].$log->filename, $log->filename, $headers);
         }
 
-        return StorageHelper::downloader(self::$map_storage_path[$object_type].'/'.$log->filename);
+        return StorageHelper::downloader(self::$map_storage_path[$object_type].$log->filename);
 
     }
 
@@ -141,8 +141,8 @@ class UploadedFilesController extends Controller
 
         if ($log) {
             // Check the file actually exists, and delete it
-            if (Storage::exists(self::$map_storage_path[$object_type].'/'.$log->filename)) {
-                Storage::delete(self::$map_storage_path[$object_type].'/'.$log->filename);
+            if (Storage::exists(self::$map_storage_path[$object_type].$log->filename)) {
+                Storage::delete(self::$map_storage_path[$object_type].$log->filename);
             }
             // Delete the record of the file
             if ($log->logUploadDelete($object, $log->filename)) {


### PR DESCRIPTION
This removes the extra trailing spaces from the files controllers, and also properly forces the download if the driver is S3 (instead of both buttons forcing a new browser window display)

Fixes #18573