### PR TITLE
Move API singletons from SettingServiceProvider into middleware

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -17,6 +17,7 @@ use App\Http\Middleware\PreventBackHistory;
 use App\Http\Middleware\RedirectIfAuthenticated;
 use App\Http\Middleware\SecurityHeaders;
 use App\Http\Middleware\SetAPIResponseHeaders;
+use App\Http\Middleware\SetPaginationDefaults;
 use App\Http\Middleware\TrimStrings;
 use App\Http\Middleware\TrustProxies;
 use App\Http\Middleware\VerifyCsrfToken;
@@ -84,6 +85,7 @@ class Kernel extends HttpKernel
             'auth:api',
             CheckLocale::class,
             LogAuthedUserHeader::class,
+            SetPaginationDefaults::class,
             SubstituteBindings::class,
         ],
 

--- a/app/Http/Middleware/SetPaginationDefaults.php
+++ b/app/Http/Middleware/SetPaginationDefaults.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class SetPaginationDefaults
+{
+    public function handle(Request $request, Closure $next)
+    {
+        $limit = config('app.max_results');
+        $intLimit = intval($request->input('limit'));
+
+        if (abs($intLimit) > 0 && $intLimit <= config('app.max_results')) {
+            $limit = abs($intLimit);
+        }
+
+        app()->instance('api_limit_value', $limit);
+
+        if ($request->filled('page') && ! $request->filled('offset')) {
+            $page = max(1, intval($request->input('page')));
+            $offset = ($page - 1) * $limit;
+        } else {
+            $offset = intval($request->input('offset'));
+            $page = $limit > 0 ? (int) floor($offset / $limit) + 1 : 1;
+        }
+
+        app()->instance('api_offset_value', $offset);
+        app()->instance('api_current_page', $page);
+
+        return $next($request);
+    }
+}

--- a/app/Providers/SettingsServiceProvider.php
+++ b/app/Providers/SettingsServiceProvider.php
@@ -32,43 +32,6 @@ class SettingsServiceProvider extends ServiceProvider
             $view->with('snipeSettings', Setting::getSettings());
         });
 
-        // Make sure the limit is actually set, is an integer and does not exceed system limits
-        app()->singleton('api_limit_value', function () {
-            $limit = config('app.max_results');
-            $int_limit = intval(request('limit'));
-
-            if ((abs($int_limit) > 0) && ($int_limit <= config('app.max_results'))) {
-                $limit = abs($int_limit);
-            }
-
-            return $limit;
-        });
-
-        // Make sure the offset is actually set and is an integer.
-        // If 'page' is passed without 'offset', derive the offset from the page number.
-        app()->singleton('api_offset_value', function () {
-            if (request()->filled('page') && ! request()->filled('offset')) {
-                $page = max(1, intval(request('page')));
-
-                return ($page - 1) * (int) app('api_limit_value');
-            }
-
-            return intval(request('offset'));
-        });
-
-        // Resolve the current page number for inclusion in API list responses.
-        // Supports both page= and legacy offset= parameters.
-        app()->singleton('api_current_page', function () {
-            if (request()->filled('page') && ! request()->filled('offset')) {
-                return max(1, intval(request('page')));
-            }
-
-            $limit = (int) app('api_limit_value');
-            $offset = (int) app('api_offset_value');
-
-            return $limit > 0 ? (int) floor($offset / $limit) + 1 : 1;
-        });
-
         /**
          * Set some common variables so that they're globally available.
          * The paths should always be public (versus private uploads)


### PR DESCRIPTION
Related to #19019, this moves the API-related singletons into middleware, where it feels like they belong.