### PR TITLE
Fixed #18802: Display dynamic support url for manufacturers properly

### DIFF
--- a/resources/views/blade/info-panel/index.blade.php
+++ b/resources/views/blade/info-panel/index.blade.php
@@ -338,11 +338,13 @@
             </x-info-element.url>
         </x-info-element>
 
-        <x-info-element icon_type="external-link" title="{{ trans('admin/manufacturers/table.support_url') }}">
-            <x-info-element.url>
-                {{ $infoPanelObj->support_url }}
-            </x-info-element.url>
-        </x-info-element>
+        @if ($infoPanelObj->manufacturer ?? $infoPanelObj->model?->manufacturer)
+            <x-info-element icon_type="external-link" title="{{ trans('admin/manufacturers/table.support_url') }}">
+                <x-info-element.url>
+                    {{ $infoPanelObj->present()->dynamicUrl($infoPanelObj->model->manufacturer->support_url) }}
+                </x-info-element.url>
+            </x-info-element>
+        @endif
 
 
         @if (($infoPanelObj->present()->displayAddress) && (config('services.google.maps_api_key')))

--- a/resources/views/blade/info-panel/manufacturer.blade.php
+++ b/resources/views/blade/info-panel/manufacturer.blade.php
@@ -54,7 +54,7 @@
                 @if($manufacturer->support_url)
                     <x-icon type="external-link" class="fa-fw"/>
                     <x-info-element.url>
-                    {{ $manufacturer->support_url }}
+                    {{ $asset->present()->dynamicUrl($asset->model->manufacturer->support_url) }}
                 </x-info-element.url>
                     <br>
                 @endif


### PR DESCRIPTION
Currently the support url for manufacturers is not being rendered properly:
<img width="578" height="330" alt="image" src="https://github.com/user-attachments/assets/7fbc9219-e2c1-4ef5-85ad-2de7720b6d15" />

This PR fixes that:
<img width="572" height="392" alt="image" src="https://github.com/user-attachments/assets/ff3a0f25-77ef-4bb3-9c05-a852e26e9035" />

> Note: the support url is doubled up (at least for assets)...It's helpful to have it displayed outside of the normally-collapsed manufacturer information box but I'm not sure which place we'd want to remove it from // @snipe 

---

Fixes #18802
