### PR TITLE
Fix soft deleted companies in migrations

### DIFF
--- a/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
+++ b/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
@@ -65,7 +65,7 @@ class DenormalizedEolAndAddColumnForExplicitDateToAssets extends Migration
             ]);
 
         Schema::table('companies', function (Blueprint $table) {
-            if (! Schema::hasColumn('companies', 'deleted_at')) {
+            if (Schema::hasColumn('companies', 'deleted_at')) {
                 $table->dropColumn('deleted_at');
             }
         });

--- a/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
+++ b/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
@@ -24,6 +24,16 @@ class DenormalizedEolAndAddColumnForExplicitDateToAssets extends Migration
             }
         });
 
+
+        // This is a back in time migration to fix restores from very old versions of Snipe-IT where
+        // companies were not soft-deletable.  We will undo this in this migration
+        // after the eol_explicit stuff is done
+        Schema::table('companies', function (Blueprint $table) {
+            if (!Schema::hasColumn('companies', 'deleted_at')) {
+                $table->datetime('deleted_at')->default(false);
+            }
+        });
+
         // Update the eol_explicit column with the value from asset_eol_date if it exists and is different from the calculated value
         Asset::whereNotNull('asset_eol_date')->with('model')->chunkById(500, function ($assetsWithEolDates) {
             foreach ($assetsWithEolDates as $asset) {
@@ -54,6 +64,14 @@ class DenormalizedEolAndAddColumnForExplicitDateToAssets extends Migration
             ->update([
                 'asset_eol_date' => $this->eolUpdateExpression(),
             ]);
+
+
+        Schema::table('companies', function (Blueprint $table) {
+            if (!Schema::hasColumn('companies', 'deleted_at')) {
+                $table->dropColumn('deleted_at');
+            }
+        });
+
     }
 
     /**

--- a/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
+++ b/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
@@ -24,12 +24,11 @@ class DenormalizedEolAndAddColumnForExplicitDateToAssets extends Migration
             }
         });
 
-
         // This is a back in time migration to fix restores from very old versions of Snipe-IT where
         // companies were not soft-deletable.  We will undo this in this migration
         // after the eol_explicit stuff is done
         Schema::table('companies', function (Blueprint $table) {
-            if (!Schema::hasColumn('companies', 'deleted_at')) {
+            if (! Schema::hasColumn('companies', 'deleted_at')) {
                 $table->datetime('deleted_at')->default(false);
             }
         });
@@ -65,9 +64,8 @@ class DenormalizedEolAndAddColumnForExplicitDateToAssets extends Migration
                 'asset_eol_date' => $this->eolUpdateExpression(),
             ]);
 
-
         Schema::table('companies', function (Blueprint $table) {
-            if (!Schema::hasColumn('companies', 'deleted_at')) {
+            if (! Schema::hasColumn('companies', 'deleted_at')) {
                 $table->dropColumn('deleted_at');
             }
         });

--- a/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
+++ b/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
@@ -29,7 +29,7 @@ class DenormalizedEolAndAddColumnForExplicitDateToAssets extends Migration
         // after the eol_explicit stuff is done
         Schema::table('companies', function (Blueprint $table) {
             if (! Schema::hasColumn('companies', 'deleted_at')) {
-                $table->datetime('deleted_at')->default(false);
+                $table->datetime('deleted_at')->nullable()->default(null);
             }
         });
 

--- a/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
+++ b/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
@@ -25,11 +25,10 @@ class DenormalizedEolAndAddColumnForExplicitDateToAssets extends Migration
         });
 
         // This is a back in time migration to fix restores from very old versions of Snipe-IT where
-        // companies were not soft-deletable.  We will undo this in this migration
-        // after the eol_explicit stuff is done
+        // companies were not soft-deletable.
         Schema::table('companies', function (Blueprint $table) {
             if (! Schema::hasColumn('companies', 'deleted_at')) {
-                $table->datetime('deleted_at')->nullable()->default(null);
+                $table->softDeletes();
             }
         });
 
@@ -64,11 +63,6 @@ class DenormalizedEolAndAddColumnForExplicitDateToAssets extends Migration
                 'asset_eol_date' => $this->eolUpdateExpression(),
             ]);
 
-        Schema::table('companies', function (Blueprint $table) {
-            if (Schema::hasColumn('companies', 'deleted_at')) {
-                $table->dropColumn('deleted_at');
-            }
-        });
 
     }
 

--- a/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
+++ b/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
@@ -63,7 +63,6 @@ class DenormalizedEolAndAddColumnForExplicitDateToAssets extends Migration
                 'asset_eol_date' => $this->eolUpdateExpression(),
             ]);
 
-
     }
 
     /**

--- a/database/migrations/2026_03_26_150316_add_deleted_at_to_companies.php
+++ b/database/migrations/2026_03_26_150316_add_deleted_at_to_companies.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
 
         Schema::table('companies', function (Blueprint $table) {
-            if (!Schema::hasColumn('companies', 'deleted_at')) {
+            if (! Schema::hasColumn('companies', 'deleted_at')) {
                 $table->softDeletes();
             }
         });

--- a/database/migrations/2026_03_26_150316_add_deleted_at_to_companies.php
+++ b/database/migrations/2026_03_26_150316_add_deleted_at_to_companies.php
@@ -11,8 +11,11 @@ return new class extends Migration
      */
     public function up(): void
     {
+
         Schema::table('companies', function (Blueprint $table) {
-            $table->softDeletes();
+            if (!Schema::hasColumn('companies', 'deleted_at')) {
+                $table->softDeletes();
+            }
         });
 
     }


### PR DESCRIPTION
We recently added soft-deletes to companies, and in doing so broke some migrations/restores from folks coming from much older versions. 

```
 INFO  Running migrations.

  2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets ....................................................... 21.93ms FAIL

   Illuminate\Database\QueryException

  SQLSTATE[42S22]: Column not found: 1054 Unknown column 'companies.deleted_at' in 'where clause' (Connection: mysql, SQL: select * from `companies` where `companies`.`id` in (1) and `companies`.`deleted_at` is null)

  at vendor/laravel/framework/src/Illuminate/Database/Connection.php:825
    821▕                     $this->getName(), $query, $this->prepareBindings($bindings), $e
    822▕                 );
    823▕             }
    824▕
  ➜ 825▕             throw new QueryException(
    826▕                 $this->getName(), $query, $this->prepareBindings($bindings), $e
    827▕             );
    828▕         }
    829▕     }

      +18 vendor frames
```

The dirty fix for us was to manually add that column, run migrations, let them fail again, and then remove the column and re-run migrations. This *should* fix that problem by adding the column, letting the rest of the migration (the eol_explicit stuff) run, then dropping the column, so that the later migration that adds the *real* `deleted_at` to the `companies` table can fire normally. 