### PR TITLE
Disabled debugbar on acceptance report

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -1236,6 +1236,9 @@ class ReportsController extends Controller
     public function getAssetAcceptanceReport($deleted = false): View
     {
         $this->authorize('reports.view');
+
+        $this->disableDebugbar();
+
         $showDeleted = $deleted == 'deleted';
 
         $query = CheckoutAcceptance::Pending()


### PR DESCRIPTION
This is really for the devs but this disables debugbar for the people that have a lot of unaccepted assets. The page might run out of memory for them.
