### PR TITLE
Adds validation check console command - helps with #18851

### DIFF
--- a/app/Console/Commands/ValidateAssets.php
+++ b/app/Console/Commands/ValidateAssets.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Asset;
+use Illuminate\Console\Command;
+use Illuminate\Support\MessageBag;
+
+class ValidateAssets extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'snipeit:validate-assets {--all : Display the valid assets in your table output as well} ';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'This runs through the list of assets and checks for any validation errors that would prevent it from being updated or checked in or out. ';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $showAll = (bool) $this->option('all');
+
+        $assets = Asset::query()
+            ->whereNull('deleted_at')
+            ->with('model')
+            ->orderBy('assets.created_at', 'desc')
+            ->get();
+
+        if (! $showAll) {
+            $this->info('Run this command with the --all option to see the full list in the console.');
+        }
+
+        $rows = $assets
+            ->filter(fn (Asset $asset) => $showAll || ! $asset->isValid())
+            ->map(fn (Asset $asset) => [
+                trans('general.id') => $asset->id,
+                trans('admin/hardware/form.tag') => $asset->asset_tag,
+                trans('admin/hardware/form.serial') => $asset->serial ?? '',
+                trans('admin/hardware/form.model') => $asset->model?->name ?? '',
+                trans('general.model_no') => $asset->model?->model_number ?? '',
+                trans('general.error') => $asset->isValid() ? '√ valid' : $this->formatValidationErrors($asset),
+            ])
+            ->values()
+            ->all();
+
+        $this->table(
+            [
+                trans('general.id'),
+                trans('admin/hardware/form.tag'),
+                trans('admin/hardware/form.serial'),
+                trans('admin/hardware/form.model'),
+                trans('general.model_no'),
+                trans('general.error'),
+            ],
+            $rows
+        );
+
+        return self::SUCCESS;
+    }
+
+    private function formatValidationErrors(Asset $asset): string
+    {
+        $errors = $asset->getErrors();
+        $messages = [];
+
+        if ($errors instanceof MessageBag) {
+            $messages = $errors->all();
+        } elseif (is_array($errors)) {
+            $messages = $errors;
+        } else {
+            $messages = [(string) $errors];
+        }
+
+        $prefixedMessages = collect($messages)
+            ->map(fn ($message) => trim((string) $message))
+            ->filter()
+            ->map(fn (string $message) => str_starts_with($message, '✘') ? $message : '✘ '.$message)
+            ->values()
+            ->all();
+
+        return implode(PHP_EOL, $prefixedMessages);
+    }
+}

--- a/tests/Feature/Console/ValidateAssetsTest.php
+++ b/tests/Feature/Console/ValidateAssetsTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use App\Models\Asset;
+use App\Models\User;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class ValidateAssetsTest extends TestCase
+{
+    public function test_it_only_outputs_invalid_assets_by_default(): void
+    {
+        [$validAsset, $invalidAsset] = $this->seedValidAndInvalidAssets();
+
+        Artisan::call('snipeit:validate-assets');
+        $output = Artisan::output();
+
+        $this->assertStringContainsString('Run this command with the --all option to see the full list in the console.', $output);
+        $this->assertStringContainsString($invalidAsset->asset_tag, $output);
+        $this->assertStringContainsString($invalidAsset->serial, $output);
+        $this->assertStringNotContainsString($validAsset->asset_tag, $output);
+        $this->assertStringNotContainsString($validAsset->serial, $output);
+        $this->assertStringNotContainsString('MessageBag', $output);
+        $this->assertStringContainsString('assigned type', strtolower($output));
+    }
+
+    public function test_it_outputs_all_assets_when_all_option_is_passed(): void
+    {
+        [$validAsset, $invalidAsset] = $this->seedValidAndInvalidAssets();
+
+        Artisan::call('snipeit:validate-assets', ['--all' => true]);
+        $output = Artisan::output();
+
+        $this->assertStringContainsString($invalidAsset->asset_tag, $output);
+        $this->assertStringContainsString($invalidAsset->serial, $output);
+        $this->assertStringContainsString($validAsset->asset_tag, $output);
+        $this->assertStringContainsString($validAsset->serial, $output);
+    }
+
+    /**
+     * @return array{0: Asset, 1: Asset}
+     */
+    private function seedValidAndInvalidAssets(): array
+    {
+        $tagSuffix = (string) Str::uuid();
+
+        $validAsset = Asset::factory()->create([
+            'asset_tag' => 'GOOD-ASSET-'.$tagSuffix,
+            'serial' => 'GOOD-SERIAL-'.$tagSuffix,
+        ]);
+
+        $invalidAsset = Asset::factory()
+            ->canBeInvalidUponCreation()
+            ->create([
+                'asset_tag' => 'BROKEN-ASSET-'.$tagSuffix,
+                'serial' => 'BROKEN-SERIAL-'.$tagSuffix,
+                'assigned_to' => User::factory()->create()->id,
+                'assigned_type' => null,
+            ]);
+
+        return [$validAsset, $invalidAsset];
+    }
+}
+

--- a/tests/Feature/Console/ValidateAssetsTest.php
+++ b/tests/Feature/Console/ValidateAssetsTest.php
@@ -63,4 +63,3 @@ class ValidateAssetsTest extends TestCase
         return [$validAsset, $invalidAsset];
     }
 }
-


### PR DESCRIPTION
This adds a console command to check the validity of assets.

Sometimes, over time, requirements may change - for example an admin might start enforcing a rule where serial numbers must be unique, or the requiredness or validation for a custom field might change. 

This cli tool allows you to check for any assets that might not be able to be saved, checked out, etc.

`php artisan snipeit:validate-assets`

<img width="903" height="138" alt="Screenshot 2026-04-13 at 10 30 51 AM" src="https://github.com/user-attachments/assets/fded6336-007f-401a-9afe-fcaf8167738e" />

with an optional flag of `--all` to show all assets.

<img width="1171" height="633" alt="Screenshot 2026-04-13 at 10 36 32 AM" src="https://github.com/user-attachments/assets/bef8b960-fc17-4b53-b0da-27b5bf6fe11e" />

If you have a LOT of assets (300k+) this might take a bit of time, since the validity of the asset is determined by many things, including whether or not the model still exists, etc.

This assists with - but I'm not sure it actually fixes #18851