### PR TITLE
SCIM: Fix address handling and work around Entra email changes

### DIFF
--- a/app/Models/SnipeSCIMConfig.php
+++ b/app/Models/SnipeSCIMConfig.php
@@ -361,7 +361,11 @@ class SnipeSCIMConfig
                         {
                             if ($value) {
                                 try {
-                                    $object->email = $value[0]['value'];
+                                    if (is_string($value)) {
+                                        $object->email = $value; // Weird MS-SCIM stuff :/
+                                    } else {
+                                        $object->email = $value[0]['value'];
+                                    }
                                 } catch (\Throwable $e) {
                                     \Log::debug($e);
                                     throw new SCIMException("Unknown email object:  '".print_r($value, true)."'", 422);
@@ -470,7 +474,7 @@ class SnipeSCIMConfig
                                 $address['primary'] = true;
                             }
 
-                            return $address;
+                            return [$address];
                         }
 
                         public function doWrite($operation, $subop, $value, Model &$object, ?Path $path = null, $removeIfNotSet = false)


### PR DESCRIPTION
When Entra does an email address change, it does it a little bit strangely, in a way we're not prepared to handle. This adds a check for "did you just pass me a string instead of an array object? Cool. I'll just use that then."

In testing against Entra's SCIM implementation, I noticed something weird - it kept trying, over and over again, to re-push the address fields, even though they were already set. It turns out we were returning the Address block wrong - we're supposed to put that in an _array_ of _objects_ (in JSON, they're different things, unlike how PHP handles them). This is because SCIM can handle multiple addresses. In fact, we do this *correctly* on phone to support Mobile phone as well as Work phone. So I fixed that too.