### PR TITLE
Custom Asset Report: Fixed [RB-21669] - use subquery for action_date

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -799,12 +799,11 @@ class ReportsController extends Controller
                 $checkout_start = Carbon::parse($request->input('checkout_date_start'))->startOfDay();
                 $checkout_end = Carbon::parse($request->input('checkout_date_end', now()))->endOfDay();
 
-                $actionlogassets = Actionlog::where('action_type', '=', 'checkout')
-                    ->where('item_type', 'LIKE', '%Asset%')
-                    ->whereBetween('action_date', [$checkout_start, $checkout_end])
-                    ->pluck('item_id');
+                $actionlogassets = Actionlog::select('id')->where('action_type', '=', 'checkout')
+                    ->where('item_type', '=', Asset::class)
+                    ->whereBetween('action_date', [$checkout_start, $checkout_end]); // we are *not* doing ->get()...
 
-                $assets->whereIn('assets.id', $actionlogassets);
+                $assets->whereIn('id', $actionlogassets); //...because this _should_ act as a 'subquery'
             }
 
             if (($request->filled('checkin_date_start'))) {


### PR DESCRIPTION
Instead of actually fetching out a list of asset ID's that you want to query against (which is how we did it before), this turns that previous query into a subquery, instead, which should work without triggering the error.

Additionally, we were using `item_type LIKE '%Asset%'` which will not perform as well as `item_type = 'App\\Models\\Asset'`.

When I was debugging the `toSql()` of the query, it came back with:

```
select `assets`.* from `assets` where `id` in (
    select `id` 
    from `action_logs` 
    where 
    `action_type` = ? and 
    `item_type` = ? and 
    `action_date` between ? and ? and 
    `action_logs`.`deleted_at` is null
) and `assets`.`deleted_at` is null  
```

Which is what I would expect we would want.

The `EXPLAIN` of that query looks pretty straightforward:

| id | select_type | table       | partitions | type   | possible_keys                                                                                                                                                                                                                                                                                               | key                           | key_len | ref                    | rows | filtered | Extra       |
| - | - | - | - | - | - | - | - | - | - | - | - |
|  1 | SIMPLE      | action_logs | NULL       | ref    | PRIMARY,action_logs_item_type_item_id_action_type_index,action_logs_action_type_index,action_logs_deleted_at_index,action_logs_action_date_index | action_logs_action_type_index | 766     | const                  |  436 |    40.06 | Using where |
|  1 | SIMPLE      | assets      | NULL       | eq_ref | PRIMARY,assets_deleted_at_status_id_index,assets_deleted_at_model_id_index,assets_deleted_at_assigned_type_assigned_to_index,assets_deleted_at_supplier_id_index,assets_deleted_at_location_id_index,assets_deleted_at_rtd_location_id_index,assets_deleted_at_asset_tag_index,assets_deleted_at_name_index | PRIMARY                       | 4       | laravel.action_logs.id |    1 |   100.00 | Using where |

Which looks pretty good to me - it's pulling from the `action_logs_action_type_index` (which isn't _too_ great, since it has a cardinality of whatever the number of valid `action_type`s we have is), but also implementing the `WHERE` clause in there. Then it does primary-key lookups on the actual assets themselves - so really quite similar as before, just having the database do it for us instead of round-tripping twice.