### PR TITLE
Declare ext-exif as a required PHP extension

### DIFF
--- a/Dockerfile.fpm-alpine
+++ b/Dockerfile.fpm-alpine
@@ -56,6 +56,7 @@ COPY --from=mlocati/php-extension-installer:2.1.15 /usr/bin/install-php-extensio
 RUN set -eux; \
     install-php-extensions \
         bcmath \
+        exif \
         gd \
         ldap \
         mysqli \

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
   "require": {
     "php": "^8.2",
     "ext-curl": "*",
+    "ext-exif": "*",
     "ext-fileinfo": "*",
     "ext-iconv": "*",
     "ext-json": "*",


### PR DESCRIPTION
ImageUploadRequest unconditionally calls `->orientate()` on every uploaded image. Intervention's `ExifCommand` throws `NotSupportedException` without `ext-exif`; ImageUploadRequest only catches `NotReadableException`, so the failure surfaces as an unhandled 500 on phone-photo uploads.

Add `ext-exif` to `composer.json`'s require block so the gap fails at `composer install` instead of at runtime.

Add `exif` to `Dockerfile.fpm-alpine`'s `install-php-extensions` command.

---

_Disclosure: drafted with a coding agent's help while investigating which PHP extensions a containerized Snipe-IT deployment needs but the manifest doesn't declare._