### PR TITLE
Adds #19083 display name as an option for label field options

### DIFF
--- a/app/Models/Labels/FieldOption.php
+++ b/app/Models/Labels/FieldOption.php
@@ -31,6 +31,14 @@ class FieldOption
             if ($asset->relationLoaded('assignedTo')) {
                 // If the "assignedTo" relationship was eager loaded then the way to get the
                 // relationship changes from $asset->assignedTo to $asset->assigned.
+                return $asset->assigned ? $asset->assigned->full_name : null;
+            }
+
+            return $asset->assignedTo ? $asset->assignedTo->full_name : null;
+        }
+        if ($dataPath[0] === 'displayName') {
+            if ($asset->relationLoaded('assignedTo')) {
+
                 return $asset->assigned ? $asset->assigned->display_name : null;
             }
 

--- a/resources/views/partials/label2-field-definitions.blade.php
+++ b/resources/views/partials/label2-field-definitions.blade.php
@@ -323,6 +323,7 @@
                                 <option value="order_number">{{trans('admin/hardware/form.order')}}</option>
                                 <option value="purchase_date">{{trans('admin/hardware/table.purchase_date')}}</option>
                                 <option value="assignedTo">{{trans('admin/hardware/table.assigned_to')}}</option>
+                                <option value="displayName">{{trans('admin/users/table.display_name')}}</option>
                                 <option value="last_audit_date">{{trans('general.last_audit')}}</option>
                                 <option value="next_audit_date">{{trans('general.next_audit_date')}}</option>
                             </optgroup>


### PR DESCRIPTION
This adds Display Name as a separate option to labels. AssignedTo use to use Display name if it was available, but now it shows the users full name instead.

Separate Option Appears under AssignedTo:
<img width="943" height="316" alt="image" src="https://github.com/user-attachments/assets/26735b25-9ac4-4d92-b589-2c7bde7b4c0d" />
Label:
<img width="310" height="169" alt="image" src="https://github.com/user-attachments/assets/d4c680ff-e8d3-402d-8a22-b11438343420" />

#19083 