### PR TITLE
Trait-ify custom fields

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -8,6 +8,7 @@ use App\Helpers\Helper;
 use App\Http\Traits\UniqueUndeletedTrait;
 use App\Models\Traits\Acceptable;
 use App\Models\Traits\CompanyableTrait;
+use App\Models\Traits\HasCustomFields;
 use App\Models\Traits\HasUploads;
 use App\Models\Traits\Loggable;
 use App\Models\Traits\Requestable;
@@ -20,7 +21,6 @@ use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Storage;
 use Watson\Validating\ValidatingTrait;
@@ -37,6 +37,7 @@ class Asset extends Depreciable
     protected $with = ['model', 'adminuser', 'location', 'company'];
 
     use CompanyableTrait;
+    use HasCustomFields;
     use HasFactory;
     use HasUploads;
     use Loggable;
@@ -252,41 +253,9 @@ class Asset extends Depreciable
         $this->attributes['expected_checkin'] = $value;
     }
 
-    public function customFieldValidationRules()
+    protected function getCustomFieldset(): ?CustomFieldset
     {
-
-        $customFieldValidationRules = [];
-
-        if (($this->model) && ($this->model->fieldset)) {
-
-            foreach ($this->model->fieldset->fields as $field) {
-
-                // this just casts booleans that may come through as strings to an actual boolean type
-                // adding !$field->field_encrypted because when the encrypted value comes through it
-                // screws things up for the encrypted validation rules (and the encrypted string
-                // is not a valid boolean type)
-                if ($field->format == 'BOOLEAN' && ! $field->field_encrypted) {
-                    $this->{$field->db_column} = filter_var($this->{$field->db_column}, FILTER_VALIDATE_BOOLEAN);
-                }
-            }
-
-            $customFieldValidationRules += $this->model->fieldset->validation_rules();
-        }
-
-        return $customFieldValidationRules;
-
-    }
-
-    /**
-     * This handles the custom field validation for assets
-     *
-     * @var array
-     */
-    public function save(array $params = [])
-    {
-        $this->rules += $this->customFieldValidationRules();
-
-        return parent::save($params);
+        return $this->model?->fieldset ?? null;
     }
 
     public function getDisplayNameAttribute()
@@ -606,40 +575,6 @@ class Asset extends Depreciable
     public function validationRules()
     {
         return $this->rules;
-    }
-
-    public function customFieldsForCheckinCheckout($checkin_checkout)
-    {
-        // Check to see if any of the custom fields were included on the form and if they have any values
-        if (($this->model) && ($this->model->fieldset) && ($this->model->fieldset->fields)) {
-
-            foreach ($this->model->fieldset->fields as $field) {
-
-                if (($field->{$checkin_checkout} == 1) && (request()->has($field->db_column))) {
-
-                    if ($field->field_encrypted == '1') {
-
-                        if (Gate::allows('assets.view.encrypted_custom_fields')) {
-                            if (is_array(request()->input($field->db_column))) {
-                                $this->{$field->db_column} = Crypt::encrypt(implode(', ', request()->input($field->db_column)));
-                            } else {
-                                $this->{$field->db_column} = Crypt::encrypt(request()->input($field->db_column));
-                            }
-                        }
-
-                    } else {
-
-                        if (is_array(request()->input($field->db_column))) {
-                            $this->{$field->db_column} = implode(', ', request()->input($field->db_column));
-                        } else {
-                            $this->{$field->db_column} = request()->input($field->db_column);
-                        }
-
-                    }
-                }
-            }
-        }
-
     }
 
     public function manufacturer()

--- a/app/Models/Traits/HasCustomFields.php
+++ b/app/Models/Traits/HasCustomFields.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Models\Traits;
+
+use App\Models\CustomFieldset;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Gate;
+
+trait HasCustomFields
+{
+    /**
+     * Return the CustomFieldset for this model instance.
+     * Override in each model to supply the correct fieldset.
+     */
+    protected function getCustomFieldset(): ?CustomFieldset
+    {
+        return null;
+    }
+
+    public function customFieldValidationRules(): array
+    {
+        $fieldset = $this->getCustomFieldset();
+
+        if (! $fieldset) {
+            return [];
+        }
+
+        foreach ($fieldset->fields as $field) {
+            if ($field->format === 'BOOLEAN' && ! $field->field_encrypted) {
+                $this->{$field->db_column} = filter_var($this->{$field->db_column}, FILTER_VALIDATE_BOOLEAN);
+            }
+        }
+
+        return $fieldset->validation_rules();
+    }
+
+    public function save(array $params = [])
+    {
+        $this->rules += $this->customFieldValidationRules();
+
+        return parent::save($params);
+    }
+
+    public function customFieldsForCheckinCheckout(string $checkin_checkout): void
+    {
+        $fieldset = $this->getCustomFieldset();
+
+        if (! $fieldset?->fields) {
+            return;
+        }
+
+        foreach ($fieldset->fields as $field) {
+            if (($field->{$checkin_checkout} == 1) && request()->has($field->db_column)) {
+                if ($field->field_encrypted == '1') {
+                    if (Gate::allows('assets.view.encrypted_custom_fields')) {
+                        $value = request()->input($field->db_column);
+                        $this->{$field->db_column} = Crypt::encrypt(is_array($value) ? implode(', ', $value) : $value);
+                    }
+                } else {
+                    $value = request()->input($field->db_column);
+                    $this->{$field->db_column} = is_array($value) ? implode(', ', $value) : $value;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR doesn't actually functionally change anything, but puts us in the position where we can start to add custom fields to things other than assets. 

In this trait,  `getCustomFieldset()` exists as an override point, which should allow us the flexibility to decide what table to put the custom fields on, even for weird edge cases where there is no "container", like users. Assets are always associated with a model, but users don't have that equivalent, so this gives us all of the flexibility we should need for those unusual cases.                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                     
For assets, the chain is indirect (Asset → AssetModel → CustomFieldset), so the override is:                                                                                                                                                                                                                       
  
```php
protected function getCustomFieldset(): ?CustomFieldset                                                                                                                                                                                                                                                            
  {                                                                                                                                                                                                                                                                                                                  
      return $this->model?->fieldset ?? null;                                                                                                                                                                                                                                                                        
  }     
```                                     
                                                                                                                                                                                                                                                                                                                     
 For users, licenses, accessories, etc., we'll add a `fieldset_id` column directly to those tables and a `belongsTo()` relationship. That override would be something like:

```php
protected function getCustomFieldset(): ?CustomFieldset
  {                                                      
      return $this->fieldset;
  }                                                                                                                                                                                                                                                                                                                  
```
   
The trait itself only ever calls `$this->getCustomFieldset()`. It has no idea how the fieldset is retrieved. Each model's override encapsulates its own indirection (or lack of it). The trait's `customFieldValidationRules()` and `customFieldsForCheckinCheckout()` work the same regardless.      

To add a custom field to a new type of first class object, we'd just need to add the `fieldset_id` migration and add the trait. (Just is obviously doing a lot of heavy lifting here, and there would have to be a few tweaks to the `custom_fields_custom_fieldset` or the `custom_fields` table (still deciding) so we can tell which type of custom field it is (asset, user, etc)


Very exciting start tho!