### PR TITLE
Throw 4xx SCIMExceptions when SCIM clients send bad data

### DIFF
--- a/app/Models/SnipeSCIMConfig.php
+++ b/app/Models/SnipeSCIMConfig.php
@@ -302,11 +302,11 @@ class SnipeSCIMConfig
                                 // addresses[type eq "work"]
                                 $matches = null;
                                 if (!preg_match('/^.+\[type eq "([a-zA-Z]+)"](?:\.([a-zA-Z]+))?$/', (string)$path, $matches)) {
-                                    throw new \Exception("Unknown path type '$path'");
+                                    throw new SCIMException("Unknown path type '$path'")->setCode(422);
                                 }
                                 $type = $matches[1];
                                 if ($type != 'work') {
-                                    throw new \Exception("Unknown object type '$type'");
+                                    throw new SCIMException("Unknown object type '$type'")->setCode(422);
                                 }
                                 $attribute = array_key_exists(2, $matches) ? $matches[2] : null;
                                 if (array_key_exists($attribute, self::$addressmap)) {
@@ -315,7 +315,7 @@ class SnipeSCIMConfig
                                 }
 
 
-                                throw new \Exception("path for update $path");
+                                throw new SCIMException("Could not handle path for update $path")->setCode(422);
                             }
                         }
 


### PR DESCRIPTION
We *mostly* tend to already throw SCIMExceptions when stuff shows up that we can't handle. But I had left a few spots where we throw a "normal" Exception in the SCIM Configuration, and we probably shouldn't. If you pass us a field we're not prepared to handle, we should say 422 - "Unprocessable Content" (formerly "Unprocessable Entity"). This should lighten the load on Rollbar a little bit, as well as help our customers out by giving them a reasonable error message when they mis-map something on the SCIM-side.