### PR TITLE
Fixes #9037 - Added breadcrumbs to top breadcrumb trail

### DIFF
--- a/app/Providers/BreadcrumbsServiceProvider.php
+++ b/app/Providers/BreadcrumbsServiceProvider.php
@@ -342,14 +342,16 @@ class BreadcrumbsServiceProvider extends ServiceProvider
             ->push(trans('admin/locations/table.clone'), route('locations.create'))
         );
 
-        Breadcrumbs::for('locations.show', fn (Trail $trail, Location $location) => $trail->parent('locations.index', route('locations.index'))
-            ->push($location->name, route('locations.show', $location))
-        );
+        Breadcrumbs::for('locations.show', function (Trail $trail, Location $location) {
+            $trail->parent('locations.index', route('locations.index'));
+            $this->pushLocationHierarchy($trail, $location);
+        });
 
-        Breadcrumbs::for('locations.edit', fn (Trail $trail, Location $location) => $trail->parent('locations.index', route('locations.index'))
-            ->push($location->display_name, route('locations.show', $location))
-            ->push(trans('general.update'))
-        );
+        Breadcrumbs::for('locations.edit', function (Trail $trail, Location $location) {
+            $trail->parent('locations.index', route('locations.index'));
+            $this->pushLocationHierarchy($trail, $location);
+            $trail->push(trans('general.update'));
+        });
 
         /**
          * Maintenances Breadcrumbs
@@ -509,5 +511,23 @@ class BreadcrumbsServiceProvider extends ServiceProvider
             ->push(trans('general.update'))
         );
 
+    }
+
+    /**
+     * Append parent -> child location breadcrumbs recursively for a location.
+     */
+    private function pushLocationHierarchy(Trail $trail, Location $location): void
+    {
+        $ancestorChain = [];
+        $cursor = $location;
+
+        while ($cursor !== null) {
+            array_unshift($ancestorChain, $cursor);
+            $cursor = $cursor->parent;
+        }
+
+        foreach ($ancestorChain as $node) {
+            $trail->push($node->name, route('locations.show', $node));
+        }
     }
 }

--- a/resources/views/blade/info-panel/index.blade.php
+++ b/resources/views/blade/info-panel/index.blade.php
@@ -275,8 +275,19 @@
         <x-info-panel.manufacturer :asset="$infoPanelObj" :manufacturer="($infoPanelObj->manufacturer ?? $infoPanelObj->model?->manufacturer)"/>
 
         @if ((isset($infoPanelObj->parent)) && ($infoPanelObj->parent))
+            @php
+                $locationAncestors = [];
+                $ancestorCursor = $infoPanelObj->parent;
+
+                while ($ancestorCursor) {
+                    array_unshift($locationAncestors, $ancestorCursor);
+                    $ancestorCursor = $ancestorCursor->parent;
+                }
+            @endphp
             <x-info-element icon_type="parent" title="{{ trans('admin/locations/table.parent') }}">
-                <a href="{{ route('locations.show', $infoPanelObj->parent->id) }}">{{ $infoPanelObj->parent->display_name }}</a>
+                @foreach ($locationAncestors as $ancestor)
+                    <a href="{{ route('locations.show', $ancestor->id) }}">{{ $ancestor->display_name }}</a>@if (! $loop->last) &rsaquo; @endif
+                @endforeach
             </x-info-element>
         @endif
 

--- a/resources/views/locations/edit.blade.php
+++ b/resources/views/locations/edit.blade.php
@@ -2,8 +2,6 @@
     'createText' => trans('admin/locations/table.create') ,
     'updateText' => trans('admin/locations/table.update'),
     'topSubmit' => true,
-    'helpPosition' => 'right',
-    'helpText' => trans('admin/locations/table.about_locations'),
     'formAction' => (isset($item->id)) ? route('locations.update', ['location' => $item->id]) : route('locations.store'),
 ])
 

--- a/tests/Feature/Locations/Ui/ShowLocationTest.php
+++ b/tests/Feature/Locations/Ui/ShowLocationTest.php
@@ -37,4 +37,26 @@ class ShowLocationTest extends TestCase
             ->get(route('locations.print_all_assigned', Location::factory()->create()))
             ->assertOk();
     }
+
+    public function test_show_page_includes_parent_location_breadcrumb_hierarchy()
+    {
+        $grandparent = Location::factory()->create(['name' => 'Grandparent Breadcrumb Location']);
+        $parent = Location::factory()->create([
+            'name' => 'Parent Breadcrumb Location',
+            'parent_id' => $grandparent->id,
+        ]);
+        $child = Location::factory()->create([
+            'name' => 'Child Breadcrumb Location',
+            'parent_id' => $parent->id,
+        ]);
+
+        $this->actingAs(User::factory()->superuser()->create())
+            ->get(route('locations.show', $child))
+            ->assertOk()
+            ->assertSeeInOrder([
+                route('locations.show', $grandparent),
+                route('locations.show', $parent),
+                route('locations.show', $child),
+            ]);
+    }
 }

--- a/tests/Feature/Locations/Ui/ShowLocationTest.php
+++ b/tests/Feature/Locations/Ui/ShowLocationTest.php
@@ -59,4 +59,33 @@ class ShowLocationTest extends TestCase
                 route('locations.show', $child),
             ]);
     }
+
+    public function test_show_page_info_panel_includes_parent_location_hierarchy_without_current_location()
+    {
+        $grandparent = Location::factory()->create(['name' => 'Grandparent Info Panel Location']);
+        $parent = Location::factory()->create([
+            'name' => 'Parent Info Panel Location',
+            'parent_id' => $grandparent->id,
+        ]);
+        $child = Location::factory()->create([
+            'name' => 'Child Info Panel Location',
+            'parent_id' => $parent->id,
+        ]);
+
+        $response = $this->actingAs(User::factory()->superuser()->create())
+            ->get(route('locations.show', $child));
+
+        $response->assertOk()
+            ->assertSeeInOrder([
+                route('locations.show', $grandparent),
+                route('locations.show', $parent),
+            ]);
+
+        $responseContent = $response->getContent();
+
+        $this->assertStringNotContainsString(
+            '<a href="'.route('locations.show', $child).'">'.$child->display_name.'</a>',
+            $responseContent
+        );
+    }
 }

--- a/tests/Feature/Locations/Ui/UpdateLocationsTest.php
+++ b/tests/Feature/Locations/Ui/UpdateLocationsTest.php
@@ -105,4 +105,27 @@ class UpdateLocationsTest extends TestCase
         // Storage::disk('local')->assertExists($logentry->filename);
 
     }
+
+    public function test_edit_page_includes_parent_location_breadcrumb_hierarchy()
+    {
+        $grandparent = Location::factory()->create(['name' => 'Grandparent Edit Breadcrumb Location']);
+        $parent = Location::factory()->create([
+            'name' => 'Parent Edit Breadcrumb Location',
+            'parent_id' => $grandparent->id,
+        ]);
+        $child = Location::factory()->create([
+            'name' => 'Child Edit Breadcrumb Location',
+            'parent_id' => $parent->id,
+        ]);
+
+        $this->actingAs(User::factory()->superuser()->create())
+            ->get(route('locations.edit', $child))
+            ->assertOk()
+            ->assertSeeInOrder([
+                route('locations.show', $grandparent),
+                route('locations.show', $parent),
+                route('locations.show', $child),
+                trans('general.update'),
+            ]);
+    }
 }


### PR DESCRIPTION
This adds the heirarchical breadcrumb trail to the locations pages. 

<img width="1547" height="363" alt="Screenshot 2026-04-13 at 4 06 25 PM" src="https://github.com/user-attachments/assets/70c33320-f911-48f7-91ee-a49896671b68" />

This also adds it to the info-panel, if a parent exist. 

<img width="232" height="51" alt="Screenshot 2026-04-13 at 4 17 52 PM" src="https://github.com/user-attachments/assets/b68882c5-1d4e-47ec-af0d-8abe27453e84" />



Fixed #9037