### PR TITLE
Change capitalization on SCIMUser; Linux filenames are case-sensitive

### DIFF
--- a/app/Models/SnipeSCIMConfig.php
+++ b/app/Models/SnipeSCIMConfig.php
@@ -132,7 +132,7 @@ class SnipeSCIMConfig
         return [
 
             // Set to 'null' to make use of auth.providers.users.model (App\User::class)
-            'class' => ScimUser::class,
+            'class' => SCIMUser::class,
             'singular' => 'User',
 
             // eager loading


### PR DESCRIPTION
What it says on the tin - my local handled `ScimUser` just fine, but on "normal" unixes, it needs to be `SCIMUser`.