### PR TITLE
Fixed #19006 - update null location on checkin

### DIFF
--- a/app/Http/Controllers/Assets/AssetCheckinController.php
+++ b/app/Http/Controllers/Assets/AssetCheckinController.php
@@ -133,14 +133,17 @@ class AssetCheckinController extends Controller
 
         $this->migrateLegacyLocations($asset);
 
-        $asset->location_id = $asset->rtd_location_id;
 
-        if ($request->filled('location_id')) {
-            Log::debug('NEW Location ID: '.$request->input('location_id'));
-            $asset->location_id = $request->input('location_id');
+        if ($request->has('location_id')) {
+            if ($request->filled('location_id')) {
+                Log::debug('NEW Location ID: ' . $request->input('location_id'));
+                $asset->location_id = $request->input('location_id');
 
-            if ($request->input('update_default_location') == 0) {
-                $asset->rtd_location_id = $request->input('location_id');
+                if ($request->input('update_default_location') == 0) {
+                    $asset->rtd_location_id = $request->input('location_id');
+                }
+            } else {
+                $asset->location_id = null;
             }
         }
 

--- a/tests/Feature/Checkins/Ui/AssetCheckinTest.php
+++ b/tests/Feature/Checkins/Ui/AssetCheckinTest.php
@@ -179,6 +179,22 @@ class AssetCheckinTest extends TestCase
         $this->assertHasTheseActionLogs($asset, ['create', 'checkin from']);
     }
 
+    public function test_location_is_nulled_when_empty_location_id_submitted_on_checkin()
+    {
+        $rtdLocation = Location::factory()->create();
+        $asset = Asset::factory()->assignedToUser()->create([
+            'location_id' => Location::factory()->create()->id,
+            'rtd_location_id' => $rtdLocation->id,
+        ]);
+
+        $this->actingAs(User::factory()->checkinAssets()->create())
+            ->post(route('hardware.checkin.store', [$asset]), [
+                'location_id' => '',
+            ]);
+
+        $this->assertNull($asset->refresh()->location_id);
+    }
+
     public function test_default_location_can_be_updated_upon_checkin()
     {
         $location = Location::factory()->create();


### PR DESCRIPTION
Previously, we were checking for `filled()` on the location_id, so it would skip updating the location to null if no location was selected.

Fixes #19006