### PR TITLE
Make accessories requestable

### DIFF
--- a/app/Http/Controllers/Accessories/AccessoriesController.php
+++ b/app/Http/Controllers/Accessories/AccessoriesController.php
@@ -77,6 +77,7 @@ class AccessoriesController extends Controller
         $accessory->created_by = auth()->id();
         $accessory->supplier_id = request('supplier_id');
         $accessory->notes = request('notes');
+        $accessory->requestable = request('requestable', 0);
 
         if ($request->has('use_cloned_image')) {
             $cloned_model_img = Accessory::select('image')->find($request->input('clone_image_from_id'));
@@ -183,6 +184,7 @@ class AccessoriesController extends Controller
             $accessory->qty = request('qty');
             $accessory->supplier_id = request('supplier_id');
             $accessory->notes = request('notes');
+            $accessory->requestable = request('requestable', 0);
 
             $accessory = $request->handleImages($accessory);
 

--- a/app/Http/Controllers/Api/ProfileController.php
+++ b/app/Http/Controllers/Api/ProfileController.php
@@ -67,7 +67,7 @@ class ProfileController extends Controller
             if ($checkoutRequest && $checkoutRequest->itemRequested()) {
                 $assets = [
                     'image' => e($checkoutRequest->itemRequested()->present()->getImageUrl()),
-                    'name' => e($checkoutRequest->name()),
+                    'name' => e($checkoutRequest->itemRequested()->display_name),
                     'type' => e($checkoutRequest->itemType()),
                     'qty' => (int) $checkoutRequest->quantity,
                     'location' => ($checkoutRequest->location()) ? e($checkoutRequest->location()->name) : null,

--- a/app/Http/Controllers/Api/ProfileController.php
+++ b/app/Http/Controllers/Api/ProfileController.php
@@ -67,7 +67,7 @@ class ProfileController extends Controller
             if ($checkoutRequest && $checkoutRequest->itemRequested()) {
                 $assets = [
                     'image' => e($checkoutRequest->itemRequested()->present()->getImageUrl()),
-                    'name' => e($checkoutRequest->itemRequested()->display_name),
+                    'name' => e($checkoutRequest->name()),
                     'type' => e($checkoutRequest->itemType()),
                     'qty' => (int) $checkoutRequest->quantity,
                     'location' => ($checkoutRequest->location()) ? e($checkoutRequest->location()->name) : null,

--- a/app/Http/Controllers/ViewAssetsController.php
+++ b/app/Http/Controllers/ViewAssetsController.php
@@ -6,6 +6,7 @@ use App\Actions\CheckoutRequests\CancelCheckoutRequestAction;
 use App\Actions\CheckoutRequests\CreateCheckoutRequestAction;
 use App\Enums\ActionType;
 use App\Exceptions\AssetNotRequestable;
+use App\Models\Accessory;
 use App\Models\Actionlog;
 use App\Models\Asset;
 use App\Models\AssetModel;
@@ -160,11 +161,17 @@ class ViewAssetsController extends Controller
             },
         ])->RequestableModels()->get();
 
-        return view('account/requestable-assets', compact('assets', 'models'));
+        $accessories = Accessory::with('category', 'location', 'requests')
+            ->withCount('checkouts as checkouts_count')
+            ->RequestableAccessories()
+            ->get();
+
+        return view('account/requestable-assets', compact('assets', 'models', 'accessories'));
     }
 
     public function getRequestItem(Request $request, $itemType, $itemId = null, $cancel_by_admin = false, $requestingUser = null): RedirectResponse
     {
+        $data = [];
         $item = null;
         $fullItemType = 'App\\Models\\'.studly_case($itemType);
 
@@ -193,11 +200,12 @@ class ViewAssetsController extends Controller
         $data['item_type'] = $itemType;
         $data['target'] = auth()->user();
 
-        if ($fullItemType == Asset::class) {
-            $data['item_url'] = route('hardware.show', $item->id);
-        } else {
-            $data['item_url'] = route("view/{$itemType}", $item->id);
-        }
+        $data['item_url'] = match ($fullItemType) {
+            Asset::class => route('hardware.show', $item->id),
+            AssetModel::class => route('view/model', $item->id),
+            Accessory::class => route('accessories.show', $item->id),
+            default => route("view/{$itemType}", $item->id),
+        };
 
         $settings = Setting::getSettings();
 
@@ -209,7 +217,7 @@ class ViewAssetsController extends Controller
 
         if (($item_request = $item->isRequestedBy($user)) || ($is_admin && $cancel_by_admin)) {
             $item->cancelRequest($is_admin && $cancel_by_admin ? $requestingUser : null);
-            $data['item_quantity'] = ($item_request) ? $item_request->qty : 1;
+            $data['item_quantity'] = ($item_request) ? $item_request->quantity : 1;
             $logaction->logaction(ActionType::RequestCanceled);
 
             if (($settings->alert_email != '') && ($settings->alerts_enabled == '1') && (! config('app.lock_passwords'))) {
@@ -222,11 +230,12 @@ class ViewAssetsController extends Controller
 
             return redirect()->back()->with('success')->with('success', trans('admin/hardware/message.requests.canceled'));
         } else {
-            if ($fullItemType === Asset::class && is_null(Asset::RequestableAssets()->find($item->id))) {
+            if (($fullItemType === Asset::class && is_null(Asset::RequestableAssets()->find($item->id)))
+                || ($fullItemType === Accessory::class && is_null(Accessory::RequestableAccessories()->find($item->id)))) {
                 return redirect()->back()->with('error', trans('admin/hardware/message.requests.error'));
             }
 
-            $item->request();
+            $item->request($data['item_quantity']);
             if (($settings->alert_email != '') && ($settings->alerts_enabled == '1') && (! config('app.lock_passwords'))) {
                 $logaction->logaction('requested');
                 try {

--- a/app/Models/Accessory.php
+++ b/app/Models/Accessory.php
@@ -6,6 +6,7 @@ use App\Models\Traits\Acceptable;
 use App\Models\Traits\CompanyableTrait;
 use App\Models\Traits\HasUploads;
 use App\Models\Traits\Loggable;
+use App\Models\Traits\Requestable;
 use App\Models\Traits\Searchable;
 use App\Presenters\AccessoryPresenter;
 use App\Presenters\Presentable;
@@ -29,6 +30,7 @@ class Accessory extends SnipeModel
     use HasUploads;
     use Loggable;
     use Presentable;
+    use Requestable;
     use Searchable;
     use SoftDeletes;
     use ValidatingTrait;
@@ -153,6 +155,15 @@ class Accessory extends SnipeModel
             $value = null;
         }
         $this->attributes['requestable'] = filter_var($value, FILTER_VALIDATE_BOOLEAN);
+    }
+
+    /**
+     * Scope query to only requestable accessories. Unlike assets, accessories
+     * have no deployable status to check, so the flag is all we need here.
+     */
+    public function scopeRequestableAccessories($query)
+    {
+        return $query->where('accessories.requestable', '1');
     }
 
     /**

--- a/app/Models/CheckoutRequest.php
+++ b/app/Models/CheckoutRequest.php
@@ -11,7 +11,7 @@ class CheckoutRequest extends Model
     use HasFactory;
     use SoftDeletes;
 
-    protected $fillable = ['user_id'];
+    protected $fillable = ['user_id', 'quantity'];
 
     protected $table = 'checkout_requests';
 

--- a/app/Models/Traits/Requestable.php
+++ b/app/Models/Traits/Requestable.php
@@ -33,7 +33,7 @@ trait Requestable
     public function request($qty = 1)
     {
         $this->requests()->save(
-            new CheckoutRequest(['user_id' => auth()->id(), 'qty' => $qty])
+            new CheckoutRequest(['user_id' => auth()->id(), 'quantity' => $qty])
         );
     }
 

--- a/resources/lang/en-US/admin/accessories/general.php
+++ b/resources/lang/en-US/admin/accessories/general.php
@@ -13,6 +13,7 @@ return [
     'no_default_eula' => 'No primary default EULA found. Add one in Settings.',
     'total' => 'Total',
     'remaining' => 'Avail',
+    'requestable' => 'Users may request this accessory',
     'update' => 'Update Accessory',
     'use_default_eula' => 'Use the <a href="#" data-toggle="modal" data-target="#eulaModal">primary default EULA</a> instead.',
     'use_default_eula_disabled' => '<del>Use the primary default EULA instead.</del> No primary default EULA is set. Please add one in Settings.',

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -660,7 +660,7 @@ return [
             'partial' => 'Deleted :success_count :object_type, but :error_count :object_type could not be deleted',
         ],
     ],
-    'no_requestable' => 'There are no requestable assets or asset models.',
+    'no_requestable' => 'There are no requestable assets, asset models, or accessories.',
 
     'countable' => [
         'accessories' => ':count Accessory|:count Accessories',

--- a/resources/views/accessories/edit.blade.php
+++ b/resources/views/accessories/edit.blade.php
@@ -100,6 +100,8 @@
 
             @include ('partials.forms.edit.image-upload', ['image_path' => app('accessories_upload_path')])
 
+            @include ('partials.forms.edit.requestable', ['requestable_text' => trans('admin/accessories/general.requestable')])
+
             <x-slot:customfooter>
                 <x-redirect_submit_options
                     index_route="accessories.index"

--- a/resources/views/account/requestable-assets.blade.php
+++ b/resources/views/account/requestable-assets.blade.php
@@ -16,7 +16,7 @@
     <div class="col-md-12">
 
 
-        @if (($assets->count() < 1) && ($models->count() < 1))
+        @if (($assets->count() < 1) && ($models->count() < 1) && ($accessories->count() < 1))
 
             <div class="col-md-12">
                 <div class="alert alert-info fade in">
@@ -40,7 +40,14 @@
                 <li>
                     <a href="#models" data-toggle="tab" title="{{ trans('general.asset_models') }}">{{ trans('general.asset_models') }}
                         <span class="badge badge-secondary"> {{ $models->count()}}</span>
-                    </a>                   
+                    </a>
+                </li>
+                @endif
+                @if ($accessories->count() > 0)
+                <li>
+                    <a href="#accessories" data-toggle="tab" title="{{ trans('general.accessories') }}">{{ trans('general.accessories') }}
+                        <span class="badge badge-secondary"> {{ $accessories->count()}}</span>
+                    </a>
                 </li>
                 @endif
             </ul>
@@ -151,6 +158,67 @@
                                 </tbody>
                             </table>
 
+                        </div>
+                    </div>
+                </div>
+                @endif
+
+                @if ($accessories->count() > 0)
+                <div class="tab-pane fade in {{ (($assets->count() == 0) && ($models->count() == 0)) ? 'active' : '' }}" id="accessories">
+                    <div class="row">
+                        <div class="col-md-12">
+                            <table
+                                    class="table table-striped snipe-table"
+                                    id="requestableAccessoriesTable"
+                                    data-cookie-id-table="requestableAccessories">
+                                <thead>
+                                    <tr role="row">
+                                        <th class="col-md-1" data-sortable="true">{{ trans('general.image') }}</th>
+                                        <th class="col-md-5" data-sortable="true">{{ trans('admin/accessories/general.accessory_name') }}</th>
+                                        <th class="col-md-2" data-sortable="true">{{ trans('admin/hardware/table.location') }}</th>
+                                        <th class="col-md-2" data-sortable="true">{{ trans('admin/accessories/general.remaining') }}</th>
+                                        <th class="col-md-2 actions" data-sortable="false">{{ trans('table.actions') }}</th>
+                                    </tr>
+                                </thead>
+
+                                <tbody>
+                                    @foreach($accessories as $requestableAccessory)
+                                        <tr>
+                                            <td>
+                                                @if (($requestableAccessory->image) && ($requestableAccessory->getImageUrl()))
+                                                    <a href="{{ $requestableAccessory->getImageUrl() }}" data-toggle="lightbox" data-type="image">
+                                                        <img src="{{ $requestableAccessory->getImageUrl() }}" style="max-height: {{ $snipeSettings->thumbnail_max_h }}px; width: auto;" class="img-responsive">
+                                                    </a>
+                                                @endif
+                                            </td>
+
+                                            <td>
+                                                @can('view', \App\Models\Accessory::class)
+                                                    <a href="{{ route('accessories.show', ['accessory' => $requestableAccessory->id]) }}">{{ $requestableAccessory->name }}</a>
+                                                @else
+                                                    {{ $requestableAccessory->name }}
+                                                @endcan
+                                            </td>
+
+                                            <td>{{ $requestableAccessory->location->name ?? '' }}</td>
+
+                                            <td>{{ $requestableAccessory->numRemaining() }}</td>
+
+                                            <td>
+                                                <form action="{{ route('account/request-item', ['itemType' => 'accessory', 'itemId' => $requestableAccessory->id]) }}" method="POST" accept-charset="utf-8">
+                                                    {{ csrf_field() }}
+                                                    <input type="text" style="width: 70px; margin-right: 10px;" class="form-control pull-left" name="request-quantity" value="1" placeholder="{{ trans('general.qty') }}">
+                                                    @if ($requestableAccessory->isRequestedBy(Auth::user()))
+                                                        <input class="btn btn-danger btn-sm" type="submit" value="{{ trans('button.cancel') }}">
+                                                    @else
+                                                        <input class="btn btn-primary btn-sm" type="submit" value="{{ trans('button.request') }}">
+                                                    @endif
+                                                </form>
+                                            </td>
+                                        </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
                         </div>
                     </div>
                 </div>

--- a/resources/views/hardware/requested.blade.php
+++ b/resources/views/hardware/requested.blade.php
@@ -53,6 +53,8 @@
                                             <a href="{{ $request->requestable->getImageUrl() }}" data-toggle="lightbox" data-type="image"><img src="{{ $request->requestable->getImageUrl() }}" style="max-height: {{ $snipeSettings->thumbnail_max_h }}px; width: auto;" class="img-responsive" alt="{{ $request->requestable->name }}"></a>
                                         @elseif (($request->itemType() == "asset_model") && ($request->requestable))
                                             <a href="{{ Storage::disk('public')->url(app('models_upload_path') . $request->requestable->image) }}" data-toggle="lightbox" data-type="image"><img src="{{ Storage::disk('public')->url(app('models_upload_path') . $request->requestable->image) }}" style="max-height: {{ $snipeSettings->thumbnail_max_h }}px; width: auto;" class="img-responsive" alt="{{ $request->requestable->name }}"></a>
+                                        @elseif (($request->itemType() == "accessory") && ($request->requestable) && ($request->requestable->getImageUrl()))
+                                            <a href="{{ $request->requestable->getImageUrl() }}" data-toggle="lightbox" data-type="image"><img src="{{ $request->requestable->getImageUrl() }}" style="max-height: {{ $snipeSettings->thumbnail_max_h }}px; width: auto;" class="img-responsive" alt="{{ $request->requestable->name }}"></a>
                                         @endif
                                         </td>
                                         <td>
@@ -63,6 +65,10 @@
                                                 </a>
                                             @elseif ($request->itemType() == "asset_model")
                                                 <a href="{{ config('app.url') }}/models/{{ $request->requestable->id }}">
+                                                    {{ $request->name() }}
+                                                </a>
+                                            @elseif ($request->itemType() == "accessory")
+                                                <a href="{{ config('app.url') }}/accessories/{{ $request->requestable->id }}">
                                                     {{ $request->name() }}
                                                 </a>
                                             @endif
@@ -111,6 +117,8 @@
                                                 @else
                                                     <a href="{{ config('app.url') }}/hardware/{{ $request->requestable->id }}/checkin" class="btn btn-sm bg-purple" data-tooltip="true" title="{{ trans('general.checkin_tooltip') }}">{{ trans('general.checkin') }}</a>
                                                 @endif
+                                            @elseif ($request->itemType() == "accessory")
+                                                <a href="{{ config('app.url') }}/accessories/{{ $request->requestable->id }}/checkout" class="btn btn-sm bg-maroon" data-tooltip="true" title="{{ trans('general.checkout_user_tooltip') }}">{{ trans('general.checkout') }}</a>
                                             @endif
                                         </td>
 

--- a/tests/Feature/Requests/Ui/AccessoryRequestTest.php
+++ b/tests/Feature/Requests/Ui/AccessoryRequestTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Tests\Feature\Requests\Ui;
+
+use App\Models\Accessory;
+use App\Models\CheckoutRequest;
+use App\Models\User;
+use Tests\TestCase;
+
+class AccessoryRequestTest extends TestCase
+{
+    public function test_requestable_index_lists_requestable_accessories(): void
+    {
+        $accessory = Accessory::factory()->create(['requestable' => true]);
+        Accessory::factory()->create(['requestable' => false]);
+
+        $this->actingAs(User::factory()->create())
+            ->get(route('requestable-assets'))
+            ->assertOk()
+            ->assertViewHas('accessories')
+            ->assertSeeText($accessory->name);
+    }
+
+    public function test_user_can_request_a_requestable_accessory(): void
+    {
+        $accessory = Accessory::factory()->create(['requestable' => true]);
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->post(route('account/request-item', [
+                'itemType' => 'accessory',
+                'itemId' => $accessory->id,
+            ]), ['request-quantity' => 3])
+            ->assertRedirect();
+
+        $request = CheckoutRequest::where('requestable_id', $accessory->id)
+            ->where('requestable_type', Accessory::class)
+            ->where('user_id', $user->id)
+            ->first();
+
+        $this->assertNotNull($request, 'A checkout request should have been created for the accessory.');
+        $this->assertEquals(3, $request->quantity, 'The requested quantity should be persisted.');
+        $this->assertNull($request->canceled_at);
+    }
+
+    public function test_user_cannot_request_an_accessory_that_is_not_requestable(): void
+    {
+        $accessory = Accessory::factory()->create(['requestable' => false]);
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->post(route('account/request-item', [
+                'itemType' => 'accessory',
+                'itemId' => $accessory->id,
+            ]))
+            ->assertRedirect()
+            ->assertSessionHas('error');
+
+        $this->assertNull(
+            CheckoutRequest::where('requestable_id', $accessory->id)
+                ->where('requestable_type', Accessory::class)
+                ->first()
+        );
+    }
+
+    public function test_user_can_cancel_their_own_accessory_request(): void
+    {
+        $accessory = Accessory::factory()->create(['requestable' => true]);
+        $user = User::factory()->create();
+        CheckoutRequest::factory()->create([
+            'requestable_id' => $accessory->id,
+            'requestable_type' => Accessory::class,
+            'user_id' => $user->id,
+        ]);
+
+        $this->actingAs($user)
+            ->post(route('account/request-item', [
+                'itemType' => 'accessory',
+                'itemId' => $accessory->id,
+            ]))
+            ->assertRedirect();
+
+        $this->assertNotNull(
+            CheckoutRequest::where('requestable_id', $accessory->id)
+                ->where('requestable_type', Accessory::class)
+                ->where('user_id', $user->id)
+                ->whereNotNull('canceled_at')
+                ->first()
+        );
+    }
+
+    public function test_admin_requested_index_renders_accessory_requests(): void
+    {
+        $accessory = Accessory::factory()->create(['requestable' => true]);
+        CheckoutRequest::factory()->create([
+            'requestable_id' => $accessory->id,
+            'requestable_type' => Accessory::class,
+            'user_id' => User::factory()->create()->id,
+        ]);
+
+        // The admin "Requested" queue is a polymorphic list of all checkout
+        // requests, so an accessory request should render there by name.
+        $this->actingAs(User::factory()->viewAssets()->create())
+            ->get(route('assets.requested'))
+            ->assertOk()
+            ->assertViewHas('requestedItems')
+            ->assertSeeText($accessory->name);
+    }
+}


### PR DESCRIPTION
## What this does

Lets accessories be flagged as **requestable** and requested by users from the *Requestable Items* page, exactly the way assets and asset models already work. Accessories are the most common thing people actually want to request (keyboards, mice, headsets, webcams) and they were the only checkout-able item type without it.

No migration is required, because the `accessories` table already has a `requestable` column that was simply never wired into the request flow.

## Why the simple semantics

The long-standing blocker on this (see #5908) has been disagreement over how *quantity* should behave when you request stock-based items. I went with the least surprising option:

- A request records **intent** plus the requested quantity, and notifies admins.
- It does **not** decrement or reserve stock.
- The admin still performs the normal checkout, which is the operation that already adjusts quantity.

So a request behaves identically for a unique asset and for a quantity-based accessory, and there's no new "reserved" state to reconcile. If maintainers later want reservation/approval semantics, this doesn't paint us into a corner, since it's purely additive.

## Changes

- `Accessory` uses the existing `Requestable` trait plus a `scopeRequestableAccessories()` scope.
- `AccessoriesController` persists the `requestable` flag on create/update; the edit form gets the existing requestable checkbox partial.
- `ViewAssetsController@getRequestableIndex` lists requestable accessories; `getRequestItem()` builds the item URL via a `match()` for all types and guards against requesting a non-requestable accessory.
- The *Requestable Items* view gets an **Accessories** tab.
- The admin *Requested* queue (which already lists every request polymorphically) now renders an accessory request's name, image and a checkout action, so an admin can see and fulfil it.
- Feature tests for requesting, cancelling, rejecting a non-requestable accessory, and rendering an accessory in the admin queue.

### Incidental bug fix

While wiring this up I found that the `Requestable` trait saved a `qty` key, but the column is `quantity` and wasn't in `$fillable`, so requested quantities were being **silently dropped**, including for asset models. This PR persists `quantity` correctly and reads it back in the request/cancel flow.

## Functional testing

Beyond the automated tests, I verified the whole flow end-to-end on a freshly seeded instance: a user requested a *USB Keyboard* accessory, and it shows up in the admin **Requested** queue with its image, name, requesting user, requested date, and working **Cancel** / **Checkout** actions.

## Open questions for maintainers

A couple of things I deliberately left alone, since they touch the broader "how should requestables work" question you mentioned in #5908 and would benefit from your direction:

1. **Placement of the admin "Requested" queue.** It currently lives under the **Assets** menu (route `assets.requested`, URL `/hardware/requested`) but is really a polymorphic list of *all* requests. Now that accessories show up there too, it arguably belongs in its own top-level "Requests" section rather than under Assets. I kept it where it is to avoid churn, but I'm happy to move or relabel it if you'd prefer.
2. **Pre-filling the requester on checkout.** When an admin clicks *Checkout* from the requested queue, the target user isn't pre-selected, so they have to pick it again. This is pre-existing and identical for assets (the asset checkout link behaves the same way), so I didn't change it here. Pre-filling the requester on approve would be a nice follow-up, ideally done uniformly for all requestable types.

## Issues this addresses

- Closes #12397 (*Make accessories requestable*), the direct duplicate, fully covered here.
- Partially addresses #5908 (*Accessories/Components/License requestable*), the accessories portion.
- Relates to #6520 (closed, *Requestable for Licenses, Accessories, Consumables and Components*).

Other related/duplicate requests I came across while researching this:

- #5694 (closed): Support requestable licenses
- #16639 (open): Requestable Licenses not displaying in Requestable Items
- #396 (closed): the original "Users request Assets" feature

## Follow-on (intentionally not in this PR)

Components and licenses can follow the identical pattern; each just needs a small migration to add a `requestable` column (accessories already had one). I kept this PR scoped to accessories so it stays small and reviewable.

## Testing

Run against SQLite locally:

```
DB_CONNECTION=sqlite php artisan test
```

The full suite passes (the 12 incomplete and 3 skipped are pre-existing), including all the existing request/checkout/notification tests that share this code path, so the `quantity` fix doesn't regress asset or model requests.

> Disclosure: I built this with the help of Claude (Claude Code) for exploring the codebase and drafting the change. I reviewed all of it, made the design decisions, and ran and validated the test suite myself before opening this PR.
