### PR TITLE
Fixed #18786 - add port number option to the restore command

### DIFF
--- a/app/Console/Commands/RestoreFromBackup.php
+++ b/app/Console/Commands/RestoreFromBackup.php
@@ -456,7 +456,11 @@ class RestoreFromBackup extends Command
         if (! file_exists($mysql_binary)) {
             return $this->error("mysql tool at: '$mysql_binary' does not exist, cannot restore. Please edit DB_DUMP_PATH in your .env to point to a directory that contains the mysqldump and mysql binary");
         }
-        $proc_results = proc_open("$mysql_binary -h ".escapeshellarg(config('database.connections.mysql.host')).' -u '.escapeshellarg(config('database.connections.mysql.username')).' '.escapeshellarg(config('database.connections.mysql.database')), // yanked -p since we pass via ENV
+        $proc_results = proc_open("$mysql_binary -h " .
+            escapeshellarg(config('database.connections.mysql.host')) .
+            ' -u ' . escapeshellarg(config('database.connections.mysql.username')) . ' ' .
+            ' -P ' . escapeshellarg(config('database.connections.mysql.port')) . ' ' .
+            escapeshellarg(config('database.connections.mysql.database')), // yanked -p since we pass via ENV
             [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
             $pipes,
             null,


### PR DESCRIPTION
If you're running MySQL on a non-standard port, the 'restore' command wouldn't work. This just adds the port number to the command-line. (It's *always* set, even if you don't have the env var in your `.env` file, then it defaults to good ole' 3306).