### PR TITLE
Added actions for normalizing permissions input

### DIFF
--- a/app/Actions/Permissions/NormalizePermissionsPayloadAction.php
+++ b/app/Actions/Permissions/NormalizePermissionsPayloadAction.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Actions\Permissions;
+
+final class NormalizePermissionsPayloadAction
+{
+    /**
+     * Normalize permissions payloads from request/model to a consistent associative array.
+     *
+     * @return array<string, mixed>
+     */
+    public static function run(mixed $permissions): array
+    {
+        if (is_string($permissions)) {
+            $decoded = json_decode($permissions, true);
+
+            return is_array($decoded) ? $decoded : [];
+        }
+
+        if (is_array($permissions)) {
+            return $permissions;
+        }
+
+        if ($permissions instanceof \stdClass) {
+            return (array) $permissions;
+        }
+
+        return [];
+    }
+}
+

--- a/app/Actions/Permissions/NormalizePermissionsPayloadAction.php
+++ b/app/Actions/Permissions/NormalizePermissionsPayloadAction.php
@@ -28,4 +28,3 @@ final class NormalizePermissionsPayloadAction
         return [];
     }
 }
-

--- a/app/Actions/Permissions/PreserveUnauthorizedPrivilegedPermissionsAction.php
+++ b/app/Actions/Permissions/PreserveUnauthorizedPrivilegedPermissionsAction.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Actions\Permissions;
+
+use App\Models\User;
+
+final class PreserveUnauthorizedPrivilegedPermissionsAction
+{
+    /**
+     * Preserve privileged permission keys unless the authenticated user may manage them.
+     *
+     * @param  array<string, mixed>  $requestedPermissions
+     * @param  array<string, mixed>  $originalPermissions
+     * @return array<string, mixed>
+     */
+    public static function run(array $requestedPermissions, User $authenticatedUser, array $originalPermissions = []): array
+    {
+        if (! $authenticatedUser->isSuperUser()) {
+            if (array_key_exists('superuser', $originalPermissions)) {
+                $requestedPermissions['superuser'] = $originalPermissions['superuser'];
+            } else {
+                unset($requestedPermissions['superuser']);
+            }
+        }
+
+        if ((! $authenticatedUser->isAdmin()) && (! $authenticatedUser->isSuperUser())) {
+            if (array_key_exists('admin', $originalPermissions)) {
+                $requestedPermissions['admin'] = $originalPermissions['admin'];
+            } else {
+                unset($requestedPermissions['admin']);
+            }
+        }
+
+        return $requestedPermissions;
+    }
+}
+

--- a/app/Actions/Permissions/PreserveUnauthorizedPrivilegedPermissionsAction.php
+++ b/app/Actions/Permissions/PreserveUnauthorizedPrivilegedPermissionsAction.php
@@ -34,4 +34,3 @@ final class PreserveUnauthorizedPrivilegedPermissionsAction
         return $requestedPermissions;
     }
 }
-

--- a/app/Http/Controllers/Api/GroupsController.php
+++ b/app/Http/Controllers/Api/GroupsController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Actions\Permissions\NormalizePermissionsPayloadAction;
 use App\Helpers\Helper;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\FilterRequest;
@@ -77,14 +78,18 @@ class GroupsController extends Controller
     {
         $this->authorize('superadmin');
         $group = new Group;
-        // Get all the available permissions
-        $permissions = json_encode(config('permissions'));
-        $groupPermissions = Helper::selectedPermissionsArray($permissions, $permissions);
+        $defaultPermissions = Helper::selectedPermissionsArray(config('permissions'), config('permissions'));
+
+        $requestedPermissions = $request->has('permissions')
+            ? NormalizePermissionsPayloadAction::run($request->input('permissions'))
+            : $defaultPermissions;
 
         $group->name = $request->input('name');
         $group->created_by = auth()->id();
         $group->notes = $request->input('notes');
-        $group->permissions = json_encode($request->input('permissions', $groupPermissions));
+        $group->permissions = json_encode(
+            Helper::selectedPermissionsArray(config('permissions'), $requestedPermissions)
+        );
 
         if ($group->save()) {
             return response()->json(Helper::formatStandardApiResponse('success', (new GroupsTransformer)->transformGroup($group), trans('admin/groups/message.success.create')));
@@ -124,9 +129,23 @@ class GroupsController extends Controller
         $this->authorize('superadmin');
         $group = Group::findOrFail($id);
 
-        $group->name = $request->input('name');
-        $group->notes = $request->input('notes');
-        $group->permissions = $request->input('permissions'); // Todo - some JSON validation stuff here
+        if ($request->has('name')) {
+            $group->name = $request->input('name');
+        }
+
+        if ($request->has('notes')) {
+            $group->notes = $request->input('notes');
+        }
+
+        // Preserve existing permissions when omitted from PATCH/PUT payload.
+        if ($request->has('permissions')) {
+            $group->permissions = json_encode(
+                Helper::selectedPermissionsArray(
+                    config('permissions'),
+                    NormalizePermissionsPayloadAction::run($request->input('permissions'))
+                )
+            );
+        }
 
         if ($group->save()) {
             return response()->json(Helper::formatStandardApiResponse('success', (new GroupsTransformer)->transformGroup($group), trans('admin/groups/message.success.update')));

--- a/app/Http/Controllers/Api/GroupsController.php
+++ b/app/Http/Controllers/Api/GroupsController.php
@@ -84,9 +84,8 @@ class GroupsController extends Controller
             ? NormalizePermissionsPayloadAction::run($request->input('permissions'))
             : $defaultPermissions;
 
-        $group->name = $request->input('name');
+        $group->fill($request->only(['name', 'notes']));
         $group->created_by = auth()->id();
-        $group->notes = $request->input('notes');
         $group->permissions = json_encode(
             Helper::selectedPermissionsArray(config('permissions'), $requestedPermissions)
         );
@@ -129,13 +128,8 @@ class GroupsController extends Controller
         $this->authorize('superadmin');
         $group = Group::findOrFail($id);
 
-        if ($request->has('name')) {
-            $group->name = $request->input('name');
-        }
-
-        if ($request->has('notes')) {
-            $group->notes = $request->input('notes');
-        }
+        // Fill only the keys present in the request, so PATCH skips absent fields naturally.
+        $group->fill($request->only(['name', 'notes']));
 
         // Preserve existing permissions when omitted from PATCH/PUT payload.
         if ($request->has('permissions')) {

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Actions\Permissions\NormalizePermissionsPayloadAction;
+use App\Actions\Permissions\PreserveUnauthorizedPrivilegedPermissionsAction;
 use App\Helpers\Helper;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\DeleteUserRequest;
@@ -436,27 +438,17 @@ class UsersController extends Controller
     {
         $this->authorize('create', User::class);
 
+        $authenticatedUser = auth()->user();
         $user = new User;
         $user->fill($request->all());
         $user->company_id = Company::getIdForCurrentUser($request->input('company_id'));
         $user->created_by = auth()->id();
 
         if ($request->has('permissions')) {
-            $permissions_array = $request->input('permissions');
-
-            if (! auth()->user()->isSuperUser()) {
-                if ((is_array($permissions_array)) && (array_key_exists('superuser', $permissions_array))) {
-                    unset($permissions_array['superuser']);
-                }
-            }
-
-            if (! auth()->user()->isAdmin()) {
-                if ((is_array($permissions_array)) && (array_key_exists('admin', $permissions_array))) {
-                    unset($permissions_array['admin']);
-                }
-            }
-
-            $user->permissions = $permissions_array;
+            $user->permissions = json_encode(PreserveUnauthorizedPrivilegedPermissionsAction::run(
+                requestedPermissions: NormalizePermissionsPayloadAction::run($request->input('permissions')),
+                authenticatedUser: $authenticatedUser,
+            ));
         }
 
         //
@@ -535,6 +527,8 @@ class UsersController extends Controller
     {
         $this->authorize('update', $user);
 
+        $authenticatedUser = auth()->user();
+
         /**
          * This is a janky hack to prevent people from changing admin demo user data on the public demo.
          * The $ids 1 and 2 are special since they are seeded as superadmins in the demo seeder.
@@ -570,32 +564,12 @@ class UsersController extends Controller
             }
 
             if ($request->has('permissions')) {
-
-                $permissions_array = $this->normalizePermissionsPayload($request->input('permissions'));
-                $orig_permissions_array = $this->normalizePermissionsPayload($user->decodePermissions());
-
-                // Strip out the individual superuser permission if the API user isn't a superadmin.
-                // If the target user did not already have a superuser key, remove any injected value.
-                if (! auth()->user()->isSuperUser()) {
-                    if (array_key_exists('superuser', $orig_permissions_array)) {
-                        $permissions_array['superuser'] = $orig_permissions_array['superuser'];
-                    } else {
-                        unset($permissions_array['superuser']);
-                    }
-                }
-
-                // Strip out the individual admin permission if the API user isn't an admin.
-                // If the target user did not already have an admin key, remove any injected value.
-                if ((! auth()->user()->isAdmin()) && (! auth()->user()->isSuperUser())) {
-                    if (array_key_exists('admin', $orig_permissions_array)) {
-                        $permissions_array['admin'] = $orig_permissions_array['admin'];
-                    } else {
-                        unset($permissions_array['admin']);
-                    }
-                }
-
                 // This is going to update the whole thing, not just what was passed.
-                $user->permissions = $permissions_array;
+                $user->permissions = json_encode(PreserveUnauthorizedPrivilegedPermissionsAction::run(
+                    requestedPermissions: NormalizePermissionsPayloadAction::run($request->input('permissions')),
+                    authenticatedUser: $authenticatedUser,
+                    originalPermissions: NormalizePermissionsPayloadAction::run($user->decodePermissions()),
+                ));
             }
 
         }
@@ -976,29 +950,5 @@ class UsersController extends Controller
         $history = $history->skip($offset)->take($limit)->get();
 
         return response()->json((new ActionlogsTransformer)->transformActionlogs($history, $total), 200, ['Content-Type' => 'application/json;charset=utf8'], JSON_UNESCAPED_UNICODE);
-    }
-
-    /**
-     * Normalize permissions payloads from request/model to a consistent associative array.
-     *
-     * @return array<string, mixed>
-     */
-    private function normalizePermissionsPayload(mixed $permissions): array
-    {
-        if (is_string($permissions)) {
-            $decoded = json_decode($permissions, true);
-
-            return is_array($decoded) ? $decoded : [];
-        }
-
-        if (is_array($permissions)) {
-            return $permissions;
-        }
-
-        if ($permissions instanceof \stdClass) {
-            return (array) $permissions;
-        }
-
-        return [];
     }
 }

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -574,7 +574,6 @@ class UsersController extends Controller
 
         }
 
-
         if ($request->filled('company_id')) {
             $user->company_id = Company::getIdForCurrentUser($request->input('company_id'));
         }

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -574,9 +574,6 @@ class UsersController extends Controller
 
         }
 
-        if ($request->filled('display_name')) {
-            $user->display_name = $request->input('display_name');
-        }
 
         if ($request->filled('company_id')) {
             $user->company_id = Company::getIdForCurrentUser($request->input('company_id'));

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -571,31 +571,30 @@ class UsersController extends Controller
 
             if ($request->has('permissions')) {
 
-                $permissions_array = $request->input('permissions');
-                $orig_permissions_array = $user->decodePermissions();
+                $permissions_array = $this->normalizePermissionsPayload($request->input('permissions'));
+                $orig_permissions_array = $this->normalizePermissionsPayload($user->decodePermissions());
 
-                // Strip out the individual superuser permission if the API user isn't a superadmin
+                // Strip out the individual superuser permission if the API user isn't a superadmin.
+                // If the target user did not already have a superuser key, remove any injected value.
                 if (! auth()->user()->isSuperUser()) {
-
-                    if (is_array($orig_permissions_array)) {
-                        if (array_key_exists('superuser', $orig_permissions_array)) {
-                            $permissions_array['superuser'] = $orig_permissions_array['superuser'];
-                        }
+                    if (array_key_exists('superuser', $orig_permissions_array)) {
+                        $permissions_array['superuser'] = $orig_permissions_array['superuser'];
+                    } else {
+                        unset($permissions_array['superuser']);
                     }
-
                 }
 
-                // Strip out the individual admin permission if the API user isn't an admin
+                // Strip out the individual admin permission if the API user isn't an admin.
+                // If the target user did not already have an admin key, remove any injected value.
                 if ((! auth()->user()->isAdmin()) && (! auth()->user()->isSuperUser())) {
-
-                    if (is_array($orig_permissions_array)) {
-                        if (array_key_exists('admin', $orig_permissions_array)) {
-                            $permissions_array['admin'] = $orig_permissions_array['admin'];
-                        }
+                    if (array_key_exists('admin', $orig_permissions_array)) {
+                        $permissions_array['admin'] = $orig_permissions_array['admin'];
+                    } else {
+                        unset($permissions_array['admin']);
                     }
                 }
 
-                // This is going to update the whole thing, not just what was passed
+                // This is going to update the whole thing, not just what was passed.
                 $user->permissions = $permissions_array;
             }
 
@@ -977,5 +976,29 @@ class UsersController extends Controller
         $history = $history->skip($offset)->take($limit)->get();
 
         return response()->json((new ActionlogsTransformer)->transformActionlogs($history, $total), 200, ['Content-Type' => 'application/json;charset=utf8'], JSON_UNESCAPED_UNICODE);
+    }
+
+    /**
+     * Normalize permissions payloads from request/model to a consistent associative array.
+     *
+     * @return array<string, mixed>
+     */
+    private function normalizePermissionsPayload(mixed $permissions): array
+    {
+        if (is_string($permissions)) {
+            $decoded = json_decode($permissions, true);
+
+            return is_array($decoded) ? $decoded : [];
+        }
+
+        if (is_array($permissions)) {
+            return $permissions;
+        }
+
+        if ($permissions instanceof \stdClass) {
+            return (array) $permissions;
+        }
+
+        return [];
     }
 }

--- a/app/Http/Controllers/GroupsController.php
+++ b/app/Http/Controllers/GroupsController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Actions\Permissions\NormalizePermissionsPayloadAction;
 use App\Helpers\Helper;
 use App\Models\Group;
 use App\Models\User;
@@ -79,14 +80,12 @@ class GroupsController extends Controller
         // create a new group instance
         $group = new Group;
         $group->name = $request->input('name');
-
-        if ($request->filled('permission')) {
-            $group->permissions = json_encode($request->array('permission'));
-        } else {
-            $group->permissions = null;
-        }
-
-        $group->permissions = json_encode($request->input('permission'));
+        $group->permissions = json_encode(
+            Helper::selectedPermissionsArray(
+                config('permissions'),
+                NormalizePermissionsPayloadAction::run($request->input('permission'))
+            )
+        );
         $group->created_by = auth()->id();
         $group->notes = $request->input('notes');
 
@@ -166,15 +165,22 @@ class GroupsController extends Controller
      */
     public function update(Request $request, Group $group): RedirectResponse
     {
-        $group->name = $request->input('name');
-
-        if ($request->filled('permission')) {
-            $group->permissions = json_encode($request->array('permission'));
-        } else {
-            $group->permissions = null;
+        if ($request->has('name')) {
+            $group->name = $request->input('name');
         }
 
-        $group->notes = $request->input('notes');
+        if ($request->has('permission')) {
+            $group->permissions = json_encode(
+                Helper::selectedPermissionsArray(
+                    config('permissions'),
+                    NormalizePermissionsPayloadAction::run($request->input('permission'))
+                )
+            );
+        }
+
+        if ($request->has('notes')) {
+            $group->notes = $request->input('notes');
+        }
 
         if (! config('app.lock_passwords')) {
             if ($group->save()) {

--- a/app/Http/Controllers/GroupsController.php
+++ b/app/Http/Controllers/GroupsController.php
@@ -165,9 +165,8 @@ class GroupsController extends Controller
      */
     public function update(Request $request, Group $group): RedirectResponse
     {
-        if ($request->has('name')) {
-            $group->name = $request->input('name');
-        }
+        $group->name = $request->input('name');
+        $group->notes = $request->input('notes');
 
         if ($request->has('permission')) {
             $group->permissions = json_encode(
@@ -176,10 +175,6 @@ class GroupsController extends Controller
                     NormalizePermissionsPayloadAction::run($request->input('permission'))
                 )
             );
-        }
-
-        if ($request->has('notes')) {
-            $group->notes = $request->input('notes');
         }
 
         if (! config('app.lock_passwords')) {

--- a/app/Http/Controllers/Users/UsersController.php
+++ b/app/Http/Controllers/Users/UsersController.php
@@ -164,7 +164,6 @@ class UsersController extends Controller
                 $user->groups()->sync($request->input('groups'));
             }
 
-
             return Helper::getRedirectOption($request, $user->id, 'Users')
                 ->with('success', trans('admin/users/message.success.create'));
         }

--- a/app/Http/Controllers/Users/UsersController.php
+++ b/app/Http/Controllers/Users/UsersController.php
@@ -160,13 +160,10 @@ class UsersController extends Controller
 
             }
 
-            if ($request->filled('groups')) {
-                if (auth()->user()->can('canEditAuthFields', $user) && auth()->user()->can('editableOnDemo')) {
-                    $user->groups()->sync($request->input('groups'));
-                }
-            } else {
-                $user->groups()->sync([]);
+            if (auth()->user()->can('canEditAuthFields', $user) && auth()->user()->can('editableOnDemo')) {
+                $user->groups()->sync($request->input('groups'));
             }
+
 
             return Helper::getRedirectOption($request, $user->id, 'Users')
                 ->with('success', trans('admin/users/message.success.create'));
@@ -318,7 +315,7 @@ class UsersController extends Controller
             ));
 
             // Only save groups if the user is a superuser
-            if (($request->has('groups')) && (auth()->user()->isSuperUser())) {
+            if (auth()->user()->isSuperUser()) {
                 $user->groups()->sync($request->input('groups'));
             }
         }

--- a/app/Http/Controllers/Users/UsersController.php
+++ b/app/Http/Controllers/Users/UsersController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers\Users;
 
+use App\Actions\Permissions\NormalizePermissionsPayloadAction;
+use App\Actions\Permissions\PreserveUnauthorizedPrivilegedPermissionsAction;
 use App\Helpers\Helper;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\DeleteUserRequest;
@@ -97,6 +99,8 @@ class UsersController extends Controller
     public function store(SaveUserRequest $request)
     {
         $this->authorize('create', User::class);
+
+        $authenticatedUser = auth()->user();
         $user = new User;
         // Username, email, and password need to be handled specially because the need to respect config values on an edit.
         $user->email = trim($request->input('email'));
@@ -130,26 +134,10 @@ class UsersController extends Controller
         $user->end_date = $request->input('end_date', null);
         $user->autoassign_licenses = $request->input('autoassign_licenses', 0);
 
-        // Strip out the superuser permission if the user isn't a superadmin
-        $permissions_array = $request->input('permission');
-
-        // Strip out the individual superuser permission if the API user isn't a superadmin
-        if (! auth()->user()->isSuperUser()) {
-
-            if ((is_array($permissions_array)) && (array_key_exists('superuser', $permissions_array))) {
-                unset($permissions_array['superuser']);
-            }
-        }
-
-        // Strip out the individual admin permission if the API user isn't an admin
-        if (! auth()->user()->isAdmin()) {
-
-            if ((is_array($permissions_array)) && (array_key_exists('admin', $permissions_array))) {
-                unset($permissions_array['admin']);
-            }
-        }
-
-        $user->permissions = json_encode($permissions_array);
+        $user->permissions = json_encode(PreserveUnauthorizedPrivilegedPermissionsAction::run(
+            requestedPermissions: NormalizePermissionsPayloadAction::run($request->input('permission')),
+            authenticatedUser: $authenticatedUser,
+        ));
 
         // we have to invoke the form request here to handle image uploads
         app(ImageUploadRequest::class)->handleImages($user, 600, 'avatar', 'avatars', 'avatar');
@@ -255,6 +243,8 @@ class UsersController extends Controller
     {
         $this->authorize('update', $user);
 
+        $authenticatedUser = auth()->user();
+
         // This is a janky hack to prevent people from changing admin demo user data on the public demo.
         // The $ids 1 and 2 are special since they are seeded as superadmins in the demo seeder.
         // Thanks, jerks. You are why we can't have nice things. - snipe
@@ -271,21 +261,7 @@ class UsersController extends Controller
 
         $this->authorize('update', $user);
 
-        // Figure out of this user was an admin before this edit
-        $orig_permissions_array = $user->decodePermissions();
-        $orig_superuser = '0';
-        $orig_admin = '0';
-        if (is_array($orig_permissions_array)) {
-            if (array_key_exists('superuser', $orig_permissions_array)) {
-                $orig_superuser = $orig_permissions_array['superuser'];
-            }
-        }
-
-        if (is_array($orig_permissions_array)) {
-            if (array_key_exists('admin', $orig_permissions_array)) {
-                $orig_admin = $orig_permissions_array['admin'];
-            }
-        }
+        $orig_permissions_array = NormalizePermissionsPayloadAction::run($user->decodePermissions());
 
         // Update the user fields
 
@@ -335,23 +311,14 @@ class UsersController extends Controller
                 $user->password = bcrypt($request->input('password'));
             }
 
-            $permissions_array = $request->input('permission');
-
-            // Strip out the superuser permission if the user isn't a superadmin
-            if (! auth()->user()->isSuperUser()) {
-                unset($permissions_array['superuser']);
-                $permissions_array['superuser'] = $orig_superuser;
-            }
-
-            if ((! auth()->user()->isSuperUser()) && (! auth()->user()->isAdmin())) {
-                unset($permissions_array['admin']);
-                $permissions_array['admin'] = $orig_admin;
-            }
-
-            $user->permissions = json_encode($permissions_array);
+            $user->permissions = json_encode(PreserveUnauthorizedPrivilegedPermissionsAction::run(
+                requestedPermissions: NormalizePermissionsPayloadAction::run($request->input('permission')),
+                authenticatedUser: $authenticatedUser,
+                originalPermissions: $orig_permissions_array,
+            ));
 
             // Only save groups if the user is a superuser
-            if (auth()->user()->isSuperUser()) {
+            if (($request->has('groups')) && (auth()->user()->isSuperUser())) {
                 $user->groups()->sync($request->input('groups'));
             }
         }

--- a/tests/Feature/Groups/Api/UpdateGroupTest.php
+++ b/tests/Feature/Groups/Api/UpdateGroupTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Feature\Groups\Api;
+
+use App\Models\Group;
+use App\Models\User;
+use Tests\TestCase;
+
+class UpdateGroupTest extends TestCase
+{
+    public function test_updating_group_requires_super_admin_permission()
+    {
+        $this->actingAsForApi(User::factory()->create())
+            ->putJson(route('api.groups.update', Group::factory()->create()))
+            ->assertForbidden();
+    }
+
+    public function test_can_update_group_with_permissions_array_payload()
+    {
+        $group = Group::factory()->create([
+            'permissions' => json_encode(['admin' => '0']),
+        ]);
+
+        $this->actingAsForApi(User::factory()->superuser()->create())
+            ->putJson(route('api.groups.update', $group), [
+                'name' => 'Updated Group Name',
+                'notes' => 'Updated Group Notes',
+                'permissions' => [
+                    'admin' => '1',
+                    'reports.view' => '0',
+                ],
+            ])
+            ->assertOk()
+            ->assertStatusMessageIs('success');
+
+        $decoded = (array) $group->refresh()->decodePermissions();
+
+        $this->assertSame('Updated Group Name', $group->name);
+        $this->assertSame('Updated Group Notes', $group->notes);
+        $this->assertSame('1', (string) ($decoded['admin'] ?? null));
+        $this->assertSame('0', (string) ($decoded['reports.view'] ?? null));
+    }
+
+    public function test_can_update_group_with_permissions_json_string_payload()
+    {
+        $group = Group::factory()->create();
+
+        $this->actingAsForApi(User::factory()->superuser()->create())
+            ->patchJson(route('api.groups.update', $group), [
+                'permissions' => '{"admin":"1","reports.view":"0","invalid.permission":"1"}',
+            ])
+            ->assertOk()
+            ->assertStatusMessageIs('success');
+
+        $decoded = (array) $group->refresh()->decodePermissions();
+
+        $this->assertArrayHasKey('admin', $decoded);
+        $this->assertArrayHasKey('reports.view', $decoded);
+        $this->assertArrayNotHasKey('invalid.permission', $decoded);
+    }
+
+    public function test_permissions_are_preserved_when_not_passed_on_update()
+    {
+        $group = Group::factory()->create([
+            'permissions' => json_encode(['admin' => '1']),
+        ]);
+
+        $this->actingAsForApi(User::factory()->superuser()->create())
+            ->patchJson(route('api.groups.update', $group), [
+                'name' => 'Rename Only',
+            ])
+            ->assertOk()
+            ->assertStatusMessageIs('success');
+
+        $decoded = (array) $group->refresh()->decodePermissions();
+
+        $this->assertSame('Rename Only', $group->name);
+        $this->assertSame('1', (string) ($decoded['admin'] ?? null));
+    }
+}

--- a/tests/Feature/Groups/Ui/UpdateGroupTest.php
+++ b/tests/Feature/Groups/Ui/UpdateGroupTest.php
@@ -32,4 +32,50 @@ class UpdateGroupTest extends TestCase
         $this->followRedirects($response)->assertSee('Success');
         $this->assertTrue(Group::where('name', 'Test Group Edited')->where('notes', 'Test Note Edited')->exists());
     }
+
+    public function test_user_can_edit_group_permissions_and_invalid_permissions_are_dropped()
+    {
+        $group = Group::factory()->create(['name' => 'Permission Test Group']);
+
+        $this->actingAs(User::factory()->superuser()->create())
+            ->put(route('groups.update', ['group' => $group]), [
+                'name' => 'Permission Test Group Edited',
+                'notes' => 'Permission test note',
+                'permission' => [
+                    'admin' => '1',
+                    'reports.view' => '0',
+                    'invalid.permission' => '1',
+                ],
+            ])
+            ->assertStatus(302)
+            ->assertSessionHasNoErrors()
+            ->assertRedirect(route('groups.index'));
+
+        $decoded = (array) $group->refresh()->decodePermissions();
+
+        $this->assertArrayHasKey('admin', $decoded);
+        $this->assertArrayHasKey('reports.view', $decoded);
+        $this->assertArrayNotHasKey('invalid.permission', $decoded);
+    }
+
+    public function test_permissions_are_preserved_if_permission_payload_not_sent()
+    {
+        $group = Group::factory()->create([
+            'permissions' => json_encode(['admin' => '1']),
+        ]);
+
+        $this->actingAs(User::factory()->superuser()->create())
+            ->put(route('groups.update', ['group' => $group]), [
+                'name' => 'Group Name Only',
+                'notes' => 'Updated notes',
+            ])
+            ->assertStatus(302)
+            ->assertSessionHasNoErrors()
+            ->assertRedirect(route('groups.index'));
+
+        $decoded = (array) $group->refresh()->decodePermissions();
+
+        $this->assertSame('Group Name Only', $group->name);
+        $this->assertSame('1', (string) ($decoded['admin'] ?? null));
+    }
 }

--- a/tests/Feature/Users/Api/CreateUserTest.php
+++ b/tests/Feature/Users/Api/CreateUserTest.php
@@ -122,4 +122,50 @@ class CreateUserTest extends TestCase
         $user = User::where('username', 'testuser')->first();
         Notification::assertSentTo($user, WelcomeNotification::class);
     }
+
+    public function test_non_admin_cannot_grant_admin_or_superuser_permissions_when_creating_user_via_api()
+    {
+        $this->actingAsForApi(User::factory()->createUsers()->create())
+            ->postJson(route('api.users.store'), [
+                'first_name' => 'Taylor',
+                'last_name' => 'Tester',
+                'username' => 'taylor-create-api',
+                'password' => 'testpassword1235!!',
+                'password_confirmation' => 'testpassword1235!!',
+                'permissions' => '{"admin":"1","superuser":"1","users.view":"1"}',
+            ])
+            ->assertOk()
+            ->assertStatusMessageIs('success');
+
+        $createdUser = User::where('username', 'taylor-create-api')->firstOrFail();
+        $decoded = (array) $createdUser->decodePermissions();
+
+        $this->assertArrayNotHasKey('admin', $decoded, 'Non-admin user should not be able to grant admin during create');
+        $this->assertArrayNotHasKey('superuser', $decoded, 'Non-admin user should not be able to grant superuser during create');
+        $this->assertEquals(1, $decoded['users.view'] ?? null, 'Non-privileged permissions should still be createable');
+    }
+
+    public function test_admin_cannot_grant_superuser_permission_when_creating_user_via_api()
+    {
+        $this->actingAsForApi(User::factory()->admin()->createUsers()->create())
+            ->postJson(route('api.users.store'), [
+                'first_name' => 'Alex',
+                'last_name' => 'Admin',
+                'username' => 'alex-create-api',
+                'password' => 'testpassword1235!!',
+                'password_confirmation' => 'testpassword1235!!',
+                'permissions' => [
+                    'admin' => '1',
+                    'superuser' => '1',
+                ],
+            ])
+            ->assertOk()
+            ->assertStatusMessageIs('success');
+
+        $createdUser = User::where('username', 'alex-create-api')->firstOrFail();
+        $decoded = (array) $createdUser->decodePermissions();
+
+        $this->assertSame('1', (string) ($decoded['admin'] ?? null), 'Admin should be able to grant admin during create');
+        $this->assertArrayNotHasKey('superuser', $decoded, 'Admin should not be able to grant superuser during create');
+    }
 }

--- a/tests/Feature/Users/Api/UpdateUserTest.php
+++ b/tests/Feature/Users/Api/UpdateUserTest.php
@@ -589,4 +589,57 @@ class UpdateUserTest extends TestCase
             'company_id' => $companyB->id,
         ])->assertStatusMessageIs('error');
     }
+
+    public function test_edit_users_permission_cannot_escalate_empty_permissions_user_to_admin_or_superuser_via_api()
+    {
+        $editingUser = User::factory()->editUsers()->create();
+        $targetUser = User::factory()->create([
+            'permissions' => null,
+        ]);
+
+        $this->actingAsForApi($editingUser)
+            ->putJson(route('api.users.update', $targetUser), [
+                'first_name' => $targetUser->first_name,
+                'username' => $targetUser->username,
+                'permissions' => [
+                    'admin' => '1',
+                    'superuser' => '1',
+                    'users.view' => '1',
+                ],
+            ])
+            ->assertOk()
+            ->assertStatusMessageIs('success');
+
+        $decoded = (array) $targetUser->refresh()->decodePermissions();
+
+        $this->assertArrayNotHasKey('admin', $decoded, 'Non-admin user should not be able to grant admin');
+        $this->assertArrayNotHasKey('superuser', $decoded, 'Non-admin user should not be able to grant superuser');
+        $this->assertEquals(1, $decoded['users.view'] ?? null, 'Non-privileged permissions should still be updateable');
+    }
+
+    public function test_admin_cannot_escalate_empty_permissions_user_to_superuser_via_api()
+    {
+        $adminUser = User::factory()->admin()->create();
+        $targetUser = User::factory()->create([
+            'permissions' => null,
+        ]);
+
+        $this->actingAsForApi($adminUser)
+            ->putJson(route('api.users.update', $targetUser), [
+                'first_name' => $targetUser->first_name,
+                'username' => $targetUser->username,
+                'permissions' => [
+                    'admin' => '1',
+                    'superuser' => '1',
+                ],
+            ])
+            ->assertOk()
+            ->assertStatusMessageIs('success');
+
+        $decoded = (array) $targetUser->refresh()->decodePermissions();
+
+        $this->assertArrayHasKey('admin', $decoded, 'Admin should be able to grant admin');
+        $this->assertSame('1', (string) $decoded['admin']);
+        $this->assertArrayNotHasKey('superuser', $decoded, 'Admin should not be able to grant superuser');
+    }
 }

--- a/tests/Feature/Users/Ui/CreateUserTest.php
+++ b/tests/Feature/Users/Ui/CreateUserTest.php
@@ -94,4 +94,60 @@ class CreateUserTest extends TestCase
         $this->followRedirects($response)->assertSee('Success');
 
     }
+
+    public function test_non_admin_cannot_grant_admin_or_superuser_permissions_when_creating_user_via_ui()
+    {
+        $response = $this->actingAs(User::factory()->createUsers()->viewUsers()->create())
+            ->from(route('users.index'))
+            ->post(route('users.store'), [
+                'first_name' => 'Taylor',
+                'last_name' => 'Tester',
+                'username' => 'taylor-create-ui',
+                'password' => 'testpassword1235!!',
+                'password_confirmation' => 'testpassword1235!!',
+                'permission' => [
+                    'admin' => '1',
+                    'superuser' => '1',
+                    'users.view' => '1',
+                ],
+            ])
+            ->assertSessionHasNoErrors()
+            ->assertStatus(302)
+            ->assertRedirect(route('users.index'));
+
+        $createdUser = User::where('username', 'taylor-create-ui')->firstOrFail();
+        $decoded = (array) $createdUser->decodePermissions();
+
+        $this->assertArrayNotHasKey('admin', $decoded, 'Non-admin user should not be able to grant admin during create');
+        $this->assertArrayNotHasKey('superuser', $decoded, 'Non-admin user should not be able to grant superuser during create');
+        $this->assertEquals(1, $decoded['users.view'] ?? null, 'Non-privileged permissions should still be createable');
+        $this->followRedirects($response)->assertSee('Success');
+    }
+
+    public function test_admin_cannot_grant_superuser_permission_when_creating_user_via_ui()
+    {
+        $response = $this->actingAs(User::factory()->admin()->createUsers()->viewUsers()->create())
+            ->from(route('users.index'))
+            ->post(route('users.store'), [
+                'first_name' => 'Alex',
+                'last_name' => 'Admin',
+                'username' => 'alex-create-ui',
+                'password' => 'testpassword1235!!',
+                'password_confirmation' => 'testpassword1235!!',
+                'permission' => [
+                    'admin' => '1',
+                    'superuser' => '1',
+                ],
+            ])
+            ->assertSessionHasNoErrors()
+            ->assertStatus(302)
+            ->assertRedirect(route('users.index'));
+
+        $createdUser = User::where('username', 'alex-create-ui')->firstOrFail();
+        $decoded = (array) $createdUser->decodePermissions();
+
+        $this->assertSame('1', (string) ($decoded['admin'] ?? null), 'Admin should be able to grant admin during create');
+        $this->assertArrayNotHasKey('superuser', $decoded, 'Admin should not be able to grant superuser during create');
+        $this->followRedirects($response)->assertSee('Success');
+    }
 }

--- a/tests/Feature/Users/Ui/UpdateUserTest.php
+++ b/tests/Feature/Users/Ui/UpdateUserTest.php
@@ -251,6 +251,59 @@ class UpdateUserTest extends TestCase
         $this->followRedirects($response)->assertSee('success');
     }
 
+    public function test_edit_users_permission_cannot_escalate_empty_permissions_user_to_admin_or_superuser_via_ui()
+    {
+        $editingUser = User::factory()->editUsers()->create();
+        $targetUser = User::factory()->create([
+            'permissions' => null,
+        ]);
+
+        $this->actingAs($editingUser)
+            ->put(route('users.update', $targetUser), [
+                'first_name' => $targetUser->first_name,
+                'username' => $targetUser->username,
+                'permission' => [
+                    'admin' => '1',
+                    'superuser' => '1',
+                    'users.view' => '1',
+                ],
+                'redirect_option' => 'index',
+            ])
+            ->assertRedirect(route('users.index'));
+
+        $decoded = (array) $targetUser->refresh()->decodePermissions();
+
+        $this->assertArrayNotHasKey('admin', $decoded, 'Non-admin user should not be able to grant admin');
+        $this->assertArrayNotHasKey('superuser', $decoded, 'Non-admin user should not be able to grant superuser');
+        $this->assertEquals(1, $decoded['users.view'] ?? null, 'Non-privileged permissions should still be updateable');
+    }
+
+    public function test_admin_cannot_escalate_empty_permissions_user_to_superuser_via_ui()
+    {
+        $adminUser = User::factory()->admin()->create();
+        $targetUser = User::factory()->create([
+            'permissions' => null,
+        ]);
+
+        $this->actingAs($adminUser)
+            ->put(route('users.update', $targetUser), [
+                'first_name' => $targetUser->first_name,
+                'username' => $targetUser->username,
+                'permission' => [
+                    'admin' => '1',
+                    'superuser' => '1',
+                ],
+                'redirect_option' => 'index',
+            ])
+            ->assertRedirect(route('users.index'));
+
+        $decoded = (array) $targetUser->refresh()->decodePermissions();
+
+        $this->assertArrayHasKey('admin', $decoded, 'Admin should be able to grant admin');
+        $this->assertSame('1', (string) $decoded['admin']);
+        $this->assertArrayNotHasKey('superuser', $decoded, 'Admin should not be able to grant superuser');
+    }
+
     /**
      * This can occur if the user edit screen is open in one tab and
      * the user is deleted in another before the edit form is submitted.

--- a/tests/Unit/Actions/Permissions/NormalizePermissionsPayloadActionTest.php
+++ b/tests/Unit/Actions/Permissions/NormalizePermissionsPayloadActionTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Unit\Actions\Permissions;
+
+use App\Actions\Permissions\NormalizePermissionsPayloadAction;
+use Tests\TestCase;
+
+class NormalizePermissionsPayloadActionTest extends TestCase
+{
+    public function test_it_returns_arrays_unchanged(): void
+    {
+        $permissions = ['users.view' => '1', 'reports.view' => 0];
+
+        $normalized = NormalizePermissionsPayloadAction::run($permissions);
+
+        $this->assertSame($permissions, $normalized);
+    }
+
+    public function test_it_decodes_valid_json_objects(): void
+    {
+        $normalized = NormalizePermissionsPayloadAction::run('{"users.view":"1","reports.view":"0"}');
+
+        $this->assertSame(['users.view' => '1', 'reports.view' => '0'], $normalized);
+    }
+
+    public function test_it_casts_std_class_payloads_to_arrays(): void
+    {
+        $permissions = (object) ['users.view' => '1'];
+
+        $normalized = NormalizePermissionsPayloadAction::run($permissions);
+
+        $this->assertSame(['users.view' => '1'], $normalized);
+    }
+
+    public function test_it_returns_empty_array_for_invalid_json_or_non_array_values(): void
+    {
+        $this->assertSame([], NormalizePermissionsPayloadAction::run('{not-valid-json}'));
+        $this->assertSame([], NormalizePermissionsPayloadAction::run('null'));
+        $this->assertSame([], NormalizePermissionsPayloadAction::run('"users.view"'));
+        $this->assertSame([], NormalizePermissionsPayloadAction::run(null));
+        $this->assertSame([], NormalizePermissionsPayloadAction::run(123));
+        $this->assertSame([], NormalizePermissionsPayloadAction::run(true));
+    }
+}

--- a/tests/Unit/Actions/Permissions/PreserveUnauthorizedPrivilegedPermissionsActionTest.php
+++ b/tests/Unit/Actions/Permissions/PreserveUnauthorizedPrivilegedPermissionsActionTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Unit\Actions\Permissions;
+
+use App\Actions\Permissions\PreserveUnauthorizedPrivilegedPermissionsAction;
+use App\Models\User;
+use Tests\TestCase;
+
+class PreserveUnauthorizedPrivilegedPermissionsActionTest extends TestCase
+{
+    public function test_superuser_can_modify_privileged_keys(): void
+    {
+        $actor = User::factory()->superuser()->create();
+
+        $normalized = PreserveUnauthorizedPrivilegedPermissionsAction::run(
+            requestedPermissions: ['admin' => '0', 'superuser' => '0', 'users.view' => '1'],
+            authenticatedUser: $actor,
+            originalPermissions: ['admin' => '1', 'superuser' => '1']
+        );
+
+        $this->assertSame('0', (string) $normalized['admin']);
+        $this->assertSame('0', (string) $normalized['superuser']);
+        $this->assertSame('1', (string) $normalized['users.view']);
+    }
+
+    public function test_admin_cannot_change_existing_superuser_key(): void
+    {
+        $actor = User::factory()->admin()->create();
+
+        $normalized = PreserveUnauthorizedPrivilegedPermissionsAction::run(
+            requestedPermissions: ['admin' => '0', 'superuser' => '0', 'users.view' => '1'],
+            authenticatedUser: $actor,
+            originalPermissions: ['admin' => '1', 'superuser' => '1']
+        );
+
+        $this->assertSame('0', (string) $normalized['admin']);
+        $this->assertSame('1', (string) $normalized['superuser']);
+        $this->assertSame('1', (string) $normalized['users.view']);
+    }
+
+    public function test_admin_cannot_add_superuser_key_when_original_is_missing(): void
+    {
+        $actor = User::factory()->admin()->create();
+
+        $normalized = PreserveUnauthorizedPrivilegedPermissionsAction::run(
+            requestedPermissions: ['admin' => '1', 'superuser' => '1', 'users.view' => '1'],
+            authenticatedUser: $actor,
+            originalPermissions: ['admin' => '0']
+        );
+
+        $this->assertArrayNotHasKey('superuser', $normalized);
+        $this->assertSame('1', (string) $normalized['admin']);
+        $this->assertSame('1', (string) $normalized['users.view']);
+    }
+
+    public function test_non_admin_cannot_change_existing_admin_or_superuser_keys(): void
+    {
+        $actor = User::factory()->editUsers()->create();
+
+        $normalized = PreserveUnauthorizedPrivilegedPermissionsAction::run(
+            requestedPermissions: ['admin' => '1', 'superuser' => '1', 'users.view' => '1'],
+            authenticatedUser: $actor,
+            originalPermissions: ['admin' => '0', 'superuser' => '0']
+        );
+
+        $this->assertSame('0', (string) $normalized['admin']);
+        $this->assertSame('0', (string) $normalized['superuser']);
+        $this->assertSame('1', (string) $normalized['users.view']);
+    }
+
+    public function test_non_admin_cannot_add_missing_admin_or_superuser_keys(): void
+    {
+        $actor = User::factory()->editUsers()->create();
+
+        $normalized = PreserveUnauthorizedPrivilegedPermissionsAction::run(
+            requestedPermissions: ['admin' => '1', 'superuser' => '1', 'users.view' => '1'],
+            authenticatedUser: $actor,
+            originalPermissions: []
+        );
+
+        $this->assertArrayNotHasKey('admin', $normalized);
+        $this->assertArrayNotHasKey('superuser', $normalized);
+        $this->assertSame('1', (string) $normalized['users.view']);
+    }
+}


### PR DESCRIPTION
This replaces our kind of clunkier way of handling decoding and encoding permissions, so that we normalize whether the user sends an array, null, or something else entirely (which definitely has happened.) 

The majority of the code here is tests, but I think the new actions clean up the controller code quite a bit. (These actions could have been a helper method, but I decided to branch out a bit. I know Otwell said he thinks people overuse actions, but I think this is a good place for them.)