### PR TITLE
Importer: allow rendering simple error messages

### DIFF
--- a/resources/views/livewire/importer.blade.php
+++ b/resources/views/livewire/importer.blade.php
@@ -39,16 +39,25 @@
                             <tbody>
                             @foreach($import_errors AS $key => $actual_import_errors)
                                 @foreach($actual_import_errors AS $table => $error_bag)
-                                    @foreach($error_bag as $field => $error_list)
+                                    {{-- general messages such as "The selected file is invalid" are simple strings --}}
+                                    @if(is_string($error_bag))
                                         <tr>
-                                            <td><b>{{ $key }}</b></td>
-                                            <td><b>{{ $field }}</b></td>
-                                            <td>
-                                                <span>{{ implode(", ",$error_list) }}</span>
-                                                <br />
-                                            </td>
+                                            <td></td>
+                                            <td></td>
+                                            <td>{{ $error_bag }}</td>
                                         </tr>
-                                    @endforeach
+                                    @elseif(is_array($error_bag))
+                                        @foreach($error_bag as $field => $error_list)
+                                            <tr>
+                                                <td><b>{{ $key }}</b></td>
+                                                <td><b>{{ $field }}</b></td>
+                                                <td>
+                                                    <span>{{ implode(", ",$error_list) }}</span>
+                                                    <br />
+                                                </td>
+                                            </tr>
+                                        @endforeach
+                                    @endif
                                 @endforeach
                             @endforeach
                             </tbody>


### PR DESCRIPTION
The importer currently expects a key value pair for error messages, but simple error messages like "The selected file is invalid" (if the file was deleted before hitting the Process button) would throw a 500. This PR fixes that. 

<img width="2348" height="424" alt="image" src="https://github.com/user-attachments/assets/28738a9f-3953-4463-83f2-051bfa9ceae7" />

---

[RB-21586]