### PR TITLE
Fixed #18905 - update location of child assets if parent asset is checked in

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -1067,6 +1067,12 @@ class AssetsController extends Controller
             });
 
         if ($asset->save()) {
+
+            // Update the location of any child assets
+            Asset::where('assigned_type', Asset::class)
+                ->where('assigned_to', $asset->id)
+                ->update(['location_id' => $asset->location_id]);
+
             event(new CheckoutableCheckedIn($asset, $target, auth()->user(), $request->input('note'), $checkin_at, $originalValues));
 
             return response()->json(Helper::formatStandardApiResponse('success', [

--- a/app/Http/Controllers/Assets/AssetCheckinController.php
+++ b/app/Http/Controllers/Assets/AssetCheckinController.php
@@ -175,6 +175,10 @@ class AssetCheckinController extends Controller
         $asset->customFieldsForCheckinCheckout('display_checkin');
 
         if ($asset->save()) {
+            // Update the location of any child assets
+            Asset::where('assigned_type', Asset::class)
+                ->where('assigned_to', $asset->id)
+                ->update(['location_id' => $asset->location_id]);
 
             event(new CheckoutableCheckedIn($asset, $target, auth()->user(), $request->input('note'), $checkin_at, $originalValues));
 

--- a/tests/Feature/Checkins/Api/AssetCheckinTest.php
+++ b/tests/Feature/Checkins/Api/AssetCheckinTest.php
@@ -120,6 +120,35 @@ class AssetCheckinTest extends TestCase
         $this->assertNull($asset->refresh()->licenseseats->first()->assigned_to);
     }
 
+    public function test_checking_in_asset_updates_location_of_assets_assigned_to_it()
+    {
+        $originalLocation = Location::factory()->create();
+        $checkedOutLocation = Location::factory()->create();
+
+        $parentAsset = Asset::factory()->assignedToLocation($checkedOutLocation)->create([
+            'location_id' => $checkedOutLocation->id,
+            'rtd_location_id' => $originalLocation->id,
+        ]);
+
+        $childAsset = Asset::factory()->create([
+            'assigned_to' => $parentAsset->id,
+            'assigned_type' => Asset::class,
+            'location_id' => $checkedOutLocation->id,
+            'rtd_location_id' => $originalLocation->id,
+        ]);
+
+        $this->actingAsForApi(User::factory()->checkinAssets()->create())
+            ->postJson(route('api.asset.checkin', $parentAsset), [
+                'location_id' => $originalLocation->id,
+            ])
+            ->assertOk();
+
+        $this->assertEquals($originalLocation->id, $parentAsset->fresh()->location_id);
+        $this->assertEquals($originalLocation->id, $childAsset->fresh()->location_id);
+        $this->assertEquals($parentAsset->id, $childAsset->fresh()->assigned_to);
+        $this->assertEquals(Asset::class, $childAsset->fresh()->assigned_type);
+    }
+
     public function test_legacy_location_values_set_to_zero_are_updated()
     {
         $asset = Asset::factory()->canBeInvalidUponCreation()->assignedToUser()->create([

--- a/tests/Feature/Checkins/Ui/AssetCheckinTest.php
+++ b/tests/Feature/Checkins/Ui/AssetCheckinTest.php
@@ -206,6 +206,34 @@ class AssetCheckinTest extends TestCase
         $this->assertNull($asset->refresh()->licenseseats->first()->assigned_to);
     }
 
+    public function test_checking_in_asset_updates_location_of_assets_assigned_to_it()
+    {
+        $originalLocation = Location::factory()->create();
+        $checkedOutLocation = Location::factory()->create();
+
+        $parentAsset = Asset::factory()->assignedToLocation($checkedOutLocation)->create([
+            'location_id' => $checkedOutLocation->id,
+            'rtd_location_id' => $originalLocation->id,
+        ]);
+
+        $childAsset = Asset::factory()->create([
+            'assigned_to' => $parentAsset->id,
+            'assigned_type' => Asset::class,
+            'location_id' => $checkedOutLocation->id,
+            'rtd_location_id' => $originalLocation->id,
+        ]);
+
+        $this->actingAs(User::factory()->checkinAssets()->create())
+            ->post(route('hardware.checkin.store', [$parentAsset]), [
+                'location_id' => $originalLocation->id,
+            ]);
+
+        $this->assertEquals($originalLocation->id, $parentAsset->fresh()->location_id);
+        $this->assertEquals($originalLocation->id, $childAsset->fresh()->location_id);
+        $this->assertEquals($parentAsset->id, $childAsset->fresh()->assigned_to);
+        $this->assertEquals(Asset::class, $childAsset->fresh()->assigned_type);
+    }
+
     public function test_legacy_location_values_set_to_zero_are_updated()
     {
         $asset = Asset::factory()->canBeInvalidUponCreation()->assignedToUser()->create([


### PR DESCRIPTION
This forces an update to the child assets on asset checkin.

Fixes #18905