### PR TITLE
"Global Multi-Company Access" permission for non-admin users

### DIFF
--- a/app/Http/Controllers/Api/CompaniesController.php
+++ b/app/Http/Controllers/Api/CompaniesController.php
@@ -211,7 +211,7 @@ class CompaniesController extends Controller
         // When FMCS is enabled and the user is not a superuser, restrict the list to
         // companies they belong to (primary company_id + pivot companies). This lets
         // non-superusers select a company from their own set when creating assets, etc.
-        if (Setting::getSettings()->full_multiple_companies_support == '1' && ! auth()->user()->isSuperUser()) {
+        if (Setting::getSettings()->full_multiple_companies_support == '1' && ! (auth()->user()->isSuperUser() || auth()->user()->isMultiCompany())) {
             $userCompanyIds = auth()->user()->allCompanies()->pluck('id');
             if ($userCompanyIds->isNotEmpty()) {
                 $companies->whereIn('companies.id', $userCompanyIds);

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -152,7 +152,7 @@ final class Company extends SnipeModel
             $current_user = auth()->user();
 
             // Super users should be able to set a company to whatever they need
-            if ($current_user->isSuperUser()) {
+            if ($current_user->isSuperUser() || $current_user->isMultiCompany()) {
                 return self::getIdFromInput($unescaped_input);
             } else {
                 $userCompanyIds = self::getCurrentUserCompanyIds();
@@ -215,7 +215,7 @@ final class Company extends SnipeModel
         }
 
         if (auth()->user()) {
-            if (auth()->user()->isSuperUser()) {
+            if (auth()->user()->isSuperUser() || auth()->user()->isMultiCompany()) {
                 return true;
             }
 
@@ -272,7 +272,7 @@ final class Company extends SnipeModel
 
         $current_user = auth()->user();
 
-        if ($current_user->isSuperUser()) {
+        if ($current_user->isSuperUser() || $current_user->isMultiCompany()) {
             return $requestedIds;
         }
 
@@ -283,13 +283,14 @@ final class Company extends SnipeModel
 
     public static function isCurrentUserAuthorized()
     {
-        return (! self::isFullMultipleCompanySupportEnabled()) || (auth()->user()->isSuperUser());
+        return (! self::isFullMultipleCompanySupportEnabled()) || (auth()->user()->isSuperUser() || auth()->user()->isMultiCompany());
     }
 
     public static function canManageUsersCompanies()
     {
         return ! self::isFullMultipleCompanySupportEnabled()
             || auth()->user()->isSuperUser()
+            || auth()->user()->isMultiCompany()
             || ! empty(self::getCurrentUserCompanyIds());
     }
 
@@ -320,7 +321,7 @@ final class Company extends SnipeModel
      */
     public static function getIdForUser($unescaped_input)
     {
-        if (! self::isFullMultipleCompanySupportEnabled() || auth()->user()->isSuperUser()) {
+        if (! self::isFullMultipleCompanySupportEnabled() || auth()->user()->isSuperUser() || auth()->user()->isMultiCompany()) {
             return self::getIdFromInput($unescaped_input);
         } else {
             return self::getIdForCurrentUser($unescaped_input);
@@ -376,7 +377,7 @@ final class Company extends SnipeModel
     public static function scopeCompanyables($query, $column = 'company_id', $table_name = null)
     {
         // If not logged in and hitting this, assume we are on the command line and don't scope?
-        if (! self::isFullMultipleCompanySupportEnabled() || (Auth::hasUser() && auth()->user()->isSuperUser()) || (! Auth::hasUser())) {
+        if (! self::isFullMultipleCompanySupportEnabled() || (Auth::hasUser() && (auth()->user()->isSuperUser() || auth()->user()->isMultiCompany())) || (! Auth::hasUser())) {
             return $query;
         } else {
             return self::scopeCompanyablesDirectly($query, $column, $table_name);
@@ -500,7 +501,7 @@ final class Company extends SnipeModel
 
         if (count($companyable_names) == 0) {
             throw new Exception('No Companyable Children to scope');
-        } elseif (! self::isFullMultipleCompanySupportEnabled() || (Auth::hasUser() && auth()->user()->isSuperUser())) {
+        } elseif (! self::isFullMultipleCompanySupportEnabled() || (Auth::hasUser() && (auth()->user()->isSuperUser() || auth()->user()->isMultiCompany()))) {
             return $query;
         } else {
             $f = function ($q) {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -566,6 +566,11 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
         return $this->checkPermissionSection('admin');
     }
 
+    public function isMultiCompany()
+    {
+        return $this->checkPermissionSection('multicompany');
+    }
+
     /**
      * Checks if the user can edit their own profile
      *

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -173,6 +173,12 @@ class AuthServiceProvider extends ServiceProvider
             }
         });
 
+        Gate::define('multicompany', function ($user) {
+            if ($user->hasAccess('multicompany')) {
+                return true;
+            }
+        });
+
         // Can the user import CSVs?
         Gate::define('import', function ($user) {
             if ($user->hasAccess('import')) {

--- a/config/permissions.php
+++ b/config/permissions.php
@@ -22,6 +22,13 @@ return [
         ],
     ],
 
+    'Multicompany' => [
+        [
+            'permission' => 'multicompany',
+            'display' => true,
+        ],
+    ],
+
     'Import' => [
         [
             'permission' => 'import',

--- a/resources/lang/en-US/permissions.php
+++ b/resources/lang/en-US/permissions.php
@@ -23,6 +23,10 @@ return [
         'name' => 'Admin Access',
         'note' => 'Determines whether the user has access to most aspects of the system EXCEPT the System Admin Settings. These users will be able to manage users, locations, categories, etc, but ARE constrained by Full Multiple Company Support if it is enabled.',
     ],
+    'multicompany' => [
+        'name' => 'All Companies Access',
+        'note' => 'This will allow users to access for all companies in FMCS mode.',
+    ],
 
     'import' => [
         'name' => 'CSV Import',


### PR DESCRIPTION
### **Related Issue**
Relates to: #19200 – [Feature]: Add "Global Multi-Company Access" permission for non-admin users in FMCS mode
 
### **Description**
This Pull Request introduces a new permission: `multicompany`
When enabled, this permission allows a user to access all companies, regardless of the companies explicitly assigned to them.

### **Purpose**
In environments using **Full Multi-Company Support (FMCS)** with a large number of companies, managing access on a per-company basis becomes difficult and time-consuming.
This change simplifies access management by providing an **optional global scope permission** for non-admin users.

### **Behavior**
When multicompany permission is enabled:
✅ The user automatically has access to all companies
✅ No need to assign companies individually
✅ Works independently of the assigned company scope

When disabled:
🔒 Default behavior remains unchanged (company-based access control)

### **Scope & Impact**
✅ Applies only to users with this permission explicitly enabled
✅ Does not modify existing permission logic for other users
✅ Fully backward compatible
✅ Designed as an optional extension of the current permission model

### **Use Case**
In environments with 100+ companies, such as centralized IT support teams:
- Users require visibility across all companies
- Assigning access company-by-company is not scalable
- This permission significantly reduces administrative overhead

**Example:**
<img width="1515" height="707" alt="image" src="https://github.com/user-attachments/assets/21d99b59-90e4-4bb7-a73c-cafbf7d6d7d0" />

 