### PR TITLE
Fixed "not deployable" translation usage

### DIFF
--- a/resources/views/hardware/edit.blade.php
+++ b/resources/views/hardware/edit.blade.php
@@ -294,7 +294,7 @@
                         $("#assignto_selector").hide();
                         $("#selected_status_status").removeClass('text-success');
                         $("#selected_status_status").addClass('text-danger');
-                        $("#selected_status_status").html('<x-icon type="warning" /> {{ (($item->assigned_to!='') && ($item->assigned_type!='') && ($item->deleted_at == '')) ? trans('admin/hardware/form.asset_not_deployable_checkin') : trans('admin/hardware/form.asset_not_deployable')  }} ');
+                        $("#selected_status_status").html('<x-icon type="warning" /> {{ (($item->assigned_to!='') && ($item->assigned_type!='') && ($item->deleted_at == '')) ? trans_choice('admin/hardware/form.asset_not_deployable_checkin', 1) : trans('admin/hardware/form.asset_not_deployable')  }} ');
                     }
                 }
             });


### PR DESCRIPTION
this update the `asset_not_deployable_checkin` translation to use `trans_choice` and passes the correct number when updating
Before:
<img width="1844" height="168" alt="image" src="https://github.com/user-attachments/assets/12b6e993-ecb8-4a9d-8b14-4f634f5bf3bc" />
After:
<img width="605" height="96" alt="image" src="https://github.com/user-attachments/assets/cb1b36a3-fcd6-4403-82a8-0631d9e18a79" />
