### PR TITLE
Better Error Reporting in Custom Rules

### DIFF
--- a/app/Rules/NumericEncrypted.php
+++ b/app/Rules/NumericEncrypted.php
@@ -27,7 +27,7 @@ class NumericEncrypted implements ValidationRule
                 $fail(trans('validation.numeric', ['attribute' => $attributeName]));
             }
         } catch (\Exception $e) {
-            report($e->getMessage());
+            report($e);
             $fail(trans('general.something_went_wrong'));
         }
     }

--- a/app/Rules/RegexEncrypted.php
+++ b/app/Rules/RegexEncrypted.php
@@ -29,7 +29,7 @@ class RegexEncrypted implements ValidationRule
                 $fail(trans('validation.regex', ['attribute' => $attributeName]));
             }
         } catch (\Exception $e) {
-            report($e->getMessage());
+            report($e);
             $fail(trans('general.something_went_wrong'));
         }
     }


### PR DESCRIPTION
Had some rollers come through but couldn't tell exactly what was happening because in the custom rules we (read: I) were doing `report($e->getMessage())` - thus not getting the full stack trace. This fixes that. 