### PR TITLE
Updated composer lock file

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ed0655f6c3c75cda1939dfc27b492029",
+    "content-hash": "09f6cf88befc67d5f5ead4d38c37e857",
     "packages": [
         {
             "name": "alek13/slack",
@@ -16835,6 +16835,7 @@
     "platform": {
         "php": "^8.2",
         "ext-curl": "*",
+        "ext-exif": "*",
         "ext-fileinfo": "*",
         "ext-iconv": "*",
         "ext-json": "*",


### PR DESCRIPTION
I noticed a warning when running `composer install`:
> Warning: The lock file is not up to date with the latest changes in composer.json. You may be getting outdated dependencies. It is recommended that you run `composer update` or `composer update <package name>`.

This PR follows up on #19061 and updates the lock file via:

```
composer update --lock
```
