### PR TITLE
Add custom fields to eula pdf

### DIFF
--- a/app/Http/Controllers/Account/AcceptanceController.php
+++ b/app/Http/Controllers/Account/AcceptanceController.php
@@ -208,6 +208,30 @@ class AcceptanceController extends Controller
             'qty' => $acceptance->qty ?? 1,
         ];
 
+        // Include asset custom fields that are explicitly allowed in outbound emails/PDFs.
+        if ($item instanceof Asset && $item->model && $item->model->fieldset) {
+            $customFields = [];
+            $fields = $item->model->fieldset->fields
+                ->where('show_in_email', true)
+                ->where('field_encrypted', false);
+
+            foreach ($fields as $field) {
+                $dbColumn = $field->db_column;
+                $value = $item->{$dbColumn};
+
+                if (! is_null($value) && $value !== '') {
+                    $customFields[] = [
+                        'label' => $field->name,
+                        'value' => $value,
+                    ];
+                }
+            }
+
+            if (! empty($customFields)) {
+                $data['custom_fields'] = $customFields;
+            }
+        }
+
         if ($request->input('asset_acceptance') === 'accepted') {
 
             $pdf_filename = 'accepted-'.$acceptance->checkoutable_id.'-'.$acceptance->display_checkoutable_type.'-eula-'.date('Y-m-d-h-i-s').'.pdf';

--- a/app/Mail/CheckinAssetMail.php
+++ b/app/Mail/CheckinAssetMail.php
@@ -58,10 +58,26 @@ class CheckinAssetMail extends BaseMailable
     {
         $this->item->load('status');
         $fields = [];
+        $customFields = [];
 
         // Check if the item has custom fields associated with it
         if (($this->item->model) && ($this->item->model->fieldset)) {
             $fields = $this->item->model->fieldset->fields;
+
+            foreach ($fields as $field) {
+                if (! $field->show_in_email || $field->field_encrypted == '1') {
+                    continue;
+                }
+
+                $value = $this->item->{$field->db_column_name()};
+
+                if (! is_null($value) && $value !== '') {
+                    $customFields[] = [
+                        'label' => $field->name,
+                        'value' => $value,
+                    ];
+                }
+            }
         }
 
         return new Content(
@@ -73,6 +89,7 @@ class CheckinAssetMail extends BaseMailable
                 'note' => $this->note,
                 'target' => $this->target,
                 'fields' => $fields,
+                'custom_fields' => $customFields,
                 'expected_checkin' => $this->expected_checkin,
             ],
         );

--- a/app/Mail/CheckoutAssetMail.php
+++ b/app/Mail/CheckoutAssetMail.php
@@ -75,6 +75,7 @@ class CheckoutAssetMail extends BaseMailable
         $eula = method_exists($this->item, 'getEula') ? $this->item->getEula() : '';
         $req_accept = $this->requiresAcceptance();
         $fields = [];
+        $customFields = [];
         $name = null;
 
         if ($this->target instanceof User) {
@@ -88,6 +89,21 @@ class CheckoutAssetMail extends BaseMailable
         // Check if the item has custom fields associated with it
         if (($this->item->model) && ($this->item->model->fieldset)) {
             $fields = $this->item->model->fieldset->fields;
+
+            foreach ($fields as $field) {
+                if (! $field->show_in_email || $field->field_encrypted == '1') {
+                    continue;
+                }
+
+                $value = $this->item->{$field->db_column_name()};
+
+                if (! is_null($value) && $value !== '') {
+                    $customFields[] = [
+                        'label' => $field->name,
+                        'value' => $value,
+                    ];
+                }
+            }
         }
 
         $accept_url = is_null($this->acceptance) ? null : route('account.accept.item', $this->acceptance);
@@ -101,6 +117,7 @@ class CheckoutAssetMail extends BaseMailable
                 'note' => $this->note,
                 'target' => $name,
                 'fields' => $fields,
+                'custom_fields' => $customFields,
                 'eula' => $eula,
                 'req_accept' => $req_accept,
                 'accept_url' => $accept_url,

--- a/app/Models/CheckoutAcceptance.php
+++ b/app/Models/CheckoutAcceptance.php
@@ -250,6 +250,16 @@ class CheckoutAcceptance extends Model
         if ($data['email'] != null) {
             $pdf->writeHTML(trans('general.email').': '.e($data['email']), true, 0, true, 0, '');
         }
+        if (! empty($data['custom_fields']) && is_iterable($data['custom_fields'])) {
+            foreach ($data['custom_fields'] as $customField) {
+                $label = $customField['label'] ?? null;
+                $value = $customField['value'] ?? null;
+
+                if (($label !== null) && ($value !== null) && ($value !== '')) {
+                    $pdf->writeHTML(e((string) $label).': '.e((string) $value), true, 0, true, 0, '');
+                }
+            }
+        }
         $pdf->Ln();
         $pdf->writeHTML('<hr>', true, 0, true, 0, '');
 

--- a/app/Models/CheckoutAcceptance.php
+++ b/app/Models/CheckoutAcceptance.php
@@ -243,23 +243,27 @@ class CheckoutAcceptance extends Model
         if ($data['item_serial'] != null) {
             $pdf->writeHTML(trans('admin/hardware/form.serial').': '.e($data['item_serial']), true, 0, true, 0, '');
         }
-        if (($data['qty'] != null) && ($data['qty'] > 1)) {
-            $pdf->writeHTML(trans('general.qty').': '.e($data['qty']), true, 0, true, 0, '');
-        }
-        $pdf->writeHTML(trans('general.assignee').': '.e($data['assigned_to']).($data['employee_num'] ? ' ('.$data['employee_num'].')' : ''), true, 0, true, 0, '');
-        if ($data['email'] != null) {
-            $pdf->writeHTML(trans('general.email').': '.e($data['email']), true, 0, true, 0, '');
-        }
-        if (! empty($data['custom_fields']) && is_iterable($data['custom_fields'])) {
+        if (!empty($data['custom_fields']) && is_iterable($data['custom_fields'])) {
             foreach ($data['custom_fields'] as $customField) {
                 $label = $customField['label'] ?? null;
                 $value = $customField['value'] ?? null;
 
                 if (($label !== null) && ($value !== null) && ($value !== '')) {
-                    $pdf->writeHTML(e((string) $label).': '.e((string) $value), true, 0, true, 0, '');
+                    $pdf->writeHTML(e((string) $label) . ': ' . e((string) $value), true, 0, true, 0, '');
                 }
             }
         }
+
+        if (($data['qty'] != null) && ($data['qty'] > 1)) {
+            $pdf->writeHTML(trans('general.qty').': '.e($data['qty']), true, 0, true, 0, '');
+        }
+        $pdf->Ln();
+        $pdf->writeHTML('<hr>', true, 0, true, 0, '');
+        $pdf->writeHTML(trans('general.assignee').': '.e($data['assigned_to']).($data['employee_num'] ? ' ('.$data['employee_num'].')' : ''), true, 0, true, 0, '');
+        if ($data['email'] != null) {
+            $pdf->writeHTML(trans('general.email').': '.e($data['email']), true, 0, true, 0, '');
+        }
+
         $pdf->Ln();
         $pdf->writeHTML('<hr>', true, 0, true, 0, '');
 

--- a/app/Notifications/AcceptanceItemAcceptedNotification.php
+++ b/app/Notifications/AcceptanceItemAcceptedNotification.php
@@ -33,6 +33,7 @@ class AcceptanceItemAcceptedNotification extends Notification
         $this->file = $params['file'] ?? null;
         $this->qty = $params['qty'] ?? null;
         $this->note = $params['note'] ?? null;
+        $this->custom_fields = $params['custom_fields'] ?? [];
 
     }
 
@@ -76,6 +77,7 @@ class AcceptanceItemAcceptedNotification extends Notification
                 'assigned_to' => $this->assigned_to,
                 'company_name' => $this->company_name,
                 'qty' => $this->qty,
+                'custom_fields' => $this->custom_fields,
                 'intro_text' => trans('mail.acceptance_accepted_greeting', ['user' => $this->assigned_to, 'item' => $this->item_name]),
             ])
             ->subject('✅ '.trans('mail.acceptance_accepted', ['user' => $this->assigned_to, 'item' => $this->item_name]))

--- a/app/Notifications/AcceptanceItemAcceptedToUserNotification.php
+++ b/app/Notifications/AcceptanceItemAcceptedToUserNotification.php
@@ -34,6 +34,7 @@ class AcceptanceItemAcceptedToUserNotification extends Notification
         $this->settings = Setting::getSettings();
         $this->file = $params['file'] ?? null;
         $this->qty = $params['qty'] ?? null;
+        $this->custom_fields = $params['custom_fields'] ?? [];
     }
 
     /**
@@ -72,6 +73,7 @@ class AcceptanceItemAcceptedToUserNotification extends Notification
                 'assigned_to' => $this->assigned_to,
                 'company_name' => $this->company_name,
                 'qty' => $this->qty,
+                'custom_fields' => $this->custom_fields,
                 'intro_text' => trans_choice('mail.acceptance_asset_accepted_to_user', $this->qty, ['qty' => $this->qty, 'site_name' => $this->settings->site_name]),
             ])
             ->attach($pdf_path)

--- a/resources/views/mail/markdown/checkin-asset.blade.php
+++ b/resources/views/mail/markdown/checkin-asset.blade.php
@@ -37,11 +37,13 @@
 @if (isset($status))
 | **{{ trans('general.status') }}** | {{ $status }} |
 @endif
-@foreach($fields as $field)
-@if (($item->{ $field->db_column_name() }!='') && ($field->show_in_email) && ($field->field_encrypted=='0'))
-| **{{ $field->name }}** | {{ $item->{ $field->db_column_name() } }} |
+@if (!empty($custom_fields))
+@foreach($custom_fields as $customField)
+@if (!empty($customField['label']) && array_key_exists('value', $customField) && $customField['value'] !== '')
+| **{{ $customField['label'] }}** | {{ $customField['value'] }} |
 @endif
 @endforeach
+@endif
 @if ($admin)
 | **{{ trans('general.administrator') }}** | {{ $admin->display_name }} |
 @endif

--- a/resources/views/mail/markdown/checkout-asset.blade.php
+++ b/resources/views/mail/markdown/checkout-asset.blade.php
@@ -40,11 +40,13 @@
 @if ((isset($expected_checkin)) && ($expected_checkin!=''))
 | **{{ trans('mail.expecting_checkin_date') }}** | {{ $expected_checkin }} |
 @endif
-@foreach($fields as $field)
-@if (($item->{ $field->db_column_name() }!='') && ($field->show_in_email) && ($field->field_encrypted=='0'))
-| **{{ $field->name }}** | {{ $item->{ $field->db_column_name() } }} |
+@if (!empty($custom_fields))
+@foreach($custom_fields as $customField)
+@if (!empty($customField['label']) && array_key_exists('value', $customField) && $customField['value'] !== '')
+| **{{ $customField['label'] }}** | {{ $customField['value'] }} |
 @endif
 @endforeach
+@endif
 @if ($admin)
 | **{{ trans('general.administrator') }}** | {{ $admin->display_name }} |
 @endif

--- a/resources/views/notifications/markdown/asset-acceptance.blade.php
+++ b/resources/views/notifications/markdown/asset-acceptance.blade.php
@@ -43,6 +43,13 @@
 @if (isset($qty))
 | **{{ trans('general.qty') }}** | {{ $qty }} |
 @endif
+@if (!empty($custom_fields))
+@foreach($custom_fields as $customField)
+@if (!empty($customField['label']) && array_key_exists('value', $customField) && $customField['value'] !== '')
+| **{{ $customField['label'] }}** | {{ $customField['value'] }} |
+@endif
+@endforeach
+@endif
 @endcomponent
 
 {{ trans('mail.best_regards') }}

--- a/tests/Feature/CheckoutAcceptances/Ui/AssetAcceptanceTest.php
+++ b/tests/Feature/CheckoutAcceptances/Ui/AssetAcceptanceTest.php
@@ -6,9 +6,12 @@ use App\Events\CheckoutAccepted;
 use App\Models\Actionlog;
 use App\Models\Asset;
 use App\Models\CheckoutAcceptance;
+use App\Models\CustomField;
 use App\Models\Setting;
 use App\Models\User;
+use App\Notifications\AcceptanceItemAcceptedNotification;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Notification;
 use Tests\TestCase;
 
 class AssetAcceptanceTest extends TestCase
@@ -201,6 +204,45 @@ class AssetAcceptanceTest extends TestCase
             ])
             ->whereNotNull('action_date')
             ->exists()
+        );
+    }
+
+    public function test_acceptance_email_includes_custom_fields_marked_show_in_email_and_not_encrypted(): void
+    {
+        Event::fake([CheckoutAccepted::class]);
+        Notification::fake();
+        $this->settings->enableAlertEmail();
+
+        $customField = CustomField::factory()->create([
+            'name' => 'Cost Center',
+            'show_in_email' => '1',
+            'field_encrypted' => '0',
+        ])->fresh();
+
+        $asset = Asset::factory()->hasMultipleCustomFields([$customField])->create();
+        $asset->{$customField->db_column} = 'ENG-42';
+        $asset->save();
+
+        $checkoutAcceptance = CheckoutAcceptance::factory()
+            ->pending()
+            ->for($asset, 'checkoutable')
+            ->create();
+
+        $this->actingAs($checkoutAcceptance->assignedTo)
+            ->post(route('account.store-acceptance', $checkoutAcceptance), [
+                'asset_acceptance' => 'accepted',
+            ])
+            ->assertRedirectToRoute('account.accept')
+            ->assertSessionHas('success');
+
+        Notification::assertSentTo(
+            $checkoutAcceptance,
+            function (AcceptanceItemAcceptedNotification $notification) {
+                $rendered = $notification->toMail()->render();
+
+                return str_contains($rendered, 'Cost Center')
+                    && str_contains($rendered, 'ENG-42');
+            }
         );
     }
 

--- a/tests/Feature/Notifications/Email/EmailNotificationsToUserUponCheckinTest.php
+++ b/tests/Feature/Notifications/Email/EmailNotificationsToUserUponCheckinTest.php
@@ -7,6 +7,7 @@ use App\Mail\CheckinAssetMail;
 use App\Models\Accessory;
 use App\Models\Asset;
 use App\Models\Consumable;
+use App\Models\CustomField;
 use App\Models\LicenseSeat;
 use App\Models\User;
 use Illuminate\Support\Facades\Mail;
@@ -97,6 +98,32 @@ class EmailNotificationsToUserUponCheckinTest extends TestCase
         $this->fireCheckInEvent($asset, $user);
 
         Mail::assertNothingSent();
+    }
+
+    public function test_checkin_email_includes_custom_fields_marked_show_in_email_and_not_encrypted()
+    {
+        $customField = CustomField::factory()->create([
+            'name' => 'Cost Center',
+            'show_in_email' => '1',
+            'field_encrypted' => '0',
+        ])->fresh();
+
+        $user = User::factory()->create();
+        $asset = Asset::factory()->hasMultipleCustomFields([$customField])->assignedToUser($user)->create();
+        $asset->{$customField->db_column} = 'ENG-42';
+        $asset->save();
+
+        $asset->model->category->update(['checkin_email' => true]);
+
+        $this->fireCheckInEvent($asset, $user);
+
+        Mail::assertSent(CheckinAssetMail::class, function (CheckinAssetMail $mail) use ($user) {
+            $rendered = $mail->render();
+
+            return $mail->hasTo($user->email)
+                && str_contains($rendered, 'Cost Center')
+                && str_contains($rendered, 'ENG-42');
+        });
     }
 
     private function fireCheckInEvent($asset, $user): void

--- a/tests/Feature/Notifications/Email/EmailNotificationsToUserUponCheckoutTest.php
+++ b/tests/Feature/Notifications/Email/EmailNotificationsToUserUponCheckoutTest.php
@@ -8,6 +8,7 @@ use App\Models\Asset;
 use App\Models\AssetModel;
 use App\Models\Category;
 use App\Models\CheckoutAcceptance;
+use App\Models\CustomField;
 use App\Models\User;
 use Illuminate\Support\Facades\Mail;
 use PHPUnit\Framework\Attributes\Group;
@@ -104,6 +105,35 @@ class EmailNotificationsToUserUponCheckoutTest extends TestCase
         $this->fireCheckoutEvent();
 
         $this->assertUserSentEmail();
+    }
+
+    public function test_email_includes_custom_fields_marked_show_in_email_and_not_encrypted()
+    {
+        $customField = CustomField::factory()->create([
+            'name' => 'Cost Center',
+            'show_in_email' => '1',
+            'field_encrypted' => '0',
+        ])->fresh();
+
+        $asset = Asset::factory()->hasMultipleCustomFields([$customField])->create();
+        $asset->{$customField->db_column} = 'ENG-42';
+        $asset->save();
+
+        $this->category = $asset->model->category;
+        $this->asset = $asset;
+        $this->user = User::factory()->create();
+
+        $this->category->update(['checkin_email' => true]);
+
+        $this->fireCheckoutEvent();
+
+        Mail::assertSent(CheckoutAssetMail::class, function (CheckoutAssetMail $mail) {
+            $rendered = $mail->render();
+
+            return $mail->hasTo($this->user->email)
+                && str_contains($rendered, 'Cost Center')
+                && str_contains($rendered, 'ENG-42');
+        });
     }
 
     public function test_handles_user_not_having_email_address_set()


### PR DESCRIPTION
This adds custom fields that are marked as "send in email" to the acceptance PDF.

<img width="1044" height="725" alt="Screenshot 2026-05-04 at 12 57 06 PM" src="https://github.com/user-attachments/assets/5bc845ea-7d23-4bfc-9002-64fa8c3e9264" />


<img width="600" height="780" alt="Screenshot 2026-05-04 at 12 58 48 PM" src="https://github.com/user-attachments/assets/a048420e-e0e0-4398-afff-943339a6cd2a" />
<img width="645" height="788" alt="Screenshot 2026-05-04 at 12 58 39 PM" src="https://github.com/user-attachments/assets/b52b3580-76fb-453b-9d26-63dba647ae8b" />
