### PR TITLE
Fixed #18869 - skip mail test if no `MAIL_REPLYTO_ADDR` is given

### DIFF
--- a/app/Http/Controllers/Api/SettingsController.php
+++ b/app/Http/Controllers/Api/SettingsController.php
@@ -162,6 +162,12 @@ class SettingsController extends Controller
     public function ajaxTestEmail(): JsonResponse
     {
         if (! config('app.lock_passwords')) {
+
+            if (config('mail.reply_to.address') == '') {
+                Log::debug('MAIL_REPLYTO_ADDR not set in env. Skipping mail test.');
+                return response()->json(['message' => trans('admin/settings/general.mail_test_no_email')], 403);
+            }
+
             try {
                 Notification::send(Setting::first(), new MailTest);
                 Log::debug('Attempting to sending to '.config('mail.reply_to.address'));

--- a/resources/lang/en-US/admin/settings/general.php
+++ b/resources/lang/en-US/admin/settings/general.php
@@ -361,6 +361,7 @@ return [
     'general_title' => 'Update General Settings',
     'mail_test' => 'Send Test',
     'mail_test_help' => 'This will attempt to send a test mail to :replyto.',
+    'mail_test_no_email' => 'MAIL_REPLYTO_ADDR not set or has no value .env config file. Cannot send test email. Please update this value in your configuration file with a valid email address.',
     'filter_by_keyword' => 'Filter by setting keyword',
     'security' => 'Security',
     'security_title' => 'Update Security Settings',

--- a/resources/views/settings/general.blade.php
+++ b/resources/views/settings/general.blade.php
@@ -263,7 +263,7 @@
                                <label for="login_note" class="col-md-3 control-label">{{trans('admin/settings/general.test_mail')}}</label>
 
                                <div class="col-md-8" id="mailtestrow">
-                                   <a class="btn btn-default btn-sm pull-left" id="mailtest" style="margin-right: 10px;">
+                                   <a class="btn btn-default btn-sm pull-left{{ (config('mail.reply_to.address') == '') ? ' disabled': '' }}" id="mailtest" style="margin-right: 10px;">
                                        {{ trans('admin/settings/general.mail_test') }}</a>
                                    <span id="mailtesticon"></span>
                                    <span id="mailtestresult"></span>
@@ -274,7 +274,15 @@
                                </div>
                                <div class="col-md-8 col-md-offset-3">
                                    <div class="help-block">
-                                       <p>{{ trans('admin/settings/general.mail_test_help', array('replyto' => config('mail.reply_to.address'))) }}</p>
+
+                                       @if (config('mail.reply_to.address') == '')
+                                           <p class="text-warning">
+                                               <x-icon type="warning"/> {{ trans('admin/settings/general.mail_test_no_email') }}
+                                           </p>
+                                       @else
+                                           <p>{{ trans('admin/settings/general.mail_test_help', array('replyto' => config('mail.reply_to.address'))) }}</p>
+                                       @endif
+
                                    </div>
                                </div>
 


### PR DESCRIPTION
This just adds some checking and better output if the .env is missing the `MAIL_REPLYTO_ADDR`, which is the address where the test emails would go. 

### Missing MAIL_REPLYTO_ADDR
<img width="1331" height="175" alt="Screenshot 2026-04-13 at 3 14 47 PM" src="https://github.com/user-attachments/assets/c2989dfd-5b70-429e-a0ec-56f02a42746d" />

## With MAIL_REPLYTO_ADDR
<img width="1327" height="202" alt="Screenshot 2026-04-13 at 3 15 00 PM" src="https://github.com/user-attachments/assets/e647f5a0-aba1-41dd-91d3-dede61c5b7de" />

Fixed #18869
