### PR TITLE
Small improvements to activity report

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -1836,4 +1836,14 @@ class Helper
             'fullValueWidth',
         );
     }
+
+    public static function normalizeFullModelName($model): string
+    {
+        if (str_contains($model, 'App\\Models\\')) {
+            return $model;
+        }
+
+        return 'App\\Models\\'.ucwords($model);
+
+    }
 }

--- a/app/Http/Controllers/Api/ReportsController.php
+++ b/app/Http/Controllers/Api/ReportsController.php
@@ -2,11 +2,13 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Helpers\Helper;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\FilterRequest;
 use App\Http\Transformers\ActionlogsTransformer;
 use App\Models\Actionlog;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Gate;
 
 class ReportsController extends Controller
 {
@@ -19,29 +21,50 @@ class ReportsController extends Controller
      */
     public function index(FilterRequest $request): JsonResponse|array
     {
-        $this->authorize('activity.view');
+
+        // If the user doesn't have permission to view the item or the target,
+        // then they shouldn't be able to see the activity log for that item or target,
+        // but if they have the general activity view permission,
+        // then they can see all activity logs regardless of the item or target.
+        if ((! Gate::allows('activity.view')) && (($request->filled('target_type')) && ($request->filled('target_id'))) || (($request->filled('item_type')) && ($request->filled('item_id')))) {
+
+            if (($request->filled('target_type')) && ($request->filled('target_id'))) {
+                $target = Helper::normalizeFullModelName(request()->input('target_type'));
+                $target::find(request()->input('target_id'))->withTrashed();
+                $this->authorize('view', $target);
+            }
+
+            if (($request->filled('item_type')) && ($request->filled('item_id'))) {
+                $item = Helper::normalizeFullModelName(request()->input('item_type'));
+                $item::find(request()->input('item_id'))->withTrashed();
+                $this->authorize('view', $item);
+            }
+
+        } else {
+            $this->authorize('activity.view');
+        }
 
         $actionlogs = Actionlog::with('item', 'user', 'adminuser', 'target', 'location');
 
-        // This invokes the Searchable model trait scopeTextSearch and will handle input by search or by advanced search filter
-        if ($request->filled('filter') || $request->filled('search')) {
-            $actionlogs->TextSearch($request->input('filter') ? $request->input('filter') : $request->input('search'));
-        }
-
         if (($request->filled('target_type')) && ($request->filled('target_id'))) {
             $actionlogs = $actionlogs->where('target_id', '=', $request->input('target_id'))
-                ->where('target_type', '=', 'App\\Models\\'.ucwords($request->input('target_type')));
+                ->where('target_type', '=', $target);
         }
 
         if (($request->filled('item_type')) && ($request->filled('item_id'))) {
             $actionlogs = $actionlogs->where(function ($query) use ($request) {
                 $query->where('item_id', '=', $request->input('item_id'))
-                    ->where('item_type', '=', 'App\\Models\\'.ucwords($request->input('item_type')))
+                    ->where('item_type', '=', Helper::normalizeFullModelName($request->input('item_type')))
                     ->orWhere(function ($query) use ($request) {
                         $query->where('target_id', '=', $request->input('item_id'))
-                            ->where('target_type', '=', 'App\\Models\\'.ucwords($request->input('item_type')));
+                            ->where('target_type', '=', Helper::normalizeFullModelName($request->input('item_type')));
                     });
             });
+        }
+
+        // This invokes the Searchable model trait scopeTextSearch and will handle input by search or by advanced search filter
+        if ($request->filled('filter') || $request->filled('search')) {
+            $actionlogs->TextSearch($request->input('filter') ? $request->input('filter') : $request->input('search'));
         }
 
         if ($request->filled('action_type')) {
@@ -100,5 +123,6 @@ class ReportsController extends Controller
         $actionlogs = $actionlogs->skip($offset)->take($limit)->get();
 
         return response()->json((new ActionlogsTransformer)->transformActionlogs($actionlogs, $total), 200, ['Content-Type' => 'application/json;charset=utf8'], JSON_UNESCAPED_UNICODE);
+
     }
 }

--- a/app/Policies/AssetModelPolicy.php
+++ b/app/Policies/AssetModelPolicy.php
@@ -13,6 +13,10 @@ class AssetModelPolicy extends SnipePermissionsPolicy
 
     public function files(User $user, $item = null)
     {
+        // Set this to true so that users who can see the asset can also see the associated model files
+        if ($user->hasAccess('assets.files')) {
+            return true;
+        }
         return $user->hasAccess($this->columnName().'.files');
     }
 }

--- a/app/Policies/AssetModelPolicy.php
+++ b/app/Policies/AssetModelPolicy.php
@@ -17,6 +17,7 @@ class AssetModelPolicy extends SnipePermissionsPolicy
         if ($user->hasAccess('assets.files')) {
             return true;
         }
+
         return $user->hasAccess($this->columnName().'.files');
     }
 }

--- a/app/Policies/SnipePermissionsPolicy.php
+++ b/app/Policies/SnipePermissionsPolicy.php
@@ -97,6 +97,11 @@ abstract class SnipePermissionsPolicy
         return Gate::allows('view', $item) || $user->hasAccess('activity.view');
     }
 
+    public function journal(User $user, $item = null)
+    {
+        return Gate::allows('view', $item) || $user->hasAccess('activity.view');
+    }
+
     public function files(User $user, $item = null)
     {
         return $user->hasAccess($this->columnName().'.files');

--- a/app/Presenters/HistoryPresenter.php
+++ b/app/Presenters/HistoryPresenter.php
@@ -9,11 +9,11 @@ class HistoryPresenter extends Presenter
      *
      * @return string
      */
-    public static function dataTableLayout($hide_fields = array())
+    public static function dataTableLayout($hide_fields = [])
     {
         $layout = [];
 
-        if (!in_array('id', $hide_fields)) {
+        if (! in_array('id', $hide_fields)) {
             array_push($layout,
                 [
                     'id' => 'id',
@@ -26,7 +26,7 @@ class HistoryPresenter extends Presenter
                 ]);
         }
 
-        if (!in_array('icon', $hide_fields)) {
+        if (! in_array('icon', $hide_fields)) {
             array_push($layout,
                 [
                     'field' => 'icon',
@@ -40,7 +40,7 @@ class HistoryPresenter extends Presenter
                 ]);
         }
 
-        if (!in_array('created_at', $hide_fields)) {
+        if (! in_array('created_at', $hide_fields)) {
             array_push($layout,
                 [
                     'field' => 'created_at',
@@ -52,7 +52,7 @@ class HistoryPresenter extends Presenter
                     'formatter' => 'dateDisplayFormatter',
                 ]);
         }
-        if (!in_array('created_by', $hide_fields)) {
+        if (! in_array('created_by', $hide_fields)) {
             array_push($layout,
                 [
                     'field' => 'created_by',
@@ -64,8 +64,7 @@ class HistoryPresenter extends Presenter
                 ]);
         }
 
-
-        if (!in_array('action_type', $hide_fields)) {
+        if (! in_array('action_type', $hide_fields)) {
             array_push($layout,
                 [
                     'field' => 'action_type',
@@ -77,7 +76,7 @@ class HistoryPresenter extends Presenter
                 ]);
         }
 
-        if (!in_array('action_date', $hide_fields)) {
+        if (! in_array('action_date', $hide_fields)) {
             array_push($layout,
                 [
                     'field' => 'action_date',
@@ -89,7 +88,7 @@ class HistoryPresenter extends Presenter
                 ]);
         }
 
-        if (!in_array('item', $hide_fields)) {
+        if (! in_array('item', $hide_fields)) {
             array_push($layout,
                 [
                     'field' => 'item',
@@ -102,8 +101,7 @@ class HistoryPresenter extends Presenter
                 ]);
         }
 
-
-        if (!in_array('serial', $hide_fields)) {
+        if (! in_array('serial', $hide_fields)) {
             array_push($layout,
                 [
                     'field' => 'item.serial',
@@ -112,7 +110,7 @@ class HistoryPresenter extends Presenter
                 ]);
         }
 
-        if (!in_array('target', $hide_fields)) {
+        if (! in_array('target', $hide_fields)) {
             array_push($layout,
                 [
                     'field' => 'target',
@@ -125,7 +123,7 @@ class HistoryPresenter extends Presenter
                 ]);
         }
 
-        if (!in_array('file', $hide_fields)) {
+        if (! in_array('file', $hide_fields)) {
             array_push($layout,
                 [
                     'field' => 'file',
@@ -138,7 +136,7 @@ class HistoryPresenter extends Presenter
                 ]);
         }
 
-        if (!in_array('file_download', $hide_fields)) {
+        if (! in_array('file_download', $hide_fields)) {
             array_push($layout,
                 [
                     'field' => 'file_download',
@@ -151,7 +149,7 @@ class HistoryPresenter extends Presenter
                 ]);
         }
 
-        if (!in_array('quantity', $hide_fields)) {
+        if (! in_array('quantity', $hide_fields)) {
             array_push($layout,
                 [
                     'field' => 'quantity',
@@ -162,7 +160,7 @@ class HistoryPresenter extends Presenter
                 ]);
         }
 
-        if (!in_array('note', $hide_fields)) {
+        if (! in_array('note', $hide_fields)) {
             array_push($layout,
                 [
                     'field' => 'note',
@@ -174,7 +172,7 @@ class HistoryPresenter extends Presenter
                 ]);
         }
 
-        if (!in_array('signature_file', $hide_fields)) {
+        if (! in_array('signature_file', $hide_fields)) {
             array_push($layout,
                 [
                     'field' => 'signature_file',
@@ -187,7 +185,7 @@ class HistoryPresenter extends Presenter
                 ]);
         }
 
-        if (!in_array('log_meta', $hide_fields)) {
+        if (! in_array('log_meta', $hide_fields)) {
             array_push($layout,
                 [
                     'field' => 'log_meta',
@@ -199,7 +197,7 @@ class HistoryPresenter extends Presenter
                 ]);
         }
 
-        if (!in_array('remote_ip', $hide_fields)) {
+        if (! in_array('remote_ip', $hide_fields)) {
             array_push($layout,
                 [
                     'field' => 'remote_ip',
@@ -210,7 +208,7 @@ class HistoryPresenter extends Presenter
                 ]);
         }
 
-        if (!in_array('user_agent', $hide_fields)) {
+        if (! in_array('user_agent', $hide_fields)) {
             array_push($layout,
                 [
                     'field' => 'user_agent',
@@ -221,7 +219,7 @@ class HistoryPresenter extends Presenter
                 ]);
         }
 
-        if (!in_array('action_source', $hide_fields)) {
+        if (! in_array('action_source', $hide_fields)) {
             array_push($layout,
                 [
                     'field' => 'action_source',

--- a/app/Presenters/HistoryPresenter.php
+++ b/app/Presenters/HistoryPresenter.php
@@ -2,9 +2,6 @@
 
 namespace App\Presenters;
 
-/**
- * Class AccessoryPresenter
- */
 class HistoryPresenter extends Presenter
 {
     /**
@@ -12,168 +9,229 @@ class HistoryPresenter extends Presenter
      *
      * @return string
      */
-    public static function dataTableLayout($serial = false)
+    public static function dataTableLayout($hide_fields = array())
     {
-        $extra = [];
-        $layout_start = [
-            [
-                'id' => 'id',
-                'searchable' => false,
-                'sortable' => true,
-                'switchable' => true,
-                'title' => trans('general.id'),
-                'visible' => false,
-                'class' => 'hidden-xs',
-            ],
-            [
-                'field' => 'icon',
-                'searchable' => false,
-                'sortable' => true,
-                'switchable' => true,
-                'title' => trans('admin/hardware/table.icon'),
-                'visible' => true,
-                'class' => 'hidden-xs',
-                'formatter' => 'iconFormatter',
-            ],
-            [
-                'field' => 'created_at',
-                'searchable' => true,
-                'sortable' => true,
-                'switchable' => true,
-                'title' => trans('general.created_at'),
-                'visible' => true,
-                'formatter' => 'dateDisplayFormatter',
-            ],
-            [
-                'field' => 'created_by',
-                'searchable' => true,
-                'sortable' => true,
-                'title' => trans('general.created_by'),
-                'visible' => true,
-                'formatter' => 'usersLinkObjFormatter',
-            ],
-            [
-                'field' => 'action_date',
-                'searchable' => false,
-                'sortable' => true,
-                'title' => trans('general.action_date'),
-                'visible' => false,
-                'formatter' => 'dateDisplayFormatter',
-            ],
-            [
-                'field' => 'action_type',
-                'searchable' => true,
-                'sortable' => true,
-                'switchable' => true,
-                'title' => trans('general.action'),
-                'visible' => true,
-            ],
-            [
-                'field' => 'item',
-                'searchable' => true,
-                'sortable' => true,
-                'switchable' => true,
-                'title' => trans('general.item'),
-                'visible' => true,
-                'formatter' => 'polymorphicItemFormatter',
-            ],
-        ];
+        $layout = [];
 
-        if ($serial) {
-            $extra = [
+        if (!in_array('id', $hide_fields)) {
+            array_push($layout,
+                [
+                    'id' => 'id',
+                    'searchable' => false,
+                    'sortable' => true,
+                    'switchable' => true,
+                    'title' => trans('general.id'),
+                    'visible' => false,
+                    'class' => 'hidden-xs',
+                ]);
+        }
+
+        if (!in_array('icon', $hide_fields)) {
+            array_push($layout,
+                [
+                    'field' => 'icon',
+                    'searchable' => false,
+                    'sortable' => true,
+                    'switchable' => true,
+                    'title' => trans('admin/hardware/table.icon'),
+                    'visible' => true,
+                    'class' => 'hidden-xs',
+                    'formatter' => 'iconFormatter',
+                ]);
+        }
+
+        if (!in_array('created_at', $hide_fields)) {
+            array_push($layout,
+                [
+                    'field' => 'created_at',
+                    'searchable' => true,
+                    'sortable' => true,
+                    'switchable' => true,
+                    'title' => trans('general.created_at'),
+                    'visible' => true,
+                    'formatter' => 'dateDisplayFormatter',
+                ]);
+        }
+        if (!in_array('created_by', $hide_fields)) {
+            array_push($layout,
+                [
+                    'field' => 'created_by',
+                    'searchable' => true,
+                    'sortable' => true,
+                    'title' => trans('general.created_by'),
+                    'visible' => true,
+                    'formatter' => 'usersLinkObjFormatter',
+                ]);
+        }
+
+
+        if (!in_array('action_type', $hide_fields)) {
+            array_push($layout,
+                [
+                    'field' => 'action_type',
+                    'searchable' => true,
+                    'sortable' => true,
+                    'switchable' => true,
+                    'title' => trans('general.action'),
+                    'visible' => true,
+                ]);
+        }
+
+        if (!in_array('action_date', $hide_fields)) {
+            array_push($layout,
+                [
+                    'field' => 'action_date',
+                    'searchable' => false,
+                    'sortable' => true,
+                    'title' => trans('general.action_date'),
+                    'visible' => false,
+                    'formatter' => 'dateDisplayFormatter',
+                ]);
+        }
+
+        if (!in_array('item', $hide_fields)) {
+            array_push($layout,
+                [
+                    'field' => 'item',
+                    'searchable' => true,
+                    'sortable' => true,
+                    'switchable' => true,
+                    'title' => trans('general.item'),
+                    'visible' => true,
+                    'formatter' => 'polymorphicItemFormatter',
+                ]);
+        }
+
+
+        if (!in_array('serial', $hide_fields)) {
+            array_push($layout,
                 [
                     'field' => 'item.serial',
                     'title' => trans('admin/hardware/table.serial'),
                     'visible' => false,
-                ],
-            ];
+                ]);
         }
 
-        $layout_end = [
-            [
-                'field' => 'target',
-                'searchable' => true,
-                'sortable' => true,
-                'switchable' => true,
-                'title' => trans('general.target'),
-                'visible' => true,
-                'formatter' => 'polymorphicItemFormatter',
-            ],
-            [
-                'field' => 'file',
-                'searchable' => true,
-                'sortable' => true,
-                'switchable' => true,
-                'title' => trans('general.file_name'),
-                'visible' => true,
-                'formatter' => 'fileNameFormatter',
-            ],
-            [
-                'field' => 'file_download',
-                'searchable' => false,
-                'sortable' => true,
-                'switchable' => true,
-                'title' => trans('general.download'),
-                'visible' => true,
-                'formatter' => 'fileDownloadButtonsFormatter',
-            ],
-            [
-                'field' => 'quantity',
-                'searchable' => false,
-                'sortable' => true,
-                'visible' => true,
-                'title' => trans('general.quantity'),
-            ],
-            [
-                'field' => 'note',
-                'searchable' => true,
-                'sortable' => true,
-                'visible' => true,
-                'title' => trans('general.notes'),
-                'formatter' => 'notesFormatter',
-            ],
-            [
-                'field' => 'signature_file',
-                'searchable' => true,
-                'sortable' => true,
-                'switchable' => true,
-                'title' => trans('general.signature'),
-                'visible' => false,
-                'formatter' => 'imageFormatter',
-            ],
-            [
-                'field' => 'log_meta',
-                'searchable' => false,
-                'sortable' => false,
-                'visible' => true,
-                'title' => trans('admin/hardware/table.changed'),
-                'formatter' => 'changeLogFormatter',
-            ],
-            [
-                'field' => 'remote_ip',
-                'searchable' => true,
-                'sortable' => true,
-                'visible' => false,
-                'title' => trans('admin/settings/general.login_ip'),
-            ],
-            [
-                'field' => 'user_agent',
-                'searchable' => true,
-                'sortable' => true,
-                'visible' => false,
-                'title' => trans('admin/settings/general.login_user_agent'),
-            ],
-            [
-                'field' => 'action_source',
-                'searchable' => true,
-                'sortable' => true,
-                'visible' => false,
-                'title' => trans('general.action_source'),
-            ],
-        ];
+        if (!in_array('target', $hide_fields)) {
+            array_push($layout,
+                [
+                    'field' => 'target',
+                    'searchable' => true,
+                    'sortable' => true,
+                    'switchable' => true,
+                    'title' => trans('general.target'),
+                    'visible' => true,
+                    'formatter' => 'polymorphicItemFormatter',
+                ]);
+        }
 
-        $merged = array_merge($layout_start, $extra, $layout_end);
+        if (!in_array('file', $hide_fields)) {
+            array_push($layout,
+                [
+                    'field' => 'file',
+                    'searchable' => true,
+                    'sortable' => true,
+                    'switchable' => true,
+                    'title' => trans('general.file_name'),
+                    'visible' => true,
+                    'formatter' => 'fileNameFormatter',
+                ]);
+        }
 
-        return json_encode($merged);
+        if (!in_array('file_download', $hide_fields)) {
+            array_push($layout,
+                [
+                    'field' => 'file_download',
+                    'searchable' => false,
+                    'sortable' => true,
+                    'switchable' => true,
+                    'title' => trans('general.download'),
+                    'visible' => true,
+                    'formatter' => 'fileDownloadButtonsFormatter',
+                ]);
+        }
+
+        if (!in_array('quantity', $hide_fields)) {
+            array_push($layout,
+                [
+                    'field' => 'quantity',
+                    'searchable' => false,
+                    'sortable' => true,
+                    'visible' => true,
+                    'title' => trans('general.quantity'),
+                ]);
+        }
+
+        if (!in_array('note', $hide_fields)) {
+            array_push($layout,
+                [
+                    'field' => 'note',
+                    'searchable' => true,
+                    'sortable' => true,
+                    'visible' => true,
+                    'title' => trans('general.notes'),
+                    'formatter' => 'notesFormatter',
+                ]);
+        }
+
+        if (!in_array('signature_file', $hide_fields)) {
+            array_push($layout,
+                [
+                    'field' => 'signature_file',
+                    'searchable' => true,
+                    'sortable' => true,
+                    'switchable' => true,
+                    'title' => trans('general.signature'),
+                    'visible' => false,
+                    'formatter' => 'imageFormatter',
+                ]);
+        }
+
+        if (!in_array('log_meta', $hide_fields)) {
+            array_push($layout,
+                [
+                    'field' => 'log_meta',
+                    'searchable' => false,
+                    'sortable' => false,
+                    'visible' => true,
+                    'title' => trans('admin/hardware/table.changed'),
+                    'formatter' => 'changeLogFormatter',
+                ]);
+        }
+
+        if (!in_array('remote_ip', $hide_fields)) {
+            array_push($layout,
+                [
+                    'field' => 'remote_ip',
+                    'searchable' => true,
+                    'sortable' => true,
+                    'visible' => false,
+                    'title' => trans('admin/settings/general.login_ip'),
+                ]);
+        }
+
+        if (!in_array('user_agent', $hide_fields)) {
+            array_push($layout,
+                [
+                    'field' => 'user_agent',
+                    'searchable' => true,
+                    'sortable' => true,
+                    'visible' => false,
+                    'title' => trans('admin/settings/general.login_user_agent'),
+                ]);
+        }
+
+        if (!in_array('action_source', $hide_fields)) {
+            array_push($layout,
+                [
+                    'field' => 'action_source',
+                    'searchable' => true,
+                    'sortable' => true,
+                    'visible' => false,
+                    'title' => trans('general.action_source'),
+                ]);
+        }
+
+        return json_encode($layout);
     }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -166,33 +166,9 @@ class AuthServiceProvider extends ServiceProvider
             }
         });
 
-        // Gate::define('accessories.files', function ($user) {
-        //     if ($user->hasAccess('accessories.files')) {
-        //         return true;
-        //     }
-        // });
-        //
-        // Gate::define('components.files', function ($user) {
-        //     if ($user->hasAccess('components.files')) {
-        //         return true;
-        //     }
-        // });
-        //
-        // Gate::define('consumables.files', function ($user) {
-        //     if ($user->hasAccess('consumables.files')) {
-        //         return true;
-        //     }
-        // });
-
         // Can the user import CSVs?
         Gate::define('import', function ($user) {
             if ($user->hasAccess('import')) {
-                return true;
-            }
-        });
-
-        Gate::define('licenses.files', function ($user) {
-            if ($user->hasAccess('licenses.files')) {
                 return true;
             }
         });

--- a/resources/views/blade/table/history.blade.php
+++ b/resources/views/blade/table/history.blade.php
@@ -1,11 +1,10 @@
 @props([
     'route',
     'name' => 'default',
-    'presenter' => \App\Presenters\HistoryPresenter::dataTableLayout(),
     'table_header' => trans('general.history'),
     'model' => null,
+    'hide_fields' => [],
 ])
-
 
 <!-- start history tab pane -->
 @can('history', $model)
@@ -14,9 +13,11 @@
     </x-slot:table_header>
 
     <x-table
-        :$presenter
+        :presenter="\App\Presenters\HistoryPresenter::dataTableLayout($hide_fields)"
         show_advanced_search="false"
         api_url="{{ $route }}"
+        fixed_number="false"
+        fixed_right_number="false"
         export_filename="export-history-{{ date('Y-m-d') }}"
     />
 @endcan

--- a/resources/views/blade/tabs/note-tab.blade.php
+++ b/resources/views/blade/tabs/note-tab.blade.php
@@ -1,0 +1,16 @@
+@props([
+    'count' => null,
+    'class' => false,
+    'item',
+])
+
+@can('journal', $item)
+    <x-tabs.nav-item
+        :$class
+        name="notes"
+        icon_type="note"
+        label="{{ trans('general.notes') }}"
+        count="{{ $count }}"
+        tooltip="{{ trans('general.notes') }}"
+    />
+@endcan

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -361,13 +361,21 @@
 
                     <!-- start audits tab pane -->
                     <x-tabs.pane name="audits">
-                        <x-table.history :table_header="trans('general.audits')" :model="$asset" :route="route('api.activity.index', ['item_id' => $asset->id, 'item_type' => 'asset', 'action_type' => 'audit'])"/>
+                        <x-table.history
+                            :table_header="trans('general.audits')"
+                            :model="$asset"
+                            :route="route('api.activity.index', ['item_id' => $asset->id, 'item_type' => 'asset', 'action_type' => 'audit'])"
+                            :hide_fields="['id','action_type', 'item', 'changed', 'target','quantity','changed','serial','signature_file','log_meta']"/>
                     </x-tabs.pane>
                     <!-- end audits tab pane -->
 
                     <!-- start notes tab pane -->
                     <x-tabs.pane name="notes">
-                        <x-table.history :table_header="trans('general.notes')" :model="$asset" :route="route('api.activity.index', ['item_id' => $asset->id, 'item_type' => 'asset', 'action_type' => 'note added'])"/>
+                        <x-table.history
+                            :table_header="trans('general.notes')"
+                            :model="$asset" :route="route('api.activity.index', ['item_id' => $asset->id, 'item_type' => 'asset', 'action_type' => 'note added'])"
+                            :hide_fields="['id','action_type', 'item', 'changed', 'target','file','file_download','quantity','changed','serial','signature_file','log_meta']"
+                        />
                     </x-tabs.pane>
                     <!-- end audits tab pane -->
 
@@ -382,7 +390,10 @@
 
                     <!-- start history tab pane -->
                     <x-tabs.pane name="history">
-                        <x-table.history :model="$asset" :route="route('api.assets.history', $asset)"/>
+                        <x-table.history
+                            :model="$asset"
+                            :route="route('api.assets.history', $asset)"
+                        />
                     </x-tabs.pane>
                     <!-- end history tab pane -->
 

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -62,6 +62,7 @@
                     <x-tabs.asset-tab count="{{ $asset->assignedAssets()->AssetsForShow()->count() }}"/>
                     <x-tabs.accessory-tab count="{{ $asset->assignedAccessories()->count() }}"/>
                     <x-tabs.maintenance-tab count="{{ $asset->maintenances->count() }}"/>
+
                     <x-tabs.nav-item
                         name="audits"
                         icon_type="audit"
@@ -69,6 +70,7 @@
                         count="{{ $asset->audits()->count() }}"
                         tooltip="{{ trans('general.audits') }}"
                     />
+                    <x-tabs.note-tab :item="$asset" count="{{ $asset->journal->count() }}"/>
                     <x-tabs.files-tab :item="$asset" count="{{ $asset->uploads()->count() }}"/>
                     <x-tabs.model-files-tab count="{{ $asset->model?->uploads()->count() }}"/>
                     <x-tabs.history-tab count="{{ $asset->history()->count() }}" :model="$asset"/>
@@ -331,18 +333,14 @@
                         </x-slot:table_header>
 
                         <x-table
-                            name="assetAccessories_{{ $asset->id }}"
+                            name="assetAccessories"
+                            buttons="accessoryButtons"
                             api_url="{{ route('api.assets.assigned_accessories', ['asset' => $asset]) }}"
                             :presenter="\App\Presenters\AssetPresenter::assignedAccessoriesDataTableLayout()"
                             export_filename="export-maintenances-{{ str_slug($asset->name) }}-{{ date('Y-m-d') }}"
                         />
                     </x-tabs.pane>
 
-                    <!-- start history tab pane -->
-                    <x-tabs.pane name="history">
-                        <x-table.history :model="$asset" :route="route('api.assets.history', $asset)"/>
-                    </x-tabs.pane>
-                    <!-- end history tab pane -->
 
                     <!-- start maintenances tab pane -->
                     <x-tabs.pane name="maintenances">
@@ -352,7 +350,7 @@
                         </x-slot:table_header>
 
                         <x-table
-                            name="assetMaintenances_{{ $asset->id }}"
+                            name="assetMaintenances"
                             buttons="maintenanceButtons"
                             api_url="{{ route('api.maintenances.index', array('asset_id' => $asset->id)) }}"
                             :presenter="\App\Presenters\MaintenancesPresenter::dataTableLayout()"
@@ -363,12 +361,13 @@
 
                     <!-- start audits tab pane -->
                     <x-tabs.pane name="audits">
+                        <x-table.history :table_header="trans('general.audits')" :model="$asset" :route="route('api.activity.index', ['item_id' => $asset->id, 'item_type' => 'asset', 'action_type' => 'audit'])"/>
+                    </x-tabs.pane>
+                    <!-- end audits tab pane -->
 
-                        <x-slot:table_header>
-                            {{ trans('general.audits') }}
-                        </x-slot:table_header>
-
-                        <x-table.assets :route="route('api.activity.index', ['item_id' => $asset->id, 'item_type' => 'asset', 'action_type' => 'audit'])"/>
+                    <!-- start notes tab pane -->
+                    <x-tabs.pane name="notes">
+                        <x-table.history :table_header="trans('general.notes')" :model="$asset" :route="route('api.activity.index', ['item_id' => $asset->id, 'item_type' => 'asset', 'action_type' => 'note added'])"/>
                     </x-tabs.pane>
                     <!-- end audits tab pane -->
 
@@ -378,8 +377,14 @@
                     </x-tabs.pane>
 
                     <x-tabs.pane name="model-files">
-                        <x-table.files object_type="models" :object="$asset->model"/>
+                        <x-table.files :table_header="trans('general.additional_files')" object_type="models" :object="$asset->model"/>
                     </x-tabs.pane>
+
+                    <!-- start history tab pane -->
+                    <x-tabs.pane name="history">
+                        <x-table.history :model="$asset" :route="route('api.assets.history', $asset)"/>
+                    </x-tabs.pane>
+                    <!-- end history tab pane -->
 
 
                 </x-slot:tabpanes>

--- a/resources/views/licenses/view.blade.php
+++ b/resources/views/licenses/view.blade.php
@@ -25,12 +25,14 @@
                             count="{{ $license->assignedCount()->count() }}"
                     />
 
+                    @can('checkout', $license)
                     <x-tabs.nav-item
                             name="available"
                             icon_type="available"
                             label="{{ trans('general.available') }}"
                             count="{{ $license->availCount()->count() }}"
                     />
+                    @endcan
 
                     <x-tabs.files-tab :item="$license" count="{{ $license->uploads()->count() }}"/>
                     <x-tabs.history-tab count="{{ $license->history()->count() }}" :model="$license"/>
@@ -55,6 +57,7 @@
                     </x-tabs.pane>
 
 
+                    @can('checkout', $license)
                     <x-tabs.pane name="available">
                         <x-slot:table_header>
                             {{ trans('general.available') }}
@@ -68,6 +71,7 @@
                         />
 
                     </x-tabs.pane>
+                    @endcan
 
 
                     <!-- start history tab pane -->
@@ -78,11 +82,9 @@
 
 
                     <!-- start files tab pane -->
-                    @can('licenses.files', $license)
                     <x-tabs.pane name="files">
                         <x-table.files object_type="licenses" :object="$license" />
                     </x-tabs.pane>
-                    @endcan
                     <!-- end files tab pane -->
 
                 </x-slot:tabpanes>

--- a/resources/views/reports/activity.blade.php
+++ b/resources/views/reports/activity.blade.php
@@ -22,7 +22,7 @@
         <x-box>
 
                 <table
-                        data-columns="{{ \App\Presenters\HistoryPresenter::dataTableLayout($serial = true) }}"
+                    data-columns="{{ \App\Presenters\HistoryPresenter::dataTableLayout() }}"
                         data-cookie-id-table="activityReport"
                         data-id-table="activityReport"
                         data-side-pagination="server"

--- a/resources/views/settings/labels.blade.php
+++ b/resources/views/settings/labels.blade.php
@@ -73,7 +73,6 @@
 
                                 <div class="col-md-12">
                                     <table
-
                                         data-columns="{{ \App\Presenters\LabelPresenter::dataTableLayout() }}"
                                         data-cookie="true"
                                         data-cookie-id-table="label2TemplateTable"
@@ -284,7 +283,7 @@
                                         <label for="purge_barcodes" class="control-label">{{ trans('admin/settings/general.purge_barcodes') }}</label>
                                     </div>
                                     <div class="col-md-7">
-                                        <a class="btn btn-default btn-sm pull-left" id="purgebarcodes" style="margin-right: 10px;">
+                                        <a class="btn btn-theme btn-sm pull-left" id="purgebarcodes" style="margin-right: 10px;">
                                             {{ trans('admin/settings/general.barcode_delete_cache') }}
                                         </a>
                                         <span id="purgebarcodesicon"></span>

--- a/tests/Feature/Reporting/ActivityReportTest.php
+++ b/tests/Feature/Reporting/ActivityReportTest.php
@@ -18,9 +18,49 @@ class ActivityReportTest extends TestCase
             ->assertForbidden();
     }
 
+    public function test_can_view_activity_if_item_is_given_and_user_has_permissions()
+    {
+        $asset = Asset::factory()->create();
+        $this->actingAsForApi(User::factory()->viewAssets()->create())
+            ->getJson(route('api.activity.index',
+                [
+                    'item_type' => 'asset',
+                    'item_id' => $asset->id,
+                ]))
+            ->assertOk()
+            ->assertJsonStructure([
+                'rows',
+            ])
+            ->assertJson(fn (AssertableJson $json) => $json->has('rows', 1)->etc());
+    }
+
+    public function test_can_view_activity_if_target_is_given_and_user_has_permissions()
+    {
+
+        $user = User::factory()->create();
+        $user->update([
+            'first_name' => 'Test Update',
+        ]);
+        $user->update([
+            'first_name' => 'Test Update Again',
+        ]);
+
+        $this->actingAsForApi(User::factory()->viewUsers()->create())
+            ->getJson(route('api.activity.index',
+                [
+                    'target_type' => 'user',
+                    'target_id' => $user->id,
+                ]))
+            ->assertOk()
+            ->assertJsonStructure([
+                'rows',
+            ])
+            ->assertJson(fn (AssertableJson $json) => $json->has('rows', 2)->etc());
+    }
+
     public function test_records_are_scoped_to_company_when_multiple_company_support_enabled()
     {
-        $this->markTestIncomplete('This test returns strange results. Need to figure out why.');
+        // $this->markTestIncomplete('This test returns strange results. Need to figure out why.');
         $this->settings->enableMultipleFullCompanySupport();
 
         $companyA = Company::factory()->create();


### PR DESCRIPTION
This adds some additional checks to the history report, and also introduces a new feature where we can suppress certain fields from the HistoryPresenter. For example:

```php
<x-table.history
    :table_header="trans('general.notes')"
    :model="$asset" :route="route('api.activity.index', ['item_id' => $asset->id, 'item_type' => 'asset', 'action_type' => 'note added'])"
    :hide_fields="['id','action_type', 'item', 'changed', 'target','file','file_download','quantity','changed','serial','signature_file','log_meta']"
/>
```

By default, we generally want the history tables to display all columns, but in some contexts, it doesn't really make sense. For example, if you're looking at an asset's audit or notes tab, you don't need to see the target or the item, since you're already looking at that asset. **Note that this is not a security feature, and the full data will still be available in the API result** - this is just to make those views a little less cluttered with repeated information. In the example above, there is no file, signature, or download for journal-style notes, so that column is never relevant and will never have anything in it - it just takes up space. 

This also adds a new tab for the notes ("journal style" notes) to the assets view. 