### PR TITLE
🎥 Advanced search improvements

### DIFF
--- a/app/Models/Traits/Searchable.php
+++ b/app/Models/Traits/Searchable.php
@@ -59,6 +59,8 @@ trait Searchable
         $filterOperator = $preparedSearch['filter_operator'];
 
         if (! empty($filters)) {
+            // Structured advanced-search filters are mutually exclusive with free-text terms.
+            // Once we detect structured payloads, we avoid the broad OR-based free-text path.
             return $this->applySearchFilters($query, $filters, $filterOperator);
         }
 
@@ -135,6 +137,7 @@ trait Searchable
         $payload = $search;
 
         if (str_starts_with($search, 'filter:')) {
+            // Some callers send filter payloads with an explicit "filter:" prefix.
             $payload = substr($search, 7);
         } elseif (! (str_starts_with($search, '{') && str_ends_with($search, '}'))) {
             return null;
@@ -160,6 +163,7 @@ trait Searchable
             $normalizedValue = trim((string) ($value ?? ''));
 
             if ($normalizedValue === '') {
+                // Ignore empty fields so clearing an input does not create noisy no-op filters.
                 continue;
             }
 
@@ -229,14 +233,17 @@ trait Searchable
         $lower = strtolower($raw);
 
         if ($lower === 'is:null') {
+            // Reserved token: interpreted as null-check operator, not exact match string.
             return ['value' => '', 'negate' => false, 'operator' => 'is_null'];
         }
 
         if ($lower === 'is:not_null') {
+            // Reserved token: interpreted as non-null check operator.
             return ['value' => '', 'negate' => false, 'operator' => 'is_not_null'];
         }
 
         if (str_starts_with($lower, 'is:')) {
+            // Generic exact-match prefix. This is checked after reserved is:null/is:not_null tokens.
             $exactValue = substr($raw, 3);
 
             return ['value' => $exactValue, 'negate' => false, 'operator' => 'exact'];
@@ -314,6 +321,8 @@ trait Searchable
                 // Exact match on the full CONCAT'd value, e.g. "John Smith" matches only
                 // users whose first_name + ' ' + last_name equals exactly "John Smith".
                 $concatSql = $this->buildMultipleColumnSearch($qualifiedColumns);
+                // buildMultipleColumnSearch intentionally returns a fragment ending in "LIKE ?";
+                // for exact matches we rewrite only the operator and keep the same SQL scaffold.
                 $concatSql = str_replace(' LIKE ?', ' = ?', $concatSql);
                 $rawMethod = $boolean === 'or' ? 'orWhereRaw' : 'whereRaw';
                 $query->{$rawMethod}($concatSql, [$value]);
@@ -342,6 +351,8 @@ trait Searchable
             $dbColumn = $this->resolveCustomFieldDbColumn($filterKey);
 
             if ($dbColumn !== null) {
+                // Structured custom-field filters currently support LIKE/NOT LIKE semantics only.
+                // (No exact/is:null operators for custom fields yet.)
                 $query->{$whereMethod}($table.'.'.$dbColumn, $likeOperator, '%'.$value.'%');
 
                 return $query;
@@ -358,7 +369,53 @@ trait Searchable
             return $this->applyAssignedToRelationFilter($query, $resolvedRelationKey, $value, $boolean, $negate);
         }
 
-        $relationColumns = (array) $searchableRelations[$resolvedRelationKey];
+        $relationColumns = $this->getStructuredFilterRelationColumns(
+            filterKey: $filterKey,
+            resolvedRelationKey: $resolvedRelationKey,
+            searchableRelations: $searchableRelations,
+        );
+
+        // For negated relation filters (e.g. location: !dam), include rows with
+        // no related record as well as rows with related records that do not match.
+        // This aligns advanced-search behavior with user expectation for "not X".
+        if ($operator !== 'exact' && $likeOperator === 'NOT LIKE') {
+            $compoundMethod = $boolean === 'or' ? 'orWhere' : 'where';
+
+            $query->{$compoundMethod}(function (Builder $compoundQuery) use ($resolvedRelationKey, $relationColumns, $value): void {
+                // Critical behavior: "not X" on relations should include records with no relation.
+                // Example: location=!dam should include users without a location.
+                $compoundQuery->doesntHave($resolvedRelationKey)
+                    ->orWhereHas($resolvedRelationKey, function (Builder $relationQuery) use ($resolvedRelationKey, $relationColumns, $value): void {
+                        $relationTable = $this->getRelationTable($resolvedRelationKey);
+                        $firstConditionAdded = false;
+
+                        foreach ($relationColumns as $relationColumn) {
+                            if (! $firstConditionAdded) {
+                                $relationQuery->where($relationTable.'.'.$relationColumn, 'NOT LIKE', '%'.$value.'%');
+                                $firstConditionAdded = true;
+
+                                continue;
+                            }
+
+                            // For negation we AND the NOT LIKE conditions so all columns must not match.
+                            $relationQuery->where($relationTable.'.'.$relationColumn, 'NOT LIKE', '%'.$value.'%');
+                        }
+
+                        if (($resolvedRelationKey === 'adminuser') || ($resolvedRelationKey === 'user')) {
+                            $concatSql = $this->buildMultipleColumnSearch([
+                                'users.first_name',
+                                'users.last_name',
+                                'users.display_name',
+                            ]);
+
+                            $relationQuery->whereRaw(str_replace('LIKE', 'NOT LIKE', $concatSql), ["%{$value}%"]);
+                        }
+                    });
+            });
+
+            return $query;
+        }
+
         $relationMethod = $boolean === 'or' ? 'orWhereHas' : 'whereHas';
 
         $query->{$relationMethod}($resolvedRelationKey, function (Builder $relationQuery) use ($resolvedRelationKey, $relationColumns, $value, $likeOperator, $operator) {
@@ -593,9 +650,9 @@ trait Searchable
         if (in_array($filterKey, $searchableAttributes, true)) {
             $method = match (true) {
                 $isNull && $boolean === 'or' => 'orWhereNull',
-                $isNull                      => 'whereNull',
-                $boolean === 'or'            => 'orWhereNotNull',
-                default                      => 'whereNotNull',
+                $isNull => 'whereNull',
+                $boolean === 'or' => 'orWhereNotNull',
+                default => 'whereNotNull',
             };
 
             $query->{$method}($table.'.'.$filterKey);
@@ -942,6 +999,36 @@ trait Searchable
     }
 
     /**
+     * Get structured-filter relation columns for a given filter key.
+     *
+     * By default, this uses all configured searchable relation columns for the
+     * resolved relation key. Models can narrow specific advanced-search fields
+     * via $searchableRelationFilterColumns, keyed by the incoming filter key
+     * shown in the UI/API (for example: 'location' => ['name']).
+     *
+     * @param  array<string, array<int, string>>  $searchableRelations
+     * @return array<int, string>
+     */
+    private function getStructuredFilterRelationColumns(string $filterKey, string $resolvedRelationKey, array $searchableRelations): array
+    {
+        $defaultColumns = (array) ($searchableRelations[$resolvedRelationKey] ?? []);
+
+        $overrides = $this->searchableRelationFilterColumns ?? [];
+
+        if (! array_key_exists($filterKey, $overrides)) {
+            return $defaultColumns;
+        }
+
+        $overrideColumns = array_values(array_filter((array) $overrides[$filterKey], 'is_string'));
+
+        // Keep only columns that are actually searchable on the resolved relation,
+        // so model-level overrides cannot accidentally reference unknown columns.
+        $validColumns = array_values(array_intersect($overrideColumns, $defaultColumns));
+
+        return $validColumns !== [] ? $validColumns : $defaultColumns;
+    }
+
+    /**
      * Get the table name of a relation.
      *
      * This method loops over a relation name,
@@ -998,6 +1085,9 @@ trait Searchable
      */
     private function buildMultipleColumnSearch(array $columns): string
     {
+        // This method deliberately returns only an SQL fragment ending with "LIKE ?"
+        // so callers can reuse it and swap operators (NOT LIKE / =) without duplicating
+        // driver-specific CONCAT syntax.
         $mappedColumns = collect($columns)->map(fn ($column) => DB::getTablePrefix().$column)->toArray();
 
         $driver = config('database.connections.'.config('database.default').'.driver');

--- a/app/Models/Traits/Searchable.php
+++ b/app/Models/Traits/Searchable.php
@@ -207,24 +207,68 @@ trait Searchable
     }
 
     /**
+     * Parse a raw filter value for an optional negation prefix.
+     *
+     * Supported negation syntax (case-insensitive prefix):
+     *   - "!flarb"    → negate = true, value = "flarb"
+     *   - "not:flarb" → negate = true, value = "flarb"
+     *
+     * Used by applySingleSearchFilter so callers can pass values like
+     * {"gleeb": "!flarb"} or {"gleeb": "not:flarb"} in the filter JSON.
+     *
+     * @return array{value: string, negate: bool}
+     */
+    private function parseFilterValue(string $raw): array
+    {
+        if (str_starts_with($raw, '!')) {
+            return ['value' => substr($raw, 1), 'negate' => true];
+        }
+
+        if (str_starts_with(strtolower($raw), 'not:')) {
+            return ['value' => substr($raw, 4), 'negate' => true];
+        }
+
+        return ['value' => $raw, 'negate' => false];
+    }
+
+    /**
      * Apply a single structured filter using the provided boolean operator.
+     *
+     * Negation: if the filter value is prefixed with "!" or "not:", the filter
+     * uses NOT LIKE (for attributes/custom fields) or whereDoesntHave (for
+     * relations), effectively excluding records matching the value.
+     *
+     * For relation filters, negation uses NOT LIKE inside whereHas, meaning
+     * "has a related record where the column does NOT contain the value".
+     * Records with no related record (e.g. unassigned assets) are excluded;
+     * use a plain empty-string filter if you need to match NULLs.
      */
     private function applySingleSearchFilter(Builder $query, string $filterKey, string $filterValue, string $boolean = 'and'): Builder
     {
+        $parsed = $this->parseFilterValue($filterValue);
+        $value = $parsed['value'];
+        $negate = $parsed['negate'];
+
+        // Skip gracefully if stripping the prefix leaves an empty value.
+        if ($value === '') {
+            return $query;
+        }
+
         $searchableAttributes = $this->getSearchableAttributes();
         $searchableCounts = $this->getSearchableCounts();
         $searchableRelations = $this->getSearchableRelations();
         $table = $this->getTable();
         $whereMethod = $boolean === 'or' ? 'orWhere' : 'where';
+        $likeOperator = $negate ? 'NOT LIKE' : 'LIKE';
 
         if (in_array($filterKey, $searchableAttributes, true)) {
-            $query->{$whereMethod}($table.'.'.$filterKey, 'LIKE', '%'.$filterValue.'%');
+            $query->{$whereMethod}($table.'.'.$filterKey, $likeOperator, '%'.$value.'%');
 
             return $query;
         }
 
         if (in_array($filterKey, $searchableCounts, true)) {
-            return $this->applyCountAliasFilter($query, $filterKey, $filterValue, $boolean);
+            return $this->applyCountAliasFilter($query, $filterKey, $value, $boolean, $negate);
         }
 
         // Check if this is a custom field (only for Assets - for *now*).
@@ -234,7 +278,7 @@ trait Searchable
             $dbColumn = $this->resolveCustomFieldDbColumn($filterKey);
 
             if ($dbColumn !== null) {
-                $query->{$whereMethod}($table.'.'.$dbColumn, 'LIKE', '%'.$filterValue.'%');
+                $query->{$whereMethod}($table.'.'.$dbColumn, $likeOperator, '%'.$value.'%');
 
                 return $query;
             }
@@ -247,38 +291,41 @@ trait Searchable
         }
 
         if ($this->isAssignedToRelationKey($resolvedRelationKey)) {
-            return $this->applyAssignedToRelationFilter($query, $resolvedRelationKey, $filterValue, $boolean);
+            return $this->applyAssignedToRelationFilter($query, $resolvedRelationKey, $value, $boolean, $negate);
         }
 
         $relationColumns = (array) $searchableRelations[$resolvedRelationKey];
         $relationMethod = $boolean === 'or' ? 'orWhereHas' : 'whereHas';
 
-        $query->{$relationMethod}($resolvedRelationKey, function (Builder $relationQuery) use ($resolvedRelationKey, $relationColumns, $filterValue) {
+        $query->{$relationMethod}($resolvedRelationKey, function (Builder $relationQuery) use ($resolvedRelationKey, $relationColumns, $value, $likeOperator) {
             $relationTable = $this->getRelationTable($resolvedRelationKey);
             $firstConditionAdded = false;
 
             foreach ($relationColumns as $relationColumn) {
                 if (! $firstConditionAdded) {
-                    $relationQuery->where($relationTable.'.'.$relationColumn, 'LIKE', '%'.$filterValue.'%');
+                    $relationQuery->where($relationTable.'.'.$relationColumn, $likeOperator, '%'.$value.'%');
                     $firstConditionAdded = true;
 
                     continue;
                 }
 
-                $relationQuery->orWhere($relationTable.'.'.$relationColumn, 'LIKE', '%'.$filterValue.'%');
+                // For negation we AND the NOT LIKE conditions so all columns must not match.
+                // For normal LIKE we OR them so any column matching is sufficient.
+                $likeOperator === 'NOT LIKE'
+                    ? $relationQuery->where($relationTable.'.'.$relationColumn, $likeOperator, '%'.$value.'%')
+                    : $relationQuery->orWhere($relationTable.'.'.$relationColumn, $likeOperator, '%'.$value.'%');
             }
 
             if (($resolvedRelationKey === 'adminuser') || ($resolvedRelationKey === 'user')) {
-                $relationQuery->orWhereRaw(
-                    $this->buildMultipleColumnSearch(
-                        [
-                            'users.first_name',
-                            'users.last_name',
-                            'users.display_name',
-                        ]
-                    ),
-                    ["%{$filterValue}%"]
-                );
+                $concatSql = $this->buildMultipleColumnSearch([
+                    'users.first_name',
+                    'users.last_name',
+                    'users.display_name',
+                ]);
+
+                $likeOperator === 'NOT LIKE'
+                    ? $relationQuery->whereRaw(str_replace('LIKE', 'NOT LIKE', $concatSql), ["%{$value}%"])
+                    : $relationQuery->orWhereRaw($concatSql, ["%{$value}%"]);
             }
         });
 
@@ -333,8 +380,13 @@ trait Searchable
 
     /**
      * Apply filters for assignees with type-specific searchable columns.
+     *
+     * When $negate is true, NOT LIKE is used inside whereHasMorph, so results
+     * are records that have an assignee whose columns do NOT contain $filterValue.
+     * (Records with no assignee are excluded; they do not satisfy "has an assignee
+     * where column NOT LIKE '%value%'".)
      */
-    private function applyAssignedToRelationFilter(Builder $query, string $relationKey, string $filterValue, string $boolean = 'and'): Builder
+    private function applyAssignedToRelationFilter(Builder $query, string $relationKey, string $filterValue, string $boolean = 'and', bool $negate = false): Builder
     {
         $relationName = $this->resolveAssignedToRelationName();
 
@@ -342,12 +394,13 @@ trait Searchable
             return $query;
         }
 
+        $likeOperator = $negate ? 'NOT LIKE' : 'LIKE';
         $relationMethod = $boolean === 'or' ? 'orWhereHasMorph' : 'whereHasMorph';
 
         return $query->{$relationMethod}(
             $relationName,
             [User::class, Asset::class, Location::class],
-            function (Builder $assigneeQuery, string $assigneeType) use ($filterValue) {
+            function (Builder $assigneeQuery, string $assigneeType) use ($filterValue, $likeOperator, $negate) {
                 $columns = $this->getAssigneeColumnsByType($assigneeType);
 
                 if (empty($columns)) {
@@ -359,20 +412,25 @@ trait Searchable
 
                 foreach ($columns as $column) {
                     if (! $firstConditionAdded) {
-                        $assigneeQuery->where($table.'.'.$column, 'LIKE', '%'.$filterValue.'%');
+                        $assigneeQuery->where($table.'.'.$column, $likeOperator, '%'.$filterValue.'%');
                         $firstConditionAdded = true;
 
                         continue;
                     }
 
-                    $assigneeQuery->orWhere($table.'.'.$column, 'LIKE', '%'.$filterValue.'%');
+                    // For negation, AND the conditions (all columns must not match).
+                    // For normal LIKE, OR them (any column matching is sufficient).
+                    $negate
+                        ? $assigneeQuery->where($table.'.'.$column, $likeOperator, '%'.$filterValue.'%')
+                        : $assigneeQuery->orWhere($table.'.'.$column, $likeOperator, '%'.$filterValue.'%');
                 }
 
                 if ($assigneeType === User::class) {
-                    $assigneeQuery->orWhereRaw(
-                        $this->buildMultipleColumnSearch(['users.first_name', 'users.last_name']),
-                        ["%{$filterValue}%"]
-                    );
+                    $concatSql = $this->buildMultipleColumnSearch(['users.first_name', 'users.last_name']);
+
+                    $negate
+                        ? $assigneeQuery->whereRaw(str_replace('LIKE', 'NOT LIKE', $concatSql), ["%{$filterValue}%"])
+                        : $assigneeQuery->orWhereRaw($concatSql, ["%{$filterValue}%"]);
                 }
             }
         );
@@ -417,15 +475,19 @@ trait Searchable
     /**
      * Apply filtering on computed count aliases (for example withCount aliases).
      */
-    private function applyCountAliasFilter(Builder $query, string $countAlias, string $filterValue, string $boolean = 'and'): Builder
+    private function applyCountAliasFilter(Builder $query, string $countAlias, string $filterValue, string $boolean = 'and', bool $negate = false): Builder
     {
         $havingMethod = $boolean === 'or' ? 'orHaving' : 'having';
 
         if (is_numeric($filterValue)) {
-            return $query->{$havingMethod}($countAlias, '=', (int) $filterValue);
+            $operator = $negate ? '!=' : '=';
+
+            return $query->{$havingMethod}($countAlias, $operator, (int) $filterValue);
         }
 
-        return $query->{$havingMethod}($countAlias, 'LIKE', '%'.$filterValue.'%');
+        $likeOperator = $negate ? 'NOT LIKE' : 'LIKE';
+
+        return $query->{$havingMethod}($countAlias, $likeOperator, '%'.$filterValue.'%');
     }
 
     /**

--- a/app/Models/Traits/Searchable.php
+++ b/app/Models/Traits/Searchable.php
@@ -56,9 +56,10 @@ trait Searchable
         $preparedSearch = $this->prepareSearchInput((string) $search);
         $terms = $preparedSearch['terms'];
         $filters = $preparedSearch['filters'];
+        $filterOperator = $preparedSearch['filter_operator'];
 
         if (! empty($filters)) {
-            return $this->applySearchFilters($query, $filters);
+            return $this->applySearchFilters($query, $filters, $filterOperator);
         }
 
         /**
@@ -101,13 +102,25 @@ trait Searchable
             return [
                 'terms' => [],
                 'filters' => $parsedFilters,
+                'filter_operator' => $this->resolveStructuredFilterOperator(),
             ];
         }
 
         return [
             'terms' => $this->prepeareSearchTerms($search),
             'filters' => [],
+            'filter_operator' => 'and',
         ];
+    }
+
+    /**
+     * Resolve the structured advanced-search operator from the current request.
+     */
+    private function resolveStructuredFilterOperator(): string
+    {
+        $operator = strtolower((string) request()->input('filter_operator', 'and'));
+
+        return $operator === 'or' ? 'or' : 'and';
     }
 
     /**
@@ -174,82 +187,100 @@ trait Searchable
      *
      * @param  array<string, string>  $filters
      */
-    private function applySearchFilters(Builder $query, array $filters): Builder
+    private function applySearchFilters(Builder $query, array $filters, string $filterOperator = 'and'): Builder
+    {
+        if ($filterOperator === 'or') {
+            $query->where(function (Builder $filterQuery) use ($filters) {
+                foreach ($filters as $filterKey => $filterValue) {
+                    $this->applySingleSearchFilter($filterQuery, $filterKey, $filterValue, 'or');
+                }
+            });
+
+            return $query;
+        }
+
+        foreach ($filters as $filterKey => $filterValue) {
+            $this->applySingleSearchFilter($query, $filterKey, $filterValue);
+        }
+
+        return $query;
+    }
+
+    /**
+     * Apply a single structured filter using the provided boolean operator.
+     */
+    private function applySingleSearchFilter(Builder $query, string $filterKey, string $filterValue, string $boolean = 'and'): Builder
     {
         $searchableAttributes = $this->getSearchableAttributes();
         $searchableCounts = $this->getSearchableCounts();
         $searchableRelations = $this->getSearchableRelations();
         $table = $this->getTable();
+        $whereMethod = $boolean === 'or' ? 'orWhere' : 'where';
 
-        foreach ($filters as $filterKey => $filterValue) {
-            if (in_array($filterKey, $searchableAttributes, true)) {
-                $query->where($table.'.'.$filterKey, 'LIKE', '%'.$filterValue.'%');
+        if (in_array($filterKey, $searchableAttributes, true)) {
+            $query->{$whereMethod}($table.'.'.$filterKey, 'LIKE', '%'.$filterValue.'%');
 
-                continue;
+            return $query;
+        }
+
+        if (in_array($filterKey, $searchableCounts, true)) {
+            return $this->applyCountAliasFilter($query, $filterKey, $filterValue, $boolean);
+        }
+
+        // Check if this is a custom field (only for Assets - for *now*).
+        // Only db_column keys (e.g. "_snipeit_cpu_4") are accepted to avoid
+        // collisions with standard attributes or relation filter keys.
+        if ($this instanceof Asset) {
+            $dbColumn = $this->resolveCustomFieldDbColumn($filterKey);
+
+            if ($dbColumn !== null) {
+                $query->{$whereMethod}($table.'.'.$dbColumn, 'LIKE', '%'.$filterValue.'%');
+
+                return $query;
             }
+        }
 
-            if (in_array($filterKey, $searchableCounts, true)) {
-                $query = $this->applyCountAliasFilter($query, $filterKey, $filterValue);
+        $resolvedRelationKey = $this->resolveSearchableRelationKey($filterKey, $searchableRelations);
 
-                continue;
-            }
+        if ($resolvedRelationKey === null) {
+            return $query;
+        }
 
-            // Check if this is a custom field (only for Assets - for *now*).
-            // Only db_column keys (e.g. "_snipeit_cpu_4") are accepted to avoid
-            // collisions with standard attributes or relation filter keys.
-            if ($this instanceof Asset) {
-                $dbColumn = $this->resolveCustomFieldDbColumn($filterKey);
+        if ($this->isAssignedToRelationKey($resolvedRelationKey)) {
+            return $this->applyAssignedToRelationFilter($query, $resolvedRelationKey, $filterValue, $boolean);
+        }
 
-                if ($dbColumn !== null) {
-                    $query->where($table.'.'.$dbColumn, 'LIKE', '%'.$filterValue.'%');
+        $relationColumns = (array) $searchableRelations[$resolvedRelationKey];
+        $relationMethod = $boolean === 'or' ? 'orWhereHas' : 'whereHas';
+
+        $query->{$relationMethod}($resolvedRelationKey, function (Builder $relationQuery) use ($resolvedRelationKey, $relationColumns, $filterValue) {
+            $relationTable = $this->getRelationTable($resolvedRelationKey);
+            $firstConditionAdded = false;
+
+            foreach ($relationColumns as $relationColumn) {
+                if (! $firstConditionAdded) {
+                    $relationQuery->where($relationTable.'.'.$relationColumn, 'LIKE', '%'.$filterValue.'%');
+                    $firstConditionAdded = true;
 
                     continue;
                 }
+
+                $relationQuery->orWhere($relationTable.'.'.$relationColumn, 'LIKE', '%'.$filterValue.'%');
             }
 
-            $resolvedRelationKey = $this->resolveSearchableRelationKey($filterKey, $searchableRelations);
-
-            if ($resolvedRelationKey === null) {
-                continue;
+            if (($resolvedRelationKey === 'adminuser') || ($resolvedRelationKey === 'user')) {
+                $relationQuery->orWhereRaw(
+                    $this->buildMultipleColumnSearch(
+                        [
+                            'users.first_name',
+                            'users.last_name',
+                            'users.display_name',
+                        ]
+                    ),
+                    ["%{$filterValue}%"]
+                );
             }
-
-            if ($this->isAssignedToRelationKey($resolvedRelationKey)) {
-                $query = $this->applyAssignedToRelationFilter($query, $resolvedRelationKey, $filterValue);
-
-                continue;
-            }
-
-            $relationColumns = (array) $searchableRelations[$resolvedRelationKey];
-
-            $query->whereHas($resolvedRelationKey, function (Builder $relationQuery) use ($resolvedRelationKey, $relationColumns, $filterValue) {
-                $relationTable = $this->getRelationTable($resolvedRelationKey);
-                $firstConditionAdded = false;
-
-                foreach ($relationColumns as $relationColumn) {
-                    if (! $firstConditionAdded) {
-                        $relationQuery->where($relationTable.'.'.$relationColumn, 'LIKE', '%'.$filterValue.'%');
-                        $firstConditionAdded = true;
-
-                        continue;
-                    }
-
-                    $relationQuery->orWhere($relationTable.'.'.$relationColumn, 'LIKE', '%'.$filterValue.'%');
-                }
-
-                if (($resolvedRelationKey === 'adminuser') || ($resolvedRelationKey === 'user')) {
-                    $relationQuery->orWhereRaw(
-                        $this->buildMultipleColumnSearch(
-                            [
-                                'users.first_name',
-                                'users.last_name',
-                                'users.display_name',
-                            ]
-                        ),
-                        ["%{$filterValue}%"]
-                    );
-                }
-            });
-        }
+        });
 
         return $query;
     }
@@ -303,7 +334,7 @@ trait Searchable
     /**
      * Apply filters for assignees with type-specific searchable columns.
      */
-    private function applyAssignedToRelationFilter(Builder $query, string $relationKey, string $filterValue): Builder
+    private function applyAssignedToRelationFilter(Builder $query, string $relationKey, string $filterValue, string $boolean = 'and'): Builder
     {
         $relationName = $this->resolveAssignedToRelationName();
 
@@ -311,7 +342,9 @@ trait Searchable
             return $query;
         }
 
-        return $query->whereHasMorph(
+        $relationMethod = $boolean === 'or' ? 'orWhereHasMorph' : 'whereHasMorph';
+
+        return $query->{$relationMethod}(
             $relationName,
             [User::class, Asset::class, Location::class],
             function (Builder $assigneeQuery, string $assigneeType) use ($filterValue) {
@@ -384,13 +417,15 @@ trait Searchable
     /**
      * Apply filtering on computed count aliases (for example withCount aliases).
      */
-    private function applyCountAliasFilter(Builder $query, string $countAlias, string $filterValue): Builder
+    private function applyCountAliasFilter(Builder $query, string $countAlias, string $filterValue, string $boolean = 'and'): Builder
     {
+        $havingMethod = $boolean === 'or' ? 'orHaving' : 'having';
+
         if (is_numeric($filterValue)) {
-            return $query->having($countAlias, '=', (int) $filterValue);
+            return $query->{$havingMethod}($countAlias, '=', (int) $filterValue);
         }
 
-        return $query->having($countAlias, 'LIKE', '%'.$filterValue.'%');
+        return $query->{$havingMethod}($countAlias, 'LIKE', '%'.$filterValue.'%');
     }
 
     /**

--- a/app/Models/Traits/Searchable.php
+++ b/app/Models/Traits/Searchable.php
@@ -207,28 +207,50 @@ trait Searchable
     }
 
     /**
-     * Parse a raw filter value for an optional negation prefix.
+     * Parse a raw filter value for an optional negation, null-check, or exact-match prefix.
      *
-     * Supported negation syntax (case-insensitive prefix):
-     *   - "!flarb"    → negate = true, value = "flarb"
-     *   - "not:flarb" → negate = true, value = "flarb"
+     * Supported syntax:
+     *   - "!flarb"      → operator = not_like,    value = "flarb"
+     *   - "not:flarb"   → operator = not_like,    value = "flarb"
+     *   - "is:null"     → operator = is_null,      value = ""   (reserved token)
+     *   - "is:not_null" → operator = is_not_null,  value = ""   (reserved token)
+     *   - "is:flarb"    → operator = exact,        value = "flarb"  (exact equality)
      *
-     * Used by applySingleSearchFilter so callers can pass values like
-     * {"gleeb": "!flarb"} or {"gleeb": "not:flarb"} in the filter JSON.
+     * `is:null` and `is:not_null` are checked before the generic `is:` prefix so they always
+     * resolve to their dedicated null-check operators regardless of casing.
      *
-     * @return array{value: string, negate: bool}
+     * The legacy `negate` boolean is preserved alongside `operator` so that
+     * existing callers that only check `negate` still work correctly.
+     *
+     * @return array{value: string, negate: bool, operator: string}
      */
     private function parseFilterValue(string $raw): array
     {
+        $lower = strtolower($raw);
+
+        if ($lower === 'is:null') {
+            return ['value' => '', 'negate' => false, 'operator' => 'is_null'];
+        }
+
+        if ($lower === 'is:not_null') {
+            return ['value' => '', 'negate' => false, 'operator' => 'is_not_null'];
+        }
+
+        if (str_starts_with($lower, 'is:')) {
+            $exactValue = substr($raw, 3);
+
+            return ['value' => $exactValue, 'negate' => false, 'operator' => 'exact'];
+        }
+
         if (str_starts_with($raw, '!')) {
-            return ['value' => substr($raw, 1), 'negate' => true];
+            return ['value' => substr($raw, 1), 'negate' => true, 'operator' => 'not_like'];
         }
 
-        if (str_starts_with(strtolower($raw), 'not:')) {
-            return ['value' => substr($raw, 4), 'negate' => true];
+        if (str_starts_with($lower, 'not:')) {
+            return ['value' => substr($raw, 4), 'negate' => true, 'operator' => 'not_like'];
         }
 
-        return ['value' => $raw, 'negate' => false];
+        return ['value' => $raw, 'negate' => false, 'operator' => 'like'];
     }
 
     /**
@@ -248,6 +270,13 @@ trait Searchable
         $parsed = $this->parseFilterValue($filterValue);
         $value = $parsed['value'];
         $negate = $parsed['negate'];
+        $operator = $parsed['operator'];
+
+        // IS NULL / IS NOT NULL are handled before value-based filtering,
+        // because there is no meaningful value to pass to LIKE for them.
+        if ($operator === 'is_null' || $operator === 'is_not_null') {
+            return $this->applyNullFilter($query, $filterKey, $operator === 'is_null', $boolean);
+        }
 
         // Skip gracefully if stripping the prefix leaves an empty value.
         if ($value === '') {
@@ -262,7 +291,42 @@ trait Searchable
         $likeOperator = $negate ? 'NOT LIKE' : 'LIKE';
 
         if (in_array($filterKey, $searchableAttributes, true)) {
-            $query->{$whereMethod}($table.'.'.$filterKey, $likeOperator, '%'.$value.'%');
+            if ($operator === 'exact') {
+                $query->{$whereMethod}($table.'.'.$filterKey, '=', $value);
+            } else {
+                $query->{$whereMethod}($table.'.'.$filterKey, $likeOperator, '%'.$value.'%');
+            }
+
+            return $query;
+        }
+
+        // Handle virtual columns — keys that are not real DB columns but map to a set
+        // of real columns searched via CONCAT (e.g. "name" → first_name + last_name on User).
+        $virtualColumns = $this->getSearchableVirtualColumns();
+
+        if (array_key_exists($filterKey, $virtualColumns)) {
+            $qualifiedColumns = array_map(
+                fn ($col) => $table.'.'.$col,
+                $virtualColumns[$filterKey]
+            );
+
+            if ($operator === 'exact') {
+                // Exact match on the full CONCAT'd value, e.g. "John Smith" matches only
+                // users whose first_name + ' ' + last_name equals exactly "John Smith".
+                $concatSql = $this->buildMultipleColumnSearch($qualifiedColumns);
+                $concatSql = str_replace(' LIKE ?', ' = ?', $concatSql);
+                $rawMethod = $boolean === 'or' ? 'orWhereRaw' : 'whereRaw';
+                $query->{$rawMethod}($concatSql, [$value]);
+            } else {
+                $concatSql = $this->buildMultipleColumnSearch($qualifiedColumns);
+
+                if ($negate) {
+                    $concatSql = str_replace(' LIKE ?', ' NOT LIKE ?', $concatSql);
+                }
+
+                $rawMethod = $boolean === 'or' ? 'orWhereRaw' : 'whereRaw';
+                $query->{$rawMethod}($concatSql, ['%'.$value.'%']);
+            }
 
             return $query;
         }
@@ -297,23 +361,33 @@ trait Searchable
         $relationColumns = (array) $searchableRelations[$resolvedRelationKey];
         $relationMethod = $boolean === 'or' ? 'orWhereHas' : 'whereHas';
 
-        $query->{$relationMethod}($resolvedRelationKey, function (Builder $relationQuery) use ($resolvedRelationKey, $relationColumns, $value, $likeOperator) {
+        $query->{$relationMethod}($resolvedRelationKey, function (Builder $relationQuery) use ($resolvedRelationKey, $relationColumns, $value, $likeOperator, $operator) {
             $relationTable = $this->getRelationTable($resolvedRelationKey);
             $firstConditionAdded = false;
 
             foreach ($relationColumns as $relationColumn) {
                 if (! $firstConditionAdded) {
-                    $relationQuery->where($relationTable.'.'.$relationColumn, $likeOperator, '%'.$value.'%');
+                    if ($operator === 'exact') {
+                        $relationQuery->where($relationTable.'.'.$relationColumn, '=', $value);
+                    } else {
+                        $relationQuery->where($relationTable.'.'.$relationColumn, $likeOperator, '%'.$value.'%');
+                    }
                     $firstConditionAdded = true;
 
                     continue;
                 }
 
-                // For negation we AND the NOT LIKE conditions so all columns must not match.
-                // For normal LIKE we OR them so any column matching is sufficient.
-                $likeOperator === 'NOT LIKE'
-                    ? $relationQuery->where($relationTable.'.'.$relationColumn, $likeOperator, '%'.$value.'%')
-                    : $relationQuery->orWhere($relationTable.'.'.$relationColumn, $likeOperator, '%'.$value.'%');
+                if ($operator === 'exact') {
+                    // For exact matches across multiple columns, OR them — any column matching
+                    // the exact value is sufficient (e.g. name OR slug).
+                    $relationQuery->orWhere($relationTable.'.'.$relationColumn, '=', $value);
+                } elseif ($likeOperator === 'NOT LIKE') {
+                    // For negation we AND the NOT LIKE conditions so all columns must not match.
+                    $relationQuery->where($relationTable.'.'.$relationColumn, $likeOperator, '%'.$value.'%');
+                } else {
+                    // For normal LIKE we OR them so any column matching is sufficient.
+                    $relationQuery->orWhere($relationTable.'.'.$relationColumn, $likeOperator, '%'.$value.'%');
+                }
             }
 
             if (($resolvedRelationKey === 'adminuser') || ($resolvedRelationKey === 'user')) {
@@ -323,9 +397,14 @@ trait Searchable
                     'users.display_name',
                 ]);
 
-                $likeOperator === 'NOT LIKE'
-                    ? $relationQuery->whereRaw(str_replace('LIKE', 'NOT LIKE', $concatSql), ["%{$value}%"])
-                    : $relationQuery->orWhereRaw($concatSql, ["%{$value}%"]);
+                if ($operator === 'exact') {
+                    $concatSql = str_replace(' LIKE ?', ' = ?', $concatSql);
+                    $relationQuery->orWhereRaw($concatSql, [$value]);
+                } elseif ($likeOperator === 'NOT LIKE') {
+                    $relationQuery->whereRaw(str_replace('LIKE', 'NOT LIKE', $concatSql), ["%{$value}%"]);
+                } else {
+                    $relationQuery->orWhereRaw($concatSql, ["%{$value}%"]);
+                }
             }
         });
 
@@ -488,6 +567,85 @@ trait Searchable
         $likeOperator = $negate ? 'NOT LIKE' : 'LIKE';
 
         return $query->{$havingMethod}($countAlias, $likeOperator, '%'.$filterValue.'%');
+    }
+
+    /**
+     * Apply an IS NULL / IS NOT NULL filter for the given filter key.
+     *
+     * Supported targets:
+     *
+     *   Direct attributes  → WHERE col IS [NOT] NULL
+     *
+     *   Virtual columns    → IS NULL:     all constituent columns must be null
+     *                        IS NOT NULL: at least one constituent column must not be null
+     *
+     *   Relation keys      → IS NULL:     doesntHave (no related record)
+     *                        IS NOT NULL: whereHas   (has a related record)
+     *
+     * Any unrecognised key is silently ignored.
+     */
+    private function applyNullFilter(Builder $query, string $filterKey, bool $isNull, string $boolean = 'and'): Builder
+    {
+        $table = $this->getTable();
+        $searchableAttributes = $this->getSearchableAttributes();
+
+        // Direct attribute column.
+        if (in_array($filterKey, $searchableAttributes, true)) {
+            $method = match (true) {
+                $isNull && $boolean === 'or' => 'orWhereNull',
+                $isNull                      => 'whereNull',
+                $boolean === 'or'            => 'orWhereNotNull',
+                default                      => 'whereNotNull',
+            };
+
+            $query->{$method}($table.'.'.$filterKey);
+
+            return $query;
+        }
+
+        // Virtual columns (e.g. 'name' → ['first_name', 'last_name'] on User).
+        $virtualColumns = $this->getSearchableVirtualColumns();
+
+        if (array_key_exists($filterKey, $virtualColumns)) {
+            $qualifiedColumns = array_map(
+                fn ($col) => $table.'.'.$col,
+                $virtualColumns[$filterKey]
+            );
+
+            if ($isNull) {
+                // All constituent columns must be null (= no name at all).
+                foreach ($qualifiedColumns as $col) {
+                    $query->whereNull($col);
+                }
+            } else {
+                // At least one constituent column must have a value.
+                $query->where(function (Builder $sub) use ($qualifiedColumns): void {
+                    foreach ($qualifiedColumns as $col) {
+                        $sub->orWhereNotNull($col);
+                    }
+                });
+            }
+
+            return $query;
+        }
+
+        // Relation key: no related record = "null", has a related record = "not null".
+        $searchableRelations = $this->getSearchableRelations();
+        $resolvedRelationKey = $this->resolveSearchableRelationKey($filterKey, $searchableRelations);
+
+        if ($resolvedRelationKey !== null && ! $this->isAssignedToRelationKey($resolvedRelationKey)) {
+            if ($isNull) {
+                $method = $boolean === 'or' ? 'orDoesntHave' : 'doesntHave';
+                $query->{$method}($resolvedRelationKey);
+            } else {
+                $method = $boolean === 'or' ? 'orWhereHas' : 'whereHas';
+                $query->{$method}($resolvedRelationKey);
+            }
+
+            return $query;
+        }
+
+        return $query;
     }
 
     /**
@@ -748,6 +906,20 @@ trait Searchable
     private function getSearchableCounts(): array
     {
         return $this->searchableCounts ?? [];
+    }
+
+    /**
+     * Get virtual column aliases defined on the model.
+     *
+     * These are filter keys that map to a set of real columns searched via
+     * CONCAT — for example, "name" → ['first_name', 'last_name'] on User,
+     * because "name" is not a real database column on that table.
+     *
+     * @return array<string, list<string>>
+     */
+    private function getSearchableVirtualColumns(): array
+    {
+        return $this->searchableVirtualColumns ?? [];
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -182,6 +182,20 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
     ];
 
     /**
+     * Virtual column aliases that map a single filter key to a set of real columns
+     * searched via CONCAT (SQL) so that, for example, filtering by "name" searches
+     * across both first_name and last_name together.
+     *
+     * Because "name" is not a real column on the users table we cannot add it to
+     * $searchableAttributes; this map bridges that gap for structured filter queries.
+     *
+     * @var array<string, list<string>>
+     */
+    protected $searchableVirtualColumns = [
+        'name' => ['first_name', 'last_name'],
+    ];
+
+    /**
      * This sets the name property on the user. It's not a real field in the database
      * (since we use first_name and last_name), but the Laravel mailable method
      * uses this to determine the name of the user to send emails to.

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -196,6 +196,30 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
     ];
 
     /**
+     * Maps filter/API keys to the actual Eloquent relation names used in
+     * $searchableRelations.  The User model uses "userloc" as its location
+     * relation name (to avoid a collision with the framework's own "location"
+     * magic), but every consumer — UI and API alike — sends the key "location".
+     *
+     * @var array<string, string>
+     */
+    protected $searchableRelationAliases = [
+        'location' => 'userloc',
+    ];
+
+    /**
+     * Narrow structured-filter relation columns for specific UI/API filter keys.
+     *
+     * The advanced-search "location" field represents the location name, so
+     * structured filters should target only userloc.name (not address/city/etc).
+     *
+     * @var array<string, list<string>>
+     */
+    protected $searchableRelationFilterColumns = [
+        'location' => ['name'],
+    ];
+
+    /**
      * This sets the name property on the user. It's not a real field in the database
      * (since we use first_name and last_name), but the Laravel mailable method
      * uses this to determine the name of the user to send emails to.

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -609,6 +609,7 @@ return [
     'search_operator' => 'Search operator',
     'and' => 'and',
     'action_source' => 'Action Source',
+    'search_tip' => 'Search tip: prefix a value with <code>!</code> or <code>not:</code> to exclude matches',
     'or' => 'or',
     'url' => 'URL',
     'phone' => 'Phone',

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -606,6 +606,8 @@ return [
     'action_permission_denied' => 'You do not have permission to :action :item_type ID :id',
     'action_permission_generic' => 'You do not have permission to :action this :item_type',
     'edit' => 'edit',
+    'search_operator' => 'Search operator',
+    'and' => 'and',
     'action_source' => 'Action Source',
     'or' => 'or',
     'url' => 'URL',

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -609,7 +609,7 @@ return [
     'search_operator' => 'Search operator',
     'and' => 'and',
     'action_source' => 'Action Source',
-    'search_tip' => 'Search tip: prefix a value with <code>!</code> or <code>not:</code> to exclude matches',
+    'search_tip' => 'Searches return a partial match by default. For more specific results, you can use <code>not:value</code> to exclude, <code>is:value</code> for an exact match, <code>is:null</code> for empty values, and <code>is:not_null</code> for non-empty. (In these examples, <code>value</code> is the text you are searching for.)',
     'or' => 'or',
     'url' => 'URL',
     'phone' => 'Phone',

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -254,12 +254,22 @@
 
             BootstrapTable.prototype.createToolbarForm = function () {
                 var filterColumnsPartial = this.filterColumnsPartial || {};
-                var html = ["<form class=\"form-horizontal toolbar-model-form\" action=\"".concat(this.options.actionForm, "\">")];
+                var html = [`<form class="form-horizontal toolbar-model-form" action="${this.options.actionForm}">`];
                 var operator = this.getAdvancedSearchOperator();
 
-                html.push("\n                    <div class=\"form-group row\">\n                        <label class=\"col-sm-4 control-label\">".concat(this.options.formatAdvancedSearchOperator(), "</label>\n                        <div class=\"col-sm-6\">\n                            <select class=\"form-control ").concat(this.constants.classes.input, "\" name=\"__advanced_search_operator\">\n                                <option value=\"and\"").concat(operator === 'and' ? ' selected' : '', ">" + advancedSearchAndText + "</option>\n                                <option value=\"or\"").concat(operator === 'or' ? ' selected' : '', ">" + advancedSearchOrText + "</option>\n                            </select>\n                        </div>\n                    </div>\n                "));
+                html.push('<div class="form-group row"><div class="col-sm-12"><p class="help-block"><i class="fa fa-solid fa-lightbulb text-info" aria-hidden="true"></i> {!! trans('general.search_tip') !!}</p></div></div>');
 
-                html.push('<div class="form-group row"><div class="col-sm-6 col-sm-offset-4"><p class="help-block" style="margin-bottom: 0;">{!! trans('general.search_tip') !!}</p></div></div>');
+                html.push(`
+                    <div class="form-group row">
+                        <label class="col-sm-4 control-label">${this.options.formatAdvancedSearchOperator()}</label>
+                        <div class="col-sm-6">
+                            <select class="form-control ${this.constants.classes.input}" name="__advanced_search_operator">
+                                <option value="and"${operator === 'and' ? ' selected' : ''}>${advancedSearchAndText}</option>
+                                <option value="or"${operator === 'or' ? ' selected' : ''}>${advancedSearchOrText}</option>
+                            </select>
+                        </div>
+                    </div>
+                `);
 
                 for (var columnIndex = 0; columnIndex < this.columns.length; columnIndex++) {
                     var column = this.columns[columnIndex];
@@ -268,7 +278,20 @@
                         var title = $('<div/>').html(column.title).text().trim();
                         var value = filterColumnsPartial[column.field] || '';
 
-                        html.push("<div class=\"form-group row\"><label class=\"col-sm-4 control-label\">".concat(title, "</label><div class=\"col-sm-6\">\n<input type=\"text\" class=\"form-control ").concat(this.constants.classes.input, "\"\n                                        name=\"").concat(column.field, "\" placeholder=\"").concat(escapeAdvancedSearchValue(title), "\" value=\"").concat(escapeAdvancedSearchValue(value), "\">\n                                </div></div>"));
+                        html.push(`
+                            <div class="form-group row">
+                                <label class="col-sm-4 control-label">${title}</label>
+                                <div class="col-sm-6">
+                                    <input
+                                        type="text"
+                                        class="form-control ${this.constants.classes.input}"
+                                        name="${column.field}"
+                                        placeholder="${escapeAdvancedSearchValue(title)}"
+                                        value="${escapeAdvancedSearchValue(value)}"
+                                    >
+                                </div>
+                            </div>
+                        `);
                     }
                 }
 

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -28,6 +28,29 @@
         var advancedSearchOperatorLabel = @json(trans('general.search_operator'));
         var advancedSearchAndText = @json(trans('general.and'));
         var advancedSearchOrText = @json(trans('general.or'));
+        var advancedSearchOperatorStorageKey = 'snipeit.bs.table.advancedSearchOperator';
+
+        var normalizeAdvancedSearchOperator = function (operator) {
+            return (operator || defaultAdvancedSearchOperator).toString().toLowerCase() === 'or' ? 'or' : 'and';
+        };
+
+        var getStoredAdvancedSearchOperator = function () {
+            try {
+                var storedOperator = localStorage.getItem(advancedSearchOperatorStorageKey);
+
+                return storedOperator ? normalizeAdvancedSearchOperator(storedOperator) : null;
+            } catch (error) {
+                return null;
+            }
+        };
+
+        var storeAdvancedSearchOperator = function (operator) {
+            try {
+                localStorage.setItem(advancedSearchOperatorStorageKey, normalizeAdvancedSearchOperator(operator));
+            } catch (error) {
+                // Ignore storage errors (private mode/quota), fallback remains in-memory.
+            }
+        };
 
             var escapeAdvancedSearchValue = function (value) {
                 return $('<div/>').text(value == null ? '' : value).html();
@@ -53,14 +76,15 @@
             });
 
             BootstrapTable.prototype.getAdvancedSearchOperator = function () {
-                var operator = (this.advancedSearchOperator || this.options.advancedSearchOperator || this.$el.data('advanced-search-filter-operator') || defaultAdvancedSearchOperator).toString().toLowerCase();
+                var operator = this.advancedSearchOperator || this.options.advancedSearchOperator || this.$el.data('advanced-search-filter-operator') || getStoredAdvancedSearchOperator() || defaultAdvancedSearchOperator;
 
-                return operator === 'or' ? 'or' : 'and';
+                return normalizeAdvancedSearchOperator(operator);
             };
 
             BootstrapTable.prototype.setAdvancedSearchOperator = function (operator) {
-                this.advancedSearchOperator = operator === 'or' ? 'or' : 'and';
+                this.advancedSearchOperator = normalizeAdvancedSearchOperator(operator);
                 this.$el.data('advanced-search-filter-operator', this.advancedSearchOperator);
+                storeAdvancedSearchOperator(this.advancedSearchOperator);
             };
 
             BootstrapTable.prototype.collectAdvancedSearchFormData = function () {
@@ -310,7 +334,9 @@
 
 
 
-            $(this).data('advanced-search-filter-operator', data_with_default('advanced-search-operator', 'and'));
+            var initialAdvancedSearchOperator = getStoredAdvancedSearchOperator() || normalizeAdvancedSearchOperator(data_with_default('advanced-search-operator', defaultAdvancedSearchOperator));
+
+            $(this).data('advanced-search-filter-operator', initialAdvancedSearchOperator);
 
             $(this).bootstrapTable({
 
@@ -323,7 +349,7 @@
                 // buttonsPrefix: "btn",
                 addrbar: {{ (config('session.bs_table_addrbar') == 'true') ? 'true' : 'false'}}, // deeplink search phrases, sorting, etc
                 advancedSearch: data_with_default('advanced-search', true),
-                advancedSearchOperator: data_with_default('advanced-search-operator', 'and'),
+                advancedSearchOperator: initialAdvancedSearchOperator,
                 buttonsClass: "tableButton tableButton btn-theme hidden-print",
                 buttonsOrder: [
                     'columns',

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -259,6 +259,8 @@
 
                 html.push("\n                    <div class=\"form-group row\">\n                        <label class=\"col-sm-4 control-label\">".concat(this.options.formatAdvancedSearchOperator(), "</label>\n                        <div class=\"col-sm-6\">\n                            <select class=\"form-control ").concat(this.constants.classes.input, "\" name=\"__advanced_search_operator\">\n                                <option value=\"and\"").concat(operator === 'and' ? ' selected' : '', ">" + advancedSearchAndText + "</option>\n                                <option value=\"or\"").concat(operator === 'or' ? ' selected' : '', ">" + advancedSearchOrText + "</option>\n                            </select>\n                        </div>\n                    </div>\n                "));
 
+                html.push('<div class="form-group row"><div class="col-sm-6 col-sm-offset-4"><p class="help-block" style="margin-bottom: 0;">{!! trans('general.search_tip') !!}</p></div></div>');
+
                 for (var columnIndex = 0; columnIndex < this.columns.length; columnIndex++) {
                     var column = this.columns[columnIndex];
 
@@ -266,7 +268,7 @@
                         var title = $('<div/>').html(column.title).text().trim();
                         var value = filterColumnsPartial[column.field] || '';
 
-                        html.push("\n                            <div class=\"form-group row\">\n                                <label class=\"col-sm-4 control-label\">".concat(title, "</label>\n                                <div class=\"col-sm-6\">\n                                    <input type=\"text\" class=\"form-control ").concat(this.constants.classes.input, "\"\n                                        name=\"").concat(column.field, "\" placeholder=\"").concat(escapeAdvancedSearchValue(title), "\" value=\"").concat(escapeAdvancedSearchValue(value), "\">\n                                </div>\n                            </div>\n                        "));
+                        html.push("<div class=\"form-group row\"><label class=\"col-sm-4 control-label\">".concat(title, "</label><div class=\"col-sm-6\">\n<input type=\"text\" class=\"form-control ").concat(this.constants.classes.input, "\"\n                                        name=\"").concat(column.field, "\" placeholder=\"").concat(escapeAdvancedSearchValue(title), "\" value=\"").concat(escapeAdvancedSearchValue(value), "\">\n                                </div></div>"));
                     }
                 }
 

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -13,6 +13,225 @@
 <script nonce="{{ csrf_token() }}">
     $(function () {
 
+        if (!$.fn.bootstrapTable || $.fn.bootstrapTable.__snipeAdvancedSearchPatched) {
+            return;
+        }
+
+        $.fn.bootstrapTable.__snipeAdvancedSearchPatched = true;
+
+        var BootstrapTable = $.BootstrapTable;
+        var baseBootstrapTablePrototype = Object.getPrototypeOf(BootstrapTable.prototype);
+        var baseInitSearch = baseBootstrapTablePrototype.initSearch;
+        var defaultAdvancedSearchOperator = 'and';
+        var advancedSearchSearchText = @json(trans('general.search'));
+        var advancedSearchCancelText = @json(trans('button.cancel'));
+        var advancedSearchOperatorLabel = @json(trans('general.search_operator'));
+        var advancedSearchAndText = @json(trans('general.and'));
+        var advancedSearchOrText = @json(trans('general.or'));
+
+            var escapeAdvancedSearchValue = function (value) {
+                return $('<div/>').text(value == null ? '' : value).html();
+            };
+
+            Object.assign($.fn.bootstrapTable.locales, {
+                formatAdvancedCloseButton: function () {
+                    return advancedSearchSearchText;
+                },
+                formatAdvancedCancelButton: function () {
+                    return advancedSearchCancelText;
+                },
+                formatAdvancedSearchOperator: function () {
+                    return advancedSearchOperatorLabel;
+                }
+            });
+
+            Object.assign($.fn.bootstrapTable.defaults, {
+                advancedSearchOperator: defaultAdvancedSearchOperator,
+                formatAdvancedCloseButton: $.fn.bootstrapTable.locales.formatAdvancedCloseButton,
+                formatAdvancedCancelButton: $.fn.bootstrapTable.locales.formatAdvancedCancelButton,
+                formatAdvancedSearchOperator: $.fn.bootstrapTable.locales.formatAdvancedSearchOperator
+            });
+
+            BootstrapTable.prototype.getAdvancedSearchOperator = function () {
+                var operator = (this.advancedSearchOperator || this.options.advancedSearchOperator || this.$el.data('advanced-search-filter-operator') || defaultAdvancedSearchOperator).toString().toLowerCase();
+
+                return operator === 'or' ? 'or' : 'and';
+            };
+
+            BootstrapTable.prototype.setAdvancedSearchOperator = function (operator) {
+                this.advancedSearchOperator = operator === 'or' ? 'or' : 'and';
+                this.$el.data('advanced-search-filter-operator', this.advancedSearchOperator);
+            };
+
+            BootstrapTable.prototype.collectAdvancedSearchFormData = function () {
+                var filters = {};
+                var operator = defaultAdvancedSearchOperator;
+
+                $.each(this.$toolbarModal.find('.toolbar-model-form').serializeArray(), function (index, field) {
+                    var value = $.trim(field.value);
+
+                    if (field.name === '__advanced_search_operator') {
+                        operator = value.toLowerCase() === 'or' ? 'or' : 'and';
+
+                        return;
+                    }
+
+                    if (value !== '') {
+                        filters[field.name] = value;
+                    }
+                });
+
+                return {
+                    filters: filters,
+                    operator: operator
+                };
+            };
+
+            BootstrapTable.prototype.applyAdvancedSearch = function () {
+                var toolbarState = this.collectAdvancedSearchFormData();
+
+                this.filterColumnsPartial = toolbarState.filters;
+                this.setAdvancedSearchOperator(toolbarState.operator);
+
+                if (this.options.sidePagination !== 'server') {
+                    this.options.pageNumber = 1;
+                    this.initSearch();
+                    this.updatePagination();
+                    this.trigger('column-advanced-search', this.filterColumnsPartial, this.getAdvancedSearchOperator());
+                }
+
+                this.hideToolbarModal();
+            };
+
+            BootstrapTable.prototype.cancelAdvancedSearch = function () {
+                this.hideToolbarModal();
+            };
+
+            BootstrapTable.prototype.createToolbarForm = function () {
+                var filterColumnsPartial = this.filterColumnsPartial || {};
+                var html = ["<form class=\"form-horizontal toolbar-model-form\" action=\"".concat(this.options.actionForm, "\">")];
+                var operator = this.getAdvancedSearchOperator();
+
+                html.push("\n                    <div class=\"form-group row\">\n                        <label class=\"col-sm-4 control-label\">".concat(this.options.formatAdvancedSearchOperator(), "</label>\n                        <div class=\"col-sm-6\">\n                            <select class=\"form-control ").concat(this.constants.classes.input, "\" name=\"__advanced_search_operator\">\n                                <option value=\"and\"").concat(operator === 'and' ? ' selected' : '', ">" + advancedSearchAndText + "</option>\n                                <option value=\"or\"").concat(operator === 'or' ? ' selected' : '', ">" + advancedSearchOrText + "</option>\n                            </select>\n                        </div>\n                    </div>\n                "));
+
+                for (var columnIndex = 0; columnIndex < this.columns.length; columnIndex++) {
+                    var column = this.columns[columnIndex];
+
+                    if (!column.checkbox && column.visible && column.searchable) {
+                        var title = $('<div/>').html(column.title).text().trim();
+                        var value = filterColumnsPartial[column.field] || '';
+
+                        html.push("\n                            <div class=\"form-group row\">\n                                <label class=\"col-sm-4 control-label\">".concat(title, "</label>\n                                <div class=\"col-sm-6\">\n                                    <input type=\"text\" class=\"form-control ").concat(this.constants.classes.input, "\"\n                                        name=\"").concat(column.field, "\" placeholder=\"").concat(escapeAdvancedSearchValue(title), "\" value=\"").concat(escapeAdvancedSearchValue(value), "\">\n                                </div>\n                            </div>\n                        "));
+                    }
+                }
+
+                html.push('</form>');
+
+                return html.join('');
+            };
+
+            BootstrapTable.prototype.initAdvancedSearchFooter = function () {
+                var _this = this;
+                var $footer = this.$toolbarModal.find('.toolbar-modal-footer');
+                var $templateButton = $footer.find('.toolbar-modal-close').first();
+                var tagName = ($templateButton.prop('tagName') || 'button').toLowerCase();
+                var baseClass = ($templateButton.attr('class') || '').replace(/\btoolbar-modal-close\b/g, '').trim();
+
+                var createFooterButton = function (text, extraClass) {
+                    var $button = $('<' + tagName + '>').addClass($.trim(baseClass + ' ' + extraClass)).html(text);
+
+                    if (tagName === 'button') {
+                        $button.attr('type', 'button');
+                    }
+
+                    if (tagName === 'a') {
+                        $button.attr('href', 'javascript:void(0)');
+                    }
+
+                    return $button;
+                };
+
+                var $cancelButton = createFooterButton(this.options.formatAdvancedCancelButton(), 'toolbar-modal-cancel');
+                var $searchButton = createFooterButton(this.options.formatAdvancedCloseButton(), 'toolbar-modal-search');
+
+                $footer.empty().append($cancelButton, $searchButton);
+
+                $cancelButton.off('click').on('click', function (event) {
+                    event.preventDefault();
+                    _this.cancelAdvancedSearch();
+                });
+
+                $searchButton.off('click').on('click', function (event) {
+                    event.preventDefault();
+                    _this.applyAdvancedSearch();
+                });
+            };
+
+            BootstrapTable.prototype.initToolbarModalBody = function () {
+                var _this = this;
+
+                this.$toolbarModal.find('.toolbar-modal-title').html(this.options.formatAdvancedSearch());
+                this.$toolbarModal.find('.toolbar-modal-body')
+                    .html(this.createToolbarForm())
+                    .off('submit', '.toolbar-model-form')
+                    .on('submit', '.toolbar-model-form', function (event) {
+                        event.preventDefault();
+                        _this.applyAdvancedSearch();
+                    });
+
+                this.initAdvancedSearchFooter();
+            };
+
+            BootstrapTable.prototype.initSearch = function () {
+                var _this = this;
+
+                baseInitSearch.apply(this, arguments);
+
+                if (!this.options.advancedSearch || this.options.sidePagination === 'server') {
+                    return;
+                }
+
+                var filters = $.isEmptyObject(this.filterColumnsPartial) ? null : this.filterColumnsPartial;
+
+                if (!filters) {
+                    return;
+                }
+
+                var operator = this.getAdvancedSearchOperator();
+
+                this.data = this.data.filter(function (item, index) {
+                    var matches = [];
+                    var matchFound = false;
+                    var allMatched = true;
+
+                    $.each(filters, function (key, value) {
+                        var searchValue = value.toLowerCase();
+                        var formattedValue = item[key];
+                        var headerIndex = _this.header.fields.indexOf(key);
+                        var isMatch;
+
+                        formattedValue = $.fn.bootstrapTable.utils.calculateObjectValue(_this.header, _this.header.formatters[headerIndex], [formattedValue, item, index], formattedValue);
+
+                        if (_this.header.formatters[headerIndex]) {
+                            formattedValue = $('<div>').html(formattedValue).text();
+                        }
+
+                        isMatch = headerIndex !== -1 && (typeof formattedValue === 'string' || typeof formattedValue === 'number') && "".concat(formattedValue).toLowerCase().includes(searchValue);
+
+                        matches.push(isMatch);
+                        matchFound = matchFound || isMatch;
+                        allMatched = allMatched && isMatch;
+                    });
+
+                    if (!matches.length) {
+                        return true;
+                    }
+
+                    return operator === 'or' ? matchFound : allMatched;
+                });
+
+                this.unsortedData = this.data.slice();
+            };
 
         var blockedFields = "searchable,sortable,switchable,title,visible,formatter,class".split(",");
 
@@ -38,10 +257,8 @@
             }
         }
 
-        // Run the function on page load
-        $(document).ready(function () {
-            resize();
-        });
+        // Run once on initial ready (already inside top-level ready block)
+        resize();
 
         // Watch for window resize events
         $(window).on('resize', function () {
@@ -93,6 +310,8 @@
 
 
 
+            $(this).data('advanced-search-filter-operator', data_with_default('advanced-search-operator', 'and'));
+
             $(this).bootstrapTable({
 
                 ajaxOptions: {
@@ -104,6 +323,7 @@
                 // buttonsPrefix: "btn",
                 addrbar: {{ (config('session.bs_table_addrbar') == 'true') ? 'true' : 'false'}}, // deeplink search phrases, sorting, etc
                 advancedSearch: data_with_default('advanced-search', true),
+                advancedSearchOperator: data_with_default('advanced-search-operator', 'and'),
                 buttonsClass: "tableButton tableButton btn-theme hidden-print",
                 buttonsOrder: [
                     'columns',
@@ -162,6 +382,11 @@
                             newParams[i] = params[i];
                         }
                     }
+
+                    if (newParams.filter) {
+                        newParams.filter_operator = $(table).data('advanced-search-filter-operator') || data_with_default('advanced-search-operator', 'and');
+                    }
+
                     return newParams;
                 },
                 formatLoadingMessage: function () {
@@ -247,6 +472,9 @@
             });
 
         });
+
+        bindBulkEditSelectionHandler();
+        initializeBootstrapTableSearchUi();
     });
 
 
@@ -1992,7 +2220,7 @@
         return value
     }
 
-    $(function () {
+    function bindBulkEditSelectionHandler() {
         $('#bulkEdit').click(function () {
             var selectedIds = $('.snipe-table').bootstrapTable('getSelections');
             $.each(selectedIds, function(key,value) {
@@ -2000,9 +2228,9 @@
             });
 
         });
-    });
+    }
 
-    $(function() {
+    function initializeBootstrapTableSearchUi() {
 
         // This handles the search box highlighting on both ajax and client-side
         // bootstrap tables
@@ -2047,7 +2275,7 @@
 
 
         });
-    });
+    }
 
 </script>
     

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -158,8 +158,24 @@
                 var _this = this;
                 var $footer = this.$toolbarModal.find('.toolbar-modal-footer');
                 var $templateButton = $footer.find('.toolbar-modal-close').first();
-                var tagName = ($templateButton.prop('tagName') || 'button').toLowerCase();
-                var baseClass = ($templateButton.attr('class') || '').replace(/\btoolbar-modal-close\b/g, '').trim();
+
+                if (!this._advancedSearchFooterButtonTagName) {
+                    this._advancedSearchFooterButtonTagName = ($templateButton.prop('tagName') || $footer.find('button,a').first().prop('tagName') || 'button').toLowerCase();
+                }
+
+                if (!this._advancedSearchFooterButtonBaseClass) {
+                    var buttonClassSource = ($templateButton.attr('class') || $footer.find('button,a').first().attr('class') || '');
+
+                    this._advancedSearchFooterButtonBaseClass = buttonClassSource
+                        .replace(/\btoolbar-modal-close\b/g, '')
+                        .replace(/\btoolbar-modal-cancel\b/g, '')
+                        .replace(/\btoolbar-modal-search\b/g, '')
+                        .replace(/\bpull-left\b/g, '')
+                        .trim();
+                }
+
+                var tagName = this._advancedSearchFooterButtonTagName;
+                var baseClass = this._advancedSearchFooterButtonBaseClass;
 
                 var createFooterButton = function (text, extraClass) {
                     var $button = $('<' + tagName + '>').addClass($.trim(baseClass + ' ' + extraClass)).html(text);
@@ -177,6 +193,9 @@
 
                 var $cancelButton = createFooterButton(this.options.formatAdvancedCancelButton(), 'toolbar-modal-cancel');
                 var $searchButton = createFooterButton(this.options.formatAdvancedCloseButton(), 'toolbar-modal-search');
+
+                // Keep cancel on the left for clearer primary/secondary action separation.
+                $cancelButton.addClass('pull-left');
 
                 $footer.empty().append($cancelButton, $searchButton);
 
@@ -417,6 +436,15 @@
                 },
                 formatLoadingMessage: function () {
                     return '<h2><x-icon type="spinner" /> {{ trans('general.loading') }} </h2>';
+                },
+                formatAdvancedCloseButton: function () {
+                    return advancedSearchSearchText;
+                },
+                formatAdvancedCancelButton: function () {
+                    return advancedSearchCancelText;
+                },
+                formatAdvancedSearchOperator: function () {
+                    return advancedSearchOperatorLabel;
                 },
                 icons: {
                     advancedSearchIcon: 'fas fa-search-plus',

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -1,5 +1,13 @@
 @push('css')
     <link rel="stylesheet" href="{{ url(mix('css/dist/bootstrap-table.css')) }}">
+    <style>
+        .advanced-search-tags { margin: 10px 0; }
+        .advanced-search-tags .tag { margin-right: 5px; }
+        .btn-advanced-search.active {
+            background-color: #e74c3c !important;
+            color: #fff !important;
+        }
+    </style>
 @endpush
 
 @push('js')
@@ -145,59 +153,75 @@
                 return $container;
             };
 
+            BootstrapTable.prototype.getAdvancedSearchButton = function () {
+                var $tableWrapper = this.$el.closest('.bootstrap-table');
+
+                if (!$tableWrapper.length) {
+                    return $();
+                }
+
+                // Try to find the button by data attribute first (most reliable)
+                var $button = $tableWrapper.find('button[data-toggle="advanced-search"]').first();
+
+                // Fallback: look in toolbar by the fa-search-plus icon
+                if (!$button.length) {
+                    $button = $tableWrapper.find('button:has(.fa-search-plus)').first();
+                }
+
+                return $button;
+            };
+
+            BootstrapTable.prototype.updateAdvancedSearchButtonState = function () {
+                var hasFilters = !$.isEmptyObject(this.filterColumnsPartial);
+                var $button = this.getAdvancedSearchButton();
+
+                if ($button.length) {
+                    $button.toggleClass('active', hasFilters);
+                }
+            };
+
             BootstrapTable.prototype.renderAdvancedSearchTags = function () {
                 var _this = this;
-                var $container = this.getAdvancedSearchTagsContainer();
+                var filters = this.filterColumnsPartial;
+                var $tagContainer = this.getAdvancedSearchTagsContainer();
 
-                if (!$container.length) {
+                if ($.isEmptyObject(filters)) {
+                    $tagContainer.empty();
+                    this.updateAdvancedSearchButtonState();
                     return;
                 }
 
-                var filters = $.isEmptyObject(this.filterColumnsPartial || {}) ? null : this.filterColumnsPartial;
+                var colMap = {};
+                this.columns.forEach(c => colMap[c.field] = c.title);
+                var op = this.getAdvancedSearchOperator();
+                var html = '<span class="label label-warning" style="margin-right:6px;display:inline-block;margin-bottom:6px;">' +
+                    advancedSearchOperatorLabel + ': ' + (op === 'or' ? advancedSearchOrText : advancedSearchAndText) + '</span>';
 
-                if (!filters) {
-                    $container.empty().hide();
-                    return;
-                }
-
-                var operatorText = this.getAdvancedSearchOperator() === 'or' ? advancedSearchOrText : advancedSearchAndText;
-                var html = ['<div class="advanced-search-tag-list">'];
-
-                html.push('<span class="label label-default" style="margin-right: 6px; display: inline-block; margin-bottom: 6px;">' +
-                    escapeAdvancedSearchValue(advancedSearchOperatorLabel) + ': ' + escapeAdvancedSearchValue(operatorText) + '</span>');
-
-                $.each(filters, function (fieldName, fieldValue) {
-                    html.push('<span class="label label-primary" style="margin-right: 6px; display: inline-block; margin-bottom: 6px;">' +
-                        '<strong>' + escapeAdvancedSearchValue(_this.getAdvancedSearchFieldTitle(fieldName)) + ':</strong> ' +
-                        escapeAdvancedSearchValue(fieldValue) +
-                        ' <a href="javascript:void(0)" class="snipe-advanced-search-tag-remove" data-field="' +
-                        escapeAdvancedSearchValue(fieldName) +
-                        '" style="color: #fff; margin-left: 6px; text-decoration: none;">&times;</a></span>');
+                Object.keys(filters).forEach(f => {
+                    html += '<span class="label label-primary" style="margin-right:6px;display:inline-block;margin-bottom:6px;"><b>' +
+                        (colMap[f] || f).replace(/<[^>]*>/g, '') + ':</b> ' + escapeAdvancedSearchValue(filters[f]) +
+                        ' <a href="javascript:void(0)" class="snipe-advanced-search-tag-remove" data-field="' + f +
+                        '" style="color:#fff;margin-left:6px;text-decoration:none;">&times;</a></span>';
                 });
 
-                html.push('</div>');
+                $tagContainer
+                    .html(html)
+                    .off('click.snipeAdvancedSearchTags')
+                    .on('click.snipeAdvancedSearchTags', '.snipe-advanced-search-tag-remove', function (e) {
+                        e.preventDefault();
+                        var field = $(this).data('field');
+                        if (field && _this.filterColumnsPartial) {
+                            delete _this.filterColumnsPartial[field];
+                            _this.options.pageNumber = 1;
+                            _this.initSearch();
+                            _this.updatePagination();
+                            _this.trigger('column-advanced-search', _this.filterColumnsPartial, _this.getAdvancedSearchOperator());
 
-                $container
-                    .html(html.join(''))
-                    .show()
-                    .off('click.snipeAdvancedSearchTags', '.snipe-advanced-search-tag-remove')
-                    .on('click.snipeAdvancedSearchTags', '.snipe-advanced-search-tag-remove', function (event) {
-                        event.preventDefault();
-
-                        var fieldName = $(this).data('field');
-
-                        if (!fieldName || !_this.filterColumnsPartial || _this.filterColumnsPartial[fieldName] == null) {
-                            return;
+                            _this.renderAdvancedSearchTags();
                         }
-
-                        delete _this.filterColumnsPartial[fieldName];
-
-                        _this.options.pageNumber = 1;
-                        _this.initSearch();
-                        _this.updatePagination();
-                        _this.trigger('column-advanced-search', _this.filterColumnsPartial, _this.getAdvancedSearchOperator());
-                        _this.renderAdvancedSearchTags();
                     });
+
+                this.updateAdvancedSearchButtonState();
             };
 
             BootstrapTable.prototype.applyAdvancedSearch = function () {
@@ -214,6 +238,7 @@
                 }
 
                 this.renderAdvancedSearchTags();
+                this.updateAdvancedSearchButtonState();
 
                 this.hideToolbarModal();
             };
@@ -620,6 +645,25 @@
 
             if (bootstrapTableInstance && typeof bootstrapTableInstance.renderAdvancedSearchTags === 'function') {
                 bootstrapTableInstance.renderAdvancedSearchTags();
+            }
+
+            // Add btn-advanced-search class to the advanced search button for styling
+            if (bootstrapTableInstance) {
+                // Use a small delay to ensure toolbar is fully rendered
+                setTimeout(function () {
+                    var $advancedSearchBtn = bootstrapTableInstance.getAdvancedSearchButton();
+                    if ($advancedSearchBtn.length) {
+                        $advancedSearchBtn.addClass('btn-advanced-search');
+
+                        // Add data attribute if not present
+                        if (!$advancedSearchBtn.attr('data-toggle')) {
+                            $advancedSearchBtn.attr('data-toggle', 'advanced-search');
+                        }
+
+                        // Initialize button state
+                        bootstrapTableInstance.updateAdvancedSearchButtonState();
+                    }
+                }, 50);
             }
 
         });
@@ -2128,7 +2172,7 @@
         if ((value) && (value.url) && (value.inlineable)) {
 
             if (value.mediatype == 'image') {
-                return '<a href="' + value.url + '" data-toggle="lightbox" data-type="image"><img src="' + value.url + '" style="max-height: {{ $snipeSettings->thumbnail_max_h }}px; width: auto;" class="img-responsive" alt=""></a>';
+                return '<a href="' + value.url + '?inline=true" data-toggle="lightbox" data-type="image"><img src="' + value.url + '" style="max-height: {{ $snipeSettings->thumbnail_max_h }}px; width: auto;" class="img-responsive" alt=""></a>';
             } else if (value.mediatype == 'video') {
                 return '<a href="' + value.url + '?inline=true" data-toggle="lightbox" data-type="video"><video style="max-height: {{ $snipeSettings->thumbnail_max_h }}px; width: auto;" class="img-responsive"><source src="' + value.url + '?inline=true"></video></a>';
             } else if (value.mediatype == 'audio') {
@@ -2419,14 +2463,13 @@
 
         //  This is necessary to make the bootstrap tooltips work inside of the
         // wenzhixin/bootstrap-table formatters
-        $('#table').on('post-body.bs.table', function () {
+        $(document).on('post-body.bs.table', '.snipe-table', function () {
             $('[data-tooltip="true"]').tooltip({
                 container: 'body'
             });
-
-
         });
     }
+
 
 </script>
     

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -1,13 +1,6 @@
 @push('css')
     <link rel="stylesheet" href="{{ url(mix('css/dist/bootstrap-table.css')) }}">
-    <style>
-        .advanced-search-tags { margin: 10px 0; }
-        .advanced-search-tags .tag { margin-right: 5px; }
-        .btn-advanced-search.active {
-            background-color: #e74c3c !important;
-            color: #fff !important;
-        }
-    </style>
+
 @endpush
 
 @push('js')
@@ -32,7 +25,7 @@
         var baseInitSearch = baseBootstrapTablePrototype.initSearch;
         var defaultAdvancedSearchOperator = 'and';
         var advancedSearchSearchText = @json(trans('general.search'));
-        var advancedSearchCancelText = @json(trans('button.cancel'));
+
         var advancedSearchOperatorLabel = @json(trans('general.search_operator'));
         var advancedSearchAndText = @json(trans('general.and'));
         var advancedSearchOrText = @json(trans('general.or'));
@@ -69,7 +62,7 @@
                     return advancedSearchSearchText;
                 },
                 formatAdvancedCancelButton: function () {
-                    return advancedSearchCancelText;
+                    return $.fn.bootstrapTable.defaults.formatClearSearch();
                 },
                 formatAdvancedSearchOperator: function () {
                     return advancedSearchOperatorLabel;
@@ -244,6 +237,18 @@
             };
 
             BootstrapTable.prototype.cancelAdvancedSearch = function () {
+                this.filterColumnsPartial = {};
+                this.options.pageNumber = 1;
+                this.initSearch();
+                this.updatePagination();
+                this.trigger('column-advanced-search', this.filterColumnsPartial, this.getAdvancedSearchOperator());
+                this.renderAdvancedSearchTags();
+                this.updateAdvancedSearchButtonState();
+                // Reset the form inputs so the fields appear empty when re-opened
+                if (this.$toolbarModal) {
+                    this.$toolbarModal.find('.toolbar-model-form')[0] && this.$toolbarModal.find('.toolbar-model-form')[0].reset();
+                    this.$toolbarModal.find('input[type="text"]').val('');
+                }
                 this.hideToolbarModal();
             };
 
@@ -557,7 +562,7 @@
                     return advancedSearchSearchText;
                 },
                 formatAdvancedCancelButton: function () {
-                    return advancedSearchCancelText;
+                    return $.fn.bootstrapTable.defaults.formatClearSearch();
                 },
                 formatAdvancedSearchOperator: function () {
                     return advancedSearchOperatorLabel;

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -111,6 +111,95 @@
                 };
             };
 
+            BootstrapTable.prototype.getAdvancedSearchFieldTitle = function (fieldName) {
+                for (var i = 0; i < this.columns.length; i++) {
+                    var column = this.columns[i];
+
+                    if (column.field === fieldName) {
+                        return $('<div/>').html(column.title || fieldName).text().trim();
+                    }
+                }
+
+                return fieldName;
+            };
+
+            BootstrapTable.prototype.getAdvancedSearchTagsContainer = function () {
+                var $tableWrapper = this.$el.closest('.bootstrap-table');
+
+                if (!$tableWrapper.length) {
+                    return $();
+                }
+
+                var $container = $tableWrapper.children('.snipe-advanced-search-tags');
+
+                if (!$container.length) {
+                    $container = $('<div class="snipe-advanced-search-tags" style="margin: 8px 0;"></div>');
+
+                    if ($tableWrapper.children('.fixed-table-container').length) {
+                        $container.insertBefore($tableWrapper.children('.fixed-table-container').first());
+                    } else {
+                        $container.insertBefore(this.$el);
+                    }
+                }
+
+                return $container;
+            };
+
+            BootstrapTable.prototype.renderAdvancedSearchTags = function () {
+                var _this = this;
+                var $container = this.getAdvancedSearchTagsContainer();
+
+                if (!$container.length) {
+                    return;
+                }
+
+                var filters = $.isEmptyObject(this.filterColumnsPartial || {}) ? null : this.filterColumnsPartial;
+
+                if (!filters) {
+                    $container.empty().hide();
+                    return;
+                }
+
+                var operatorText = this.getAdvancedSearchOperator() === 'or' ? advancedSearchOrText : advancedSearchAndText;
+                var html = ['<div class="advanced-search-tag-list">'];
+
+                html.push('<span class="label label-default" style="margin-right: 6px; display: inline-block; margin-bottom: 6px;">' +
+                    escapeAdvancedSearchValue(advancedSearchOperatorLabel) + ': ' + escapeAdvancedSearchValue(operatorText) + '</span>');
+
+                $.each(filters, function (fieldName, fieldValue) {
+                    html.push('<span class="label label-primary" style="margin-right: 6px; display: inline-block; margin-bottom: 6px;">' +
+                        '<strong>' + escapeAdvancedSearchValue(_this.getAdvancedSearchFieldTitle(fieldName)) + ':</strong> ' +
+                        escapeAdvancedSearchValue(fieldValue) +
+                        ' <a href="javascript:void(0)" class="snipe-advanced-search-tag-remove" data-field="' +
+                        escapeAdvancedSearchValue(fieldName) +
+                        '" style="color: #fff; margin-left: 6px; text-decoration: none;">&times;</a></span>');
+                });
+
+                html.push('</div>');
+
+                $container
+                    .html(html.join(''))
+                    .show()
+                    .off('click.snipeAdvancedSearchTags', '.snipe-advanced-search-tag-remove')
+                    .on('click.snipeAdvancedSearchTags', '.snipe-advanced-search-tag-remove', function (event) {
+                        event.preventDefault();
+
+                        var fieldName = $(this).data('field');
+
+                        if (!fieldName || !_this.filterColumnsPartial || _this.filterColumnsPartial[fieldName] == null) {
+                            return;
+                        }
+
+                        delete _this.filterColumnsPartial[fieldName];
+
+                        _this.options.pageNumber = 1;
+                        _this.initSearch();
+                        _this.updatePagination();
+                        _this.trigger('column-advanced-search', _this.filterColumnsPartial, _this.getAdvancedSearchOperator());
+                        _this.renderAdvancedSearchTags();
+                    });
+            };
+
             BootstrapTable.prototype.applyAdvancedSearch = function () {
                 var toolbarState = this.collectAdvancedSearchFormData();
 
@@ -123,6 +212,8 @@
                     this.updatePagination();
                     this.trigger('column-advanced-search', this.filterColumnsPartial, this.getAdvancedSearchOperator());
                 }
+
+                this.renderAdvancedSearchTags();
 
                 this.hideToolbarModal();
             };
@@ -524,6 +615,12 @@
                 }
 
             });
+
+            var bootstrapTableInstance = $(this).data('bootstrap.table');
+
+            if (bootstrapTableInstance && typeof bootstrapTableInstance.renderAdvancedSearchTags === 'function') {
+                bootstrapTableInstance.renderAdvancedSearchTags();
+            }
 
         });
 

--- a/tests/Feature/Search/SearchableTraitTest.php
+++ b/tests/Feature/Search/SearchableTraitTest.php
@@ -711,4 +711,106 @@ class SearchableTraitTest extends TestCase
             ->assertOk()
             ->assertJson(fn (AssertableJson $json) => $json->has('rows', 1)->etc());
     }
+
+    /**
+     * Test negation filter using "!" prefix on a direct attribute.
+     * filter={"name":"!Dell"} should return all assets whose name does NOT contain "Dell".
+     */
+    public function test_negation_filter_with_bang_prefix_on_attribute()
+    {
+        Asset::factory()->create(['name' => 'MacBook Pro', 'asset_tag' => 'NEG-001']);
+        Asset::factory()->create(['name' => 'Dell XPS 13', 'asset_tag' => 'NEG-002']);
+        Asset::factory()->create(['name' => 'HP Pavilion', 'asset_tag' => 'NEG-003']);
+
+        $this->actingAsForApi(User::factory()->viewAssets()->create())
+            ->getJson(route('api.assets.index', [
+                'filter' => json_encode(['name' => '!Dell']),
+            ]))
+            ->assertOk()
+            ->assertJson(fn (AssertableJson $json) => $json->has('rows', 2)->etc());
+    }
+
+    /**
+     * Test negation filter using "not:" prefix on a direct attribute.
+     * filter={"name":"not:Dell"} should behave identically to "!Dell".
+     */
+    public function test_negation_filter_with_not_prefix_on_attribute()
+    {
+        Asset::factory()->create(['name' => 'MacBook Pro', 'asset_tag' => 'NOTP-001']);
+        Asset::factory()->create(['name' => 'Dell XPS 13', 'asset_tag' => 'NOTP-002']);
+        Asset::factory()->create(['name' => 'HP Pavilion', 'asset_tag' => 'NOTP-003']);
+
+        $this->actingAsForApi(User::factory()->viewAssets()->create())
+            ->getJson(route('api.assets.index', [
+                'filter' => json_encode(['name' => 'not:Dell']),
+            ]))
+            ->assertOk()
+            ->assertJson(fn (AssertableJson $json) => $json->has('rows', 2)->etc());
+    }
+
+    /**
+     * Test that combining a positive filter and a negation filter works correctly.
+     * filter={"asset_tag":"COMBO","name":"!Dell"} should return assets tagged COMBO that
+     * are NOT named Dell.
+     */
+    public function test_combined_positive_and_negation_filters()
+    {
+        Asset::factory()->create(['name' => 'MacBook Pro', 'asset_tag' => 'COMBO-001']);
+        Asset::factory()->create(['name' => 'Dell XPS 13', 'asset_tag' => 'COMBO-002']);
+        Asset::factory()->create(['name' => 'HP Pavilion',  'asset_tag' => 'OTHER-001']);
+
+        $this->actingAsForApi(User::factory()->viewAssets()->create())
+            ->getJson(route('api.assets.index', [
+                'filter' => json_encode(['asset_tag' => 'COMBO', 'name' => '!Dell']),
+            ]))
+            ->assertOk()
+            ->assertJson(fn (AssertableJson $json) => $json->has('rows', 1)->etc());
+    }
+
+    /**
+     * Test negation filter on a relation attribute.
+     * filter={"manufacturer":"!Apple"} should return assets whose manufacturer does NOT
+     * contain "Apple".
+     */
+    public function test_negation_filter_on_relation()
+    {
+        $apple = Manufacturer::factory()->create(['name' => 'Apple']);
+        $dell  = Manufacturer::factory()->create(['name' => 'Dell']);
+
+        $appleModel = AssetModel::factory()->create(['manufacturer_id' => $apple->id]);
+        $dellModel  = AssetModel::factory()->create(['manufacturer_id' => $dell->id]);
+
+        Asset::factory()->create(['model_id' => $appleModel->id, 'asset_tag' => 'REL-001']);
+        Asset::factory()->create(['model_id' => $dellModel->id,  'asset_tag' => 'REL-002']);
+
+        $this->actingAsForApi(User::factory()->viewAssets()->create())
+            ->getJson(route('api.assets.index', [
+                'filter' => json_encode(['manufacturer' => '!Apple']),
+            ]))
+            ->assertOk()
+            ->assertJson(fn (AssertableJson $json) => $json->has('rows', 1)->etc());
+    }
+
+    /**
+     * Test negation filter on a custom field.
+     * filter={"_snipeit_cpu_X":"!Intel"} should return assets where the CPU field
+     * does NOT contain "Intel".
+     */
+    public function test_negation_filter_on_custom_field()
+    {
+        $field    = CustomField::factory()->cpu()->create();
+        $dbColumn = $field->db_column_name();
+
+        Asset::factory()->create([$dbColumn => '3.2GHz Intel Core i9', 'asset_tag' => 'CF-001']);
+        Asset::factory()->create([$dbColumn => '2.4GHz AMD Ryzen 7',   'asset_tag' => 'CF-002']);
+
+        Asset::flushCustomFieldFilterMap();
+
+        $this->actingAsForApi(User::factory()->viewAssets()->create())
+            ->getJson(route('api.assets.index', [
+                'filter' => json_encode([$dbColumn => '!Intel']),
+            ]))
+            ->assertOk()
+            ->assertJson(fn (AssertableJson $json) => $json->has('rows', 1)->etc());
+    }
 }

--- a/tests/Feature/Search/SearchableTraitTest.php
+++ b/tests/Feature/Search/SearchableTraitTest.php
@@ -775,10 +775,10 @@ class SearchableTraitTest extends TestCase
     public function test_negation_filter_on_relation()
     {
         $apple = Manufacturer::factory()->create(['name' => 'Apple']);
-        $dell  = Manufacturer::factory()->create(['name' => 'Dell']);
+        $dell = Manufacturer::factory()->create(['name' => 'Dell']);
 
         $appleModel = AssetModel::factory()->create(['manufacturer_id' => $apple->id]);
-        $dellModel  = AssetModel::factory()->create(['manufacturer_id' => $dell->id]);
+        $dellModel = AssetModel::factory()->create(['manufacturer_id' => $dell->id]);
 
         Asset::factory()->create(['model_id' => $appleModel->id, 'asset_tag' => 'REL-001']);
         Asset::factory()->create(['model_id' => $dellModel->id,  'asset_tag' => 'REL-002']);
@@ -798,7 +798,7 @@ class SearchableTraitTest extends TestCase
      */
     public function test_negation_filter_on_custom_field()
     {
-        $field    = CustomField::factory()->cpu()->create();
+        $field = CustomField::factory()->cpu()->create();
         $dbColumn = $field->db_column_name();
 
         Asset::factory()->create([$dbColumn => '3.2GHz Intel Core i9', 'asset_tag' => 'CF-001']);

--- a/tests/Feature/Search/SearchableTraitTest.php
+++ b/tests/Feature/Search/SearchableTraitTest.php
@@ -333,6 +333,71 @@ class SearchableTraitTest extends TestCase
     }
 
     /**
+     * "name" is a virtual column on User (CONCAT of first_name + last_name).
+     * A positive filter should match on concatenated full name.
+     */
+    public function test_user_name_virtual_column_filter_positive()
+    {
+        $ts = now()->timestamp;
+        User::factory()->create(['first_name' => 'VirtFirst'.$ts, 'last_name' => 'VirtLast'.$ts]);
+        User::factory()->create(['first_name' => 'Other'.$ts, 'last_name' => 'Person'.$ts]);
+
+        $this->actingAsForApi(User::factory()->superuser()->create())
+            ->getJson(route('api.users.index', [
+                'filter' => json_encode(['name' => 'VirtFirst'.$ts]),
+            ]))
+            ->assertOk()
+            ->assertJson(fn (AssertableJson $json) => $json->has('rows', 1)->etc());
+    }
+
+    /**
+     * A negated "name" filter using the "!" prefix should exclude matching users,
+     * returning only those whose full name does NOT contain the term.
+     */
+    public function test_user_name_virtual_column_filter_negation_bang_prefix()
+    {
+        $ts = now()->timestamp;
+        $negUser  = User::factory()->create(['first_name' => 'NegFirst'.$ts,  'last_name' => 'NegLast'.$ts]);
+        $safeUser = User::factory()->create(['first_name' => 'SafeFirst'.$ts, 'last_name' => 'SafeLast'.$ts]);
+
+        $response = $this->actingAsForApi(User::factory()->superuser()->create())
+            ->getJson(route('api.users.index', [
+                'filter' => json_encode(['name' => '!NegFirst'.$ts]),
+            ]))
+            ->assertOk();
+
+        $returnedIds = collect($response->json('rows'))->pluck('id')->map(fn ($id) => (int) $id)->all();
+
+        // The matched (negated) user must not appear in results.
+        $this->assertNotContains((int) $negUser->id, $returnedIds);
+
+        // The safe user should appear in results.
+        $this->assertContains((int) $safeUser->id, $returnedIds);
+    }
+
+    /**
+     * A negated "name" filter using the "not:" prefix should behave identically to "!".
+     */
+    public function test_user_name_virtual_column_filter_negation_not_colon_prefix()
+    {
+        $ts = now()->timestamp;
+        User::factory()->create(['first_name' => 'NotFirst'.$ts, 'last_name' => 'NotLast'.$ts]);
+
+        $response = $this->actingAsForApi(User::factory()->superuser()->create())
+            ->getJson(route('api.users.index', [
+                'filter' => json_encode(['name' => 'not:NotFirst'.$ts]),
+            ]))
+            ->assertOk();
+
+        $returnedIds = collect($response->json('rows'))->pluck('id')->map(fn ($id) => (int) $id)->all();
+
+        $this->assertNotContains(
+            (int) User::where('first_name', 'NotFirst'.$ts)->value('id'),
+            $returnedIds
+        );
+    }
+
+    /**
      * Test Category free-text search on attributes
      */
     public function test_category_free_text_search_on_attributes()
@@ -691,6 +756,106 @@ class SearchableTraitTest extends TestCase
     }
 
     /**
+     * "is:null" on a direct nullable attribute should match rows where that column is NULL.
+     * "is:not_null" should match rows where it is not NULL.
+     */
+    public function test_is_null_filter_on_nullable_attribute()
+    {
+        $ts = now()->timestamp;
+
+        $withNotes    = Asset::factory()->create(['notes' => 'Some notes '.$ts]);
+        $withoutNotes = Asset::factory()->create(['notes' => null]);
+
+        $superuser = User::factory()->viewAssets()->create();
+
+        // is:null → only the asset with no notes
+        $response = $this->actingAsForApi($superuser)
+            ->getJson(route('api.assets.index', ['filter' => json_encode(['notes' => 'is:null'])]))
+            ->assertOk();
+
+        $returnedIds = collect($response->json('rows'))->pluck('id')->map(fn ($id) => (int) $id)->all();
+
+        $this->assertContains((int) $withoutNotes->id, $returnedIds);
+        $this->assertNotContains((int) $withNotes->id, $returnedIds);
+
+        // is:not_null → only the asset with notes
+        $response2 = $this->actingAsForApi($superuser)
+            ->getJson(route('api.assets.index', ['filter' => json_encode(['notes' => 'is:not_null'])]))
+            ->assertOk();
+
+        $returnedIds2 = collect($response2->json('rows'))->pluck('id')->map(fn ($id) => (int) $id)->all();
+
+        $this->assertContains((int) $withNotes->id, $returnedIds2);
+        $this->assertNotContains((int) $withoutNotes->id, $returnedIds2);
+    }
+
+    /**
+     * "is:not_null" on the User virtual "name" column should match users where
+     * at least one constituent column (first_name, last_name) is not null.
+     * All factory-created users have a first_name, so they should all appear.
+     */
+    public function test_is_null_filter_on_virtual_name_column()
+    {
+        $ts = now()->timestamp;
+
+        $userWithName = User::factory()->create([
+            'first_name' => 'VirtNullFirst'.$ts,
+            'last_name'  => 'VirtNullLast'.$ts,
+        ]);
+
+        $superuser = User::factory()->superuser()->create();
+
+        // is:not_null → users with at least first_name set should be returned.
+        $response = $this->actingAsForApi($superuser)
+            ->getJson(route('api.users.index', ['filter' => json_encode(['name' => 'is:not_null'])]))
+            ->assertOk();
+
+        $returnedIds = collect($response->json('rows'))->pluck('id')->map(fn ($id) => (int) $id)->all();
+
+        // The user with an actual name must appear.
+        $this->assertContains((int) $userWithName->id, $returnedIds);
+
+        // The acting superuser itself also has a name, so it should appear too.
+        $this->assertContains((int) $superuser->id, $returnedIds);
+    }
+
+    /**
+     * "is:null" on a searchable relation key should return records that have no
+     * related record (equivalent to doesntHave).
+     * "is:not_null" should return only records that have a related record.
+     */
+    public function test_is_null_filter_on_relation_key()
+    {
+        $ts = now()->timestamp;
+
+        $supplier    = \App\Models\Supplier::factory()->create(['name' => 'RelNullSupplier'.$ts]);
+        $withSupplier    = Asset::factory()->create(['supplier_id' => $supplier->id]);
+        $withoutSupplier = Asset::factory()->create(['supplier_id' => null]);
+
+        $superuser = User::factory()->viewAssets()->create();
+
+        // is:null on supplier → assets with no supplier
+        $response = $this->actingAsForApi($superuser)
+            ->getJson(route('api.assets.index', ['filter' => json_encode(['supplier' => 'is:null'])]))
+            ->assertOk();
+
+        $returnedIds = collect($response->json('rows'))->pluck('id')->map(fn ($id) => (int) $id)->all();
+
+        $this->assertContains((int) $withoutSupplier->id, $returnedIds);
+        $this->assertNotContains((int) $withSupplier->id, $returnedIds);
+
+        // is:not_null on supplier → assets with a supplier
+        $response2 = $this->actingAsForApi($superuser)
+            ->getJson(route('api.assets.index', ['filter' => json_encode(['supplier' => 'is:not_null'])]))
+            ->assertOk();
+
+        $returnedIds2 = collect($response2->json('rows'))->pluck('id')->map(fn ($id) => (int) $id)->all();
+
+        $this->assertContains((int) $withSupplier->id, $returnedIds2);
+        $this->assertNotContains((int) $withoutSupplier->id, $returnedIds2);
+    }
+
+    /**
      * Test custom field partial match via filter.
      */
     public function test_custom_field_filter_partial_match()
@@ -710,6 +875,104 @@ class SearchableTraitTest extends TestCase
             ]))
             ->assertOk()
             ->assertJson(fn (AssertableJson $json) => $json->has('rows', 1)->etc());
+    }
+
+    /**
+     * "is:{value}" on a direct attribute should match records where the column equals
+     * the value exactly — no partial/wildcard matching.
+     */
+    public function test_exact_match_filter_on_direct_attribute()
+    {
+        $ts = now()->timestamp;
+
+        $exact  = Asset::factory()->create(['notes' => 'ExactNote'.$ts]);
+        $partial = Asset::factory()->create(['notes' => 'ExactNote'.$ts.'SomeSuffix']);
+        Asset::factory()->create(['notes' => 'Unrelated'.$ts]);
+
+        $superuser = User::factory()->viewAssets()->create();
+
+        // is:ExactNote{ts} should only return the exact match, not the partial one.
+        $response = $this->actingAsForApi($superuser)
+            ->getJson(route('api.assets.index', ['filter' => json_encode(['notes' => 'is:ExactNote'.$ts])]))
+            ->assertOk();
+
+        $returnedIds = collect($response->json('rows'))->pluck('id')->map(fn ($id) => (int) $id)->all();
+
+        $this->assertContains((int) $exact->id, $returnedIds);
+        $this->assertNotContains((int) $partial->id, $returnedIds);
+    }
+
+    /**
+     * "is:{value}" on a relation key should match records where the related model's
+     * column equals the value exactly.
+     */
+    public function test_exact_match_filter_on_relation()
+    {
+        $ts = now()->timestamp;
+
+        $exactSupplier   = \App\Models\Supplier::factory()->create(['name' => 'ExactSupplier'.$ts]);
+        $partialSupplier = \App\Models\Supplier::factory()->create(['name' => 'ExactSupplier'.$ts.'Extra']);
+
+        $exactAsset   = Asset::factory()->create(['supplier_id' => $exactSupplier->id]);
+        $partialAsset = Asset::factory()->create(['supplier_id' => $partialSupplier->id]);
+
+        $superuser = User::factory()->viewAssets()->create();
+
+        $response = $this->actingAsForApi($superuser)
+            ->getJson(route('api.assets.index', [
+                'filter' => json_encode(['supplier' => 'is:ExactSupplier'.$ts]),
+            ]))
+            ->assertOk();
+
+        $returnedIds = collect($response->json('rows'))->pluck('id')->map(fn ($id) => (int) $id)->all();
+
+        $this->assertContains((int) $exactAsset->id, $returnedIds);
+        $this->assertNotContains((int) $partialAsset->id, $returnedIds);
+    }
+
+    /**
+     * "is:{value}" on the User virtual "name" column should match only users whose
+     * CONCAT(first_name, ' ', last_name) equals the value exactly.
+     */
+    public function test_exact_match_filter_on_virtual_name_column()
+    {
+        $ts = now()->timestamp;
+
+        $exactUser   = User::factory()->create(['first_name' => 'John'.$ts, 'last_name' => 'Smith'.$ts]);
+        $partialUser = User::factory()->create(['first_name' => 'John'.$ts, 'last_name' => 'Smithson'.$ts]);
+
+        $response = $this->actingAsForApi(User::factory()->superuser()->create())
+            ->getJson(route('api.users.index', [
+                'filter' => json_encode(['name' => 'is:John'.$ts.' Smith'.$ts]),
+            ]))
+            ->assertOk();
+
+        $returnedIds = collect($response->json('rows'))->pluck('id')->map(fn ($id) => (int) $id)->all();
+
+        $this->assertContains((int) $exactUser->id, $returnedIds);
+        $this->assertNotContains((int) $partialUser->id, $returnedIds);
+    }
+
+    /**
+     * Confirm that the reserved "is:null" and "is:not_null" tokens are still honoured
+     * as null checks even after adding generic "is:{value}" exact-match support.
+     */
+    public function test_is_null_tokens_still_work_after_exact_match_addition()
+    {
+        $withNotes    = Asset::factory()->create(['notes' => 'SomeValue'.now()->timestamp]);
+        $withoutNotes = Asset::factory()->create(['notes' => null]);
+
+        $superuser = User::factory()->viewAssets()->create();
+
+        // is:null should still mean IS NULL, not exact match on the string "null".
+        $response = $this->actingAsForApi($superuser)
+            ->getJson(route('api.assets.index', ['filter' => json_encode(['notes' => 'is:null'])]))
+            ->assertOk();
+
+        $returnedIds = collect($response->json('rows'))->pluck('id')->map(fn ($id) => (int) $id)->all();
+
+        $this->assertContains((int) $withoutNotes->id, $returnedIds);
+        $this->assertNotContains((int) $withNotes->id, $returnedIds);
     }
 
     /**

--- a/tests/Feature/Search/SearchableTraitTest.php
+++ b/tests/Feature/Search/SearchableTraitTest.php
@@ -357,7 +357,7 @@ class SearchableTraitTest extends TestCase
     public function test_user_name_virtual_column_filter_negation_bang_prefix()
     {
         $ts = now()->timestamp;
-        $negUser  = User::factory()->create(['first_name' => 'NegFirst'.$ts,  'last_name' => 'NegLast'.$ts]);
+        $negUser = User::factory()->create(['first_name' => 'NegFirst'.$ts,  'last_name' => 'NegLast'.$ts]);
         $safeUser = User::factory()->create(['first_name' => 'SafeFirst'.$ts, 'last_name' => 'SafeLast'.$ts]);
 
         $response = $this->actingAsForApi(User::factory()->superuser()->create())
@@ -763,7 +763,7 @@ class SearchableTraitTest extends TestCase
     {
         $ts = now()->timestamp;
 
-        $withNotes    = Asset::factory()->create(['notes' => 'Some notes '.$ts]);
+        $withNotes = Asset::factory()->create(['notes' => 'Some notes '.$ts]);
         $withoutNotes = Asset::factory()->create(['notes' => null]);
 
         $superuser = User::factory()->viewAssets()->create();
@@ -800,7 +800,7 @@ class SearchableTraitTest extends TestCase
 
         $userWithName = User::factory()->create([
             'first_name' => 'VirtNullFirst'.$ts,
-            'last_name'  => 'VirtNullLast'.$ts,
+            'last_name' => 'VirtNullLast'.$ts,
         ]);
 
         $superuser = User::factory()->superuser()->create();
@@ -828,8 +828,8 @@ class SearchableTraitTest extends TestCase
     {
         $ts = now()->timestamp;
 
-        $supplier    = \App\Models\Supplier::factory()->create(['name' => 'RelNullSupplier'.$ts]);
-        $withSupplier    = Asset::factory()->create(['supplier_id' => $supplier->id]);
+        $supplier = Supplier::factory()->create(['name' => 'RelNullSupplier'.$ts]);
+        $withSupplier = Asset::factory()->create(['supplier_id' => $supplier->id]);
         $withoutSupplier = Asset::factory()->create(['supplier_id' => null]);
 
         $superuser = User::factory()->viewAssets()->create();
@@ -885,7 +885,7 @@ class SearchableTraitTest extends TestCase
     {
         $ts = now()->timestamp;
 
-        $exact  = Asset::factory()->create(['notes' => 'ExactNote'.$ts]);
+        $exact = Asset::factory()->create(['notes' => 'ExactNote'.$ts]);
         $partial = Asset::factory()->create(['notes' => 'ExactNote'.$ts.'SomeSuffix']);
         Asset::factory()->create(['notes' => 'Unrelated'.$ts]);
 
@@ -910,10 +910,10 @@ class SearchableTraitTest extends TestCase
     {
         $ts = now()->timestamp;
 
-        $exactSupplier   = \App\Models\Supplier::factory()->create(['name' => 'ExactSupplier'.$ts]);
-        $partialSupplier = \App\Models\Supplier::factory()->create(['name' => 'ExactSupplier'.$ts.'Extra']);
+        $exactSupplier = Supplier::factory()->create(['name' => 'ExactSupplier'.$ts]);
+        $partialSupplier = Supplier::factory()->create(['name' => 'ExactSupplier'.$ts.'Extra']);
 
-        $exactAsset   = Asset::factory()->create(['supplier_id' => $exactSupplier->id]);
+        $exactAsset = Asset::factory()->create(['supplier_id' => $exactSupplier->id]);
         $partialAsset = Asset::factory()->create(['supplier_id' => $partialSupplier->id]);
 
         $superuser = User::factory()->viewAssets()->create();
@@ -938,7 +938,7 @@ class SearchableTraitTest extends TestCase
     {
         $ts = now()->timestamp;
 
-        $exactUser   = User::factory()->create(['first_name' => 'John'.$ts, 'last_name' => 'Smith'.$ts]);
+        $exactUser = User::factory()->create(['first_name' => 'John'.$ts, 'last_name' => 'Smith'.$ts]);
         $partialUser = User::factory()->create(['first_name' => 'John'.$ts, 'last_name' => 'Smithson'.$ts]);
 
         $response = $this->actingAsForApi(User::factory()->superuser()->create())
@@ -959,7 +959,7 @@ class SearchableTraitTest extends TestCase
      */
     public function test_is_null_tokens_still_work_after_exact_match_addition()
     {
-        $withNotes    = Asset::factory()->create(['notes' => 'SomeValue'.now()->timestamp]);
+        $withNotes = Asset::factory()->create(['notes' => 'SomeValue'.now()->timestamp]);
         $withoutNotes = Asset::factory()->create(['notes' => null]);
 
         $superuser = User::factory()->viewAssets()->create();
@@ -1075,5 +1075,74 @@ class SearchableTraitTest extends TestCase
             ]))
             ->assertOk()
             ->assertJson(fn (AssertableJson $json) => $json->has('rows', 1)->etc());
+    }
+
+    /**
+     * Negation filter "!blah" on the "location" relation key for Assets
+     * should exclude assets with a location name containing "blah".
+     */
+    public function test_negation_filter_on_asset_location_relation()
+    {
+        $ts = now()->timestamp;
+
+        $blahLocation = Location::factory()->create(['name' => 'Blah Office '.$ts]);
+        $safeLocation = Location::factory()->create(['name' => 'Safe Office '.$ts]);
+
+        $blahAsset = Asset::factory()->create(['location_id' => $blahLocation->id]);
+        $safeAsset = Asset::factory()->create(['location_id' => $safeLocation->id]);
+
+        $response = $this->actingAsForApi(User::factory()->viewAssets()->create())
+            ->getJson(route('api.assets.index', [
+                'filter' => json_encode(['location' => '!Blah']),
+            ]))
+            ->assertOk();
+
+        $returnedIds = collect($response->json('rows'))->pluck('id')->map(fn ($id) => (int) $id)->all();
+
+        // Asset in the "blah" location must NOT appear.
+        $this->assertNotContains((int) $blahAsset->id, $returnedIds);
+        // Asset in a different location MUST appear.
+        $this->assertContains((int) $safeAsset->id, $returnedIds);
+    }
+
+    /**
+     * Negation filter "!blah" on the "location" relation key for Users
+     * should exclude users whose location name contains "blah".
+     *
+     * The User model stores location via the "userloc" Eloquent relation
+     * (not "location"), so a "location" → "userloc" alias must be registered.
+     */
+    public function test_negation_filter_on_user_location_relation()
+    {
+        $ts = now()->timestamp;
+
+        $blahLocation = Location::factory()->create([
+            'name' => 'Blah Floor '.$ts,
+            'address' => 'Safe Address '.$ts,
+        ]);
+        $safeLocation = Location::factory()->create([
+            'name' => 'Safe Floor '.$ts,
+            // Regression guard: structured filter on "location" should not inspect address.
+            'address' => 'Blah Address '.$ts,
+        ]);
+
+        $blahUser = User::factory()->create(['location_id' => $blahLocation->id]);
+        $safeUser = User::factory()->create(['location_id' => $safeLocation->id]);
+        $nullLocationUser = User::factory()->create(['location_id' => null]);
+
+        $response = $this->actingAsForApi(User::factory()->superuser()->create())
+            ->getJson(route('api.users.index', [
+                'filter' => json_encode(['location' => '!Blah']),
+            ]))
+            ->assertOk();
+
+        $returnedIds = collect($response->json('rows'))->pluck('id')->map(fn ($id) => (int) $id)->all();
+
+        // The user in the "blah" location must NOT appear.
+        $this->assertNotContains((int) $blahUser->id, $returnedIds);
+        // The user in a safe location MUST appear.
+        $this->assertContains((int) $safeUser->id, $returnedIds);
+        // Users with no location should also be included for negated filters.
+        $this->assertContains((int) $nullLocationUser->id, $returnedIds);
     }
 }


### PR DESCRIPTION
This is going to need some testing, but this adds a bunch of small (or maybe kinda big?) improvements to the advanced search. We've been using the out-of-the-box bootstrap-tables advanced search, which is clunky at best. Like, it works, but it's not very flexible and the UI was pretty awful.

This PR adds:

- tags that show what you've searched on on top of the results
- a highlighted advanced search button that shows that there is an active advanced search going on
- a "not" operator that lets you *exclude* values from your search results <-- this one is very exciting for the API-users out there
- a "clear search" button that clears all of the form values
- better text on the search button to show that it's actually performing a search (versus the "close" button we had before, which, wtf?)


<img width="1439" height="835" alt="Screenshot 2026-05-05 at 1 00 58 PM" src="https://github.com/user-attachments/assets/b4bd9036-e5c7-4f4c-85fe-8db2a770fe1e" />

<img width="1443" height="847" alt="Screenshot 2026-05-05 at 12 57 28 PM" src="https://github.com/user-attachments/assets/03d17eb6-6e23-44e2-a52d-a8c6dd2f315f" />


https://github.com/user-attachments/assets/84746efb-2622-4fde-8fbb-93a98078362d

I'll probably fiddle around with the display on this a bit, but I'm pretty happy with these improvements. 