### PR TITLE
🎥 Fixed #19133 - added optional clear asset name to quick scan checkin/audit

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -1140,7 +1140,9 @@ class AssetsController extends Controller
         $asset->assignedTo()->disassociate($asset);
         $asset->accepted = null;
 
-        if ($request->has('name')) {
+        if ($request->input('clear_name') == '1') {
+            $asset->name = null;
+        } elseif ($request->has('name')) {
             $asset->name = $request->input('name');
         }
 
@@ -1282,6 +1284,10 @@ class AssetsController extends Controller
             }
 
             $asset->last_audit_date = date('Y-m-d H:i:s');
+
+            if ($request->input('clear_name') == '1') {
+                $asset->name = null;
+            }
 
             // Set up the payload for re-display in the API response
             $payload = [

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -83,6 +83,7 @@ return [
     'user_requests_count' => 'Requests',
     'city' => 'City',
     'click_here' => 'Click here',
+    'clear_name' => 'Clear asset name',
     'clear_selection' => 'Clear Selection',
     'companies' => 'Companies',
     'companies_var' => 'Company|Companies',

--- a/resources/views/hardware/quickscan-checkin.blade.php
+++ b/resources/views/hardware/quickscan-checkin.blade.php
@@ -70,7 +70,15 @@
                             </div>
                         </div>
 
-
+                        <!-- Clear Name -->
+                        <div class="form-group">
+                            <div class="col-sm-offset-3 col-md-9">
+                                <label class="form-control">
+                                    <input type="checkbox" value="1" name="clear_name">
+                                    <span>{{ trans('general.clear_name') }}</span>
+                                </label>
+                            </div>
+                        </div>
 
                 </div> <!--/.box-body-->
                 <div class="box-footer">

--- a/resources/views/hardware/quickscan.blade.php
+++ b/resources/views/hardware/quickscan.blade.php
@@ -95,6 +95,16 @@
                             </div>
                         </div>
 
+                        <!-- Clear Name -->
+                        <div class="form-group">
+                            <div class="col-sm-offset-3 col-md-9">
+                                <label class="form-control">
+                                    <input type="checkbox" value="1" name="clear_name">
+                                    <span>{{ trans('general.clear_name') }}</span>
+                                </label>
+                            </div>
+                        </div>
+
                     </div> <!--/.box-body-->
                     <div class="box-footer">
                         <a class="btn btn-link" href="{{ route('hardware.index') }}"> {{ trans('button.cancel') }}</a>

--- a/tests/Feature/Assets/Api/AuditAssetTest.php
+++ b/tests/Feature/Assets/Api/AuditAssetTest.php
@@ -162,4 +162,33 @@ class AuditAssetTest extends TestCase
         $asset->refresh();
         $this->assertNull($asset->next_audit_date);
     }
+
+    public function test_asset_name_is_cleared_on_audit_when_clear_name_is_set()
+    {
+        $asset = Asset::factory()->create(['name' => 'My Asset Name']);
+
+        $this->actingAsForApi(User::factory()->auditAssets()->create())
+            ->postJson(route('api.asset.audit.legacy'), [
+                'asset_tag' => $asset->asset_tag,
+                'clear_name' => '1',
+            ])
+            ->assertStatusMessageIs('success')
+            ->assertStatus(200);
+
+        $this->assertNull($asset->refresh()->name);
+    }
+
+    public function test_asset_name_is_not_cleared_on_audit_when_clear_name_is_not_set()
+    {
+        $asset = Asset::factory()->create(['name' => 'My Asset Name']);
+
+        $this->actingAsForApi(User::factory()->auditAssets()->create())
+            ->postJson(route('api.asset.audit.legacy'), [
+                'asset_tag' => $asset->asset_tag,
+            ])
+            ->assertStatusMessageIs('success')
+            ->assertStatus(200);
+
+        $this->assertEquals('My Asset Name', $asset->refresh()->name);
+    }
 }

--- a/tests/Feature/Checkins/Api/AssetCheckinByTagTest.php
+++ b/tests/Feature/Checkins/Api/AssetCheckinByTagTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Feature\Checkins\Api;
+
+use App\Models\Asset;
+use App\Models\User;
+use Tests\TestCase;
+
+class AssetCheckinByTagTest extends TestCase
+{
+    public function test_checking_in_asset_by_tag_requires_correct_permission()
+    {
+        $asset = Asset::factory()->assignedToUser()->create();
+
+        $this->actingAsForApi(User::factory()->create())
+            ->postJson(route('api.asset.checkinbytag'), ['asset_tag' => $asset->asset_tag])
+            ->assertForbidden();
+    }
+
+    public function test_asset_can_be_checked_in_by_tag()
+    {
+        $asset = Asset::factory()->assignedToUser()->create();
+
+        $this->actingAsForApi(User::factory()->checkinAssets()->create())
+            ->postJson(route('api.asset.checkinbytag'), ['asset_tag' => $asset->asset_tag])
+            ->assertOk()
+            ->assertStatusMessageIs('success');
+
+        $this->assertNull($asset->refresh()->assignedTo);
+    }
+
+    public function test_checkin_by_tag_returns_error_for_unknown_tag()
+    {
+        $this->actingAsForApi(User::factory()->checkinAssets()->create())
+            ->postJson(route('api.asset.checkinbytag'), ['asset_tag' => 'DOES-NOT-EXIST'])
+            ->assertOk()
+            ->assertStatusMessageIs('error');
+    }
+
+    public function test_asset_name_is_cleared_on_checkin_by_tag_when_clear_name_is_set()
+    {
+        $asset = Asset::factory()->assignedToUser()->create(['name' => 'My Asset Name']);
+
+        $this->actingAsForApi(User::factory()->checkinAssets()->create())
+            ->postJson(route('api.asset.checkinbytag'), [
+                'asset_tag' => $asset->asset_tag,
+                'clear_name' => '1',
+            ])
+            ->assertOk()
+            ->assertStatusMessageIs('success');
+
+        $this->assertNull($asset->refresh()->name);
+    }
+
+    public function test_asset_name_is_not_cleared_on_checkin_by_tag_when_clear_name_is_not_set()
+    {
+        $asset = Asset::factory()->assignedToUser()->create(['name' => 'My Asset Name']);
+
+        $this->actingAsForApi(User::factory()->checkinAssets()->create())
+            ->postJson(route('api.asset.checkinbytag'), ['asset_tag' => $asset->asset_tag])
+            ->assertOk()
+            ->assertStatusMessageIs('success');
+
+        $this->assertEquals('My Asset Name', $asset->refresh()->name);
+    }
+}

--- a/tests/Feature/Checkins/Api/AssetCheckinTest.php
+++ b/tests/Feature/Checkins/Api/AssetCheckinTest.php
@@ -191,4 +191,28 @@ class AssetCheckinTest extends TestCase
                 && $event->note === 'hi there';
         }, 1);
     }
+
+    public function test_asset_name_is_cleared_on_checkin_when_clear_name_is_set()
+    {
+        $asset = Asset::factory()->assignedToUser()->create(['name' => 'My Asset Name']);
+
+        $this->actingAsForApi(User::factory()->checkinAssets()->create())
+            ->postJson(route('api.asset.checkin', $asset), ['clear_name' => '1'])
+            ->assertOk()
+            ->assertStatusMessageIs('success');
+
+        $this->assertNull($asset->refresh()->name);
+    }
+
+    public function test_asset_name_is_not_cleared_on_checkin_when_clear_name_is_not_set()
+    {
+        $asset = Asset::factory()->assignedToUser()->create(['name' => 'My Asset Name']);
+
+        $this->actingAsForApi(User::factory()->checkinAssets()->create())
+            ->postJson(route('api.asset.checkin', $asset))
+            ->assertOk()
+            ->assertStatusMessageIs('success');
+
+        $this->assertEquals('My Asset Name', $asset->refresh()->name);
+    }
 }


### PR DESCRIPTION
This just adds a checkbox to clear the asset's name on checkin/audit scanner options. Some folks use asset names (and some don't), but for those using asset names like "Snipe's MBP", it's helpful if folks can clear that name on checkin. 

https://github.com/user-attachments/assets/d26c0868-be4a-46e4-adff-95a5edab7c95

Fixes #19133