### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ Since the release of the JSON REST API, several third-party developers have been
 - [InQRy (archived)](https://github.com/Microsoft/InQRy) by [@Microsoft](https://github.com/Microsoft)
 - [Marksman (archived)](https://github.com/Scope-IT/marksman) - A Windows agent for Snipe-IT
 - [Python Module (archived)](https://github.com/jbloomer/SnipeIT-PythonAPI) by [@jbloomer](https://github.com/jbloomer)
+- [IT-Tools](https://github.com/chrisnox/Snipeit-it-tools) by @chrisnox — 
+Browser bookmarklets for PDF handover protocols, digital signatures, 
+label printing (Zebra ZD410), AirWatch MDM sync and Lansweeper CSV import.
 
 We also have a handful of [Google Apps scripts](https://github.com/grokability/google-apps-scripts-for-snipe-it) to help with various tasks.
 

--- a/README.md
+++ b/README.md
@@ -98,9 +98,7 @@ Since the release of the JSON REST API, several third-party developers have been
 - [InQRy (archived)](https://github.com/Microsoft/InQRy) by [@Microsoft](https://github.com/Microsoft)
 - [Marksman (archived)](https://github.com/Scope-IT/marksman) - A Windows agent for Snipe-IT
 - [Python Module (archived)](https://github.com/jbloomer/SnipeIT-PythonAPI) by [@jbloomer](https://github.com/jbloomer)
-- [IT-Tools](https://github.com/chrisnox/Snipeit-it-tools) by @chrisnox — 
-Browser bookmarklets for PDF handover protocols, digital signatures, 
-label printing (Zebra ZD410), AirWatch MDM sync and Lansweeper CSV import.
+[IT-Tools](https://github.com/chrisnox/Snipeit-it-tools) by @chrisnox - Browser bookmarklets for PDF handover/return protocols, digital signatures, label printing (Zebra ZD410), AirWatch MDM sync and Lansweeper CSV import.
 
 We also have a handful of [Google Apps scripts](https://github.com/grokability/google-apps-scripts-for-snipe-it) to help with various tasks.
 


### PR DESCRIPTION
## Add IT-Tools to Third-Party Integrations

Hi Snipe-IT team,

I'd like to add **IT-Tools** to the third-party integrations list.

### What it does

IT-Tools is a self-hosted PHP/Docker companion app for Snipe-IT that 
adds browser bookmarklets for daily IT workflows:

- **Handover & Return PDF** — A4 protocol generated directly from a 
  user page (`/users/{id}`), with mode picker (handover/return), 
  accessory list, condition tracking and optional digital signature
- **Digital Signature** — Employee signs on screen → PDF uploaded 
  automatically to the employee file and each checked-out asset in 
  SnipeIT
- **Outlook Mail** — Pre-filled handover mail to accounting, triggered 
  from any asset page (`/hardware/{id}`)
- **Label Print** — Accessory labels on Zebra ZD410 (50×25mm, QR code 
  linking back to SnipeIT), filtered by category
- **AirWatch MDM Sync** — Compares AirWatch devices against SnipeIT, 
  creates missing assets with dry-run preview
- **Lansweeper CSV Import** — Reads Lansweeper exports, creates missing 
  notebooks in SnipeIT with dry-run preview

All bookmarklets are installed once via a self-hosted install page and 
work without any SnipeIT code changes. The tool communicates exclusively 
via the SnipeIT REST API.

### Tech stack

- PHP 8.2 + Apache (Docker)
- MariaDB (can share existing instance)
- No modifications to SnipeIT required

### Links

- **GitHub:** https://github.com/chrisnox/Snipeit-it-tools
- **Version:** v2.4.2
- **License:** MIT
- **Author:** Chris M. (@chrisnox)

### Suggested line to add

```markdown