### PR TITLE
Change branch of home-forked SCIM server to re-introduce logging

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "ext-mbstring": "*",
     "ext-pdo": "*",
     "alek13/slack": "^2.0",
-    "arietimmerman/laravel-scim-server": "dev-upstream_master",
+    "arietimmerman/laravel-scim-server": "dev-scimv2_with_logging",
     "bacon/bacon-qr-code": "^2.0",
     "doctrine/cache": "^1.10",
     "doctrine/dbal": "^3.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6dbe361f8555681a027fca2d2c2e61fd",
+    "content-hash": "3ad09b8be28e9a805ed3c1cc51c9ffaa",
     "packages": [
         {
             "name": "alek13/slack",
@@ -74,16 +74,16 @@
         },
         {
             "name": "arietimmerman/laravel-scim-server",
-            "version": "dev-upstream_master",
+            "version": "dev-scimv2_with_logging",
             "source": {
                 "type": "git",
                 "url": "https://github.com/grokability/laravel-scim-server.git",
-                "reference": "da40db79d76cf3b4c7e57cde41df6ecf8119afb7"
+                "reference": "dfef93c7344be3c3c255d54694e182c5ec784bab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/grokability/laravel-scim-server/zipball/da40db79d76cf3b4c7e57cde41df6ecf8119afb7",
-                "reference": "da40db79d76cf3b4c7e57cde41df6ecf8119afb7",
+                "url": "https://api.github.com/repos/grokability/laravel-scim-server/zipball/dfef93c7344be3c3c255d54694e182c5ec784bab",
+                "reference": "dfef93c7344be3c3c255d54694e182c5ec784bab",
                 "shasum": ""
             },
             "require": {
@@ -131,9 +131,9 @@
             ],
             "description": "Laravel Package for creating a SCIM server",
             "support": {
-                "source": "https://github.com/grokability/laravel-scim-server/tree/upstream_master"
+                "source": "https://github.com/grokability/laravel-scim-server/tree/scimv2_with_logging"
             },
-            "time": "2025-08-28T19:24:40+00:00"
+            "time": "2026-05-12T11:17:15+00:00"
         },
         {
             "name": "aws/aws-crt-php",


### PR DESCRIPTION
In moving to the _new_ version of SCIM, I somehow managed to un-merge my cool SCIM-logging stuff.

This PR changes us to point to the _new_ branch which has re-introduced the SCIM-logging. I have tested this, on my local, with a few of the major SCIM providers, so it _should_ work. But I would love to grab a little more feedback before we merge.

That being said, if we need to get this merged to go live with the release, I'm OK with it.