### PR TITLE
Bump note length validation for supplier model

### DIFF
--- a/app/Models/Supplier.php
+++ b/app/Models/Supplier.php
@@ -30,7 +30,7 @@ class Supplier extends SnipeModel
         'fax' => 'min:7|max:35|nullable',
         'phone' => 'min:7|max:35|nullable',
         'contact' => 'max:100|nullable',
-        'notes' => 'max:191|nullable', // Default string length is 191 characters..
+        'notes' => 'max:16383|nullable', // text is 65535 but each character can take up to 4 bytes in utf8mb4
         'email' => 'email|max:150|nullable',
         'address' => 'max:250|nullable',
         'address2' => 'max:250|nullable',


### PR DESCRIPTION
Originally the notes field on Supplier was a string and the validation rule accurately limited the length via `max`. Eventually it was [changed](https://github.com/grokability/snipe-it/blob/b5a46a370f85c6e87c8a9fa4a4593424bb027712/database/migrations/2025_11_10_205136_change_suppliers_notes_to_text.php#L15) to `text` but the rule wasn't updated.

This PR updates the max length to 16,383 characters.

---

[FD-55765]
