### PR TITLE
Add artisan command to clear compiled views (for docker startup.sh)

### DIFF
--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -124,6 +124,7 @@ fi
 php artisan migrate --force
 php artisan config:clear
 php artisan config:cache
+php artisan view:clear
 
 # we do this after the artisan commands to ensure that if the laravel
 # log got created by root, we set the permissions back


### PR DESCRIPTION
After the recent update to 8.4.1 this command was mandatory, but wasnt applied to docker environment, therefore (atleast for my company) views were broken (empty licenses for example). Had to manually exec into the container and execute this command.

Adding it to the startup script should bring no real downsides, but should fix this for all others and all future version of snipe-it that have the same requirement for clearing compiled views

Edit: Not sure if this should be against develop or master, cannot confirm as https://snipe-it.readme.io/docs/contributing-overview is currently unavailable.