### PR TITLE
Fixed #18797: Fix link to components in asset view

### DIFF
--- a/app/Presenters/ComponentPresenter.php
+++ b/app/Presenters/ComponentPresenter.php
@@ -219,7 +219,7 @@ class ComponentPresenter extends Presenter
                 'sortable' => true,
                 'title' => trans('general.name'),
                 'visible' => true,
-                'formatter' => 'hardwareLinkFormatter',
+                'formatter' => 'componentsLinkFormatter',
             ],
             [
                 'field' => 'qty',


### PR DESCRIPTION
When viewing components checked out to assets the link to the components is `/hardware/{id}` and not `/components/{id}`. This PR fixes that.

<img width="1542" height="698" alt="image" src="https://github.com/user-attachments/assets/1492ae89-78a4-4bd5-957f-72b77f17fbbe" />

---

[FD-54576]
Fixes #18797