### PR TITLE
Removes Unused License Route

### DIFF
--- a/routes/web/licenses.php
+++ b/routes/web/licenses.php
@@ -10,10 +10,6 @@ use Tabuna\Breadcrumbs\Trail;
 Route::group(['prefix' => 'licenses', 'middleware' => ['auth']], function () {
     Route::get('{licenseId}/clone', [Licenses\LicensesController::class, 'getClone'])->name('clone/license');
 
-    Route::get('{licenseId}/freecheckout',
-        [Licenses\LicensesController::class, 'getFreeLicense']
-    )->name('licenses.freecheckout');
-
     Route::get('{license}/checkout/{seatId?}', [Licenses\LicenseCheckoutController::class, 'create'])
         ->name('licenses.checkout')
         ->breadcrumbs(fn (Trail $trail, License $license) =>


### PR DESCRIPTION
[snipe/snipe-it#5916](https://github.com/snipe/snipe-it/pull/5916) — controller refactor (2018) that split LicensesController into 3 controllers, dropping getFreeLicense without updating or killing the route

Resolves RB-20776