### PR TITLE
Authentication/LDAP - Fixed [FD-56031] - throw Exception if STARTTLS fails

### DIFF
--- a/app/Models/Ldap.php
+++ b/app/Models/Ldap.php
@@ -97,7 +97,9 @@ class Ldap extends Model
         ldap_set_option($connection, LDAP_OPT_NETWORK_TIMEOUT, 20);
 
         if ($ldap_use_tls == '1') {
-            ldap_start_tls($connection);
+            if (!ldap_start_tls($connection)) {
+                throw new Exception('STARTTLS Failed.');
+            }
         }
 
         return $connection;


### PR DESCRIPTION
If you've marked your LDAP integration as requiring `STARTTLS`, the connection needs to fail if the STARTTLS command fails in LDAP. Right now, we don't pay attention to the response code.