### PR TITLE
Labels: FD[55918] Fixes location not displaying on labels when assigned to.

### DIFF
--- a/app/Models/Labels/FieldOption.php
+++ b/app/Models/Labels/FieldOption.php
@@ -37,7 +37,7 @@ class FieldOption
                 return $assigned->getRawOriginal('display_name') ?? $assigned->display_name;
             }
 
-            return $assigned->display_name;
+            return $assigned->full_name;
         }
 
         // Handle Laravel's stupid Carbon datetime casting

--- a/app/Models/Labels/FieldOption.php
+++ b/app/Models/Labels/FieldOption.php
@@ -3,6 +3,7 @@
 namespace App\Models\Labels;
 
 use App\Models\Asset;
+use App\Models\User;
 
 class FieldOption
 {
@@ -36,8 +37,10 @@ class FieldOption
             if ($dataPath[0] === 'displayName') {
                 return $assigned->getRawOriginal('display_name') ?? $assigned->display_name;
             }
-
-            return $assigned->full_name;
+            if ($assigned instanceof User) {
+                return $assigned->full_name;
+            }
+            return $assigned->name ?? $assigned->display_name ?? null;
         }
 
         // Handle Laravel's stupid Carbon datetime casting

--- a/app/Models/Labels/FieldOption.php
+++ b/app/Models/Labels/FieldOption.php
@@ -27,22 +27,17 @@ class FieldOption
         // assignedTo directly on the asset is a special case where
         // we want to avoid returning the property directly
         // and instead return the entity's presented name.
-        if ($dataPath[0] === 'assignedTo') {
-            if ($asset->relationLoaded('assignedTo')) {
-                // If the "assignedTo" relationship was eager loaded then the way to get the
-                // relationship changes from $asset->assignedTo to $asset->assigned.
-                return $asset->assigned ? $asset->assigned->full_name : null;
+        if (in_array($dataPath[0], ['assignedTo', 'displayName'])) {
+            $assigned = $asset->relationLoaded('assignedTo') ? $asset->assigned : $asset->assignedTo;
+
+            if (!$assigned) {
+                return null;
+            }
+            if ($dataPath[0] === 'displayName') {
+                return $assigned->getRawOriginal('display_name') ?? $assigned->display_name;
             }
 
-            return $asset->assignedTo ? $asset->assignedTo->full_name : null;
-        }
-        if ($dataPath[0] === 'displayName') {
-            if ($asset->relationLoaded('assignedTo')) {
-
-                return $asset->assigned ? $asset->assigned->display_name : null;
-            }
-
-            return $asset->assignedTo ? $asset->assignedTo->display_name : null;
+            return $assigned->display_name;
         }
 
         // Handle Laravel's stupid Carbon datetime casting


### PR DESCRIPTION
This fixes locations from not displaying on labels under Assigned to. displayName now attempts to return the raw `display_name` and falls back on the accessor. This also uses `instanceOf` to use the right accessor for User/Location/Asset

Here is a screenshot of all three working now:
<img width="820" height="150" alt="image" src="https://github.com/user-attachments/assets/3e33db95-2429-4321-88ac-43ba1e560f39" />
