### PR TITLE
Fixed #18987 - fix SCIM error on mismapped fields

### DIFF
--- a/app/Models/SnipeSCIMConfig.php
+++ b/app/Models/SnipeSCIMConfig.php
@@ -302,11 +302,11 @@ class SnipeSCIMConfig
                                 // addresses[type eq "work"]
                                 $matches = null;
                                 if (!preg_match('/^.+\[type eq "([a-zA-Z]+)"](?:\.([a-zA-Z]+))?$/', (string)$path, $matches)) {
-                                    throw new SCIMException("Unknown path type '$path'")->setCode(422);
+                                    throw new SCIMException("Unknown path type '$path'", 422);
                                 }
                                 $type = $matches[1];
                                 if ($type != 'work') {
-                                    throw new SCIMException("Unknown object type '$type'")->setCode(422);
+                                    throw new SCIMException("Unknown object type '$type'", 422);
                                 }
                                 $attribute = array_key_exists(2, $matches) ? $matches[2] : null;
                                 if (array_key_exists($attribute, self::$addressmap)) {
@@ -315,7 +315,7 @@ class SnipeSCIMConfig
                                 }
 
 
-                                throw new SCIMException("Could not handle path for update $path")->setCode(422);
+                                throw new SCIMException("Could not handle path for update $path", 422);
                             }
                         }
 


### PR DESCRIPTION
It's not a particularly big deal, as the exception happening was *already* going to happen (due to a mis-mapped SCIM configuration), but we should actually return the 422 status code properly - I had used a PHPv8.4-ism of `new Blah()->method();` which, since we support PHPv8.2 and 8.3, wouldn't work on those older versions.