### PR TITLE
🎥 Added bulk deletion of licenses

### DIFF
--- a/app/Http/Controllers/Api/LicensesController.php
+++ b/app/Http/Controllers/Api/LicensesController.php
@@ -247,7 +247,7 @@ class LicensesController extends Controller
         if ($license->assigned_seats_count == 0) {
             // Delete the license and the associated license seats
             DB::table('license_seats')
-                ->where('id', $license->id)
+                ->where('license_id', $license->id)
                 ->update(['assigned_to' => null, 'asset_id' => null]);
 
             $licenseSeats = $license->licenseseats();

--- a/app/Http/Controllers/Api/LicensesController.php
+++ b/app/Http/Controllers/Api/LicensesController.php
@@ -28,7 +28,7 @@ class LicensesController extends Controller
     {
         $this->authorize('view', License::class);
 
-        $licenses = License::with('company', 'manufacturer', 'supplier', 'category', 'adminuser')->withCount('freeSeats as free_seats_count');
+        $licenses = License::with('company', 'manufacturer', 'supplier', 'category', 'adminuser', 'licenseSeatsRelation', 'assignedCount')->withCount('freeSeats as free_seats_count');
         $settings = Setting::getSettings();
 
         if ($request->input('status') == 'inactive') {

--- a/app/Http/Controllers/Licenses/BulkLicensesController.php
+++ b/app/Http/Controllers/Licenses/BulkLicensesController.php
@@ -38,6 +38,11 @@ class BulkLicensesController extends Controller
                 continue;
             }
 
+            // Since assigned_seats_count == 0, all seats already have assigned_to and asset_id as null,
+            // so this update is effectively a no-op. It mirrors the single destroy() and is kept as a
+            // safety net. Bypassing Eloquent events here is intentional and safe — there is nothing
+            // assigned to trigger events on. Prior checkout/checkin history is preserved in action_log
+            // (keyed by LicenseSeat item_type/item_id) and remains accessible even after soft-delete.
             DB::table('license_seats')
                 ->where('license_id', $license->id)
                 ->update(['assigned_to' => null, 'asset_id' => null]);

--- a/app/Http/Controllers/Licenses/BulkLicensesController.php
+++ b/app/Http/Controllers/Licenses/BulkLicensesController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers\Licenses;
+
+use App\Http\Controllers\Controller;
+use App\Models\License;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
+
+class BulkLicensesController extends Controller
+{
+    public function destroy(Request $request)
+    {
+        $this->authorize('delete', License::class);
+
+        $errors = [];
+        $success_count = 0;
+
+        foreach ($request->ids as $id) {
+            $license = License::find($id);
+
+            if (is_null($license)) {
+                $errors[] = trans('admin/licenses/message.does_not_exist');
+
+                continue;
+            }
+
+            if (! Gate::allows('delete', $license)) {
+                $errors[] = trans('general.insufficient_permissions');
+
+                continue;
+            }
+
+            if ($license->assigned_seats_count > 0) {
+                $errors[] = trans('admin/licenses/message.delete.bulk_checkout_warning', ['license_name' => $license->name]);
+
+                continue;
+            }
+
+            DB::table('license_seats')
+                ->where('license_id', $license->id)
+                ->update(['assigned_to' => null, 'asset_id' => null]);
+
+            $license->licenseseats()->delete();
+            $license->delete();
+            $success_count++;
+        }
+
+        if (count($errors) > 0) {
+            if ($success_count > 0) {
+                return redirect()->route('licenses.index')
+                    ->with('success', trans_choice('admin/licenses/message.delete.partial_success', $success_count, ['count' => $success_count]))
+                    ->with('multi_error_messages', $errors);
+            }
+
+            return redirect()->route('licenses.index')->with('multi_error_messages', $errors);
+        }
+
+        return redirect()->route('licenses.index')->with('success', trans('admin/licenses/message.delete.bulk_success'));
+    }
+}

--- a/app/Http/Transformers/LicensesTransformer.php
+++ b/app/Http/Transformers/LicensesTransformer.php
@@ -75,7 +75,10 @@ class LicensesTransformer
             'checkin' => Gate::allows('checkin', License::class),
             'clone' => Gate::allows('create', License::class),
             'update' => Gate::allows('update', License::class),
-            'delete' => (Gate::allows('delete', License::class) && ($license->free_seats_count == $license->seats)) ? true : false,
+            'delete' => $license->isDeletable(),
+            'bulk_selectable' => [
+                'delete' => $license->isDeletable(),
+            ],
         ];
 
         $array += $permissions_array;

--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -640,11 +640,11 @@ class License extends Depreciable
     /**
      * This is really dumb - needs to be refactored, since we have ~3 diff methods that do almost the same thing
      *
-     * @author A. Gianotto <snipe@snipe.net>
+     * @return int
      *
      * @since  [v2.0]
      *
-     * @return Relation
+     * @author A. Gianotto <snipe@snipe.net>
      */
     public function numRemaining()
     {

--- a/app/Presenters/LicensePresenter.php
+++ b/app/Presenters/LicensePresenter.php
@@ -16,6 +16,13 @@ class LicensePresenter extends Presenter
     {
         $layout = [
             [
+                'field' => 'checkbox',
+                'checkbox' => true,
+                'formatter' => 'checkboxEnabledFormatter',
+                'titleTooltip' => trans('general.select_all_none'),
+                'printIgnore' => true,
+                'class' => 'hidden-print',
+            ], [
                 'field' => 'id',
                 'searchable' => false,
                 'sortable' => true,
@@ -115,7 +122,7 @@ class LicensePresenter extends Presenter
                 'searchable' => false,
                 'sortable' => false,
                 'switchable' => true,
-                'title' => '% ' . trans('general.remaining'),
+                'title' => '% '.trans('general.remaining'),
                 'visible' => true,
                 'formatter' => 'progressBarFormatter',
             ], [

--- a/resources/lang/en-US/admin/licenses/message.php
+++ b/resources/lang/en-US/admin/licenses/message.php
@@ -37,6 +37,9 @@ return [
         'confirm' => 'Are you sure you wish to delete this license?',
         'error' => 'There was an issue deleting the license. Please try again.',
         'success' => 'The license was deleted successfully.',
+        'bulk_success' => 'The selected licenses were deleted successfully.',
+        'partial_success' => 'License deleted successfully. See additional information below. | :count licenses were deleted successfully. See additional information below.',
+        'bulk_checkout_warning' => ':license_name has seats that are currently checked out and cannot be deleted. Please check in all seats before deleting.',
     ],
 
     'checkout' => [

--- a/resources/views/licenses/index.blade.php
+++ b/resources/views/licenses/index.blade.php
@@ -12,6 +12,18 @@
     <x-container>
         <x-box>
 
+            <x-slot:bulkactions>
+                <x-table.bulk-actions
+                    name='licenses'
+                    action_route="{{ route('licenses.bulk.delete') }}"
+                    model_name="license"
+                >
+                    @can('delete', App\Models\License::class)
+                        <option value="delete">{{ trans('general.delete') }}</option>
+                    @endcan
+                </x-table.bulk-actions>
+            </x-slot:bulkactions>
+
             <x-table.licenses
                 fixed_right_number="2"
                 fixed_number="1"

--- a/routes/web/licenses.php
+++ b/routes/web/licenses.php
@@ -1,9 +1,9 @@
 <?php
 
 use App\Http\Controllers\Licenses;
-use Illuminate\Support\Facades\Route;
 use App\Models\License;
 use App\Models\LicenseSeat;
+use Illuminate\Support\Facades\Route;
 use Tabuna\Breadcrumbs\Trail;
 
 // Licenses
@@ -12,20 +12,18 @@ Route::group(['prefix' => 'licenses', 'middleware' => ['auth']], function () {
 
     Route::get('{license}/checkout/{seatId?}', [Licenses\LicenseCheckoutController::class, 'create'])
         ->name('licenses.checkout')
-        ->breadcrumbs(fn (Trail $trail, License $license) =>
-        $trail->parent('licenses.show', $license)
+        ->breadcrumbs(fn (Trail $trail, License $license) => $trail->parent('licenses.show', $license)
             ->push(trans('general.checkout'), route('licenses.checkout', $license))
         );
 
     Route::post(
         '{licenseId}/checkout/{seatId?}',
         [Licenses\LicenseCheckoutController::class, 'store']
-    ); //name() would duplicate here, so we skip it.
+    ); // name() would duplicate here, so we skip it.
 
     Route::get('{licenseSeat}/checkin/{backto?}', [Licenses\LicenseCheckinController::class, 'create'])
         ->name('licenses.checkin')
-        ->breadcrumbs(fn (Trail $trail, LicenseSeat $licenseSeat) =>
-        $trail->parent('licenses.show', $licenseSeat->license)
+        ->breadcrumbs(fn (Trail $trail, LicenseSeat $licenseSeat) => $trail->parent('licenses.show', $licenseSeat->license)
             ->push(trans('general.checkin'), route('licenses.checkin', $licenseSeat))
         );
 
@@ -47,9 +45,11 @@ Route::group(['prefix' => 'licenses', 'middleware' => ['auth']], function () {
         'export',
         [
             Licenses\LicensesController::class,
-            'getExportLicensesCsv'
+            'getExportLicensesCsv',
         ]
     )->name('licenses.export');
+
+    Route::post('bulk/delete', [Licenses\BulkLicensesController::class, 'destroy'])->name('licenses.bulk.delete');
 });
 
 Route::resource('licenses', Licenses\LicensesController::class, [

--- a/tests/Feature/Licenses/Api/DeleteLicensesTest.php
+++ b/tests/Feature/Licenses/Api/DeleteLicensesTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Licenses\Api;
 
 use App\Models\Company;
 use App\Models\License;
+use App\Models\LicenseSeat;
 use App\Models\User;
 use Tests\Concerns\TestsFullMultipleCompaniesSupport;
 use Tests\Concerns\TestsPermissionsRequirement;
@@ -86,5 +87,37 @@ class DeleteLicensesTest extends TestCase implements TestsFullMultipleCompaniesS
             ->deleteJson(route('api.licenses.destroy', $license));
 
         $this->assertTrue($license->fresh()->licenseseats->isEmpty());
+    }
+
+    public function test_all_seats_for_deleted_license_are_soft_deleted()
+    {
+        $license = License::factory()->create(['seats' => 5]);
+
+        $this->actingAsForApi(User::factory()->deleteLicenses()->create())
+            ->deleteJson(route('api.licenses.destroy', $license))
+            ->assertStatusMessageIs('success');
+
+        $this->assertEquals(5, LicenseSeat::onlyTrashed()->where('license_id', $license->id)->count());
+    }
+
+    public function test_deleting_license_does_not_affect_seats_of_other_licenses()
+    {
+        $licenseToDelete = License::factory()->create(['seats' => 3]);
+        $otherLicense = License::factory()->create(['seats' => 2]);
+
+        $assignedUser = User::factory()->create();
+        $otherLicense->freeSeat()->update(['assigned_to' => $assignedUser->id]);
+
+        $this->actingAsForApi(User::factory()->deleteLicenses()->create())
+            ->deleteJson(route('api.licenses.destroy', $licenseToDelete))
+            ->assertStatusMessageIs('success');
+
+        $this->assertSoftDeleted($licenseToDelete);
+        $this->assertNotSoftDeleted($otherLicense);
+        $this->assertEquals(
+            $assignedUser->id,
+            LicenseSeat::where('license_id', $otherLicense->id)->whereNotNull('assigned_to')->value('assigned_to'),
+            'Seat on another license had its assignment incorrectly cleared'
+        );
     }
 }

--- a/tests/Feature/Licenses/Ui/BulkDeleteLicensesTest.php
+++ b/tests/Feature/Licenses/Ui/BulkDeleteLicensesTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Tests\Feature\Licenses\Ui;
+
+use App\Models\Company;
+use App\Models\License;
+use App\Models\LicenseSeat;
+use App\Models\User;
+use Tests\Concerns\TestsPermissionsRequirement;
+use Tests\TestCase;
+
+class BulkDeleteLicensesTest extends TestCase implements TestsPermissionsRequirement
+{
+    public function test_requires_permission()
+    {
+        $this->actingAs(User::factory()->create())
+            ->post(route('licenses.bulk.delete'), [
+                'ids' => [1, 2, 3],
+            ])
+            ->assertForbidden();
+    }
+
+    public function test_licenses_without_checked_out_seats_can_be_bulk_deleted()
+    {
+        $license1 = License::factory()->create(['seats' => 5]);
+        $license2 = License::factory()->create(['seats' => 5]);
+
+        $this->actingAs(User::factory()->deleteLicenses()->create())
+            ->post(route('licenses.bulk.delete'), [
+                'ids' => [$license1->id, $license2->id],
+            ])
+            ->assertRedirect(route('licenses.index'))
+            ->assertSessionHas('success', trans('admin/licenses/message.delete.bulk_success'));
+
+        $this->assertSoftDeleted($license1);
+        $this->assertSoftDeleted($license2);
+    }
+
+    public function test_licenses_with_checked_out_seats_cannot_be_bulk_deleted()
+    {
+        $license = License::factory()->create(['seats' => 5]);
+        LicenseSeat::factory()->assignedToUser()->create(['license_id' => $license->id]);
+
+        $this->actingAs(User::factory()->deleteLicenses()->create())
+            ->post(route('licenses.bulk.delete'), [
+                'ids' => [$license->id],
+            ])
+            ->assertRedirect(route('licenses.index'))
+            ->assertSessionMissing('success');
+
+        $this->assertModelExists($license);
+        $this->assertNotSoftDeleted($license);
+    }
+
+    public function test_seats_are_cleaned_up_when_license_is_bulk_deleted()
+    {
+        $license = License::factory()->create(['seats' => 3]);
+
+        $this->actingAs(User::factory()->deleteLicenses()->create())
+            ->post(route('licenses.bulk.delete'), [
+                'ids' => [$license->id],
+            ])
+            ->assertRedirect(route('licenses.index'));
+
+        $this->assertSoftDeleted($license);
+        $this->assertEquals(0, LicenseSeat::where('license_id', $license->id)->whereNotNull('assigned_to')->orWhere('license_id', $license->id)->whereNotNull('asset_id')->count());
+    }
+
+    public function test_fmcs_prevents_deleting_license_from_other_company()
+    {
+        [$myCompany, $otherCompany] = Company::factory()->count(2)->create();
+
+        $actor = User::factory()->deleteLicenses()->create(['company_id' => $myCompany->id]);
+        $otherLicense = License::factory()->create(['company_id' => $otherCompany->id, 'seats' => 1]);
+
+        $this->settings->enableMultipleFullCompanySupport();
+
+        $this->actingAs($actor)
+            ->post(route('licenses.bulk.delete'), [
+                'ids' => [$otherLicense->id],
+            ])
+            ->assertRedirect(route('licenses.index'))
+            ->assertSessionMissing('success');
+
+        $this->assertModelExists($otherLicense);
+        $this->assertNotSoftDeleted($otherLicense);
+    }
+
+    public function test_partial_success_when_some_licenses_have_checked_out_seats()
+    {
+        $cleanLicense = License::factory()->create(['seats' => 5]);
+        $checkedOutLicense = License::factory()->create(['seats' => 5]);
+        LicenseSeat::factory()->assignedToUser()->create(['license_id' => $checkedOutLicense->id]);
+
+        $this->actingAs(User::factory()->deleteLicenses()->create())
+            ->post(route('licenses.bulk.delete'), [
+                'ids' => [$cleanLicense->id, $checkedOutLicense->id],
+            ])
+            ->assertRedirect(route('licenses.index'))
+            ->assertSessionHas('success');
+
+        $this->assertSoftDeleted($cleanLicense);
+        $this->assertNotSoftDeleted($checkedOutLicense);
+    }
+}


### PR DESCRIPTION
Mostly what it says on the tin - BUT in diving into this, I did catch an API bug that had gone unnoticed for a bit (we were using

```php
DB::table('license_seats')
                ->where('id', $license->id)
                ->update(['assigned_to' => null, 'asset_id' => null]);
```

instead of 

```php
DB::table('license_seats')
                ->where('license_id', $license->id)
                ->update(['assigned_to' => null, 'asset_id' => null]);
```


https://github.com/user-attachments/assets/8bd5dab4-56b3-4050-a49c-ddcffd77ec07

I'm not sure why we're not using that checkbox formatter in other places, but I'll try to tackle that next. I don't think it would work for all cases, but for stuff where we're doing a simple delete (and not checkin/checkout/etc where there are other conditions) we can add that for a better UI.

