### PR TITLE
Fixes #18715 Fixes disabled CSS rules for select2

### DIFF
--- a/resources/assets/less/overrides.less
+++ b/resources/assets/less/overrides.less
@@ -1391,30 +1391,4 @@ Radio toggle styles for permission settings and check/uncheck all
 
     }
   }
-
-  .select2-container--default.select2-container--disabled .select2-selection--single,
-  .select2-container--default.select2-container--disabled .select2-selection--multiple {
-    background-color: #f5f5f5 !important; /* lighter grey */
-    border: 1px solid #d2d6de !important;
-    color: #777 !important;
-  }
-
-  /* Text inside */
-
-  .select2-container--default.select2-container--disabled .select2-selection__rendered {
-    color: #777 !important;
-  }
-
-  /* Placeholder text */
-
-  .select2-container--default.select2-container--disabled .select2-selection__placeholder {
-    color: #999 !important;
-  }
-
-  /* Remove that dark overlay look */
-
-  .select2-container--default.select2-container--disabled {
-    opacity: 1 !important;
-  }
-
 }

--- a/resources/assets/less/overrides.less
+++ b/resources/assets/less/overrides.less
@@ -1392,5 +1392,29 @@ Radio toggle styles for permission settings and check/uncheck all
     }
   }
 
+  .select2-container--default.select2-container--disabled .select2-selection--single,
+  .select2-container--default.select2-container--disabled .select2-selection--multiple {
+    background-color: #f5f5f5 !important; /* lighter grey */
+    border: 1px solid #d2d6de !important;
+    color: #777 !important;
+  }
+
+  /* Text inside */
+
+  .select2-container--default.select2-container--disabled .select2-selection__rendered {
+    color: #777 !important;
+  }
+
+  /* Placeholder text */
+
+  .select2-container--default.select2-container--disabled .select2-selection__placeholder {
+    color: #999 !important;
+  }
+
+  /* Remove that dark overlay look */
+
+  .select2-container--default.select2-container--disabled {
+    opacity: 1 !important;
+  }
 
 }

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -299,18 +299,35 @@
 
 
         input[type="*"]:disabled,
-        input[type=checkbox]:disabled,
-        input[type=radio]:disabled,
+        input:disabled,
+        input[type="checkbox"]:disabled,
+        input[type="radio"]:disabled,
         input[readonly],
+        textarea[readonly],
         .select2-container--default.select2-container--disabled .select2-selection--single,
+        .select2-container--default.select2-container--disabled .select2-selection--multiple,
         .select2-container--default.select2-container--disabled .select2-selection__rendered,
-        textarea[readonly]
-        {
+        .select2-container--default.select2-container--disabled .select2-search__field,
+        .select2-container--default.select2-container--disabled .select2-search--inline .select2-search__field,
+        .select2-container--default.select2-container--disabled .select2-selection--multiple .select2-selection__rendered,
+        .select2-container--default.select2-container--disabled .select2-selection--multiple .select2-search--inline {
             background-color: light-dark(rgb(234, 232, 232), rgb(117, 116, 117)) !important;
+            color: var(--color-fg) !important;
+            border-color: var(--input-border-color) !important;
+            box-shadow: none !important;
             cursor: not-allowed !important;
+            opacity: 1 !important;
         }
 
+        .select2-container--default.select2-container--disabled .select2-search__field::placeholder {
+            color: var(--text-help) !important;
+            opacity: 1 !important;
+        }
 
+        .select2-container--default.select2-container--disabled .select2-search__field {
+            -webkit-text-fill-color: var(--text-help) !important;
+        }
+        
 
         input[type="search"].search-highlight {
             background-color: var(--search-highlight);

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -297,8 +297,6 @@
         }
 
 
-
-        input[type="*"]:disabled,
         input:disabled,
         input[type="checkbox"]:disabled,
         input[type="radio"]:disabled,
@@ -327,7 +325,7 @@
         .select2-container--default.select2-container--disabled .select2-search__field {
             -webkit-text-fill-color: var(--text-help) !important;
         }
-        
+
 
         input[type="search"].search-highlight {
             background-color: var(--search-highlight);

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -296,7 +296,6 @@
             border-color: var(--input-border-color) !important;
         }
 
-
         input:disabled,
         input[type="checkbox"]:disabled,
         input[type="radio"]:disabled,
@@ -305,27 +304,15 @@
         .select2-container--default.select2-container--disabled .select2-selection--single,
         .select2-container--default.select2-container--disabled .select2-selection--multiple,
         .select2-container--default.select2-container--disabled .select2-selection__rendered,
-        .select2-container--default.select2-container--disabled .select2-search__field,
-        .select2-container--default.select2-container--disabled .select2-search--inline .select2-search__field,
-        .select2-container--default.select2-container--disabled .select2-selection--multiple .select2-selection__rendered,
         .select2-container--default.select2-container--disabled .select2-selection--multiple .select2-search--inline {
             background-color: light-dark(rgb(234, 232, 232), rgb(117, 116, 117)) !important;
-            color: var(--color-fg) !important;
-            border-color: var(--input-border-color) !important;
-            box-shadow: none !important;
             cursor: not-allowed !important;
-            opacity: 1 !important;
         }
 
         .select2-container--default.select2-container--disabled .select2-search__field::placeholder {
             color: var(--text-help) !important;
             opacity: 1 !important;
         }
-
-        .select2-container--default.select2-container--disabled .select2-search__field {
-            -webkit-text-fill-color: var(--text-help) !important;
-        }
-
 
         input[type="search"].search-highlight {
             background-color: var(--search-highlight);

--- a/resources/views/partials/forms/edit/company-select.blade.php
+++ b/resources/views/partials/forms/edit/company-select.blade.php
@@ -4,7 +4,9 @@
     <div class="form-group">
         <label for="{{ $fieldname }}" class="col-md-3 control-label">{{ $translated_name }}</label>
         <div class="col-md-6">
-            <select class="js-data-ajax" disabled="true" data-endpoint="companies" data-placeholder="{{ trans('general.select_company') }}" name="{{ $fieldname }}" style="width: 100%" aria-label="{{ $fieldname }}"{{ (isset($multiple) && ($multiple=='true')) ? " multiple='multiple'" : '' }}>
+            <select class="js-data-ajax" disabled data-endpoint="companies"
+                    data-placeholder="{{ trans('general.select_company') }}" name="{{ $fieldname }}" style="width: 100%"
+                    aria-label="{{ $fieldname }}"{{ (isset($multiple) && ($multiple=='true')) ? " multiple='multiple'" : '' }}>
                 @if ($company_id = old($fieldname, (isset($item)) ? $item->{$fieldname} : ''))
                     <option value="{{ $company_id }}" selected="selected" role="option" aria-selected="true"  role="option">
                         {{ (\App\Models\Company::find($company_id)) ? \App\Models\Company::find($company_id)->name : '' }}

--- a/resources/views/partials/forms/edit/company-select.blade.php
+++ b/resources/views/partials/forms/edit/company-select.blade.php
@@ -41,7 +41,5 @@
             </select>
         </div>
         {!! $errors->first($fieldname, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
-
     </div>
-
 @endif


### PR DESCRIPTION
This cleans up the disabled css rules for select2 and other inputs. adding a few rules for more disabled select 2 search and selection classes.	Also calls `disabled` vs `disabled="true"` in the company field partial.

Custom Report and other spots using the company select2 look good:
<img width="937" height="387" alt="image" src="https://github.com/user-attachments/assets/4c2b161e-185d-4699-b9c7-44d74afc5538" />
<img width="937" height="464" alt="image" src="https://github.com/user-attachments/assets/5b84f5e9-624f-4d38-b7c0-a9f404c1ccf7" />

<img width="937" height="464" alt="image" src="https://github.com/user-attachments/assets/70fab7a6-221b-4bf9-94a7-14818c3b34e3" />
<img width="937" height="464" alt="image" src="https://github.com/user-attachments/assets/c8581b95-c3f6-4d3a-bb29-3a4a6fc95506" />
<img width="937" height="464" alt="image" src="https://github.com/user-attachments/assets/2b8d972a-73cf-4310-9c1a-e96ecf09629d" />
<img width="937" height="464" alt="image" src="https://github.com/user-attachments/assets/c8694a16-4778-4ea6-a34a-10e03bf7d865" />


Fixes: #18715 