### PR TITLE
Fixed #19128: Rendering on general settings page

### DIFF
--- a/resources/views/settings/general.blade.php
+++ b/resources/views/settings/general.blade.php
@@ -304,7 +304,7 @@
                        </fieldset>
 
 
-                       <fieldset name="checkin-preferences"">
+                       <fieldset name="checkin-preferences">
                            <x-form.legend>
                                {{ trans('admin/settings/general.legends.checkin') }}
                            </x-form.legend>
@@ -381,7 +381,7 @@
                                        @endif
                                        <p class="help-block">
                                            {{ trans('admin/settings/general.dashboard_message_help') }}
-                                           <i class="fab fa-markdown" aria-hidden="true"> {!!  trans('general.github_markdown') !!}
+                                           <i class="fab fa-markdown" aria-hidden="true"></i> {!!  trans('general.github_markdown') !!}
                                        </p>
                                    </div>
                                </div>


### PR DESCRIPTION
The general setting page is missing a closing tag for an icon and that messing with the rendering for the rest of the page. This PR fixes that.

Before:
<img width="1506" height="1468" alt="image" src="https://github.com/user-attachments/assets/53b4adc7-353d-4915-b6c4-e0fa976c2a6b" />


After:
<img width="1510" height="1344" alt="image" src="https://github.com/user-attachments/assets/db49f992-8883-486e-a7d2-85847cedf3fd" />

---

Fixes #19128
