### PR TITLE
#18736 add cumulative cost of an asset with maintenances

### DIFF
--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -364,9 +364,9 @@ class AssetsController extends Controller
             $total_asset_cost = ($asset->assignedAssets()?->AssetsForShow()) ? $asset->assignedAssets()?->AssetsForShow()?->sum('purchase_cost') : 0;
             $total_license_cost = ($asset->licenses) ? $asset->licenses->sum('purchase_cost') : 0;
             $total_accessory_cost = ($asset->accessories) ? $asset->accessories()->sum('purchase_cost') : 0;
-            $total_component_cost = ($asset->components) ? $asset->components->sum('purchase_cost') : 0;
+            $total_component_cost = ($asset->components) ? $asset->components->sum('calculated_purchase_cost') : 0;
 
-            $total_cost_for_asset = $total_license_cost + $total_asset_cost + $total_maintenance_cost;
+            $total_cost_for_asset = $asset->purchase_cost + $total_maintenance_cost + $total_asset_cost + $total_license_cost + $total_accessory_cost + $total_component_cost;
 
             return view('hardware/view', compact('asset', 'qr_code', 'settings'))
                 ->with('total_maintenance_cost', $total_maintenance_cost)

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -360,8 +360,23 @@ class AssetsController extends Controller
                 'url' => route('qr_code/hardware', $asset),
             ];
 
+            $total_maintenance_cost = $asset->maintenances?->sum('cost');
+            $total_asset_cost = ($asset->assignedAssets()?->AssetsForShow()) ? $asset->assignedAssets()?->AssetsForShow()?->sum('purchase_cost') : 0;
+            $total_license_cost = ($asset->licenses) ? $asset->licenses->sum('purchase_cost') : 0;
+            $total_accessory_cost = ($asset->accessories) ? $asset->accessories()->sum('purchase_cost') : 0;
+            $total_component_cost = ($asset->components) ? $asset->getComponentCost() : 0;
+
+            $total_cost_for_asset = $total_license_cost + $total_asset_cost + $total_maintenance_cost;
+
             return view('hardware/view', compact('asset', 'qr_code', 'settings'))
-                ->with('use_currency', $use_currency)->with('audit_log', $audit_log);
+                ->with('total_maintenance_cost', $total_maintenance_cost)
+                ->with('total_asset_cost', $total_asset_cost)
+                ->with('total_license_cost', $total_license_cost)
+                ->with('total_accessory_cost', $total_accessory_cost)
+                ->with('total_component_cost', $total_component_cost)
+                ->with('total_cost_for_asset', $total_cost_for_asset)
+                ->with('use_currency', $use_currency)
+                ->with('audit_log', $audit_log);
         }
 
         return redirect()->route('hardware.index')->with('error', trans('admin/hardware/message.does_not_exist'));

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -364,7 +364,7 @@ class AssetsController extends Controller
             $total_asset_cost = ($asset->assignedAssets()?->AssetsForShow()) ? $asset->assignedAssets()?->AssetsForShow()?->sum('purchase_cost') : 0;
             $total_license_cost = ($asset->licenses) ? $asset->licenses->sum('purchase_cost') : 0;
             $total_accessory_cost = ($asset->accessories) ? $asset->accessories()->sum('purchase_cost') : 0;
-            $total_component_cost = ($asset->components) ? $asset->getComponentCost() : 0;
+            $total_component_cost = ($asset->components) ? $asset->components->sum('purchase_cost') : 0;
 
             $total_cost_for_asset = $total_license_cost + $total_asset_cost + $total_maintenance_cost;
 

--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -192,8 +192,8 @@ class AssetsTransformer
                         'pivot_id' => $component->pivot->id,
                         'name' => e($component->name),
                         'qty' => $component->pivot->assigned_qty,
-                        'price_cost' => $component->purchase_cost,
-                        'purchase_total' => $component->purchase_cost * $component->pivot->assigned_qty,
+                        'purchase_cost' => $component->purchase_cost,
+                        'purchase_total' => $component->calculated_purchase_cost,
                         'checkout_date' => Helper::getFormattedDateObject($component->pivot->created_at, 'datetime'),
 
                     ];

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -765,7 +765,6 @@ class Asset extends Depreciable
     }
 
     public function accessories()
-
     {
         return $this->morphMany(AccessoryCheckout::class, 'assigned', 'assigned_type', 'assigned_to');
 
@@ -777,11 +776,9 @@ class Asset extends Depreciable
         //     ->withPivot('id', 'assigned_qty', 'created_at', 'note', 'created_by');
     }
 
-
     // {
     //     return $this->morphMany(AccessoryCheckout::class, 'assigned', 'assigned_type', 'assigned_to')->withTrashed();
     // }
-
 
     /**
      * Get the asset's location based on the assigned user

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -761,8 +761,27 @@ class Asset extends Depreciable
      */
     public function assignedAccessories()
     {
-        return $this->morphMany(AccessoryCheckout::class, 'assigned', 'assigned_type', 'assigned_to');
+        return $this->morphMany(AccessoryCheckout::class, 'assigned', 'assigned_type', 'assigned_to')->with('accessories');
     }
+
+    public function accessories()
+
+    {
+        return $this->morphMany(AccessoryCheckout::class, 'assigned', 'assigned_type', 'assigned_to');
+
+        // return $this->hasManyThrough(Accessory::class, AccessoryCheckout::class, 'assigned_to', 'id')
+        //     ->where('assigned_type', self::ASSET);
+        // return $this->hasManyThrough(AccessoryCheckout::class, AssetModel::class, 'id', 'id', 'model_id', 'accessory_id');
+        //
+        // return $this->belongsToMany(AccessoryCheckout::class, 'components_assets', 'asset_id', 'component_id')
+        //     ->withPivot('id', 'assigned_qty', 'created_at', 'note', 'created_by');
+    }
+
+
+    // {
+    //     return $this->morphMany(AccessoryCheckout::class, 'assigned', 'assigned_type', 'assigned_to')->withTrashed();
+    // }
+
 
     /**
      * Get the asset's location based on the assigned user
@@ -1251,6 +1270,16 @@ class Asset extends Depreciable
         $cost = 0;
         foreach ($this->components as $component) {
             $cost += $component->pivot->assigned_qty * $component->purchase_cost;
+        }
+
+        return $cost;
+    }
+
+    public function getAccessoryCost()
+    {
+        $cost = 0;
+        foreach ($this->assignedAccessories() as $accessory) {
+            $cost += $accessory->pivot->assigned_qty * $accessory->purchase_cost;
         }
 
         return $cost;

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -1264,12 +1264,7 @@ class Asset extends Depreciable
 
     public function getComponentCost()
     {
-        $cost = 0;
-        foreach ($this->components as $component) {
-            $cost += $component->pivot->assigned_qty * $component->purchase_cost;
-        }
-
-        return $cost;
+        return (float) $this->components->sum('calculated_purchase_cost');
     }
 
     public function getAccessoryCost()

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -761,23 +761,19 @@ class Asset extends Depreciable
      */
     public function assignedAccessories()
     {
-        return $this->morphMany(AccessoryCheckout::class, 'assigned', 'assigned_type', 'assigned_to')->with('accessories');
+        return $this->morphMany(AccessoryCheckout::class, 'assigned', 'assigned_type', 'assigned_to')->with('accessory');
     }
 
     public function accessories()
     {
-
-        // return $this->belongsToMany('App\Role')->withPivot('column1', 'column2');
-        //
-        // return $this->morphMany(AccessoryCheckout::class, 'assigned', 'assigned_type', 'assigned_to');
-
-        return $this->hasManyThrough(Accessory::class, AccessoryCheckout::class, 'assigned_to', 'id')
-            ->where('assigned_type', self::ASSET);
-
-        // return $this->hasManyThrough(AccessoryCheckout::class, AssetModel::class, 'id', 'id', 'model_id', 'accessory_id');
-
-        // return $this->belongsToMany(AccessoryCheckout::class, 'components_assets', 'asset_id', 'component_id')
-        //     ->withPivot('id', 'assigned_qty', 'created_at', 'note', 'created_by');
+        return $this->hasManyThrough(
+            Accessory::class,
+            AccessoryCheckout::class,
+            'assigned_to',
+            'id',
+            'id',
+            'accessory_id'
+        )->where('assigned_type', self::class);
     }
 
     // {
@@ -1278,12 +1274,7 @@ class Asset extends Depreciable
 
     public function getAccessoryCost()
     {
-        $cost = 0;
-        foreach ($this->assignedAccessories() as $accessory) {
-            $cost += $accessory->pivot->assigned_qty * $accessory->purchase_cost;
-        }
-
-        return $cost;
+        return (float) $this->accessories()->sum('purchase_cost');
     }
 
     /**

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -766,12 +766,16 @@ class Asset extends Depreciable
 
     public function accessories()
     {
-        return $this->morphMany(AccessoryCheckout::class, 'assigned', 'assigned_type', 'assigned_to');
 
-        // return $this->hasManyThrough(Accessory::class, AccessoryCheckout::class, 'assigned_to', 'id')
-        //     ->where('assigned_type', self::ASSET);
-        // return $this->hasManyThrough(AccessoryCheckout::class, AssetModel::class, 'id', 'id', 'model_id', 'accessory_id');
+        // return $this->belongsToMany('App\Role')->withPivot('column1', 'column2');
         //
+        // return $this->morphMany(AccessoryCheckout::class, 'assigned', 'assigned_type', 'assigned_to');
+
+        return $this->hasManyThrough(Accessory::class, AccessoryCheckout::class, 'assigned_to', 'id')
+            ->where('assigned_type', self::ASSET);
+
+        // return $this->hasManyThrough(AccessoryCheckout::class, AssetModel::class, 'id', 'id', 'model_id', 'accessory_id');
+
         // return $this->belongsToMany(AccessoryCheckout::class, 'components_assets', 'asset_id', 'component_id')
         //     ->withPivot('id', 'assigned_qty', 'created_at', 'note', 'created_by');
     }

--- a/app/Models/Component.php
+++ b/app/Models/Component.php
@@ -8,6 +8,7 @@ use App\Models\Traits\Loggable;
 use App\Models\Traits\Searchable;
 use App\Presenters\ComponentPresenter;
 use App\Presenters\Presentable;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -163,6 +164,26 @@ class Component extends SnipeModel
     public function assets()
     {
         return $this->belongsToMany(Asset::class, 'components_assets')->withPivot('id', 'assigned_qty', 'created_at', 'created_by', 'note');
+    }
+
+    protected function calculatedPurchaseCost(): Attribute
+    {
+        return Attribute::make(
+            get: function ($value) {
+                $unitPurchaseCost = $this->getRawOriginal('purchase_cost');
+                $assignedQty = $this->pivot?->assigned_qty;
+
+                if ($unitPurchaseCost === null) {
+                    return $assignedQty !== null ? 0.0 : null;
+                }
+
+                if ($assignedQty !== null) {
+                    return (float) $unitPurchaseCost * (int) $assignedQty;
+                }
+
+                return (float) $unitPurchaseCost;
+            }
+        );
     }
 
     /**

--- a/resources/views/blade/data-row.blade.php
+++ b/resources/views/blade/data-row.blade.php
@@ -13,7 +13,7 @@
         @endif
         {{ $label }}
     </dt>
-    <dd style="text-align: {{ $align }} !important">
+    <dd {{ $attributes->merge(['style' => 'text-align: '.$align.' !important;']) }}>
         @if ((!$slot->isEmpty()) && ($copy_what!=''))
             <x-copy-to-clipboard copy_what="{{ $copy_what }}">{{ $slot }}</x-copy-to-clipboard>
         @elseif (!$slot->isEmpty())

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -285,26 +285,10 @@
 
                             <x-well class="well-sm">
                                 <div class="well-display">
-                                    <x-data-row icon_type="maintenances" label="Active Maintenances" align="right">
-                                        {{ $asset->maintenances->whereNull('completion_date')->count() }}
+                                    <x-data-row icon_type="money" :label="trans('general.purchase_cost')" align="right">
+                                        {{ Helper::formatCurrencyOutput($asset->purchase_cost) }}
                                     </x-data-row>
 
-                                    <x-data-row icon_type="checkout" :label="trans('general.checkouts_count')" align="right">
-                                        {{ ($asset->checkouts) ? (int) $asset->checkouts->count() : '0' }}
-                                    </x-data-row>
-
-                                    <x-data-row icon_type="checkin" :label="trans('general.checkins_count')" align="right">
-                                        {{ ($asset->checkins) ? (int) $asset->checkins->count() : '0' }}
-                                    </x-data-row>
-
-                                    <x-data-row icon_type="request" :label="trans('general.user_requests_count')" align="right">
-                                        {{ ($asset->userRequests) ? (int) $asset->userRequests->count() : '0' }}
-                                    </x-data-row>
-                                </div>
-                            </x-well>
-
-                            <x-well class="well-sm">
-                                <div class="well-display">
                                     <x-data-row icon_type="maintenances" :label="trans('general.maintenances')" align="right">
                                         {{ Helper::formatCurrencyOutput($total_maintenance_cost) }}
                                     </x-data-row>
@@ -331,6 +315,27 @@
 
                                 </div>
                             </x-well>
+
+                            <x-well class="well-sm">
+                                <div class="well-display">
+                                    <x-data-row icon_type="maintenances" label="Active Maintenances" align="right">
+                                        {{ $asset->maintenances->whereNull('completion_date')->count() }}
+                                    </x-data-row>
+
+                                    <x-data-row icon_type="checkout" :label="trans('general.checkouts_count')" align="right">
+                                        {{ ($asset->checkouts) ? (int) $asset->checkouts->count() : '0' }}
+                                    </x-data-row>
+
+                                    <x-data-row icon_type="checkin" :label="trans('general.checkins_count')" align="right">
+                                        {{ ($asset->checkins) ? (int) $asset->checkins->count() : '0' }}
+                                    </x-data-row>
+
+                                    <x-data-row icon_type="request" :label="trans('general.user_requests_count')" align="right">
+                                        {{ ($asset->userRequests) ? (int) $asset->userRequests->count() : '0' }}
+                                    </x-data-row>
+                                </div>
+                            </x-well>
+
 
 
                             @if (($snipeSettings->qr_code=='1') || $snipeSettings->label2_2d_type!='none')

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -285,21 +285,50 @@
 
                             <x-well class="well-sm">
                                 <div class="well-display">
-                                    <x-data-row icon_type="maintenances" label="Active Maintenances">
+                                    <x-data-row icon_type="maintenances" label="Active Maintenances" align="right">
                                         {{ $asset->maintenances->whereNull('completion_date')->count() }}
                                     </x-data-row>
 
-                                    <x-data-row icon_type="checkout" :label="trans('general.checkouts_count')">
+                                    <x-data-row icon_type="checkout" :label="trans('general.checkouts_count')" align="right">
                                         {{ ($asset->checkouts) ? (int) $asset->checkouts->count() : '0' }}
                                     </x-data-row>
 
-                                    <x-data-row icon_type="checkin" :label="trans('general.checkins_count')">
+                                    <x-data-row icon_type="checkin" :label="trans('general.checkins_count')" align="right">
                                         {{ ($asset->checkins) ? (int) $asset->checkins->count() : '0' }}
                                     </x-data-row>
 
-                                    <x-data-row icon_type="request" :label="trans('general.user_requests_count')">
+                                    <x-data-row icon_type="request" :label="trans('general.user_requests_count')" align="right">
                                         {{ ($asset->userRequests) ? (int) $asset->userRequests->count() : '0' }}
                                     </x-data-row>
+                                </div>
+                            </x-well>
+
+                            <x-well class="well-sm">
+                                <div class="well-display">
+                                    <x-data-row icon_type="maintenances" :label="trans('general.maintenances')" align="right">
+                                        {{ Helper::formatCurrencyOutput($total_maintenance_cost) }}
+                                    </x-data-row>
+
+                                    <x-data-row icon_type="accessories" :label="trans('general.accessories')" align="right">
+                                        {{ Helper::formatCurrencyOutput($total_accessory_cost) }}
+                                    </x-data-row>
+
+                                    <x-data-row icon_type="licenses" :label="trans('general.licenses')" align="right">
+                                        {{ Helper::formatCurrencyOutput($total_license_cost) }}
+                                    </x-data-row>
+
+                                    <x-data-row icon_type="components" :label="trans('general.components')" align="right">
+                                        {{ Helper::formatCurrencyOutput($total_component_cost) }}
+                                    </x-data-row>
+
+                                    <x-data-row icon_type="assets" :label="trans('general.assets')" align="right">
+                                        {{ Helper::formatCurrencyOutput($total_asset_cost) }}
+                                    </x-data-row>
+
+                                    <x-data-row :label="trans('general.total_cost')" align="right" style="border-top: 1px solid var(--box-header-top-border-color) !important;">
+                                        {{ Helper::formatCurrencyOutput($total_cost_for_asset) }}
+                                    </x-data-row>
+
                                 </div>
                             </x-well>
 

--- a/tests/Unit/AssetTest.php
+++ b/tests/Unit/AssetTest.php
@@ -8,6 +8,7 @@ use App\Models\AccessoryCheckout;
 use App\Models\Asset;
 use App\Models\AssetModel;
 use App\Models\Category;
+use App\Models\Component;
 use App\Models\Setting;
 use App\Models\Statuslabel;
 use App\Models\User;
@@ -323,5 +324,50 @@ class AssetTest extends TestCase
 
         $this->assertCount(3, $asset->accessories()->get());
         $this->assertSame(35.0, $asset->getAccessoryCost());
+    }
+
+    public function test_asset_components_calculated_total_uses_assigned_quantity(): void
+    {
+        $asset = Asset::factory()->create();
+
+        $firstComponent = Component::factory()->create(['purchase_cost' => 10]);
+        $secondComponent = Component::factory()->create(['purchase_cost' => 25]);
+
+        $asset->components()->attach($firstComponent->id, [
+            'assigned_qty' => 3,
+            'created_by' => User::factory()->create()->id,
+            'created_at' => now(),
+        ]);
+
+        $asset->components()->attach($secondComponent->id, [
+            'assigned_qty' => 2,
+            'created_by' => User::factory()->create()->id,
+            'created_at' => now(),
+        ]);
+
+        $freshAsset = $asset->fresh();
+
+        $this->assertEquals(35, $freshAsset->components->sum('purchase_cost'));
+        $this->assertEquals(80, $freshAsset->components->sum('calculated_purchase_cost'));
+        $this->assertSame(80.0, $freshAsset->getComponentCost());
+    }
+
+    public function test_asset_components_calculated_total_treats_null_purchase_cost_as_zero(): void
+    {
+        $asset = Asset::factory()->create();
+
+        $componentWithoutCost = Component::factory()->create(['purchase_cost' => null]);
+
+        $asset->components()->attach($componentWithoutCost->id, [
+            'assigned_qty' => 4,
+            'created_by' => User::factory()->create()->id,
+            'created_at' => now(),
+        ]);
+
+        $freshAsset = $asset->fresh();
+
+        $this->assertSame(0.0, $freshAsset->components->first()->calculated_purchase_cost);
+        $this->assertEquals(0, $freshAsset->components->sum('calculated_purchase_cost'));
+        $this->assertSame(0.0, $freshAsset->getComponentCost());
     }
 }

--- a/tests/Unit/AssetTest.php
+++ b/tests/Unit/AssetTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Unit;
 
 use App\Http\Controllers\Assets\BulkAssetsController;
+use App\Models\Accessory;
+use App\Models\AccessoryCheckout;
 use App\Models\Asset;
 use App\Models\AssetModel;
 use App\Models\Category;
@@ -288,5 +290,38 @@ class AssetTest extends TestCase
         $filtered = array_diff([$deployable->id, $undeployable->id], $undeployableIds);
 
         $this->assertEquals([$deployable->id], array_values($filtered));
+    }
+
+    public function test_asset_accessories_relationship_uses_accessory_checkout_rows(): void
+    {
+        $asset = Asset::factory()->create();
+        $otherAsset = Asset::factory()->create();
+
+        $primaryAccessory = Accessory::factory()->create(['purchase_cost' => 10]);
+        $secondaryAccessory = Accessory::factory()->create(['purchase_cost' => 15]);
+
+        AccessoryCheckout::factory()->create([
+            'accessory_id' => $primaryAccessory->id,
+            'assigned_to' => $asset->id,
+            'assigned_type' => Asset::class,
+        ]);
+        AccessoryCheckout::factory()->create([
+            'accessory_id' => $primaryAccessory->id,
+            'assigned_to' => $asset->id,
+            'assigned_type' => Asset::class,
+        ]);
+        AccessoryCheckout::factory()->create([
+            'accessory_id' => $secondaryAccessory->id,
+            'assigned_to' => $asset->id,
+            'assigned_type' => Asset::class,
+        ]);
+        AccessoryCheckout::factory()->create([
+            'accessory_id' => $primaryAccessory->id,
+            'assigned_to' => $otherAsset->id,
+            'assigned_type' => Asset::class,
+        ]);
+
+        $this->assertCount(3, $asset->accessories()->get());
+        $this->assertSame(35.0, $asset->getAccessoryCost());
     }
 }


### PR DESCRIPTION
This adds the running total of the costs associated with an asset, including maintenances, to the asset view screen.

<img width="1058" height="508" alt="View_Asset_1001245636____Snipe-IT_Demo" src="https://github.com/user-attachments/assets/394ddea1-0723-4431-bece-b6b7d9718cfb" />

Fixes #18736