### PR TITLE
Remove redundant paragonie/sodium_compat dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,6 @@
     "onnov/detect-encoding": "^2.0",
     "osa-eg/laravel-teams-notification": "^2.1",
     "paragonie/constant_time_encoding": "^2.3",
-    "paragonie/sodium_compat": "^1.19",
     "phpdocumentor/reflection-docblock": "^5.1",
     "phpspec/prophecy": "^1.10",
     "pragmarx/google2fa-laravel": "^1.3",


### PR DESCRIPTION
This package depends on `paragonie/sodium_compat: ^1.19`, but also `php: ^8.2`. Since `libsodium` was added in PHP 7.2, the dependency on `paragonie/sodium_compat` seems redundant?