### PR TITLE
Added page number support in API, added `per_page`, `total_pages`, and `current_page` to API response

### DIFF
--- a/app/Http/Transformers/DatatablesTransformer.php
+++ b/app/Http/Transformers/DatatablesTransformer.php
@@ -21,12 +21,11 @@ class DatatablesTransformer
         $objects_array['per_page'] = $limit;
         $objects_array['total_pages'] = $total_pages;
 
-        $base_query = collect(request()->query())->except(['page', 'offset'])->all();
         $objects_array['prev_page_url'] = $current_page > 1
-            ? request()->url().'?'.http_build_query(array_merge($base_query, ['page' => $current_page - 1]))
+            ? request()->fullUrlWithQuery(['page' => $current_page - 1])
             : null;
         $objects_array['next_page_url'] = $current_page < $total_pages
-            ? request()->url().'?'.http_build_query(array_merge($base_query, ['page' => $current_page + 1]))
+            ? request()->fullUrlWithQuery(['page' => $current_page + 1])
             : null;
 
         return $objects_array;

--- a/app/Http/Transformers/DatatablesTransformer.php
+++ b/app/Http/Transformers/DatatablesTransformer.php
@@ -11,6 +11,10 @@ class DatatablesTransformer
     {
         (isset($total)) ? $objects_array['total'] = $total : $objects_array['total'] = count($objects);
         $objects_array['rows'] = $objects;
+        $objects_array['current_page'] = app('api_current_page');
+        $limit = app('api_limit_value');
+        $objects_array['per_page'] = $limit;
+        $objects_array['total_pages'] = $limit > 0 ? (int) ceil($objects_array['total'] / $limit) : 1;
 
         return $objects_array;
     }

--- a/app/Http/Transformers/DatatablesTransformer.php
+++ b/app/Http/Transformers/DatatablesTransformer.php
@@ -23,10 +23,10 @@ class DatatablesTransformer
 
         $base_query = collect(request()->query())->except(['page', 'offset'])->all();
         $objects_array['prev_page_url'] = $current_page > 1
-            ? request()->url().'?'.http_build_query(array_merge($base_query, ['page' => $current_page - 1, 'limit' => $limit]))
+            ? request()->url().'?'.http_build_query(array_merge($base_query, ['page' => $current_page - 1]))
             : null;
         $objects_array['next_page_url'] = $current_page < $total_pages
-            ? request()->url().'?'.http_build_query(array_merge($base_query, ['page' => $current_page + 1, 'limit' => $limit]))
+            ? request()->url().'?'.http_build_query(array_merge($base_query, ['page' => $current_page + 1]))
             : null;
 
         return $objects_array;

--- a/app/Http/Transformers/DatatablesTransformer.php
+++ b/app/Http/Transformers/DatatablesTransformer.php
@@ -11,7 +11,7 @@ class DatatablesTransformer
     {
         $objects_array = [
             'total' => $total ?? count($objects),
-            'rows'  => $objects,
+            'rows' => $objects,
         ];
         $current_page = app('api_current_page');
         $limit = (int) app('api_limit_value');
@@ -39,7 +39,7 @@ class DatatablesTransformer
     {
         $objects_array = [
             'total' => $total ?? count($objects),
-            'rows'  => $objects,
+            'rows' => $objects,
         ];
 
         return $objects_array;

--- a/app/Http/Transformers/DatatablesTransformer.php
+++ b/app/Http/Transformers/DatatablesTransformer.php
@@ -11,10 +11,21 @@ class DatatablesTransformer
     {
         (isset($total)) ? $objects_array['total'] = $total : $objects_array['total'] = count($objects);
         $objects_array['rows'] = $objects;
-        $objects_array['current_page'] = app('api_current_page');
-        $limit = app('api_limit_value');
+        $current_page = app('api_current_page');
+        $limit = (int) app('api_limit_value');
+        $total_pages = $limit > 0 ? (int) ceil($objects_array['total'] / $limit) : 1;
+
+        $objects_array['current_page'] = $current_page;
         $objects_array['per_page'] = $limit;
-        $objects_array['total_pages'] = $limit > 0 ? (int) ceil($objects_array['total'] / $limit) : 1;
+        $objects_array['total_pages'] = $total_pages;
+
+        $base_query = collect(request()->query())->except(['page', 'offset'])->all();
+        $objects_array['prev_page_url'] = $current_page > 1
+            ? request()->url().'?'.http_build_query(array_merge($base_query, ['page' => $current_page - 1, 'limit' => $limit]))
+            : null;
+        $objects_array['next_page_url'] = $current_page < $total_pages
+            ? request()->url().'?'.http_build_query(array_merge($base_query, ['page' => $current_page + 1, 'limit' => $limit]))
+            : null;
 
         return $objects_array;
     }

--- a/app/Http/Transformers/DatatablesTransformer.php
+++ b/app/Http/Transformers/DatatablesTransformer.php
@@ -9,8 +9,10 @@ class DatatablesTransformer
      **/
     public function transformDatatables($objects, $total = null)
     {
-        (isset($total)) ? $objects_array['total'] = $total : $objects_array['total'] = count($objects);
-        $objects_array['rows'] = $objects;
+        $objects_array = [
+            'total' => $total ?? count($objects),
+            'rows'  => $objects,
+        ];
         $current_page = app('api_current_page');
         $limit = (int) app('api_limit_value');
         $total_pages = $limit > 0 ? (int) ceil($objects_array['total'] / $limit) : 1;
@@ -35,8 +37,10 @@ class DatatablesTransformer
      **/
     public function transformBulkResponseWithStatusAndObjects($objects, $total)
     {
-        (isset($total)) ? $objects_array['total'] = $total : $objects_array['total'] = count($objects);
-        $objects_array['rows'] = $objects;
+        $objects_array = [
+            'total' => $total ?? count($objects),
+            'rows'  => $objects,
+        ];
 
         return $objects_array;
     }

--- a/app/Providers/SettingsServiceProvider.php
+++ b/app/Providers/SettingsServiceProvider.php
@@ -44,11 +44,28 @@ class SettingsServiceProvider extends ServiceProvider
             return $limit;
         });
 
-        // Make sure the offset is actually set and is an integer
+        // Make sure the offset is actually set and is an integer.
+        // If 'page' is passed without 'offset', derive the offset from the page number.
         app()->singleton('api_offset_value', function () {
-            $offset = intval(request('offset'));
+            if (request()->filled('page') && ! request()->filled('offset')) {
+                $page = max(1, intval(request('page')));
+                return ($page - 1) * app('api_limit_value');
+            }
 
-            return $offset;
+            return intval(request('offset'));
+        });
+
+        // Resolve the current page number for inclusion in API list responses.
+        // Supports both page= and legacy offset= parameters.
+        app()->singleton('api_current_page', function () {
+            if (request()->filled('page') && ! request()->filled('offset')) {
+                return max(1, intval(request('page')));
+            }
+
+            $limit = app('api_limit_value');
+            $offset = app('api_offset_value');
+
+            return $limit > 0 ? (int) floor($offset / $limit) + 1 : 1;
         });
 
         /**

--- a/app/Providers/SettingsServiceProvider.php
+++ b/app/Providers/SettingsServiceProvider.php
@@ -49,6 +49,7 @@ class SettingsServiceProvider extends ServiceProvider
         app()->singleton('api_offset_value', function () {
             if (request()->filled('page') && ! request()->filled('offset')) {
                 $page = max(1, intval(request('page')));
+
                 return ($page - 1) * (int) app('api_limit_value');
             }
 

--- a/app/Providers/SettingsServiceProvider.php
+++ b/app/Providers/SettingsServiceProvider.php
@@ -49,7 +49,7 @@ class SettingsServiceProvider extends ServiceProvider
         app()->singleton('api_offset_value', function () {
             if (request()->filled('page') && ! request()->filled('offset')) {
                 $page = max(1, intval(request('page')));
-                return ($page - 1) * app('api_limit_value');
+                return ($page - 1) * (int) app('api_limit_value');
             }
 
             return intval(request('offset'));
@@ -62,8 +62,8 @@ class SettingsServiceProvider extends ServiceProvider
                 return max(1, intval(request('page')));
             }
 
-            $limit = app('api_limit_value');
-            $offset = app('api_offset_value');
+            $limit = (int) app('api_limit_value');
+            $offset = (int) app('api_offset_value');
 
             return $limit > 0 ? (int) floor($offset / $limit) + 1 : 1;
         });

--- a/tests/Feature/Assets/Api/AssetPaginationTest.php
+++ b/tests/Feature/Assets/Api/AssetPaginationTest.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Tests\Feature\Assets\Api;
+
+use App\Models\Asset;
+use App\Models\User;
+use Tests\TestCase;
+
+class AssetPaginationTest extends TestCase
+{
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->superuser()->create();
+    }
+
+    public function test_response_includes_pagination_fields()
+    {
+        Asset::factory()->count(3)->create();
+
+        $this->actingAsForApi($this->user)
+            ->getJson(route('api.assets.index'))
+            ->assertOk()
+            ->assertJsonStructure(['total', 'rows', 'current_page', 'per_page', 'total_pages']);
+    }
+
+    public function test_default_request_returns_page_one()
+    {
+        Asset::factory()->count(3)->create();
+
+        $this->actingAsForApi($this->user)
+            ->getJson(route('api.assets.index'))
+            ->assertOk()
+            ->assertJsonPath('current_page', 1);
+    }
+
+    public function test_offset_zero_returns_page_one()
+    {
+        Asset::factory()->count(10)->create();
+
+        $this->actingAsForApi($this->user)
+            ->getJson(route('api.assets.index', ['offset' => 0, 'limit' => 5]))
+            ->assertOk()
+            ->assertJsonPath('current_page', 1);
+    }
+
+    public function test_offset_derives_correct_page_number()
+    {
+        Asset::factory()->count(10)->create();
+
+        $this->actingAsForApi($this->user)
+            ->getJson(route('api.assets.index', ['offset' => 5, 'limit' => 5]))
+            ->assertOk()
+            ->assertJsonPath('current_page', 2);
+    }
+
+    public function test_page_one_returns_current_page_one()
+    {
+        Asset::factory()->count(10)->create();
+
+        $this->actingAsForApi($this->user)
+            ->getJson(route('api.assets.index', ['page' => 1, 'limit' => 5]))
+            ->assertOk()
+            ->assertJsonPath('current_page', 1);
+    }
+
+    public function test_page_two_returns_current_page_two()
+    {
+        Asset::factory()->count(10)->create();
+
+        $this->actingAsForApi($this->user)
+            ->getJson(route('api.assets.index', ['page' => 2, 'limit' => 5]))
+            ->assertOk()
+            ->assertJsonPath('current_page', 2);
+    }
+
+    public function test_page_one_returns_first_items()
+    {
+        foreach (range(1, 10) as $i) {
+            Asset::factory()->create(['asset_tag' => sprintf('PAG-TEST-%03d', $i)]);
+        }
+
+        $tags = $this->actingAsForApi($this->user)
+            ->getJson(route('api.assets.index', ['page' => 1, 'limit' => 5, 'sort' => 'asset_tag', 'order' => 'asc']))
+            ->assertOk()
+            ->json('rows.*.asset_tag');
+
+        $this->assertEquals(
+            ['PAG-TEST-001', 'PAG-TEST-002', 'PAG-TEST-003', 'PAG-TEST-004', 'PAG-TEST-005'],
+            $tags
+        );
+    }
+
+    public function test_page_two_returns_second_set_of_items()
+    {
+        foreach (range(1, 10) as $i) {
+            Asset::factory()->create(['asset_tag' => sprintf('PAG-TEST-%03d', $i)]);
+        }
+
+        $tags = $this->actingAsForApi($this->user)
+            ->getJson(route('api.assets.index', ['page' => 2, 'limit' => 5, 'sort' => 'asset_tag', 'order' => 'asc']))
+            ->assertOk()
+            ->json('rows.*.asset_tag');
+
+        $this->assertEquals(
+            ['PAG-TEST-006', 'PAG-TEST-007', 'PAG-TEST-008', 'PAG-TEST-009', 'PAG-TEST-010'],
+            $tags
+        );
+    }
+
+    public function test_offset_returns_correct_items()
+    {
+        foreach (range(1, 10) as $i) {
+            Asset::factory()->create(['asset_tag' => sprintf('PAG-TEST-%03d', $i)]);
+        }
+
+        $tags = $this->actingAsForApi($this->user)
+            ->getJson(route('api.assets.index', ['offset' => 5, 'limit' => 5, 'sort' => 'asset_tag', 'order' => 'asc']))
+            ->assertOk()
+            ->json('rows.*.asset_tag');
+
+        $this->assertEquals(
+            ['PAG-TEST-006', 'PAG-TEST-007', 'PAG-TEST-008', 'PAG-TEST-009', 'PAG-TEST-010'],
+            $tags
+        );
+    }
+
+    public function test_page_param_respects_limit()
+    {
+        Asset::factory()->count(10)->create();
+
+        $response = $this->actingAsForApi($this->user)
+            ->getJson(route('api.assets.index', ['page' => 1, 'limit' => 4]))
+            ->assertOk();
+
+        $this->assertCount(4, $response->json('rows'));
+    }
+
+    public function test_page_beyond_results_returns_empty_rows()
+    {
+        Asset::factory()->count(5)->create();
+
+        $response = $this->actingAsForApi($this->user)
+            ->getJson(route('api.assets.index', ['page' => 99, 'limit' => 5]))
+            ->assertOk();
+
+        $this->assertCount(0, $response->json('rows'));
+        $this->assertEquals(5, $response->json('total'));
+    }
+
+    public function test_offset_takes_precedence_over_page_when_both_provided()
+    {
+        Asset::factory()->count(10)->create();
+
+        // offset=0 should win over page=3, giving current_page=1
+        $this->actingAsForApi($this->user)
+            ->getJson(route('api.assets.index', ['offset' => 0, 'page' => 3, 'limit' => 5]))
+            ->assertOk()
+            ->assertJsonPath('current_page', 1);
+    }
+
+    public function test_per_page_reflects_the_limit_parameter()
+    {
+        Asset::factory()->count(3)->create();
+
+        $this->actingAsForApi($this->user)
+            ->getJson(route('api.assets.index', ['limit' => 25]))
+            ->assertOk()
+            ->assertJsonPath('per_page', 25);
+    }
+
+    public function test_total_pages_is_correct_for_even_division()
+    {
+        Asset::factory()->count(10)->create();
+
+        $this->actingAsForApi($this->user)
+            ->getJson(route('api.assets.index', ['limit' => 5]))
+            ->assertOk()
+            ->assertJsonPath('total_pages', 2);
+    }
+
+    public function test_total_pages_rounds_up_for_uneven_division()
+    {
+        Asset::factory()->count(11)->create();
+
+        $this->actingAsForApi($this->user)
+            ->getJson(route('api.assets.index', ['limit' => 5]))
+            ->assertOk()
+            ->assertJsonPath('total_pages', 3);
+    }
+
+    public function test_total_pages_is_one_when_results_fit_in_single_page()
+    {
+        Asset::factory()->count(3)->create();
+
+        $this->actingAsForApi($this->user)
+            ->getJson(route('api.assets.index', ['limit' => 5]))
+            ->assertOk()
+            ->assertJsonPath('total_pages', 1);
+    }
+}

--- a/tests/Feature/Assets/Api/AssetPaginationTest.php
+++ b/tests/Feature/Assets/Api/AssetPaginationTest.php
@@ -219,6 +219,17 @@ class AssetPaginationTest extends TestCase
         $this->assertStringContainsString('limit=5', $url);
     }
 
+    public function test_page_urls_do_not_include_limit_when_not_in_original_request()
+    {
+        Asset::factory()->count(600)->create();
+
+        $response = $this->actingAsForApi($this->user)
+            ->getJson(route('api.assets.index', ['page' => 1]))
+            ->assertOk();
+
+        $this->assertStringNotContainsString('limit=', $response->json('next_page_url'));
+    }
+
     public function test_both_page_urls_null_when_single_page()
     {
         Asset::factory()->count(3)->create();

--- a/tests/Feature/Assets/Api/AssetPaginationTest.php
+++ b/tests/Feature/Assets/Api/AssetPaginationTest.php
@@ -161,14 +161,73 @@ class AssetPaginationTest extends TestCase
             ->assertJsonPath('current_page', 1);
     }
 
-    public function test_per_page_reflects_the_limit_parameter()
+    public function test_per_page_reflects_the_limit_parameter_as_an_integer()
+    {
+        Asset::factory()->count(3)->create();
+
+        $response = $this->actingAsForApi($this->user)
+            ->getJson(route('api.assets.index', ['limit' => 25]))
+            ->assertOk()
+            ->assertJsonPath('per_page', 25);
+
+        $this->assertIsInt($response->json('per_page'));
+    }
+
+    public function test_prev_page_url_is_null_on_first_page()
+    {
+        Asset::factory()->count(10)->create();
+
+        $this->actingAsForApi($this->user)
+            ->getJson(route('api.assets.index', ['page' => 1, 'limit' => 5]))
+            ->assertOk()
+            ->assertJsonPath('prev_page_url', null);
+    }
+
+    public function test_next_page_url_is_null_on_last_page()
+    {
+        Asset::factory()->count(10)->create();
+
+        $this->actingAsForApi($this->user)
+            ->getJson(route('api.assets.index', ['page' => 2, 'limit' => 5]))
+            ->assertOk()
+            ->assertJsonPath('next_page_url', null);
+    }
+
+    public function test_next_page_url_contains_correct_page_number()
+    {
+        Asset::factory()->count(10)->create();
+
+        $url = $this->actingAsForApi($this->user)
+            ->getJson(route('api.assets.index', ['page' => 1, 'limit' => 5]))
+            ->assertOk()
+            ->json('next_page_url');
+
+        $this->assertStringContainsString('page=2', $url);
+        $this->assertStringContainsString('limit=5', $url);
+    }
+
+    public function test_prev_page_url_contains_correct_page_number()
+    {
+        Asset::factory()->count(10)->create();
+
+        $url = $this->actingAsForApi($this->user)
+            ->getJson(route('api.assets.index', ['page' => 2, 'limit' => 5]))
+            ->assertOk()
+            ->json('prev_page_url');
+
+        $this->assertStringContainsString('page=1', $url);
+        $this->assertStringContainsString('limit=5', $url);
+    }
+
+    public function test_both_page_urls_null_when_single_page()
     {
         Asset::factory()->count(3)->create();
 
         $this->actingAsForApi($this->user)
-            ->getJson(route('api.assets.index', ['limit' => 25]))
+            ->getJson(route('api.assets.index', ['page' => 1, 'limit' => 50]))
             ->assertOk()
-            ->assertJsonPath('per_page', 25);
+            ->assertJsonPath('prev_page_url', null)
+            ->assertJsonPath('next_page_url', null);
     }
 
     public function test_total_pages_is_correct_for_even_division()


### PR DESCRIPTION
I've wanted to get this done for a long time, and finally that time is now. While bootstrap-tables requires us to send API results in a certain format in order for our table lists to work, it made it a bit of a pain for a third-party integration developer to build integrations with listings of things, since they would be forced to get the total number of results, then figure out what the next offset and limit needs to be in their code. Not impossible, but certainly a friction point and unnecessary extra work. 

This should make developing Snipe-IT integrations much less painful.

<img width="500" height="280" alt="yasssssss" src="https://github.com/user-attachments/assets/cad52324-17a9-4c1a-b304-e56a3c4713e6" />


(For the purposes of the below code, I changed my `MAX_RESULTS` to `2` in my `.env`.)

### Before

```json
{
    "total": 45,
    "rows": [
        {
            "id": 45,
            "name": "Lisbon",
            ...
            "available_actions": {
                "update": true,
                "delete": false,
                "bulk_selectable": {
                    "delete": false
                },
                "clone": true,
                "restore": false
            }
        },
        {
            "id": 44,
            "name": "fdjgdo  elshj lkdsf",
            ...
            "available_actions": {
                "update": true,
                "delete": true,
                "bulk_selectable": {
                    "delete": true
                },
                "clone": true,
                "restore": false
            }
        }
    ]
}
```

### After

```json
{
    "total": 45,
    "rows": [
        {
            "id": 45,
            "name": "Lisbon",
            ...
            "available_actions": {
                "update": true,
                "delete": false,
                "bulk_selectable": {
                    "delete": false
                },
                "clone": true,
                "restore": false
            }
        },
        {
            "id": 44,
            "name": "fdjgdo  elshj lkdsf",
            ...
            "available_actions": {
                "update": true,
                "delete": true,
                "bulk_selectable": {
                    "delete": true
                },
                "clone": true,
                "restore": false
            }
        }
    ],
    "current_page": 1,
    "per_page": 2,
    "total_pages": 23,
    "prev_page_url": null,
    "next_page_url": "https://snipe-it.test/api/v1/locations?page=2"
}
```

If the total number of results is less than the max API results, `prev_page_url` and `next_page_url` return null.