### PR TITLE
🎥 Fixed #18952 - allow non-image files to be uploaded on create/edit maintenances

### DIFF
--- a/app/Http/Controllers/MaintenancesController.php
+++ b/app/Http/Controllers/MaintenancesController.php
@@ -3,12 +3,15 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\ImageUploadRequest;
+use App\Http\Requests\UploadFileRequest;
 use App\Models\Asset;
 use App\Models\Maintenance;
 use Carbon\Carbon;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Validator;
 
 /**
  * This controller handles all actions related to Asset Maintenance for
@@ -72,6 +75,7 @@ class MaintenancesController extends Controller
     public function store(ImageUploadRequest $request): RedirectResponse
     {
         $this->authorize('update', Asset::class);
+        $this->validateUploadedFiles($request);
 
         $assets = Asset::whereIn('id', $request->input('selected_assets'))->get();
 
@@ -102,12 +106,14 @@ class MaintenancesController extends Controller
                 $maintenance->asset_maintenance_time = (int) $completionDate->diffInDays($startDate, true);
             }
 
-            $maintenance = $request->handleImages($maintenance);
+            $request->handleImages($maintenance);
 
             // Was the asset maintenance created?
             if (! $maintenance->save()) {
                 return redirect()->back()->withInput()->withErrors($maintenance->getErrors());
             }
+
+            $this->storeUploadedFiles($request, $maintenance);
         }
 
         return redirect()->route('maintenances.index')
@@ -156,6 +162,7 @@ class MaintenancesController extends Controller
     {
         $this->authorize('update', Asset::class);
         $this->authorize('update', $maintenance->asset);
+        $this->validateUploadedFiles($request);
 
         $maintenance->supplier_id = $request->input('supplier_id');
         $maintenance->is_warranty = $request->input('is_warranty', 0);
@@ -184,14 +191,66 @@ class MaintenancesController extends Controller
             $completionDate = Carbon::parse($maintenance->completion_date);
             $maintenance->asset_maintenance_time = (int) $completionDate->diffInDays($startDate, true);
         }
-        $maintenance = $request->handleImages($maintenance);
+        $request->handleImages($maintenance);
 
         if ($maintenance->save()) {
+            $this->storeUploadedFiles($request, $maintenance);
+
             return redirect()->route('maintenances.index')
                 ->with('success', trans('admin/maintenances/message.edit.success'));
         }
 
         return redirect()->back()->withInput()->withErrors($maintenance->getErrors());
+    }
+
+    /**
+     * Stores any generic file uploads submitted from the maintenance form.
+     */
+    private function storeUploadedFiles(ImageUploadRequest $request, Maintenance $maintenance): void
+    {
+        if (! $request->hasFile('file')) {
+            return;
+        }
+
+        $objectType = 'maintenances';
+        $storagePath = self::$map_storage_path[$objectType];
+
+        if (! Storage::exists($storagePath)) {
+            Storage::makeDirectory($storagePath, 775);
+        }
+
+        $uploadFileRequest = app(UploadFileRequest::class);
+
+        foreach ((array) $request->file('file') as $file) {
+            if (! $file) {
+                continue;
+            }
+
+            $fileName = $uploadFileRequest->handleFile(
+                $storagePath,
+                self::$map_file_prefix[$objectType].'-'.$maintenance->id,
+                $file
+            );
+
+            $maintenance->logUpload($fileName, $request->input('file_notes'));
+        }
+    }
+
+    /**
+     * Validate generic file uploads with the shared UploadFileRequest rules.
+     */
+    private function validateUploadedFiles(ImageUploadRequest $request): void
+    {
+        if (! $request->hasFile('file')) {
+            return;
+        }
+
+        $uploadFileRequest = app(UploadFileRequest::class);
+
+        Validator::make(
+            array_merge($request->all(), ['file' => $request->file('file')]),
+            $uploadFileRequest->rules()
+        )->validate();
     }
 
     /**

--- a/resources/views/maintenances/edit.blade.php
+++ b/resources/views/maintenances/edit.blade.php
@@ -182,6 +182,7 @@
 
 
         @include ('partials.forms.edit.image-upload', ['image_path' => app('maintenances_path')])
+        @include ('partials.forms.edit.file-upload', ['input_id' => 'maintenanceFileUpload'])
 
 
         <!-- Notes -->

--- a/resources/views/partials/forms/edit/file-upload.blade.php
+++ b/resources/views/partials/forms/edit/file-upload.blade.php
@@ -1,0 +1,41 @@
+<div class="form-group {{ $errors->has('file.*') ? 'has-error' : '' }}" id="{{ $input_id }}-upload">
+    <label class="col-md-3 control-label" for="{{ $input_id }}">
+        {{ trans('general.file_upload') }}
+    </label>
+
+    <div class="col-md-9">
+        <label class="btn btn-sm btn-theme" for="{{ $input_id }}">
+            {{ trans('button.select_files') }}
+            <input
+                type="file"
+                name="file[]"
+                multiple
+                class="js-uploadFile"
+                id="{{ $input_id }}"
+                data-maxsize="{{ Helper::file_upload_max_size() }}"
+                accept="{{ config('filesystems.allowed_upload_mimetypes') }}"
+                style="display:none"
+                aria-label="file"
+                aria-hidden="true"
+            >
+        </label>
+
+        <span id="{{ $input_id }}-info"></span>
+        <p class="help-block" id="{{ $input_id }}-status">{{ trans('general.upload_filetypes_help', ['allowed_filetypes' => config('filesystems.allowed_upload_extensions'), 'size' => Helper::file_upload_max_size_readable()]) }}</p>
+
+        @foreach ($errors->get('file.*') as $messages)
+            @foreach ($messages as $message)
+                <span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> {{ $message }}</span><br>
+            @endforeach
+        @endforeach
+
+        <x-input.textarea
+            name="file_notes"
+            :value="old('file_notes')"
+            placeholder="Notes (Optional)"
+            rows="3"
+            aria-label="file_notes"
+        />
+    </div>
+</div>
+

--- a/tests/Feature/Maintenances/Ui/CreateMaintenanceTest.php
+++ b/tests/Feature/Maintenances/Ui/CreateMaintenanceTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Maintenances\Ui;
 
+use App\Models\Actionlog;
 use App\Models\Asset;
 use App\Models\Maintenance;
 use App\Models\Supplier;
@@ -29,6 +30,7 @@ class CreateMaintenanceTest extends TestCase
     public function test_can_create_maintenance()
     {
         Storage::fake('public');
+        Storage::fake('local');
         $actor = User::factory()->superuser()->create();
         $asset = Asset::factory()->create();
         $supplier = Supplier::factory()->create();
@@ -44,6 +46,7 @@ class CreateMaintenanceTest extends TestCase
                 'is_warranty' => '1',
                 'cost' => '100.00',
                 'image' => UploadedFile::fake()->image('test_image.png'),
+                'file' => [UploadedFile::fake()->create('maintenance.pdf', 64, 'application/pdf')],
                 'notes' => 'A note',
                 'url' => 'https://snipeitapp.com',
             ])
@@ -55,6 +58,16 @@ class CreateMaintenanceTest extends TestCase
 
         // Assert file was stored...
         Storage::disk('public')->assertExists(app('maintenances_path').$maintenance->image);
+
+        $uploadedLog = Actionlog::query()
+            ->where('action_type', 'uploaded')
+            ->where('item_type', Maintenance::class)
+            ->where('item_id', $maintenance->id)
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($uploadedLog);
+        Storage::disk('local')->assertExists('private_uploads/maintenances/'.$uploadedLog->filename);
 
         $this->assertDatabaseHas('maintenances', [
             'asset_id' => $asset->id,
@@ -72,6 +85,6 @@ class CreateMaintenanceTest extends TestCase
             'created_by' => $actor->id,
         ]);
 
-        $this->assertHasTheseActionLogs($maintenance, ['create']);
+        $this->assertHasTheseActionLogs($maintenance, ['create', 'uploaded']);
     }
 }

--- a/tests/Feature/Maintenances/Ui/EditMaintenanceTest.php
+++ b/tests/Feature/Maintenances/Ui/EditMaintenanceTest.php
@@ -23,6 +23,9 @@ class EditMaintenanceTest extends TestCase
 
     public function test_can_update_maintenance()
     {
+        Storage::fake('public');
+        Storage::fake('local');
+
         $actor = User::factory()->superuser()->create();
         $asset = Asset::factory()->create();
         $maintenance = Maintenance::factory()->create(['asset_id' => $asset]);
@@ -38,6 +41,7 @@ class EditMaintenanceTest extends TestCase
                 'completion_date' => '2021-01-10',
                 'is_warranty' => 1,
                 'image' => UploadedFile::fake()->image('test_image.png'),
+                'file' => [UploadedFile::fake()->create('maintenance-update.pdf', 64, 'application/pdf')],
                 'cost' => '100.99',
                 'notes' => 'A note',
                 'url' => 'https://snipeitapp.com',
@@ -50,6 +54,16 @@ class EditMaintenanceTest extends TestCase
 
         // Assert file was stored...
         Storage::disk('public')->assertExists(app('maintenances_path').$maintenance->image);
+
+        $uploadedLog = Actionlog::query()
+            ->where('action_type', 'uploaded')
+            ->where('item_type', Maintenance::class)
+            ->where('item_id', $maintenance->id)
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($uploadedLog);
+        Storage::disk('local')->assertExists('private_uploads/maintenances/'.$uploadedLog->filename);
 
         $this->assertDatabaseHas('maintenances', [
             'asset_id' => $asset->id,
@@ -65,7 +79,7 @@ class EditMaintenanceTest extends TestCase
             'cost' => '100.99',
         ]);
 
-        $this->assertHasTheseActionLogs($maintenance, ['create', 'update']);
+        $this->assertHasTheseActionLogs($maintenance, ['create', 'update', 'uploaded']);
 
         $updateLog = Actionlog::query()
             ->where('item_type', Maintenance::class)


### PR DESCRIPTION
This only affects maintenances for now, but this now lets you upload non-image files on the create/edit screen - stuff like invoices, warrantee info, etc. You could always add this after the fact, but this lets you do it right on maintenance creation. 

https://github.com/user-attachments/assets/513e9948-c1e8-4039-9f3e-cf1ce0790392

We *should* be able to extend this to other things as well. 


Fixed #18952