### PR TITLE
FMCS Location+Parent Scoping: Fixed FD-53555 - Adds company-scoped dropdown for parent location in GUI

### DIFF
--- a/app/Http/Controllers/Api/LocationsController.php
+++ b/app/Http/Controllers/Api/LocationsController.php
@@ -484,6 +484,10 @@ class LocationsController extends Controller
             $locations->where('locations.id', '!=', (int) $request->input('excludeId'));
         }
 
+        if ((Setting::getSettings()->full_multiple_companies_support == '1') && $request->filled('companyId')) {
+            $locations->where('locations.company_id', '=', (int) $request->input('companyId'));
+        }
+
         $locations = $locations->orderBy('name', 'ASC')->get();
 
         $locations_with_children = [];

--- a/resources/views/locations/edit.blade.php
+++ b/resources/views/locations/edit.blade.php
@@ -1,3 +1,16 @@
+@push('js')
+<script nonce="{{ csrf_token() }}">
+    $(function () {
+        $('[name="company_id"]').on('select2:select select2:clear', function (e) {
+            var companyId = $(this).val() || null;
+            var $parentSelect = $('#parent_id_location_select');
+            $parentSelect.data('company-id', companyId);
+            $parentSelect.val(null).trigger('change');
+        });
+    });
+</script>
+@endpush
+
 @extends('layouts/edit-form', [
     'createText' => trans('admin/locations/table.create') ,
     'updateText' => trans('admin/locations/table.update'),
@@ -10,7 +23,7 @@
 @include ('partials.forms.edit.name', ['translated_name' => trans('admin/locations/table.name')])
 
 <!-- parent -->
-@include ('partials.forms.edit.location-select', ['translated_name' => trans('admin/locations/table.parent'), 'fieldname' => 'parent_id', 'exclude_id' => isset($item) ? $item->id : null])
+@include ('partials.forms.edit.location-select', ['translated_name' => trans('admin/locations/table.parent'), 'fieldname' => 'parent_id', 'exclude_id' => isset($item) ? $item->id : null, 'company_id' => isset($item) ? $item->company_id : null])
 
 <!-- Manager-->
 @include ('partials.forms.edit.user-select', ['translated_name' => trans('admin/users/table.manager'), 'fieldname' => 'manager_id'])


### PR DESCRIPTION
With FMCS enabled, this clears and filters the location parent option if it's switched.

 1. API selectlist — now filters by companyId when FMCS is enabled, so the dropdown only shows same-company locations                                                            
  2. Blade form — passes $item->company_id to the parent select, so on the edit form it's pre-filtered to the location's company from page load                                   
  3. JS — when the user changes the company select, clears the parent location value and updates the jQuery data store so the next search uses the new company filter     

https://github.com/user-attachments/assets/1abc36b7-d8dc-44f5-ab49-1778eda59dd6

