### PR TITLE
Bulk checkin assets from UI

### DIFF
--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -78,6 +78,10 @@ class BulkAssetsController extends Controller
         }
 
         if ($request->input('bulk_actions') === 'checkin') {
+            $referer = request()->headers->get('referer');
+            if ($referer && parse_url($referer, PHP_URL_HOST) === parse_url(config('app.url'), PHP_URL_HOST)) {
+                redirect()->setIntendedUrl($referer);
+            }
             $request->session()->flashInput(['selected_assets' => $asset_ids]);
 
             return redirect()->route('hardware.bulkcheckin.show');
@@ -867,7 +871,7 @@ class BulkAssetsController extends Controller
         });
 
         if (! $errors) {
-            return redirect()->to('hardware')->with('success', trans_choice('admin/hardware/message.multi-checkin.success', count($asset_ids)));
+            return redirect()->intended(route('hardware.index'))->with('success', trans_choice('admin/hardware/message.multi-checkin.success', count($asset_ids)));
         }
 
         return redirect()->route('hardware.bulkcheckin.show')->withInput()

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Assets;
 
+use App\Events\CheckoutableCheckedIn;
 use App\Events\CheckoutablesCheckedOutInBulk;
 use App\Helpers\Helper;
 use App\Http\Controllers\Controller;
@@ -9,13 +10,16 @@ use App\Http\Requests\AssetCheckoutRequest;
 use App\Http\Traits\CheckInOutTrait;
 use App\Models\Asset;
 use App\Models\AssetModel;
+use App\Models\CheckoutAcceptance;
 use App\Models\Company;
 use App\Models\CustomField;
+use App\Models\LicenseSeat;
 use App\Models\Setting;
 use App\Models\Statuslabel;
 use App\View\Label;
 use Carbon\Carbon;
 use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -71,6 +75,12 @@ class BulkAssetsController extends Controller
             $request->session()->flashInput(['selected_assets' => $asset_ids]);
 
             return redirect()->route('hardware.bulkcheckout.show');
+        }
+
+        if ($request->input('bulk_actions') === 'checkin') {
+            $request->session()->flashInput(['selected_assets' => $asset_ids]);
+
+            return redirect()->route('hardware.bulkcheckin.show');
         }
 
         if ($request->input('bulk_actions') === 'maintenance') {
@@ -757,6 +767,112 @@ class BulkAssetsController extends Controller
             return redirect()->route('hardware.bulkcheckout.show')->withInput()->with('error', trans_choice('admin/hardware/message.multi-checkout.error', $request->input('selected_assets')));
         }
 
+    }
+
+    /**
+     * Show Bulk Checkin Page
+     */
+    public function showCheckin(): View
+    {
+        $this->authorize('checkin', Asset::class);
+
+        $notAssigned = collect();
+
+        if (old('selected_assets') && is_array(old('selected_assets'))) {
+            $assets = Asset::findMany(old('selected_assets'));
+
+            [$assigned, $notAssigned] = $assets->partition(function (Asset $asset) {
+                return $asset->assigned_to;
+            });
+
+            session()->flashInput(['selected_assets' => $assigned->pluck('id')->values()->toArray()]);
+        }
+
+        $do_not_change = ['' => trans('general.do_not_change')];
+        $status_label_list = $do_not_change + Helper::statusLabelList();
+
+        return view('hardware/bulk-checkin', [
+            'statusLabel_list' => $status_label_list,
+            'removed_assets' => $notAssigned,
+        ]);
+    }
+
+    /**
+     * Process Multiple Checkin Request
+     */
+    public function storeCheckin(Request $request): RedirectResponse
+    {
+        $this->authorize('checkin', Asset::class);
+
+        if (! is_array($request->input('selected_assets'))) {
+            return redirect()->route('hardware.bulkcheckin.show')->withInput()->with('error', trans('admin/hardware/message.multi-checkin.no_assets_selected'));
+        }
+
+        $asset_ids = array_filter($request->input('selected_assets'));
+
+        $assets = Asset::findOrFail($asset_ids);
+
+        $checkin_at = date('Y-m-d H:i:s');
+        if ($request->filled('checkin_at') && $request->input('checkin_at') != date('Y-m-d')) {
+            $checkin_at = $request->input('checkin_at');
+        }
+
+        $errors = [];
+        $admin = auth()->user();
+
+        DB::transaction(function () use ($assets, $admin, $checkin_at, $request, &$errors) {
+            foreach ($assets as $asset) {
+                $this->authorize('checkin', $asset);
+
+                if (is_null($asset->assignedTo)) {
+                    continue;
+                }
+
+                $target = $asset->assignedTo;
+                $originalValues = $asset->getRawOriginal();
+
+                $asset->expected_checkin = null;
+                $asset->assignedTo()->disassociate($asset);
+                $asset->accepted = null;
+
+                if ($request->filled('status_id')) {
+                    $asset->status_id = $request->input('status_id');
+                }
+
+                $asset->location_id = $asset->rtd_location_id;
+                $asset->last_checkin = $checkin_at;
+
+                if ($request->boolean('checkin_licenses')) {
+                    $asset->licenseseats->each(function (LicenseSeat $seat) {
+                        $seat->update(['assigned_to' => null]);
+                    });
+                }
+
+                CheckoutAcceptance::pending()->whereHasMorph('checkoutable', [Asset::class], function (Builder $query) use ($asset) {
+                    $query->where('id', $asset->id);
+                })->get()->each->delete();
+
+                if ($asset->save()) {
+                    if ($request->boolean('checkin_child_assets')) {
+                        Asset::where('assigned_type', Asset::class)
+                            ->where('assigned_to', $asset->id)
+                            ->update(['location_id' => $asset->location_id]);
+                    }
+
+                    event(new CheckoutableCheckedIn($asset, $target, $admin, $request->input('note'), $checkin_at, $originalValues));
+                } else {
+                    $errors = array_merge_recursive($errors, $asset->getErrors()->toArray());
+                }
+            }
+        });
+
+        if (! $errors) {
+            return redirect()->to('hardware')->with('success', trans_choice('admin/hardware/message.multi-checkin.success', count($asset_ids)));
+        }
+
+        return redirect()->route('hardware.bulkcheckin.show')->withInput()
+            ->with('error', trans_choice('admin/hardware/message.multi-checkin.error', count($asset_ids)))
+            ->withErrors($errors);
     }
 
     public function restore(Request $request): RedirectResponse

--- a/resources/lang/en-US/admin/hardware/form.php
+++ b/resources/lang/en-US/admin/hardware/form.php
@@ -64,4 +64,6 @@ return [
     'optional_infos' => 'Optional Information',
     'order_details' => 'Order Related Information',
     'calc_eol' => 'If nulling the EOL date, use automatic EOL calculation based on the purchase date and EOL rate.',
+    'checkin_licenses' => 'Checkin associated license seats',
+    'checkin_child_assets' => 'Checkin associated assets',
 ];

--- a/resources/lang/en-US/admin/hardware/general.php
+++ b/resources/lang/en-US/admin/hardware/general.php
@@ -8,6 +8,7 @@ return [
     'bulk_checkout' => 'Bulk Checkout',
     'bulk_checkin' => 'Bulk Checkin',
     'checkin' => 'Checkin Asset',
+    'checkin_assets' => 'Checkin Assets',
     'checkout' => 'Checkout Asset',
     'clear' => 'Clear',
     'clone' => 'Clone Asset',

--- a/resources/lang/en-US/admin/hardware/message.php
+++ b/resources/lang/en-US/admin/hardware/message.php
@@ -94,6 +94,12 @@ return [
         'success' => 'Asset checked out successfully.|Assets checked out successfully.',
     ],
 
+    'multi-checkin' => [
+        'error' => 'Asset was not checked in, please try again|Assets were not checked in, please try again',
+        'success' => 'Asset checked in successfully.|Assets checked in successfully.',
+        'no_assets_selected' => 'You must select at least one asset from the list',
+    ],
+
     'checkin' => [
         'error' => 'Asset was not checked in, please try again',
         'success' => 'Asset checked in successfully.',

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -580,6 +580,7 @@ return [
     'error_user_company_accept_view' => 'An Asset assigned to you belongs to a different company so you can\'t accept nor deny it, please check with your manager',
     'error_assets_already_checked_out' => 'One or more of the assets are already checked out',
     'assigned_assets_removed' => 'The following were removed from the selected assets because they are already checked out',
+    'unassigned_assets_removed' => 'The following were removed from the selected assets because they are not currently checked out',
     'upload_files' => 'Upload Files',
     'uploaded_files' => 'Uploaded Files',
     'sign_in_place' => 'Sign/Accept in place',

--- a/resources/views/blade/table/bulk-assets.blade.php
+++ b/resources/views/blade/table/bulk-assets.blade.php
@@ -36,6 +36,12 @@
                         @endcan
                     @endif
 
+                    @if((!isset($status)) || ($status == 'Deployed'))
+                        @can('checkin', \App\Models\Asset::class)
+                            <option value="checkin">{{ trans('admin/hardware/general.bulk_checkin') }}</option>
+                        @endcan
+                    @endif
+
                     @can('delete', \App\Models\Asset::class)
                         <option value="delete">{{ trans('general.bulk_delete') }}</option>
                     @endcan

--- a/resources/views/hardware/bulk-checkin.blade.php
+++ b/resources/views/hardware/bulk-checkin.blade.php
@@ -1,0 +1,146 @@
+@extends('layouts/default')
+
+{{-- Page title --}}
+@section('title')
+    {{ trans('admin/hardware/general.bulk_checkin') }}
+@parent
+@stop
+
+{{-- Page content --}}
+@section('content')
+
+<style>
+  .input-group {
+    padding-left: 0px !important;
+  }
+</style>
+
+<div class="row">
+  <!-- left column -->
+  <div class="col-md-7">
+    <div class="box box-default">
+      <div class="box-header with-border">
+        <h2 class="box-title"> {{ trans('admin/hardware/form.tag') }} </h2>
+      </div>
+      <div class="box-body">
+        <form class="form-horizontal" method="post" action="{{ route('hardware.bulkcheckin.store') }}" autocomplete="off">
+          {{ csrf_field() }}
+
+            @if ($removed_assets->isNotEmpty())
+                <div class="box box-solid box-warning">
+                    <div class="box-header with-border">
+                        <span class="box-title col-xs-12">Warning</span>
+                    </div>
+                    <div class="box-body">
+                        <p>{{ trans('general.unassigned_assets_removed') }}</p>
+                        <ul>
+                            @foreach($removed_assets as $removed_asset)
+                                <li>
+                                    <a href="{{ route('hardware.show', $removed_asset->id) }}">
+                                        {{ $removed_asset->present()->fullName }}
+                                    </a>
+                                </li>
+                            @endforeach
+                        </ul>
+                    </div>
+                </div>
+            @endif
+
+            @include('partials.forms.edit.asset-select', [
+                'translated_name'       => trans('general.assets'),
+                'fieldname'             => 'selected_assets[]',
+                'multiple'              => true,
+                'required'              => true,
+                'asset_status_type'     => 'Deployed',
+                'select_id'             => 'assigned_assets_select',
+                'asset_selector_div_id' => 'assets_to_checkin_div',
+                'asset_ids'             => old('selected_assets'),
+            ])
+
+            <!-- Status -->
+            <div class="form-group {{ $errors->has('status_id') ? 'error' : '' }}">
+                <label for="status_id" class="col-md-3 control-label">
+                    {{ trans('admin/hardware/form.status') }}
+                </label>
+                <div class="col-md-7">
+                    <x-input.select
+                            name="status_id"
+                            :options="$statusLabel_list"
+                            :selected="old('status_id', $status_id ?? null)"
+                            style="width: 100%;"
+                            aria-label="status_id"
+                    />
+                    {!! $errors->first('status_id', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                </div>
+            </div>
+
+            <!-- Checkin Date -->
+            <div class="form-group {{ $errors->has('checkin_at') ? 'error' : '' }}">
+                <label for="checkin_at" class="col-sm-3 control-label">
+                    {{ trans('admin/hardware/form.checkin_date') }}
+                </label>
+                <div class="col-md-8">
+                    <div class="input-group date col-md-5" data-provide="datepicker" data-date-format="yyyy-mm-dd" data-date-end-date="0d" data-date-clear-btn="true">
+                        <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="checkin_at" id="checkin_at" value="{{ old('checkin_at') }}">
+                        <span class="input-group-addon"><x-icon type="calendar" /></span>
+                    </div>
+                    {!! $errors->first('checkin_at', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                </div>
+            </div>
+
+            <!-- Note -->
+            <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">
+                <label for="note" class="col-sm-3 control-label">
+                    {{ trans('general.notes') }}
+                </label>
+                <div class="col-md-8">
+                    <textarea class="col-md-6 form-control" id="note" name="note">{{ old('note') }}</textarea>
+                    {!! $errors->first('note', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                </div>
+            </div>
+
+            <!-- Checkin associated license seats -->
+            <div class="form-group">
+                <div class="col-md-9 col-md-offset-3">
+                    <label class="form-control" for="checkin_licenses">
+                        <input type="hidden" name="checkin_licenses" value="0" />
+                        <input type="checkbox" value="1" name="checkin_licenses" id="checkin_licenses"
+                            @checked(old('checkin_licenses', '1') == '1') />
+                        {{ trans('admin/hardware/form.checkin_licenses') }}
+                    </label>
+                </div>
+            </div>
+
+            <!-- Checkin associated assets -->
+            <div class="form-group">
+                <div class="col-md-9 col-md-offset-3">
+                    <label class="form-control" for="checkin_child_assets">
+                        <input type="hidden" name="checkin_child_assets" value="0" />
+                        <input type="checkbox" value="1" name="checkin_child_assets" id="checkin_child_assets"
+                            @checked(old('checkin_child_assets', '1') == '1') />
+                        {{ trans('admin/hardware/form.checkin_child_assets') }}
+                    </label>
+                </div>
+            </div>
+
+      </div> <!--./box-body-->
+      <div class="box-footer">
+        <a class="btn btn-link" href="{{ URL::previous() }}"> {{ trans('button.cancel') }}</a>
+        <button type="submit" class="btn btn-success pull-right"><x-icon type="checkmark" /> {{ trans('admin/hardware/general.checkin_assets') }}</button>
+      </div>
+        </form>
+    </div>
+  </div> <!--/.col-md-7-->
+</div>
+@stop
+
+@section('moar_scripts')
+<script nonce="{{ csrf_token() }}">
+    $(function () {
+        $("form").submit(function() {
+            $(this).find(":input").filter(function(){ return !this.value; }).attr("disabled", "disabled");
+            return true;
+        });
+    });
+</script>
+@stop

--- a/routes/web/hardware.php
+++ b/routes/web/hardware.php
@@ -168,6 +168,16 @@ Route::group(
             [BulkAssetsController::class, 'storeCheckout']
         )->name('hardware.bulkcheckout.store');
 
+        Route::get('bulkcheckin', [BulkAssetsController::class, 'showCheckin'])
+            ->name('hardware.bulkcheckin.show')
+            ->breadcrumbs(fn (Trail $trail) => $trail->parent('hardware.index')
+                ->push(trans('admin/hardware/general.bulk_checkin'), route('hardware.index'))
+            );
+
+        Route::post('bulkcheckin',
+            [BulkAssetsController::class, 'storeCheckin']
+        )->name('hardware.bulkcheckin.store');
+
     });
 
 Route::resource('hardware',

--- a/tests/Feature/Checkins/Ui/BulkAssetCheckinTest.php
+++ b/tests/Feature/Checkins/Ui/BulkAssetCheckinTest.php
@@ -1,0 +1,267 @@
+<?php
+
+namespace Tests\Feature\Checkins\Ui;
+
+use App\Events\CheckoutableCheckedIn;
+use App\Models\Asset;
+use App\Models\CheckoutAcceptance;
+use App\Models\LicenseSeat;
+use App\Models\Location;
+use App\Models\Statuslabel;
+use App\Models\User;
+use Illuminate\Support\Facades\Event;
+use Tests\TestCase;
+
+class BulkAssetCheckinTest extends TestCase
+{
+    public function test_requires_checkin_permission()
+    {
+        $asset = Asset::factory()->assignedToUser()->create();
+
+        $this->actingAs(User::factory()->create())
+            ->post(route('hardware.bulkcheckin.store'), [
+                'selected_assets' => [$asset->id],
+            ])
+            ->assertForbidden();
+    }
+
+    public function test_show_page_requires_checkin_permission()
+    {
+        $this->actingAs(User::factory()->create())
+            ->get(route('hardware.bulkcheckin.show'))
+            ->assertForbidden();
+    }
+
+    public function test_show_page_renders()
+    {
+        $this->actingAs(User::factory()->checkinAssets()->create())
+            ->get(route('hardware.bulkcheckin.show'))
+            ->assertOk();
+    }
+
+    public function test_bulk_edit_routing_redirects_to_bulk_checkin_show()
+    {
+        $assets = Asset::factory()->assignedToUser()->count(2)->create();
+
+        $this->actingAs(User::factory()->checkinAssets()->viewAssets()->create())
+            ->post(route('hardware.bulkedit.show'), [
+                'ids' => $assets->pluck('id')->toArray(),
+                'bulk_actions' => 'checkin',
+                'sort' => 'id',
+                'order' => 'asc',
+            ])
+            ->assertRedirectToRoute('hardware.bulkcheckin.show');
+    }
+
+    public function test_can_bulk_checkin_assets()
+    {
+        Event::fake([CheckoutableCheckedIn::class]);
+
+        $user = User::factory()->create();
+        $assets = Asset::factory()->assignedToUser($user)->count(2)->create([
+            'expected_checkin' => now()->addDay(),
+            'accepted' => 'accepted',
+        ]);
+
+        $response = $this->actingAs(User::factory()->checkinAssets()->viewAssets()->create())
+            ->post(route('hardware.bulkcheckin.store'), [
+                'selected_assets' => $assets->pluck('id')->toArray(),
+            ])
+            ->assertStatus(302);
+
+        $assets->each(function (Asset $asset) {
+            $fresh = $asset->fresh();
+            $this->assertNull($fresh->assigned_to);
+            $this->assertNull($fresh->assigned_type);
+            $this->assertNull($fresh->expected_checkin);
+            $this->assertNull($fresh->accepted);
+            $this->assertNotNull($fresh->last_checkin);
+        });
+
+        Event::assertDispatched(CheckoutableCheckedIn::class, 2);
+
+        $this->followRedirects($response)->assertSee('alert-success');
+    }
+
+    public function test_skips_assets_not_checked_out()
+    {
+        Event::fake([CheckoutableCheckedIn::class]);
+
+        $assignedAsset = Asset::factory()->assignedToUser()->create();
+        $unassignedAsset = Asset::factory()->create();
+
+        $this->actingAs(User::factory()->checkinAssets()->create())
+            ->post(route('hardware.bulkcheckin.store'), [
+                'selected_assets' => [$assignedAsset->id, $unassignedAsset->id],
+            ])
+            ->assertStatus(302);
+
+        $this->assertNull($assignedAsset->fresh()->assigned_to);
+        $this->assertNotNull($unassignedAsset->fresh()->id);
+
+        Event::assertDispatched(CheckoutableCheckedIn::class, 1);
+    }
+
+    public function test_status_can_be_changed_upon_bulk_checkin()
+    {
+        $rtdStatus = Statuslabel::factory()->readyToDeploy()->create();
+        $assets = Asset::factory()->assignedToUser()->count(2)->create();
+
+        $this->actingAs(User::factory()->checkinAssets()->create())
+            ->post(route('hardware.bulkcheckin.store'), [
+                'selected_assets' => $assets->pluck('id')->toArray(),
+                'status_id' => $rtdStatus->id,
+            ]);
+
+        $assets->each(function (Asset $asset) use ($rtdStatus) {
+            $this->assertEquals($rtdStatus->id, $asset->fresh()->status_id);
+        });
+    }
+
+    public function test_location_is_set_to_rtd_location_upon_bulk_checkin()
+    {
+        $rtdLocation = Location::factory()->create();
+        $checkedOutLocation = Location::factory()->create();
+
+        $assets = Asset::factory()->assignedToUser()->count(2)->create([
+            'location_id' => $checkedOutLocation->id,
+            'rtd_location_id' => $rtdLocation->id,
+        ]);
+
+        $this->actingAs(User::factory()->checkinAssets()->create())
+            ->post(route('hardware.bulkcheckin.store'), [
+                'selected_assets' => $assets->pluck('id')->toArray(),
+            ]);
+
+        $assets->each(function (Asset $asset) use ($rtdLocation) {
+            $this->assertEquals($rtdLocation->id, $asset->fresh()->location_id);
+        });
+    }
+
+    public function test_license_seats_are_cleared_when_checkbox_is_checked()
+    {
+        $asset = Asset::factory()->assignedToUser()->create();
+        LicenseSeat::factory()->assignedToUser()->for($asset)->create();
+
+        $this->assertNotNull($asset->licenseseats->first()->assigned_to);
+
+        $this->actingAs(User::factory()->checkinAssets()->create())
+            ->post(route('hardware.bulkcheckin.store'), [
+                'selected_assets' => [$asset->id],
+                'checkin_licenses' => '1',
+            ]);
+
+        $this->assertNull($asset->fresh()->licenseseats->first()->assigned_to);
+    }
+
+    public function test_license_seats_are_retained_when_checkbox_is_unchecked()
+    {
+        $asset = Asset::factory()->assignedToUser()->create();
+        LicenseSeat::factory()->assignedToUser()->for($asset)->create();
+
+        $originalAssignedTo = $asset->licenseseats->first()->assigned_to;
+        $this->assertNotNull($originalAssignedTo);
+
+        $this->actingAs(User::factory()->checkinAssets()->create())
+            ->post(route('hardware.bulkcheckin.store'), [
+                'selected_assets' => [$asset->id],
+                'checkin_licenses' => '0',
+            ]);
+
+        $this->assertEquals($originalAssignedTo, $asset->fresh()->licenseseats->first()->assigned_to);
+    }
+
+    public function test_pending_checkout_acceptances_are_cleared_upon_bulk_checkin()
+    {
+        $asset = Asset::factory()->assignedToUser()->create();
+        $acceptance = CheckoutAcceptance::factory()->for($asset, 'checkoutable')->pending()->create();
+
+        $this->actingAs(User::factory()->checkinAssets()->create())
+            ->post(route('hardware.bulkcheckin.store'), [
+                'selected_assets' => [$asset->id],
+            ]);
+
+        $this->assertFalse($acceptance->exists(), 'Pending acceptance was not deleted upon bulk checkin');
+    }
+
+    public function test_checkin_date_and_note_are_passed_to_event()
+    {
+        Event::fake([CheckoutableCheckedIn::class]);
+
+        $asset = Asset::factory()->assignedToUser()->create();
+
+        $this->actingAs(User::factory()->checkinAssets()->create())
+            ->post(route('hardware.bulkcheckin.store'), [
+                'selected_assets' => [$asset->id],
+                'checkin_at' => '2024-06-15',
+                'note' => 'bulk checkin note',
+            ]);
+
+        Event::assertDispatched(function (CheckoutableCheckedIn $event) {
+            return $event->action_date === '2024-06-15'
+                && $event->note === 'bulk checkin note';
+        });
+    }
+
+    public function test_child_asset_locations_are_updated_when_checkbox_is_checked()
+    {
+        $originalLocation = Location::factory()->create();
+        $checkedOutLocation = Location::factory()->create();
+
+        $parentAsset = Asset::factory()->assignedToLocation($checkedOutLocation)->create([
+            'location_id' => $checkedOutLocation->id,
+            'rtd_location_id' => $originalLocation->id,
+        ]);
+
+        $childAsset = Asset::factory()->create([
+            'assigned_to' => $parentAsset->id,
+            'assigned_type' => Asset::class,
+            'location_id' => $checkedOutLocation->id,
+        ]);
+
+        $this->actingAs(User::factory()->checkinAssets()->create())
+            ->post(route('hardware.bulkcheckin.store'), [
+                'selected_assets' => [$parentAsset->id],
+                'checkin_child_assets' => '1',
+            ]);
+
+        $this->assertEquals($originalLocation->id, $parentAsset->fresh()->location_id);
+        $this->assertEquals($originalLocation->id, $childAsset->fresh()->location_id);
+    }
+
+    public function test_child_asset_locations_are_retained_when_checkbox_is_unchecked()
+    {
+        $originalLocation = Location::factory()->create();
+        $checkedOutLocation = Location::factory()->create();
+
+        $parentAsset = Asset::factory()->assignedToLocation($checkedOutLocation)->create([
+            'location_id' => $checkedOutLocation->id,
+            'rtd_location_id' => $originalLocation->id,
+        ]);
+
+        $childAsset = Asset::factory()->create([
+            'assigned_to' => $parentAsset->id,
+            'assigned_type' => Asset::class,
+            'location_id' => $checkedOutLocation->id,
+        ]);
+
+        $this->actingAs(User::factory()->checkinAssets()->create())
+            ->post(route('hardware.bulkcheckin.store'), [
+                'selected_assets' => [$parentAsset->id],
+                'checkin_child_assets' => '0',
+            ]);
+
+        $this->assertEquals($originalLocation->id, $parentAsset->fresh()->location_id);
+        $this->assertEquals($checkedOutLocation->id, $childAsset->fresh()->location_id);
+    }
+
+    public function test_returns_error_when_no_assets_selected()
+    {
+        $this->actingAs(User::factory()->checkinAssets()->create())
+            ->post(route('hardware.bulkcheckin.store'), [
+                'selected_assets' => null,
+            ])
+            ->assertRedirectToRoute('hardware.bulkcheckin.show')
+            ->assertSessionHas('error');
+    }
+}

--- a/tests/Feature/Checkins/Ui/BulkAssetCheckinTest.php
+++ b/tests/Feature/Checkins/Ui/BulkAssetCheckinTest.php
@@ -255,6 +255,61 @@ class BulkAssetCheckinTest extends TestCase
         $this->assertEquals($checkedOutLocation->id, $childAsset->fresh()->location_id);
     }
 
+    public function test_origin_url_is_stored_when_routing_to_bulk_checkin()
+    {
+        $assets = Asset::factory()->assignedToUser()->count(2)->create();
+        $originUrl = route('hardware.index').'?status_type=Deployed';
+
+        $this->actingAs(User::factory()->checkinAssets()->viewAssets()->create())
+            ->from($originUrl)
+            ->post(route('hardware.bulkedit.show'), [
+                'ids' => $assets->pluck('id')->toArray(),
+                'bulk_actions' => 'checkin',
+                'sort' => 'id',
+                'order' => 'asc',
+            ])
+            ->assertSessionHas('url.intended', $originUrl);
+    }
+
+    public function test_successful_checkin_redirects_to_origin_url()
+    {
+        $asset = Asset::factory()->assignedToUser()->create();
+        $originUrl = route('hardware.index').'?status_type=Deployed';
+
+        $this->actingAs(User::factory()->checkinAssets()->create())
+            ->withSession(['url.intended' => $originUrl])
+            ->post(route('hardware.bulkcheckin.store'), [
+                'selected_assets' => [$asset->id],
+            ])
+            ->assertRedirect($originUrl);
+    }
+
+    public function test_external_referer_is_not_stored_as_intended_url()
+    {
+        $assets = Asset::factory()->assignedToUser()->count(2)->create();
+
+        $this->actingAs(User::factory()->checkinAssets()->viewAssets()->create())
+            ->from('https://evil.example.com/phish')
+            ->post(route('hardware.bulkedit.show'), [
+                'ids' => $assets->pluck('id')->toArray(),
+                'bulk_actions' => 'checkin',
+                'sort' => 'id',
+                'order' => 'asc',
+            ])
+            ->assertSessionMissing('url.intended');
+    }
+
+    public function test_successful_checkin_falls_back_to_hardware_index_without_origin_url()
+    {
+        $asset = Asset::factory()->assignedToUser()->create();
+
+        $this->actingAs(User::factory()->checkinAssets()->create())
+            ->post(route('hardware.bulkcheckin.store'), [
+                'selected_assets' => [$asset->id],
+            ])
+            ->assertRedirect(route('hardware.index'));
+    }
+
     public function test_returns_error_when_no_assets_selected()
     {
         $this->actingAs(User::factory()->checkinAssets()->create())


### PR DESCRIPTION
This will need a little more UI love (<del>remembering whether the admin came from the assets page, user page, location page, etc and redirecting them back there, specifically</del>) but this should get the job done for now. 

https://github.com/user-attachments/assets/67e5f1b6-20fe-44c2-8590-c660f858cc68

https://github.com/user-attachments/assets/957fd1b6-cf41-4691-909e-e286f0703f89

### Testing

- make sure notifications are sent (if the category/admin settings require it) and that the content within is accurate
- make sure the status - if selected ted - correctly updates
- make sure the activity report accurately reflects the checkin and the status change (if applicable)
- make sure the child assets and licenses also reflect the checkin
- make sure the redirects return you back to where you were before the bulk action

One thing I'm curious about is how we might want to handle the status of child assets. Right now, they don't change (which is probably fine) but we might need to add another dropdown for those, if the assets we're checkin in have child assets.
