### PR TITLE
Don't 500 on malformed emails input

### DIFF
--- a/app/Models/SnipeSCIMConfig.php
+++ b/app/Models/SnipeSCIMConfig.php
@@ -196,7 +196,12 @@ class SnipeSCIMConfig
                         public function doWrite($operation, $subop, $value, Model &$object, Path $path = null, $removeIfNotSet = false)
                         {
                             if ($value) {
-                                $object->email = $value[0]['value'];
+                                try {
+                                    $object->email = $value[0]['value'];
+                                } catch (\Exception $e) {
+                                    \Log::debug($e);
+                                    throw new SCIMException("Unknown email object:  '" . print_r($value, true) . "'", 422);
+                                }
                             } else {
                                 $object->email = null;
                             }


### PR DESCRIPTION
It was tempting to put a bunch of `is_array()` and `array_key_exists()` and so on in the `if` here, but I just figured why not do a plain `try / catch` instead and handle everything all at once - also makes it cleaner to read.

We're getting some mis-formatted JSON coming in sometimes to our SCIM endpoint, and this should at least return a `422` (Content Not Acceptable) instead of 500-ing.