### PR TITLE
Move and rename CheckInOutRequest to CheckInOutTrait

### DIFF
--- a/app/Http/Controllers/Accessories/AccessoryCheckoutController.php
+++ b/app/Http/Controllers/Accessories/AccessoryCheckoutController.php
@@ -4,9 +4,9 @@ namespace App\Http\Controllers\Accessories;
 
 use App\Events\CheckoutableCheckedOut;
 use App\Helpers\Helper;
-use App\Http\Traits\CheckInOutTrait;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\AccessoryCheckoutRequest;
+use App\Http\Traits\CheckInOutTrait;
 use App\Models\Accessory;
 use App\Models\AccessoryCheckout;
 use App\Models\CheckoutAcceptance;

--- a/app/Http/Controllers/Accessories/AccessoryCheckoutController.php
+++ b/app/Http/Controllers/Accessories/AccessoryCheckoutController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers\Accessories;
 
 use App\Events\CheckoutableCheckedOut;
 use App\Helpers\Helper;
-use App\Http\Controllers\CheckInOutRequest;
+use App\Http\Traits\CheckInOutTrait;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\AccessoryCheckoutRequest;
 use App\Models\Accessory;
@@ -18,7 +18,7 @@ use Illuminate\Http\Request;
 
 class AccessoryCheckoutController extends Controller
 {
-    use CheckInOutRequest;
+    use CheckInOutTrait;
 
     /**
      * Return the form to checkout an Accessory to a user.

--- a/app/Http/Controllers/Api/AccessoriesController.php
+++ b/app/Http/Controllers/Api/AccessoriesController.php
@@ -4,11 +4,11 @@ namespace App\Http\Controllers\Api;
 
 use App\Events\CheckoutableCheckedOut;
 use App\Helpers\Helper;
-use App\Http\Traits\CheckInOutTrait;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\AccessoryCheckoutRequest;
 use App\Http\Requests\ImageUploadRequest;
 use App\Http\Requests\StoreAccessoryRequest;
+use App\Http\Traits\CheckInOutTrait;
 use App\Http\Transformers\AccessoriesTransformer;
 use App\Http\Transformers\ActionlogsTransformer;
 use App\Http\Transformers\SelectlistTransformer;

--- a/app/Http/Controllers/Api/AccessoriesController.php
+++ b/app/Http/Controllers/Api/AccessoriesController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers\Api;
 
 use App\Events\CheckoutableCheckedOut;
 use App\Helpers\Helper;
-use App\Http\Controllers\CheckInOutRequest;
+use App\Http\Traits\CheckInOutTrait;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\AccessoryCheckoutRequest;
 use App\Http\Requests\ImageUploadRequest;
@@ -25,7 +25,7 @@ use Illuminate\Support\Facades\DB;
 
 class AccessoriesController extends Controller
 {
-    use CheckInOutRequest;
+    use CheckInOutTrait;
 
     /**
      * Display a listing of the resource.

--- a/app/Http/Controllers/Assets/AssetCheckoutController.php
+++ b/app/Http/Controllers/Assets/AssetCheckoutController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers\Assets;
 
 use App\Exceptions\CheckoutNotAllowed;
 use App\Helpers\Helper;
-use App\Http\Controllers\CheckInOutRequest;
+use App\Http\Traits\CheckInOutTrait;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\AssetCheckoutRequest;
 use App\Models\Asset;
@@ -17,7 +17,7 @@ use Illuminate\Http\RedirectResponse;
 
 class AssetCheckoutController extends Controller
 {
-    use CheckInOutRequest;
+    use CheckInOutTrait;
 
     /**
      * Returns a view that presents a form to check an asset out to a

--- a/app/Http/Controllers/Assets/AssetCheckoutController.php
+++ b/app/Http/Controllers/Assets/AssetCheckoutController.php
@@ -4,9 +4,9 @@ namespace App\Http\Controllers\Assets;
 
 use App\Exceptions\CheckoutNotAllowed;
 use App\Helpers\Helper;
-use App\Http\Traits\CheckInOutTrait;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\AssetCheckoutRequest;
+use App\Http\Traits\CheckInOutTrait;
 use App\Models\Asset;
 use App\Models\CheckoutAcceptance;
 use App\Models\Setting;

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -4,9 +4,9 @@ namespace App\Http\Controllers\Assets;
 
 use App\Events\CheckoutablesCheckedOutInBulk;
 use App\Helpers\Helper;
-use App\Http\Traits\CheckInOutTrait;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\AssetCheckoutRequest;
+use App\Http\Traits\CheckInOutTrait;
 use App\Models\Asset;
 use App\Models\AssetModel;
 use App\Models\Company;

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers\Assets;
 
 use App\Events\CheckoutablesCheckedOutInBulk;
 use App\Helpers\Helper;
-use App\Http\Controllers\CheckInOutRequest;
+use App\Http\Traits\CheckInOutTrait;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\AssetCheckoutRequest;
 use App\Models\Asset;
@@ -27,7 +27,7 @@ use Illuminate\Support\Facades\Log;
 
 class BulkAssetsController extends Controller
 {
-    use CheckInOutRequest;
+    use CheckInOutTrait;
 
     /**
      * Display the bulk edit page.

--- a/app/Http/Controllers/Kits/CheckoutKitController.php
+++ b/app/Http/Controllers/Kits/CheckoutKitController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers\Kits;
 
-use App\Http\Controllers\CheckInOutRequest;
+use App\Http\Traits\CheckInOutTrait;
 use App\Http\Controllers\Controller;
 use App\Models\Asset;
 use App\Models\PredefinedKit;
@@ -23,7 +23,7 @@ class CheckoutKitController extends Controller
 {
     public $kitService;
 
-    use CheckInOutRequest;
+    use CheckInOutTrait;
 
     public function __construct(PredefinedKitCheckoutService $kitService)
     {

--- a/app/Http/Controllers/Kits/CheckoutKitController.php
+++ b/app/Http/Controllers/Kits/CheckoutKitController.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Controllers\Kits;
 
-use App\Http\Traits\CheckInOutTrait;
 use App\Http\Controllers\Controller;
+use App\Http\Traits\CheckInOutTrait;
 use App\Models\Asset;
 use App\Models\PredefinedKit;
 use App\Models\User;

--- a/app/Http/Traits/CheckInOutTrait.php
+++ b/app/Http/Traits/CheckInOutTrait.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace App\Http\Traits;
 
 use App\Models\Asset;
 use App\Models\Location;
 use App\Models\SnipeModel;
 use App\Models\User;
 
-trait CheckInOutRequest
+trait CheckInOutTrait
 {
     /**
      * Find target for checkout


### PR DESCRIPTION
This just renames and moves the `app/Http/CheckInOutRequest.php` file to `app/Http/Traits/CheckInOutTrait/CheckInOutTrait.php`. It's not actually a request (in the Form Request sense), and really behaves like a trait, so moving it and renaming it makes sense here I think.

I'm not sure why it was called that in the first place, but that file is super old, so I'm sure it was just an oversight. 