### PR TITLE
Fixed #19095 and #19096 - SCIM updates in Azure/Entra

### DIFF
--- a/app/Models/SCIMUser.php
+++ b/app/Models/SCIMUser.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
 class SCIMUser extends User
 {
     protected $table = 'users';
@@ -19,6 +21,11 @@ class SCIMUser extends User
     public function groups()
     {
         return $this->belongsToMany(\App\Models\Group::class, 'users_groups', 'user_id', 'group_id');
+    }
+
+    public function companies(): BelongsToMany
+    {
+        return $this->belongsToMany(Company::class, 'company_user', 'user_id', 'company_id');
     }
 
 }

--- a/app/Models/SnipeSCIMConfig.php
+++ b/app/Models/SnipeSCIMConfig.php
@@ -166,6 +166,42 @@ class SnipeMutableCollection extends MutableCollection
     }
 }
 
+// Company is stored only in the company_user pivot, not company_id. Read from the pivot
+// and sync it on write. For new users (not yet saved) defer the sync via a saved() callback.
+class SCIMCompanyAttribute extends MappedTable
+{
+    protected function doRead(&$object, $attributes = [])
+    {
+        return $object->companies->first()?->name;
+    }
+
+    private function applyCompany(?int $companyId, Model &$object): void
+    {
+        $ids = $companyId ? [$companyId] : [];
+
+        if ($object->exists) {
+            $object->companies()->sync($ids);
+        } else {
+            $object->saved(fn () => $object->companies()->sync($ids));
+        }
+    }
+
+    public function add($value, Model &$object)
+    {
+        $this->applyCompany($value ? Company::firstOrCreate(['name' => $value])->id : null, $object);
+    }
+
+    public function replace($value, Model &$object, $path = null, $removeIfNotSet = false)
+    {
+        $this->applyCompany($value ? Company::firstOrCreate(['name' => $value])->id : null, $object);
+    }
+
+    public function patch($operation, $value, Model &$object, ?Path $path = null, $removeIfNotSet = false)
+    {
+        $this->applyCompany($value ? Company::firstOrCreate(['name' => $value])->id : null, $object);
+    }
+}
+
 class EloquentWithRemove extends Eloquent
 {
     public function remove($value, Model &$object, ?Path $path = null)
@@ -557,7 +593,7 @@ class SnipeSCIMConfig
                 ),
                 (new AttributeSchema(self::GROKABILITY, false))->withSubAttributes(
                     new MappedTable('location', 'location', Location::class, 'location_id', 'name'),
-                    new MappedTable('company', 'company', Company::class, 'company_id', 'name'),
+                    new SCIMCompanyAttribute('company', 'company', Company::class, 'company_id', 'name'),
                 )
             ),
         ];

--- a/app/Models/SnipeSCIMConfig.php
+++ b/app/Models/SnipeSCIMConfig.php
@@ -361,7 +361,11 @@ class SnipeSCIMConfig
                         {
                             if ($value) {
                                 try {
-                                    $object->email = $value[0]['value'];
+                                    if (is_string($value)) {
+                                        $object->email = $value; // Weird MS-SCIM stuff :/
+                                    } else {
+                                        $object->email = $value[0]['value'];
+                                    }
                                 } catch (\Throwable $e) {
                                     \Log::debug($e);
                                     throw new SCIMException("Unknown email object:  '".print_r($value, true)."'", 422);
@@ -470,7 +474,7 @@ class SnipeSCIMConfig
                                 $address['primary'] = true;
                             }
 
-                            return $address;
+                            return [$address];
                         }
 
                         public function doWrite($operation, $subop, $value, Model &$object, ?Path $path = null, $removeIfNotSet = false)

--- a/app/Models/SnipeSCIMConfig.php
+++ b/app/Models/SnipeSCIMConfig.php
@@ -166,6 +166,39 @@ class SnipeMutableCollection extends MutableCollection
     }
 }
 
+class MappedTable extends Attribute
+{
+    public function __construct(
+        private string $scim_attribute_name,
+        private string $relationship_name,
+        private string $relationship_class,
+        private string $relationship_id_field,
+        private string $relationship_field
+    ) {
+        parent::__construct($this->scim_attribute_name);
+    }
+
+    protected function doRead(&$object, $attributes = [])
+    {
+        return $object->{$this->relationship_name}?->{$this->relationship_field};
+    }
+
+    public function add($value, Model &$object)
+    {
+        $object->{$this->relationship_id_field} = $value ? $this->relationship_class::firstOrCreate([$this->relationship_field => $value])->id : null;
+    }
+
+    public function replace($value, Model &$object, $path = null, $removeIfNotSet = false)
+    {
+        $object->{$this->relationship_id_field} = $value ? $this->relationship_class::firstOrCreate([$this->relationship_field => $value])->id : null;
+    }
+
+    public function patch($operation, $value, Model &$object, ?Path $path = null, $removeIfNotSet = false)
+    {
+        $object->{$this->relationship_id_field} = $value ? $this->relationship_class::firstOrCreate([$this->relationship_field => $value])->id : null;
+    }
+}
+
 // Company is stored only in the company_user pivot, not company_id. Read from the pivot
 // and sync it on write. For new users (not yet saved) defer the sync via a saved() callback.
 class SCIMCompanyAttribute extends MappedTable
@@ -207,39 +240,6 @@ class EloquentWithRemove extends Eloquent
     public function remove($value, Model &$object, ?Path $path = null)
     {
         $object->{$this->attribute} = null;
-    }
-}
-
-class MappedTable extends Attribute
-{
-    public function __construct(
-        private string $scim_attribute_name,
-        private string $relationship_name,
-        private string $relationship_class,
-        private string $relationship_id_field,
-        private string $relationship_field)
-    {
-        parent::__construct($this->scim_attribute_name);
-    }
-
-    protected function doRead(&$object, $attributes = [])
-    {
-        return $object->{$this->relationship_name}?->{$this->relationship_field};
-    }
-
-    public function add($value, Model &$object)
-    {
-        $object->{$this->relationship_id_field} = $value ? $this->relationship_class::firstOrCreate([$this->relationship_field => $value])->id : null;
-    }
-
-    public function replace($value, Model &$object, $path = null, $removeIfNotSet = false)
-    {
-        $object->{$this->relationship_id_field} = $value ? $this->relationship_class::firstOrCreate([$this->relationship_field => $value])->id : null;
-    }
-
-    public function patch($operation, $value, Model &$object, ?Path $path = null, $removeIfNotSet = false)
-    {
-        $object->{$this->relationship_id_field} = $value ? $this->relationship_class::firstOrCreate([$this->relationship_field => $value])->id : null;
     }
 }
 

--- a/app/Models/SnipeSCIMConfig.php
+++ b/app/Models/SnipeSCIMConfig.php
@@ -12,6 +12,7 @@ use ArieTimmerman\Laravel\SCIMServer\Attribute\Meta;
 use ArieTimmerman\Laravel\SCIMServer\Attribute\MutableCollection;
 use ArieTimmerman\Laravel\SCIMServer\Attribute\Schema as AttributeSchema;
 use ArieTimmerman\Laravel\SCIMServer\Exceptions\SCIMException;
+use ArieTimmerman\Laravel\SCIMServer\Parser\Parser;
 use ArieTimmerman\Laravel\SCIMServer\Parser\Path;
 use ArieTimmerman\Laravel\SCIMServer\SCIM\Schema;
 use Illuminate\Database\Eloquent\Model;
@@ -29,6 +30,140 @@ function complex($name = null): Complex
 function eloquent($name, $attribute = null): Attribute
 {
     return new Eloquent($name, $attribute);
+}
+
+// Extends Complex to handle schema-qualified attribute keys in PATCH add/replace operations.
+// Azure Entra ID sends PATCH without a "path" field, putting the full URN as the value dict key
+// e.g. {"op":"add","value":{"urn:...grokability...:location":"Head Office"}}.
+// The upstream library's add() only searches the default (core) schema, silently dropping grokability attrs.
+class SnipeRootComplex extends Complex
+{
+    private function findInSchema(string $schemaUrn, string $attrName): ?object
+    {
+        $schemaNode = $this->getSubNode($schemaUrn);
+
+        return ($schemaNode instanceof AttributeSchema) ? $schemaNode->getSubNode($attrName) : null;
+    }
+
+    public function add($value, Model &$object)
+    {
+        $match = false;
+        $this->dirty = true;
+
+        if ($this->mutability == 'readOnly') {
+            return;
+        }
+
+        foreach ($value as $key => $v) {
+            if (is_numeric($key)) {
+                throw new SCIMException('Invalid key: '.$key.' for complex object '.$this->getFullKey());
+            }
+
+            $path = Parser::parse($key);
+
+            if ($path->isNotEmpty()) {
+                $attributeNames = $path->getAttributePathAttributes();
+                $schema = $path->getAttributePath()?->path?->schema;
+                $path = $path->shiftAttributePathAttributes();
+
+                $subNode = ($schema !== null) ? $this->findInSchema($schema, $attributeNames[0]) : null;
+                if ($subNode === null) {
+                    $subNode = $this->getSubNode($attributeNames[0]);
+                }
+
+                $match = true;
+
+                $newValue = $v;
+                if ($path->isNotEmpty()) {
+                    $newValue = [implode('.', $path->getAttributePathAttributes()) => $v];
+                }
+
+                if ($subNode !== null) {
+                    $subNode->add($newValue, $object);
+                }
+            }
+        }
+
+        if (! $match && $this->parent == null) {
+            foreach ($this->subAttributes as $attribute) {
+                if ($attribute instanceof AttributeSchema) {
+                    $attribute->add($value, $object);
+                }
+            }
+        }
+    }
+
+    public function replace($value, Model &$object, ?Path $path = null, $removeIfNotSet = false)
+    {
+        $this->dirty = true;
+
+        if ($this->mutability == 'readOnly') {
+            return;
+        }
+
+        foreach ($value as $key => $v) {
+            if (is_numeric($key)) {
+                throw new SCIMException('Invalid key: '.$key.' for complex object '.$this->getFullKey());
+            }
+
+            $subNode = null;
+
+            if (strpos($key, ':') !== false) {
+                $parsed = Parser::parse($key);
+                $schemaUrn = $parsed->getAttributePath()?->path?->schema;
+                $attrName = $parsed->getAttributePathAttributes()[0] ?? null;
+                if ($schemaUrn !== null && $attrName !== null) {
+                    $subNode = $this->findInSchema($schemaUrn, $attrName);
+                }
+                if ($subNode === null) {
+                    $subNode = $this->getSubNode($key);
+                }
+            } else {
+                $path = Parser::parse($key);
+                if ($path->isNotEmpty()) {
+                    $attributeNames = $path->getAttributePathAttributes();
+                    $path = $path->shiftAttributePathAttributes();
+                    $subNode = $this->getSubNode($attributeNames[0] ?? $path->getAttributePath()?->path?->schema);
+                }
+            }
+
+            if ($subNode !== null) {
+                $newValue = $v;
+                if ($path !== null && $path->isNotEmpty()) {
+                    $newValue = [implode('.', $path->getAttributePathAttributes()) => $v];
+                }
+                $subNode->replace($newValue, $object, $path);
+            }
+        }
+
+        if ($subNode == null && $this->parent == null) {
+            foreach ($this->subAttributes as $attribute) {
+                if ($attribute instanceof AttributeSchema) {
+                    $attribute->replace($value, $object, $path);
+                }
+            }
+        }
+
+        if ($removeIfNotSet) {
+            foreach ($this->subAttributes as $attribute) {
+                if (! $attribute->isDirty()) {
+                    $attribute->remove(null, $object);
+                }
+            }
+        }
+    }
+}
+
+// Azure Entra ID sends op=replace with path=members and only the single user being provisioned,
+// not the full member list. Using sync() would wipe all other members on every user update.
+// Override replace() to use syncWithoutDetaching() so it behaves like add(); op=remove with a
+// filter path still handles explicit removals correctly.
+class SnipeMutableCollection extends MutableCollection
+{
+    public function replace($value, Model &$object, ?Path $path = null)
+    {
+        $this->add($value, $object);
+    }
 }
 
 class EloquentWithRemove extends Eloquent
@@ -132,7 +267,7 @@ class SnipeSCIMConfig
             'withRelations' => [],
             'description' => 'User Account',
 
-            'map' => complex()->withSubAttributes(
+            'map' => (new SnipeRootComplex)->withSubAttributes(
                 new class('schemas', ['urn:ietf:params:scim:schemas:core:2.0:User', self::ENTERPRISE, self::GROKABILITY]) extends Constant
                 {
                     public function replace($value, &$object, $path = null)
@@ -471,7 +606,7 @@ class SnipeSCIMConfig
                             $fail('The name has already been taken.');
                         }
                     }),
-                    (new MutableCollection('members'))->withSubAttributes(
+                    (new SnipeMutableCollection('members'))->withSubAttributes(
                         eloquent('value', 'id')->ensure('required'),
                         (new class('$ref') extends Eloquent
                         {


### PR DESCRIPTION
This PR *should* fix a few different-but-related SCIM issues we're seeing in Azure/Entra - #19095 and #19096. It also adds support for multiple companies, which it did not natively support before (because I forgot to add it when I added multiple-company-for-users-support.)
                                                                                                                                                                                                                                                                                                               
**Company and location not being set on users** (#19095)

Azure Entra ID sends `PATCH` requests without a path field, encoding the attribute namespace as part of the value dict key:                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                               
```json
{"op":"add","value":{                                                                                                                                                                                                                                                                                              
   "urn:ietf:params:scim:schemas:extension:grokability:2.0:User:location": "Head Office",                                                                                                                                                                                                                           
   "urn:ietf:params:scim:schemas:extension:grokability:2.0:User:company": "My Company"                                                                                                                                                                                                                              
}}   
```                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                               
The upstream SCIM library's `Complex::add()` parses the schema URN out of the key correctly but then ignores it, falling back to the default (core) schema to look up the attribute. Since `location` and `company` live in the _grokability_ extension schema, they were silently dropped.                                
                                   
`SnipeRootComplex` overrides `add()` and `replace()` on the root user mapping to use the parsed schema URN to find the correct schema node first, matching the behavior already present in the library's path-based patch() method. The same fix is applied to `replace()` which had the same issue.        

**Company not syncing to pivot table**  (also #19095) 

Company is now stored only in the `company_user` pivot, not in `company_id`. The previous `MappedTable` for company only wrote to `company_id` and read via the company relationship, so updates to existing users via SCIM `PATCH` left the pivot stale, breaking `canReceiveFromCompany()` and FMCS scoping.

`SCIMCompanyAttribute` overrides read to use `$user->companies->first()` from the pivot, and write to call `companies()->sync()` directly. For new users not yet persisted, the sync is deferred via a `saved()` callback.                
                                   
**Group members being replaced with a single user**  (#19096)                                                                                                                                                                                                                                                                  
                                    
Azure Entra ID sends `op=replace, path=members` with only the _single_ user being provisioned at that moment, not the full member list. The upstream `MutableCollection::replace()` calls `sync()`, which was treating this as "set the group to exactly this one member", wiping everyone else.                           
                                                     
`SnipeMutableCollection` overrides `replace()` to delegate to `add()` (`syncWithoutDetaching`), so members are added without removing existing ones. Explicit removals _still_ work via `op=remove` with a filter path, which Azure sends correctly and hits `detach()` unchanged.     

**Why was any of this necessary, one might ask...**

Two differences in how Azure sends PATCH requests:                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                     
1. Schema-qualified value keys (location/company bug) - _Most_ SCIM providers use an _explicit_ path field to identify the attribute: `{"op":"add","path":"urn:...:location","value":"Head Office"}`. Azure omits the path and puts the full URN as the key in the value dict instead. Both are valid per [RFC-7644](https://datatracker.ietf.org/doc/html/rfc7644), but the SCIM library we use only handled the _path_ form correctly. (One could definitely argue we should fix this in our forked version of the SCIM library, but that's @uberbrady's baby and he's on vacation until Tuesday. )
2. `op=replace` for group membership - _Most_ providers use `op=add` with `path=members` to add a user to a group, which is the intuitive match to the operation's name. Azure uses `op=replace` with only the single user being provisioned - not the full member list - which is technically a valid replace-to-this-list operation but only makes sense if you send the complete membership. Other providers that do send `op=replace` typically include all current members, so `sync()` would produce the right result. Azure's per-user incremental approach does not, hence the workaround we had to do here.

This one is definitely going to need some testing, so anyone with a dev install and SCIM access, feel free to chime in.