### PR TITLE
Improved test macros for streamed content

### DIFF
--- a/tests/Feature/Reporting/CustomReportTest.php
+++ b/tests/Feature/Reporting/CustomReportTest.php
@@ -88,30 +88,26 @@ class CustomReportTest extends TestCase implements TestsPermissionsRequirement
 
         $this->actingAs($superUser)
             ->post('reports/custom', ['asset_name' => '1', 'asset_tag' => '1', 'serial' => '1'])
-            ->assertSeeTextInStreamedResponse('Asset A')
-            ->assertSeeTextInStreamedResponse('Asset B');
+            ->assertSeeTextInStreamedResponse(['Asset A', 'Asset B']);
 
         $this->actingAs($userInCompanyA)
             ->post('reports/custom', ['asset_name' => '1', 'asset_tag' => '1', 'serial' => '1'])
-            ->assertSeeTextInStreamedResponse('Asset A')
-            ->assertSeeTextInStreamedResponse('Asset B');
+            ->assertSeeTextInStreamedResponse(['Asset A', 'Asset B']);
 
         $this->actingAs($userInCompanyB)
             ->post('reports/custom', ['asset_name' => '1', 'asset_tag' => '1', 'serial' => '1'])
-            ->assertSeeTextInStreamedResponse('Asset A')
-            ->assertSeeTextInStreamedResponse('Asset B');
+            ->assertSeeTextInStreamedResponse(['Asset A', 'Asset B']);
 
         $this->settings->enableMultipleFullCompanySupport();
 
         $this->actingAs($superUser)
             ->post('reports/custom', ['asset_name' => '1', 'asset_tag' => '1', 'serial' => '1'])
-            ->assertSeeTextInStreamedResponse('Asset A')
-            ->assertSeeTextInStreamedResponse('Asset B');
+            ->assertSeeTextInStreamedResponse(['Asset A', 'Asset B']);
 
         $this->actingAs($userInCompanyA)
             ->post('reports/custom', ['asset_name' => '1', 'asset_tag' => '1', 'serial' => '1'])
             ->assertSeeTextInStreamedResponse('Asset A')
-            ->assertDontSeeTextInStreamedResponse('Asset B');
+            ->assertDontSeeTextInStreamedResponse(['Asset B']);
 
         $this->actingAs($userInCompanyB)
             ->post('reports/custom', ['asset_name' => '1', 'asset_tag' => '1', 'serial' => '1'])

--- a/tests/Feature/Reporting/CustomReportTest.php
+++ b/tests/Feature/Reporting/CustomReportTest.php
@@ -9,9 +9,7 @@ use App\Models\ReportTemplate;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Crypt;
-use Illuminate\Testing\TestResponse;
 use League\Csv\Reader;
-use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\Group;
 use Tests\Concerns\TestsPermissionsRequirement;
 use Tests\TestCase;
@@ -19,37 +17,6 @@ use Tests\TestCase;
 #[Group('custom-reporting')]
 class CustomReportTest extends TestCase implements TestsPermissionsRequirement
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        TestResponse::macro(
-            'assertSeeTextInStreamedResponse',
-            function (string $needle) {
-                Assert::assertTrue(
-                    collect(Reader::createFromString($this->streamedContent())->getRecords())
-                        ->pluck(0)
-                        ->contains($needle)
-                );
-
-                return $this;
-            }
-        );
-
-        TestResponse::macro(
-            'assertDontSeeTextInStreamedResponse',
-            function (string $needle) {
-                Assert::assertFalse(
-                    collect(Reader::createFromString($this->streamedContent())->getRecords())
-                        ->pluck(0)
-                        ->contains($needle)
-                );
-
-                return $this;
-            }
-        );
-    }
-
     public function test_requires_permission()
     {
         $this->actingAs(User::factory()->create())

--- a/tests/Feature/Reporting/UnacceptedAssetReportTest.php
+++ b/tests/Feature/Reporting/UnacceptedAssetReportTest.php
@@ -3,44 +3,10 @@
 namespace Tests\Feature\Reporting;
 
 use App\Models\User;
-use Illuminate\Testing\TestResponse;
-use League\Csv\Reader;
-use PHPUnit\Framework\Assert;
 use Tests\TestCase;
 
 class UnacceptedAssetReportTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        TestResponse::macro(
-            'assertSeeTextInStreamedResponse',
-            function (string $needle) {
-                Assert::assertTrue(
-                    collect(Reader::createFromString($this->streamedContent())->getRecords())
-                        ->pluck(0)
-                        ->contains($needle)
-                );
-
-                return $this;
-            }
-        );
-
-        TestResponse::macro(
-            'assertDontSeeTextInStreamedResponse',
-            function (string $needle) {
-                Assert::assertFalse(
-                    collect(Reader::createFromString($this->streamedContent())->getRecords())
-                        ->pluck(0)
-                        ->contains($needle)
-                );
-
-                return $this;
-            }
-        );
-    }
-
     public function test_permission_required_to_view_unaccepted_asset_report()
     {
         $this->actingAs(User::factory()->create())

--- a/tests/Support/CustomTestMacros.php
+++ b/tests/Support/CustomTestMacros.php
@@ -4,6 +4,7 @@ namespace Tests\Support;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Testing\TestResponse;
+use League\Csv\Reader;
 use PHPUnit\Framework\Assert;
 use RuntimeException;
 
@@ -144,6 +145,32 @@ trait CustomTestMacros
                         "Response messages did not contain the key: {$key}"
                     );
                 }
+
+                return $this;
+            }
+        );
+
+        TestResponse::macro(
+            'assertSeeTextInStreamedResponse',
+            function (string $needle) {
+                Assert::assertTrue(
+                    collect(Reader::createFromString($this->streamedContent())->getRecords())
+                        ->pluck(0)
+                        ->contains($needle)
+                );
+
+                return $this;
+            }
+        );
+
+        TestResponse::macro(
+            'assertDontSeeTextInStreamedResponse',
+            function (string $needle) {
+                Assert::assertFalse(
+                    collect(Reader::createFromString($this->streamedContent())->getRecords())
+                        ->pluck(0)
+                        ->contains($needle)
+                );
 
                 return $this;
             }

--- a/tests/Support/CustomTestMacros.php
+++ b/tests/Support/CustomTestMacros.php
@@ -155,7 +155,7 @@ trait CustomTestMacros
             function (string $needle) {
                 Assert::assertTrue(
                     collect(Reader::createFromString($this->streamedContent())->getRecords())
-                        ->pluck(0)
+                        ->flatten()
                         ->contains($needle)
                 );
 
@@ -168,7 +168,7 @@ trait CustomTestMacros
             function (string $needle) {
                 Assert::assertFalse(
                     collect(Reader::createFromString($this->streamedContent())->getRecords())
-                        ->pluck(0)
+                        ->flatten()
                         ->contains($needle)
                 );
 

--- a/tests/Support/CustomTestMacros.php
+++ b/tests/Support/CustomTestMacros.php
@@ -152,12 +152,18 @@ trait CustomTestMacros
 
         TestResponse::macro(
             'assertSeeTextInStreamedResponse',
-            function (string $needle) {
-                Assert::assertTrue(
-                    collect(Reader::createFromString($this->streamedContent())->getRecords())
-                        ->flatten()
-                        ->contains($needle)
-                );
+            function (array|string $needles): self {
+                if (! is_array($needles)) {
+                    $needles = [$needles];
+                }
+
+                $records = collect(Reader::createFromString($this->streamedContent())->getRecords())->flatten();
+
+                foreach ($needles as $needle) {
+                    Assert::assertTrue(
+                        $records->contains($needle)
+                    );
+                }
 
                 return $this;
             }
@@ -165,12 +171,18 @@ trait CustomTestMacros
 
         TestResponse::macro(
             'assertDontSeeTextInStreamedResponse',
-            function (string $needle) {
-                Assert::assertFalse(
-                    collect(Reader::createFromString($this->streamedContent())->getRecords())
-                        ->flatten()
-                        ->contains($needle)
-                );
+            function (array|string $needles): self {
+                if (! is_array($needles)) {
+                    $needles = [$needles];
+                }
+
+                $records = collect(Reader::createFromString($this->streamedContent())->getRecords())->flatten();
+
+                foreach ($needles as $needle) {
+                    Assert::assertFalse(
+                        $records->contains($needle)
+                    );
+                }
 
                 return $this;
             }


### PR DESCRIPTION
This PR fixes and improves test macros for assertions on streamed content.

`assertSeeTextInStreamedResponse` and `assertDontSeeTextInStreamedResponse` now look at the entire response content instead of only the first column as well as allowing an array to be passed as well.

It's mainly set up for the reporting work I'm currently doing.




