### PR TITLE
Allow custom report to filter on assigned/unassigned

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -798,6 +798,14 @@ class ReportsController extends Controller
                 $assets->onlyTrashed();
             }
 
+            if ($request->input('assignment_status') === 'assigned') {
+                $assets->whereNotNull('assets.assigned_to');
+            }
+
+            if ($request->input('assignment_status') === 'unassigned') {
+                $assets->whereNull('assets.assigned_to');
+            }
+
             $assets->orderBy('assets.id', 'ASC')->chunk(500, function ($assets) use ($handle, $customfields, $request) {
 
                 $executionTime = microtime(true) - $_SERVER['REQUEST_TIME_FLOAT'];

--- a/app/Http/Requests/CustomAssetReportRequest.php
+++ b/app/Http/Requests/CustomAssetReportRequest.php
@@ -29,6 +29,7 @@ class CustomAssetReportRequest extends Request
     public function rules()
     {
         return [
+            'assignment_status' => 'nullable|in:all,assigned,unassigned',
             'purchase_start' => 'date|date_format:Y-m-d|nullable',
             'purchase_end' => 'date|date_format:Y-m-d|nullable',
             'purchase_cost_end' => 'numeric|nullable|gte:purchase_cost_start',

--- a/resources/views/reports/custom.blade.php
+++ b/resources/views/reports/custom.blade.php
@@ -632,6 +632,42 @@
               <div class="col-md-9 col-md-offset-3">
                   <label class="form-control">
                       <input
+                          name="assignment_status"
+                          id="assignment_status_all"
+                          type="radio"
+                          value="all"
+                          @checked($template->radioValue('assignment_status', 'all', true))
+                          aria-label="assignment_status"
+                      >
+                      {{ trans('general.all') }} {{ trans('general.assigned') }} / {{ trans('general.unassigned') }}
+                  </label>
+                  <label class="form-control">
+                      <input
+                          name="assignment_status"
+                          id="assignment_status_assigned"
+                          type="radio"
+                          value="assigned"
+                          @checked($template->radioValue('assignment_status', 'assigned'))
+                          aria-label="assignment_status"
+                      >
+                      {{ trans('general.assigned') }}
+                  </label>
+                  <label class="form-control">
+                      <input
+                          name="assignment_status"
+                          id="assignment_status_unassigned"
+                          type="radio"
+                          value="unassigned"
+                          @checked($template->radioValue('assignment_status', 'unassigned'))
+                          aria-label="assignment_status"
+                      >
+                      {{ trans('general.unassigned') }}
+                  </label>
+              </div>
+
+              <div class="col-md-9 col-md-offset-3">
+                  <label class="form-control">
+                      <input
                           name="deleted_assets"
                           id="deleted_assets_exclude_deleted"
                           type="radio"

--- a/tests/Feature/Reporting/CustomReportTest.php
+++ b/tests/Feature/Reporting/CustomReportTest.php
@@ -177,6 +177,36 @@ class CustomReportTest extends TestCase implements TestsPermissionsRequirement
             ->assertDontSeeTextInStreamedResponse('Asset E');
     }
 
+    public function test_can_limit_custom_report_to_assigned_assets(): void
+    {
+        Asset::factory()->assignedToUser()->create(['name' => 'Assigned Asset']);
+        Asset::factory()->create(['name' => 'Unassigned Asset']);
+
+        $this->actingAs(User::factory()->canViewReports()->create())
+            ->post('reports/custom', [
+                'asset_name' => '1',
+                'assignment_status' => 'assigned',
+            ])
+            ->assertOk()
+            ->assertSeeTextInStreamedResponse('Assigned Asset')
+            ->assertDontSeeTextInStreamedResponse('Unassigned Asset');
+    }
+
+    public function test_can_limit_custom_report_to_unassigned_assets(): void
+    {
+        Asset::factory()->assignedToUser()->create(['name' => 'Assigned Asset']);
+        Asset::factory()->create(['name' => 'Unassigned Asset']);
+
+        $this->actingAs(User::factory()->canViewReports()->create())
+            ->post('reports/custom', [
+                'asset_name' => '1',
+                'assignment_status' => 'unassigned',
+            ])
+            ->assertOk()
+            ->assertDontSeeTextInStreamedResponse('Assigned Asset')
+            ->assertSeeTextInStreamedResponse('Unassigned Asset');
+    }
+
     public function test_custom_report_decrypts_encrypted_custom_fields_when_user_has_permission(): void
     {
         $customField = CustomField::factory()->encrypt()->create();


### PR DESCRIPTION
This just adds a radio button to the custom report that allows you to filter by only assigned or unassigned