### PR TITLE
Fixed #18810: Display acceptance url in checkout asset email

### DIFF
--- a/resources/views/mail/markdown/checkout-asset.blade.php
+++ b/resources/views/mail/markdown/checkout-asset.blade.php
@@ -65,11 +65,11 @@
 @component('mail::panel')
 {!! $eula !!}
 @endcomponent
+@endif
 
 
 @if ($req_accept == 1 && $accept_url)
 **[✔ {{ trans('mail.i_have_read') }}]({{ $accept_url }})**
-@endif
 @endif
 
 {{ trans('mail.best_regards') }}

--- a/tests/Feature/Notifications/Email/EmailNotificationsToUserUponCheckoutTest.php
+++ b/tests/Feature/Notifications/Email/EmailNotificationsToUserUponCheckoutTest.php
@@ -7,6 +7,7 @@ use App\Mail\CheckoutAssetMail;
 use App\Models\Asset;
 use App\Models\AssetModel;
 use App\Models\Category;
+use App\Models\CheckoutAcceptance;
 use App\Models\User;
 use Illuminate\Support\Facades\Mail;
 use PHPUnit\Framework\Attributes\Group;
@@ -49,6 +50,31 @@ class EmailNotificationsToUserUponCheckoutTest extends TestCase
         $this->fireCheckoutEvent();
 
         $this->assertUserSentEmail();
+    }
+
+    public function test_email_contains_link_to_confirm_acceptance_when_category_requires_acceptance()
+    {
+        $this->category->update(['require_acceptance' => true]);
+
+        $this->fireCheckoutEvent();
+
+        Mail::assertSent(CheckoutAssetMail::class, function (CheckoutAssetMail $mail) {
+            $acceptance = CheckoutAcceptance::query()
+                ->forUser($this->user)
+                ->whereCheckoutableId($this->asset->id)
+                ->whereCheckoutableType(Asset::class)
+                ->firstOrFail();
+
+            $url = route('account.accept.item', $acceptance);
+
+            $mailContents = $mail->render();
+
+            if (! str_contains($mailContents, $url)) {
+                $this->fail('Email does not contain the acceptance url');
+            }
+
+            return $mail->hasTo($this->user->email);
+        });
     }
 
     public function test_email_sent_to_user_when_category_using_default_eula()

--- a/tests/Feature/Notifications/Email/EmailNotificationsToUserUponCheckoutTest.php
+++ b/tests/Feature/Notifications/Email/EmailNotificationsToUserUponCheckoutTest.php
@@ -70,7 +70,7 @@ class EmailNotificationsToUserUponCheckoutTest extends TestCase
             $mailContents = $mail->render();
 
             if (! str_contains($mailContents, $url)) {
-                $this->fail('Email does not contain the acceptance url');
+                $this->fail("Email does not contain the acceptance url. Expected to find $url in email contents.");
             }
 
             return $mail->hasTo($this->user->email);


### PR DESCRIPTION
The email markdown is missing an `@endif`. This PR adds it so the link is rendered again:

<img width="2180" height="2154" alt="image" src="https://github.com/user-attachments/assets/2fb64c6d-fb83-498e-b12e-a4c352dbb019" />

>  👀  "here is the eual"?? whatever works for testing 😅 

---

Fixes #18810