### PR TITLE
feat(labels): add printable label offset for partially used sheets

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -1402,6 +1402,7 @@ class AssetsController extends Controller
                 // bulkedit=false and count=0 are default values for label generation
                 $label = $label->with('assets', $assets)
                     ->with('settings', $settings)
+                    ->with('offset', max(0, (int) $request->input('offset', 0)))
                     ->with('bulkedit', false)
                     ->with('count', 0);
 

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -178,9 +178,12 @@ class BulkAssetsController extends Controller
                 case 'labels':
                     $this->authorize('view', Asset::class);
 
+                    $offset = max(0, (int) $request->input('offset', 0));
+
                     return (new Label)
                         ->with('assets', $assets)
                         ->with('settings', Setting::getSettings())
+                        ->with('offset', $offset)
                         ->with('bulkedit', true)
                         ->with('count', 0);
 

--- a/resources/views/blade/table/bulk-assets.blade.php
+++ b/resources/views/blade/table/bulk-assets.blade.php
@@ -44,6 +44,22 @@
                 @endif
             </select>
 
+            <label for="table-label-offset" class="js-label-offset-toggle" style="margin-left: 8px; margin-right: 6px;">
+                Offset
+            </label>
+            <input
+                id="table-label-offset"
+                type="number"
+                name="offset"
+                class="form-control js-label-offset js-label-offset-toggle"
+                value="0"
+                min="0"
+                step="1"
+                style="width: 120px;"
+                aria-label="label offset"
+                title="Skip this many labels before printing"
+            >
+
             <button class="btn btn-theme" id="{{ Illuminate\Support\Str::camel($name) }}Button" disabled>{{ trans('button.go') }}</button>
             </label>
             </div>

--- a/resources/views/hardware/labels.blade.php
+++ b/resources/views/hardware/labels.blade.php
@@ -12,6 +12,9 @@ $settings->labels_width = $settings->labels_width - $settings->labels_display_sg
 $settings->labels_height = $settings->labels_height - $settings->labels_display_bgutter;
 // Leave space on bottom for 1D barcode if necessary
 $qr_size = ($settings->alt_barcode_enabled=='1') && ($settings->label2_1d_type!='') ? $settings->labels_height - .3 : $settings->labels_height - 0.1;
+$offset = max(0, (int) ($offset ?? 0));
+$count = (int) ($count ?? 0);
+$total_labels = count($assets) + $offset;
 ?>
 
 <style>
@@ -106,6 +109,16 @@ $qr_size = ($settings->alt_barcode_enabled=='1') && ($settings->label2_1d_type!=
     @endif
 </style>
 
+@for ($i = 0; $i < $offset; $i++)
+    <?php $count++; ?>
+    <div class="label"></div>
+
+    @if (($count % $settings->labels_per_page == 0) && $count!=$total_labels)
+    <div class="page-break"></div>
+    <div class="next-padding">&nbsp;</div>
+    @endif
+@endfor
+
 @foreach ($assets as $asset)
     <?php $count++; ?>
     <div class="label">
@@ -166,7 +179,7 @@ $qr_size = ($settings->alt_barcode_enabled=='1') && ($settings->label2_1d_type!=
 
     </div>
 
-    @if (($count % $settings->labels_per_page == 0) && $count!=count($assets))
+    @if (($count % $settings->labels_per_page == 0) && $count!=$total_labels)
     <div class="page-break"></div>
     <div class="next-padding">&nbsp;</div>
     @endif

--- a/resources/views/partials/asset-bulk-actions.blade.php
+++ b/resources/views/partials/asset-bulk-actions.blade.php
@@ -42,6 +42,22 @@
         @endif
     </select>
 
+    <label for="asset-label-offset" class="js-label-offset-toggle" style="margin-left: 8px; margin-right: 6px;">
+        Offset
+    </label>
+    <input
+        id="asset-label-offset"
+        type="number"
+        name="offset"
+        class="form-control js-label-offset js-label-offset-toggle"
+        value="0"
+        min="0"
+        step="1"
+        style="width: 120px;"
+        aria-label="label offset"
+        title="Skip this many labels before printing"
+    >
+
     <button class="btn btn-theme" id="{{ (isset($id_button)) ? $id_button : 'bulkAssetEditButton' }}" disabled>{{ trans('button.go') }}</button>
     </form>
 </div>

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -926,6 +926,28 @@
        }
     });
 
+    function updateLabelOffsetInputState($form) {
+        var action = $form.find('select[name="bulk_actions"]').val();
+        var $offsetInput = $form.find('.js-label-offset');
+        var $offsetToggles = $form.find('.js-label-offset-toggle');
+
+        if ($offsetInput.length === 0) {
+            return;
+        }
+
+        var enabled = action === 'labels';
+        $offsetInput.prop('disabled', !enabled);
+        $offsetToggles.toggle(enabled);
+    }
+
+    $(document).on('change', 'form select[name="bulk_actions"]', function () {
+        updateLabelOffsetInputState($(this).closest('form'));
+    });
+
+    $('form').each(function () {
+        updateLabelOffsetInputState($(this));
+    });
+
 
 
     // This specifies the footer columns that should have special styles associated


### PR DESCRIPTION
I noticed when using Avery sheets or any other multi label page, I have been unable to re-use sheets if i did not print all of the label slots available.

I added a simple offset option to skip empty positions on a partially used sheet. This works fine for multiple labels per page and does not cause breaks with tapes like the brother TZE label generations. 

I did use copilot to help find the controller that handles generating the bulk label PDF. I tested the implementation on my dev server and provided screenshots as proof. Please let me know if you have any questions.

<img width="2360" height="1203" alt="image" src="https://github.com/user-attachments/assets/70b0b753-023c-484c-b1dd-d538fc7babc4" />

<img width="1243" height="377" alt="image" src="https://github.com/user-attachments/assets/bb6b571a-43fa-4e2f-882b-43a3c0aa337d" />

