### PR TITLE
Add new unique constraint and improved nonce-checking logic for SAML

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -106,15 +106,21 @@ class LoginController extends Controller
         if ($saml->isEnabled() && ! empty($samlData)) {
 
             try {
+
                 $user = $saml->samlLogin($samlData);
                 $notValidAfter = new \Carbon\Carbon(@$samlData['assertionNotOnOrAfter']);
                 if (\Carbon::now()->greaterThanOrEqualTo($notValidAfter)) {
                     abort(400, 'Expired SAML Assertion');
                 }
-                if (SamlNonce::where('nonce', @$samlData['nonce'])->count() > 0) {
-                    abort(400, 'Assertion has already been used');
+                try {
+                    SamlNonce::create([
+                        'nonce' => $samlData['nonce'],
+                        'not_valid_after' => $notValidAfter,
+                    ]);
+                } catch (\Exception $e) {
+                    \Log::error($e);
+                    abort(400, 'Assertion has already been used.');
                 }
-                Log::debug('okay, fine, this is a new nonce then. Good for you.');
                 if (! is_null($user)) {
                     Auth::login($user);
                 } else {
@@ -128,10 +134,6 @@ class LoginController extends Controller
                     $user->last_login = \Carbon::now();
                     $user->saveQuietly();
                 }
-                $s = new SamlNonce;
-                $s->nonce = @$samlData['nonce'];
-                $s->not_valid_after = $notValidAfter;
-                $s->save();
 
             } catch (\Exception $e) {
                 Log::debug('There was an error authenticating the SAML user: '.$e->getMessage());

--- a/database/migrations/2026_05_05_125206_add_unique_index_to_nonces.php
+++ b/database/migrations/2026_05_05_125206_add_unique_index_to_nonces.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('saml_nonces', function (Blueprint $table) {
+            $table->dropIndex(['nonce']);
+            $table->unique('nonce');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('saml_nonces', function (Blueprint $table) {
+            $table->dropUnique(['nonce']);
+            $table->index('nonce');
+        });
+    }
+};


### PR DESCRIPTION
There was a possible race-condition in the Nonce-checking code for SAML. You would have to try to use an assertion twice within a **very** miniscule timeframe, but it would've been possible to potentially use a nonce more than once, which is not what a nonce is supposed to do.

This adds a unique constraint, and changes the code to optimistically insert a record into the `saml_nonces` table, and on exception (probably from a duplicate key), it errors.