### PR TITLE
Strikethrough if component is deleted

### DIFF
--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -417,7 +417,7 @@ class AssetsTransformer
                 ] : null,
                 'available_actions' => [
                     'checkin' => (($component_checkout->component?->deleted_at == '') && Gate::allows('checkin', Component::class)),
-                    'view' => (($component_checkout->component?->deleted_at == '') && Gate::allows('view', Component::class))
+                    'view' => (($component_checkout->component?->deleted_at == '') && Gate::allows('view', Component::class)),
                 ],
             ];
         }

--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -406,6 +406,7 @@ class AssetsTransformer
                     'id' => $component_checkout->component?->id,
                     'name' => e($component_checkout->component?->display_name),
                     'type' => 'component',
+                    'deleted_at' => $component_checkout->component?->deleted_at,
                 ],
                 'assigned_qty' => $component_checkout->assigned_qty,
                 'note' => ($component_checkout->note) ? e($component_checkout->note) : null,
@@ -414,7 +415,10 @@ class AssetsTransformer
                     'id' => (int) $component_checkout->adminuser->id,
                     'name' => e($component_checkout->adminuser->display_name),
                 ] : null,
-                'available_actions' => ['checkin' => Gate::allows('checkin', Component::class)],
+                'available_actions' => [
+                    'checkin' => (($component_checkout->component?->deleted_at == '') && Gate::allows('checkin', Component::class)),
+                    'view' => (($component_checkout->component?->deleted_at == '') && Gate::allows('view', Component::class))
+                ],
             ];
         }
 

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -1220,6 +1220,11 @@
                 value.name = value.name + ' (' + value.username + ')';
             }
 
+            // Show as strikethrough if it's been deleted
+            if (value.deleted_at && value.deleted_at != '') {
+                return '<nobr><span class="text-muted" data-tooltip="true" title="{{ trans('general.deleted') }} ' + value.type + '"><del><i class="' + item_icon + ' fa-fw"></i> ' + value.name + '</del></span></nobr>';
+            }
+
             return '<nobr><a href="{{ config('app.url') }}/' + item_destination +'/' + value.id + '" data-tooltip="true" title="' + value.type + '"><i class="' + item_icon + ' fa-fw"></i> ' + value.name + '</a></nobr>';
 
         } else {


### PR DESCRIPTION
This adds a strikethrough and unlinks an item if it's been deleted. Unfortunately, I don't know of a way to show the qty without it being counted in the footer, but I'll keep poking at that.

<img width="1320" height="654" alt="Screenshot 2026-04-08 at 12 27 57 PM" src="https://github.com/user-attachments/assets/cfd789b2-4a96-4579-8db3-f8de0a1fcf92" />

