### PR TITLE
Fixed RB-4103: Allow more models to access dynamic url presenter method

### DIFF
--- a/app/Presenters/AssetPresenter.php
+++ b/app/Presenters/AssetPresenter.php
@@ -3,7 +3,6 @@
 namespace App\Presenters;
 
 use App\Models\CustomField;
-use App\Models\Setting;
 use Carbon\CarbonImmutable;
 use DateTime;
 use Illuminate\Support\Facades\Storage;
@@ -671,21 +670,6 @@ class AssetPresenter extends Presenter
         }
 
         return false;
-    }
-
-    /**
-     * Used to take user created URL and dynamically fill in the needed values per asset
-     *
-     * @return string
-     */
-    public function dynamicUrl($dynamic_url)
-    {
-        $url = (str_replace('{LOCALE}', Setting::getSettings()->locale, $dynamic_url));
-        $url = (str_replace('{SERIAL}', urlencode($this->model->serial), $url));
-        $url = (str_replace('{MODEL_NAME}', urlencode($this->model->model->name), $url));
-        $url = (str_replace('{MODEL_NUMBER}', urlencode($this->model->model->model_number), $url));
-
-        return $url;
     }
 
     /**

--- a/app/Presenters/Presenter.php
+++ b/app/Presenters/Presenter.php
@@ -2,6 +2,8 @@
 
 namespace App\Presenters;
 
+use App\Models\Asset;
+use App\Models\Setting;
 use App\Models\SnipeModel;
 
 abstract class Presenter
@@ -96,6 +98,31 @@ abstract class Presenter
         }
 
         return '';
+    }
+
+    /**
+     * Used to take user created URL and dynamically fill in the needed values per item
+     *
+     * @return string
+     */
+    public function dynamicUrl($dynamic_url)
+    {
+        $url = (str_replace('{LOCALE}', Setting::getSettings()->locale, $dynamic_url));
+
+        if ($this->model instanceof Asset) {
+            $url = (str_replace('{SERIAL}', urlencode($this->model->serial), $url));
+            $url = (str_replace('{MODEL_NAME}', urlencode($this->model->model->name), $url));
+            $url = (str_replace('{MODEL_NUMBER}', urlencode($this->model->model->model_number), $url));
+
+            return $url;
+        }
+
+        $url = (str_replace('{SERIAL}', urlencode($this->serial), $url));
+        $url = (str_replace('{MODEL_NAME}', urlencode($this->model_name), $url));
+        $url = (str_replace('{MODEL_NUMBER}', urlencode($this->model_number), $url));
+
+        return $url;
+
     }
 
     public function __get($property)

--- a/resources/views/blade/info-panel/index.blade.php
+++ b/resources/views/blade/info-panel/index.blade.php
@@ -332,10 +332,10 @@
             </x-info-element.url>
         </x-info-element>
 
-        @if ($infoPanelObj->manufacturer ?? $infoPanelObj->model?->manufacturer)
+        @if ($infoPanelObj->manufacturer)
             <x-info-element icon_type="external-link" title="{{ trans('admin/manufacturers/table.support_url') }}">
                 <x-info-element.url>
-                    {{ $infoPanelObj->present()->dynamicUrl($infoPanelObj->model->manufacturer->support_url) }}
+                    {{ $infoPanelObj->present()->dynamicUrl($infoPanelObj->manufacturer->support_url) }}
                 </x-info-element.url>
             </x-info-element>
         @endif

--- a/resources/views/blade/info-panel/manufacturer.blade.php
+++ b/resources/views/blade/info-panel/manufacturer.blade.php
@@ -35,10 +35,10 @@
                 @endif
 
 
-                    @if(($asset) && ($asset->model) && ($manufacturer->warranty_lookup_url))
+                    @if(($asset) && ($manufacturer->warranty_lookup_url))
                     <x-icon type="external-link" class="fa-fw"/>
                     <x-info-element.url>
-                    {{ $asset->present()->dynamicUrl($asset->model->manufacturer->warranty_lookup_url) }}
+                    {{ $asset->present()->dynamicUrl($asset->manufacturer->warranty_lookup_url) }}
                     </x-info-element.url>
                     <br>
                 @endif
@@ -54,7 +54,7 @@
                 @if($manufacturer->support_url)
                     <x-icon type="external-link" class="fa-fw"/>
                     <x-info-element.url>
-                    {{ $asset->present()->dynamicUrl($asset->model->manufacturer->support_url) }}
+                    {{ $asset->present()->dynamicUrl($asset->manufacturer->support_url) }}
                 </x-info-element.url>
                     <br>
                 @endif

--- a/tests/Unit/Presenters/AccessoryPresenterTest.php
+++ b/tests/Unit/Presenters/AccessoryPresenterTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Unit\Presenters;
+
+use App\Models\Accessory;
+use Tests\TestCase;
+
+class AccessoryPresenterTest extends TestCase
+{
+    public function test_dynamic_url()
+    {
+        $this->settings->set(['locale' => 'en-US']);
+
+        $accessory = Accessory::factory()->create(['model_number' => 'MN-123']);
+
+        $this->assertEquals(
+            'https://example.com/en-US/MN-123',
+            $accessory->present()->dynamicUrl('https://example.com/{LOCALE}/{MODEL_NUMBER}')
+        );
+    }
+}

--- a/tests/Unit/Presenters/AssetPresenterTest.php
+++ b/tests/Unit/Presenters/AssetPresenterTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Unit\Presenters;
+
+use App\Models\Asset;
+use App\Models\AssetModel;
+use Tests\TestCase;
+
+class AssetPresenterTest extends TestCase
+{
+    public function test_dynamic_url()
+    {
+        $this->settings->set(['locale' => 'en-US']);
+
+        $assetModel = AssetModel::factory()->create([
+            'model_number' => 'MN-123',
+            'name' => 'Macbook',
+        ]);
+
+        $asset = Asset::factory()
+            ->for($assetModel, 'model')
+            ->create(['serial' => 'SN-123']);
+
+        $this->assertEquals(
+            'https://example.com/en-US/SN-123/MN-123/Macbook',
+            $asset->present()->dynamicUrl('https://example.com/{LOCALE}/{SERIAL}/{MODEL_NUMBER}/{MODEL_NAME}')
+        );
+    }
+}

--- a/tests/Unit/Presenters/ComponentPresenterTest.php
+++ b/tests/Unit/Presenters/ComponentPresenterTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Unit\Presenters;
+
+use App\Models\Component;
+use Tests\TestCase;
+
+class ComponentPresenterTest extends TestCase
+{
+    public function test_dynamic_url()
+    {
+        $this->settings->set(['locale' => 'en-US']);
+
+        $component = Component::factory()->create([
+            'serial' => 'SN-123',
+            'model_number' => 'MN-123',
+        ]);
+
+        $this->assertEquals(
+            'https://example.com/en-US/SN-123/MN-123',
+            $component->present()->dynamicUrl('https://example.com/{LOCALE}/{SERIAL}/{MODEL_NUMBER}')
+        );
+    }
+}

--- a/tests/Unit/Presenters/ConsumablePresenterTest.php
+++ b/tests/Unit/Presenters/ConsumablePresenterTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Unit\Presenters;
+
+use App\Models\Consumable;
+use Tests\TestCase;
+
+class ConsumablePresenterTest extends TestCase
+{
+    public function test_dynamic_url()
+    {
+        $this->settings->set(['locale' => 'en-US']);
+
+        $consumable = Consumable::factory()->create(['model_number' => 'MN-123']);
+
+        $this->assertEquals(
+            'https://example.com/en-US/MN-123',
+            $consumable->present()->dynamicUrl('https://example.com/{LOCALE}/{MODEL_NUMBER}')
+        );
+    }
+}

--- a/tests/Unit/Presenters/LicensePresenterTest.php
+++ b/tests/Unit/Presenters/LicensePresenterTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Unit\Presenters;
+
+use App\Models\License;
+use Tests\TestCase;
+
+class LicensePresenterTest extends TestCase
+{
+    public function test_dynamic_url()
+    {
+        $this->settings->set(['locale' => 'en-US']);
+
+        $license = License::factory()->create();
+
+        $this->assertEquals(
+            'https://example.com/en-US',
+            $license->present()->dynamicUrl('https://example.com/{LOCALE}')
+        );
+    }
+}


### PR DESCRIPTION
This PR fixes an issue when attempting to render dynamic support and warranty urls by moving the logic up to the base presenter so the primary model types can all access it.

---

[RB-4103]