### PR TITLE
[FD-55583] Fixed google webhook check in notification

### DIFF
--- a/app/Notifications/CheckinAssetNotification.php
+++ b/app/Notifications/CheckinAssetNotification.php
@@ -139,23 +139,22 @@ class CheckinAssetNotification extends Notification
         $target = $this->target;
         $item = $this->item;
         $note = $this->note;
-
+//
         return GoogleChatMessage::create()
             ->to($this->settings->webhook_endpoint)
             ->card(
                 Card::create()
                     ->header(
-                        '<strong>'.trans('mail.Asset_Checkin_Notification', ['tag' => '']).'</strong>' ?: '',
+                        '<strong>' . trans('mail.Asset_Checkin_Notification', ['tag' => '']) . '</strong>' ?: '',
                         htmlspecialchars_decode($item->display_name) ?: '',
                     )
                     ->section(
                         Section::create(
                             KeyValue::create(
                                 trans('mail.checked_into') ?: '',
-                                ($item->location) ? $item->location->name : '',
-                                trans('admin/hardware/form.status').': '.$item->status?->name,
-                            )
-                                ->onClick(route('hardware.show', $item->id))
+                                ($item->location) ? $item->location?->name : '',
+                                trans('admin/hardware/form.status') . ': ' . $item->status?->name
+                            )->onClick(route('hardware.show', $item->id))
                         )
                     )
             );


### PR DESCRIPTION
This adds a nullsafe operator to `$item->location?->name` for google chat check-in notifications. The chat message/card was failing to build otherwise
Before:
<img width="263" height="228" alt="image" src="https://github.com/user-attachments/assets/4954036d-3238-49e3-b7ff-47e44ee1aa6c" />
After:
<img width="333" height="442" alt="image" src="https://github.com/user-attachments/assets/d317320e-cbf2-404f-a704-3784a7790317" />

Fixes: [FD-55583]