### PR TITLE
Fixed anchor tag on report index page

### DIFF
--- a/resources/views/reports/index.blade.php
+++ b/resources/views/reports/index.blade.php
@@ -13,9 +13,9 @@
     <div class="row" style="padding-bottom: 10px;">
 
         <div class="col-md-3 col-sm-6">
-            <span href="{{ route('reports.activity') }}" class="btn btn-theme btn-block" style="margin-bottom: 10px; white-space: normal;">
+            <a href="{{ route('reports.activity') }}" class="btn btn-theme btn-block" style="margin-bottom: 10px; white-space: normal;">
                 <x-icon type="reports"/> {{ trans('general.activity_report') }}
-            </span>
+            </a>
         </div>
 
         <div class="col-md-3 col-sm-6">


### PR DESCRIPTION
On the reports index page, the activity report tag was a span instead of an anchor. This PR fixes that. 

<img width="2034" height="572" alt="image" src="https://github.com/user-attachments/assets/1bc05b8c-565a-4536-86e6-5aa28e894b79" />
