### PR TITLE
Styling - Fixed FD-56071 - Apply nav and link colors appropriately

### DIFF
--- a/app/Http/Middleware/CheckColorSettings.php
+++ b/app/Http/Middleware/CheckColorSettings.php
@@ -36,31 +36,32 @@ class CheckColorSettings
     {
 
         // Set defaults in case this is accessed via the /setup screen
-        $nav_color = '#ffffff';
+        $nav_link_color = '#ffffff';
         $link_dark_color = '#89c9ed';
         $link_light_color = '#3c8dbc';
 
         if ($settings = Setting::getSettings()) {
-            $nav_color = $settings->nav_link_color;
+            $nav_link_color = $settings->nav_link_color;
             $link_dark_color = $settings->link_dark_color;
             $link_light_color = $settings->link_light_color;
         }
 
         // Override system settings
         if ($request->user()) {
-
-            if ($request->user()->nav_color) {
-                $nav_color = $request->user()->nav_color;
+            if ($request->user()->nav_link_color) {
+                $nav_link_color = $request->user()->nav_link_color;
             }
+
             if ($request->user()->link_dark_color) {
                 $link_dark_color = $request->user()->link_dark_color;
             }
-            if ($request->user()->nav_color) {
+
+            if ($request->user()->link_light_color) {
                 $link_light_color = $request->user()->link_light_color;
             }
         }
 
-        view()->share('nav_link_color', $nav_color);
+        view()->share('nav_link_color', $nav_link_color);
         view()->share('link_dark_color', $link_dark_color);
         view()->share('link_light_color', $link_light_color);
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -753,21 +753,57 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
     protected function linkLightColor(): Attribute
     {
         return Attribute::make(
-            get: fn (?string $value) => CssColor::sanitize($value, '#296282'),
+            get: function (?string $value) {
+                $fallback = '#296282';
+
+                if ($value) {
+                    return CssColor::sanitize($value, $fallback);
+                }
+
+                if (Setting::getSettings()) {
+                    return CssColor::sanitize(Setting::getSettings()->link_light_color, $fallback);
+                }
+
+                return CssColor::sanitize($value, $fallback);
+            },
         );
     }
 
     protected function linkDarkColor(): Attribute
     {
         return Attribute::make(
-            get: fn (?string $value) => CssColor::sanitize($value, '#5fa4cc'),
+            get: function (?string $value) {
+                $fallback = '#5fa4cc';
+
+                if ($value) {
+                    return CssColor::sanitize($value, $fallback);
+                }
+
+                if (Setting::getSettings()) {
+                    return CssColor::sanitize(Setting::getSettings()->link_dark_color, $fallback);
+                }
+
+                return CssColor::sanitize($value, $fallback);
+            },
         );
     }
 
     protected function navLinkColor(): Attribute
     {
         return Attribute::make(
-            get: fn (?string $value) => CssColor::sanitize($value, '#ffffff'),
+            get: function (?string $value) {
+                $fallback = '#ffffff';
+
+                if ($value) {
+                    return CssColor::sanitize($value, $fallback);
+                }
+
+                if (Setting::getSettings()) {
+                    return CssColor::sanitize(Setting::getSettings()->nav_link_color, $fallback);
+                }
+
+                return CssColor::sanitize($value, $fallback);
+            },
         );
     }
 

--- a/resources/views/account/profile.blade.php
+++ b/resources/views/account/profile.blade.php
@@ -48,10 +48,10 @@
               </div>
 
               <!-- Light Link color -->
-              <div class="form-group {{ $errors->has('link_dark_color') ? 'error' : '' }}">
+              <div class="form-group {{ $errors->has('link_light_color') ? 'error' : '' }}">
                   <label for="link_light_color" class="col-md-3 control-label">{{ trans('admin/settings/general.link_light_color') }}</label>
                   <div class="col-md-9">
-                      <x-input.colorpicker :item="$user" id="link_light_color" placeholder="{{ $link_dark_color }}" :value="old('link_light_color', ($user->link_dark_color ?? $link_dark_color))" name="link_light_color" />
+                      <x-input.colorpicker :item="$user" id="link_light_color" placeholder="{{ $link_light_color }}" :value="old('link_light_color', ($user->link_light_color ?? $link_light_color))" name="link_light_color" />
                       {!! $errors->first('link_light_color', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                       <p class="help-block">{{ trans('admin/settings/general.link_light_color_help') }}</p>
                   </div>

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -208,4 +208,76 @@ class UserTest extends TestCase
         $user = User::generateFormattedNameFromFullName($fullname, 'firstnamelastinitial');
         $this->assertEquals($expected_email, $user['username'].'@example.com');
     }
+
+    public function test_link_light_color_attribute()
+    {
+        // if global branding and user are not set we use the app default defined in the accessor:
+        $this->settings->set(['link_light_color' => null]);
+        $this->assertEquals(
+            '#296282',
+            User::factory()->create()->link_light_color
+        );
+
+        // nothing set on user we use global branding:
+        $this->settings->set(['link_light_color' => '#ff6700']);
+        $this->assertEquals(
+            '#ff6700',
+            User::factory()->create()->link_light_color
+        );
+
+        // user has it set we use it:
+        $user = User::factory()->create(['link_light_color' => '#61b329']);
+        $this->assertEquals(
+            '#61b329',
+            $user->link_light_color
+        );
+    }
+
+    public function test_link_dark_color_attribute()
+    {
+        // if global branding and user are not set we use the app default defined in the accessor:
+        $this->settings->set(['link_dark_color' => null]);
+        $this->assertEquals(
+            '#5fa4cc',
+            User::factory()->create()->link_dark_color
+        );
+
+        // nothing set on user we use global branding:
+        $this->settings->set(['link_dark_color' => '#ff6700']);
+        $this->assertEquals(
+            '#ff6700',
+            User::factory()->create()->link_dark_color
+        );
+
+        // user has it set we use it:
+        $user = User::factory()->create(['link_dark_color' => '#61b329']);
+        $this->assertEquals(
+            '#61b329',
+            $user->link_dark_color
+        );
+    }
+
+    public function test_nav_link_color_attribute()
+    {
+        // if global branding and user are not set we use the app default defined in the accessor:
+        $this->settings->set(['nav_link_color' => null]);
+        $this->assertEquals(
+            '#ffffff',
+            User::factory()->create()->nav_link_color
+        );
+
+        // nothing set on user we use global branding:
+        $this->settings->set(['nav_link_color' => '#ff6700']);
+        $this->assertEquals(
+            '#ff6700',
+            User::factory()->create()->nav_link_color
+        );
+
+        // user has it set we use it:
+        $user = User::factory()->create(['nav_link_color' => '#61b329']);
+        $this->assertEquals(
+            '#61b329',
+            $user->nav_link_color
+        );
+    }
 }


### PR DESCRIPTION
Currently, setting branding settings globally overrides user settings in dark mode. This PR fixes that by updating the accessors to use the user's preference, the global branding preference, or the application default, in that order. 

<img width="1042" height="1096" alt="image" src="https://github.com/user-attachments/assets/654bdf03-a27f-48f1-b5c0-a4ab189bf9d4" />


[FD-56071]