### PR TITLE
Fixed asset maintenances page not rendering with missing asset

### DIFF
--- a/app/Http/Controllers/Api/MaintenancesController.php
+++ b/app/Http/Controllers/Api/MaintenancesController.php
@@ -38,6 +38,7 @@ class MaintenancesController extends Controller
         $this->authorize('view', Asset::class);
 
         $maintenances = Maintenance::select('maintenances.*')
+            ->whereHas('asset')
             ->with('asset', 'asset.model', 'asset.location', 'asset.defaultLoc', 'supplier', 'asset.company', 'asset.status', 'adminuser', 'asset.assignedTo');
 
         // This invokes the Searchable model trait scopeTextSearch and will handle input by search or by advanced search filter


### PR DESCRIPTION
If an asset does not exist for the ID that an asset maintenance record has then the maintenance page would not render. This PR fixes that. 

<img width="2800" height="896" alt="image" src="https://github.com/user-attachments/assets/056b53d9-83a0-4651-9d49-a97c43f2b239" />

---

[RB-21081]
[RB-21082]
[RB-21083]
