### PR TITLE
Optimize incorrect checkout acceptances command

### DIFF
--- a/app/Console/Commands/CleanIncorrectCheckoutAcceptances.php
+++ b/app/Console/Commands/CleanIncorrectCheckoutAcceptances.php
@@ -30,41 +30,70 @@ class CleanIncorrectCheckoutAcceptances extends Command
     {
         $deletions = 0;
         $skips = 0;
+        $total = CheckoutAcceptance::count();
 
-        // This walks *every* checkoutacceptance. That's gnarly. But necessary
-        $this->withProgressBar(CheckoutAcceptance::all(), function ($checkoutAcceptance) use (&$deletions, &$skips) {
-            $item = $checkoutAcceptance->checkoutable;
-            $checkout_to_id = $checkoutAcceptance->assigned_to_id;
-            if (is_null($item)) {
-                $this->info("'Checkoutable' Item is null, going to next record");
+        $this->info("Processing {$total} checkout acceptances...");
+        $bar = $this->output->createProgressBar($total);
+        $bar->start();
 
-                return; // 'false' allegedly breaks execution entirely, so 'true' maybe doesn't? hrm. just straight return maybe?
-            }
-            if (get_class($item) == LicenseSeat::class) {
-                $item = $item->license;
-            }
-            foreach ($item->assetlog()->where('action_type', 'checkout')->get() as $assetlog) {
-                if ($assetlog->target_id == $checkout_to_id && $assetlog->target_type != User::class) {
-                    // We have a checkout-to an ID for a non-User, which matches to an ID in the checkout_acceptances table
+        // Chunk to avoid loading the whole table into memory; eager-load checkoutable
+        // to eliminate the N+1 on that relationship.
+        CheckoutAcceptance::with('checkoutable')
+            ->chunkById(500, function ($chunk) use (&$deletions, &$skips, $bar) {
+                $idsToDelete = [];
 
-                    // now, let's compare the _times_ - are they close?
-                    // I'm picking `created_at` over `action_date` because I'm more interested in when the actionlogs
-                    // were _created_, not when they were alleged to have happened - those created_at times need to be within 'X' seconds of
-                    // each other (currently 5)
-                    if ($assetlog->created_at->diffInSeconds($checkoutAcceptance->created_at, true) <= 5) { // we're allowing for five _ish_ seconds of slop
-                        $deletions++;
-                        $checkoutAcceptance->forceDelete(); // HARD delete this record; it should have never been
+                foreach ($chunk as $checkoutAcceptance) {
+                    $item = $checkoutAcceptance->checkoutable;
+                    $checkout_to_id = $checkoutAcceptance->assigned_to_id;
 
-                        return;
-                    } else {
-                        // $this->info("The two records are too far apart");
+                    if (is_null($item)) {
+                        $skips++;
+                        $bar->advance();
+
+                        continue;
                     }
-                } else {
-                    // $this->info("No match! checkout to id: " . $checkout_to_id." target_id: ".$assetlog->target_id." target_type: ".$assetlog->target_type);
+
+                    if (get_class($item) === LicenseSeat::class) {
+                        $item = $item->license;
+                        if (is_null($item)) {
+                            $skips++;
+                            $bar->advance();
+
+                            continue;
+                        }
+                    }
+
+                    // Push all filtering (including the ±5-second window) into the DB;
+                    // exists() returns as soon as one matching row is found rather than
+                    // fetching all checkout logs into PHP.
+                    $shouldDelete = $item->assetlog()
+                        ->where('action_type', 'checkout')
+                        ->where('target_id', $checkout_to_id)
+                        ->where('target_type', '!=', User::class)
+                        ->whereBetween('created_at', [
+                            $checkoutAcceptance->created_at->copy()->subSeconds(5),
+                            $checkoutAcceptance->created_at->copy()->addSeconds(5),
+                        ])
+                        ->exists();
+
+                    if ($shouldDelete) {
+                        $idsToDelete[] = $checkoutAcceptance->id;
+                        $deletions++;
+                    } else {
+                        $skips++;
+                    }
+
+                    $bar->advance();
                 }
-            }
-            $skips++;
-        });
-        $this->error("Final deletion count: $deletions, and skip count: $skips");
+
+                // Bulk-delete the bad records in one query per chunk instead of one per row.
+                if (! empty($idsToDelete)) {
+                    CheckoutAcceptance::whereIn('id', $idsToDelete)->forceDelete();
+                }
+            });
+
+        $bar->finish();
+        $this->newLine();
+        $this->info("Final deletion count: {$deletions}, and skip count: {$skips}");
     }
 }

--- a/tests/Feature/Console/CleanIncorrectCheckoutAcceptancesTest.php
+++ b/tests/Feature/Console/CleanIncorrectCheckoutAcceptancesTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use App\Models\Actionlog;
+use App\Models\Asset;
+use App\Models\CheckoutAcceptance;
+use App\Models\License;
+use App\Models\LicenseSeat;
+use App\Models\Location;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Tests\TestCase;
+
+class CleanIncorrectCheckoutAcceptancesTest extends TestCase
+{
+    public function test_deletes_acceptance_when_checkout_target_is_non_user()
+    {
+        $location = Location::factory()->create();
+        $asset = Asset::factory()->create();
+        $now = now();
+
+        $badAcceptance = CheckoutAcceptance::factory()
+            ->withoutActionLog()
+            ->create([
+                'checkoutable_type' => Asset::class,
+                'checkoutable_id' => $asset->id,
+                'assigned_to_id' => $location->id,
+                'created_at' => $now,
+            ]);
+
+        Actionlog::factory()->create([
+            'action_type' => 'checkout',
+            'target_id' => $location->id,
+            'target_type' => Location::class,
+            'item_id' => $asset->id,
+            'item_type' => Asset::class,
+            'created_at' => $now,
+        ]);
+
+        $this->artisan('snipeit:clean-checkout-acceptances')->assertExitCode(0);
+
+        $this->assertDatabaseMissing('checkout_acceptances', ['id' => $badAcceptance->id]);
+    }
+
+    public function test_preserves_acceptance_when_checkout_target_is_user()
+    {
+        // The factory creates a matching action_log with target_type = User::class by default
+        $goodAcceptance = CheckoutAcceptance::factory()->create();
+
+        $this->artisan('snipeit:clean-checkout-acceptances')->assertExitCode(0);
+
+        $this->assertDatabaseHas('checkout_acceptances', ['id' => $goodAcceptance->id]);
+    }
+
+    public function test_preserves_acceptance_when_action_log_timestamp_is_too_far_apart()
+    {
+        $location = Location::factory()->create();
+        $asset = Asset::factory()->create();
+        $now = now();
+
+        $acceptance = CheckoutAcceptance::factory()
+            ->withoutActionLog()
+            ->create([
+                'checkoutable_type' => Asset::class,
+                'checkoutable_id' => $asset->id,
+                'assigned_to_id' => $location->id,
+                'created_at' => $now,
+            ]);
+
+        // 10 seconds away — outside the ±5-second window
+        Actionlog::factory()->create([
+            'action_type' => 'checkout',
+            'target_id' => $location->id,
+            'target_type' => Location::class,
+            'item_id' => $asset->id,
+            'item_type' => Asset::class,
+            'created_at' => $now->copy()->addSeconds(10),
+        ]);
+
+        $this->artisan('snipeit:clean-checkout-acceptances')->assertExitCode(0);
+
+        $this->assertDatabaseHas('checkout_acceptances', ['id' => $acceptance->id]);
+    }
+
+    public function test_skips_acceptance_with_soft_deleted_checkoutable()
+    {
+        $acceptance = CheckoutAcceptance::factory()->withoutActionLog()->create();
+        Model::withoutEvents(fn () => $acceptance->checkoutable->delete());
+
+        $this->artisan('snipeit:clean-checkout-acceptances')->assertExitCode(0);
+
+        $this->assertDatabaseHas('checkout_acceptances', ['id' => $acceptance->id]);
+    }
+
+    public function test_deletes_license_seat_acceptance_when_checkout_target_is_non_user()
+    {
+        $location = Location::factory()->create();
+        $licenseSeat = LicenseSeat::factory()->create();
+        $license = $licenseSeat->license;
+        $now = now();
+
+        $badAcceptance = CheckoutAcceptance::factory()
+            ->withoutActionLog()
+            ->create([
+                'checkoutable_type' => LicenseSeat::class,
+                'checkoutable_id' => $licenseSeat->id,
+                'assigned_to_id' => $location->id,
+                'created_at' => $now,
+            ]);
+
+        // Action log lives on the License, not the LicenseSeat
+        Actionlog::factory()->create([
+            'action_type' => 'checkout',
+            'target_id' => $location->id,
+            'target_type' => Location::class,
+            'item_id' => $license->id,
+            'item_type' => License::class,
+            'created_at' => $now,
+        ]);
+
+        $this->artisan('snipeit:clean-checkout-acceptances')->assertExitCode(0);
+
+        $this->assertDatabaseMissing('checkout_acceptances', ['id' => $badAcceptance->id]);
+    }
+}


### PR DESCRIPTION
This just tries to optimize the CleanIncorrectCheckoutAcceptances to solve for some n+1 issues that would likely only show up on folks with a lot of action_logs.