### PR TITLE
Fixes #18811  locale for Requestable notifications

### DIFF
--- a/app/Actions/CheckoutRequests/CreateCheckoutRequestAction.php
+++ b/app/Actions/CheckoutRequests/CreateCheckoutRequestAction.php
@@ -44,7 +44,7 @@ class CreateCheckoutRequestAction
         $asset->request();
         $asset->increment('requests_counter', 1);
         try {
-            $settings->notify(new RequestAssetNotification($data));
+            $settings->notify((new RequestAssetNotification($data))->locale($settings->locale));
         } catch (\Exception $e) {
             Log::warning($e);
         }

--- a/app/Http/Controllers/ViewAssetsController.php
+++ b/app/Http/Controllers/ViewAssetsController.php
@@ -205,7 +205,7 @@ class ViewAssetsController extends Controller
             $logaction->logaction(ActionType::RequestCanceled);
 
             if (($settings->alert_email != '') && ($settings->alerts_enabled == '1') && (! config('app.lock_passwords'))) {
-                $settings->notify((new RequestAssetNotification($data))->locale($settings->locale));
+                $settings->notify((new RequestAssetCancelation($data))->locale($settings->locale));
             }
 
             return redirect()->back()->with('success')->with('success', trans('admin/hardware/message.requests.canceled'));

--- a/app/Http/Controllers/ViewAssetsController.php
+++ b/app/Http/Controllers/ViewAssetsController.php
@@ -205,7 +205,7 @@ class ViewAssetsController extends Controller
             $logaction->logaction(ActionType::RequestCanceled);
 
             if (($settings->alert_email != '') && ($settings->alerts_enabled == '1') && (! config('app.lock_passwords'))) {
-                $settings->notify(new RequestAssetCancelation($data));
+                $settings->notify((new RequestAssetNotification($data))->locale($settings->locale));
             }
 
             return redirect()->back()->with('success')->with('success', trans('admin/hardware/message.requests.canceled'));
@@ -213,7 +213,7 @@ class ViewAssetsController extends Controller
             $item->request();
             if (($settings->alert_email != '') && ($settings->alerts_enabled == '1') && (! config('app.lock_passwords'))) {
                 $logaction->logaction('requested');
-                $settings->notify(new RequestAssetNotification($data));
+                $settings->notify((new RequestAssetNotification($data))->locale($settings->locale));
             }
 
             return redirect()->route('requestable-assets')->with('success')->with('success', trans('admin/hardware/message.requests.success'));

--- a/app/Notifications/RequestAssetNotification.php
+++ b/app/Notifications/RequestAssetNotification.php
@@ -102,8 +102,6 @@ class RequestAssetNotification extends Notification
         if (($this->item->model) && ($this->item->model->fieldset)) {
             $fields = $this->item->model->fieldset->fields;
         }
-        $originalLocale = app()->getLocale();
-        app()->setLocale($this->settings->locale);
 
         $message = (new MailMessage)->markdown('notifications.markdown.asset-requested',
             [
@@ -123,8 +121,6 @@ class RequestAssetNotification extends Notification
                     'X-System-Sender', 'Snipe-IT'
                 );
             });
-        
-        app()->setLocale($originalLocale);
 
         return $message;
     }

--- a/app/Notifications/RequestAssetNotification.php
+++ b/app/Notifications/RequestAssetNotification.php
@@ -102,6 +102,8 @@ class RequestAssetNotification extends Notification
         if (($this->item->model) && ($this->item->model->fieldset)) {
             $fields = $this->item->model->fieldset->fields;
         }
+        $originalLocale = app()->getLocale();
+        app()->setLocale($this->settings->locale);
 
         $message = (new MailMessage)->markdown('notifications.markdown.asset-requested',
             [
@@ -121,6 +123,8 @@ class RequestAssetNotification extends Notification
                     'X-System-Sender', 'Snipe-IT'
                 );
             });
+        
+        app()->setLocale($originalLocale);
 
         return $message;
     }


### PR DESCRIPTION
This adds the localization saved in settings to the requestable notifications. Before it was sending in the current user's preferred language.

Fixes: #18811