### PR TITLE
Bulk Asset Checkin: Fixed #19214  Added option to change location

### DIFF
--- a/app/Http/Controllers/Assets/AssetCheckinController.php
+++ b/app/Http/Controllers/Assets/AssetCheckinController.php
@@ -10,6 +10,7 @@ use App\Http\Traits\MigratesLegacyAssetLocations;
 use App\Models\Asset;
 use App\Models\CheckoutAcceptance;
 use App\Models\LicenseSeat;
+use App\Models\Location;
 use App\Models\Statuslabel;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Builder;
@@ -137,10 +138,19 @@ class AssetCheckinController extends Controller
 
         if ($request->has('location_id')) {
             if ($request->filled('location_id')) {
-                Log::debug('NEW Location ID: '.$request->input('location_id'));
-                $asset->location_id = $request->input('location_id');
+                // Resolve via the scoped Location query so non-existent IDs and IDs the actor
+                // cannot see under FMCS are rejected before we write them to the asset.
+                $submittedLocation = Location::find($request->input('location_id'));
+
+                if (! $submittedLocation) {
+                    return redirect()->back()->withInput()
+                        ->with('error', trans('admin/hardware/message.create.target_not_found.location'));
+                }
+
+                Log::debug('NEW Location ID: '.$submittedLocation->id);
+                $asset->location_id = $submittedLocation->id;
                 if ($request->input('update_default_location') == 0) {
-                    $asset->rtd_location_id = $request->input('location_id');
+                    $asset->rtd_location_id = $submittedLocation->id;
                 }
             } else {
                 // Explicitly submitted as empty — clear the location

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -8,12 +8,14 @@ use App\Helpers\Helper;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\AssetCheckoutRequest;
 use App\Http\Traits\CheckInOutTrait;
+use App\Http\Traits\MigratesLegacyAssetLocations;
 use App\Models\Asset;
 use App\Models\AssetModel;
 use App\Models\CheckoutAcceptance;
 use App\Models\Company;
 use App\Models\CustomField;
 use App\Models\LicenseSeat;
+use App\Models\Location;
 use App\Models\Setting;
 use App\Models\Statuslabel;
 use App\Models\User;
@@ -33,6 +35,7 @@ use Illuminate\Support\Facades\Log;
 class BulkAssetsController extends Controller
 {
     use CheckInOutTrait;
+    use MigratesLegacyAssetLocations;
 
     /**
      * Display the bulk edit page.
@@ -824,6 +827,18 @@ class BulkAssetsController extends Controller
 
         $assets = Asset::withTrashed()->findOrFail($asset_ids);
 
+        // Resolve via the scoped Location query so non-existent IDs and IDs the actor
+        // cannot see under FMCS are rejected before we touch any asset.
+        $submittedLocation = null;
+        if ($request->filled('location_id')) {
+            $submittedLocation = Location::find($request->input('location_id'));
+
+            if (! $submittedLocation) {
+                return redirect()->route('hardware.bulkcheckin.show')->withInput()
+                    ->with('error', trans('admin/hardware/message.create.target_not_found.location'));
+            }
+        }
+
         $checkin_at = date('Y-m-d H:i:s');
         if ($request->filled('checkin_at') && $request->input('checkin_at') != date('Y-m-d')) {
             $checkin_at = $request->input('checkin_at');
@@ -832,7 +847,7 @@ class BulkAssetsController extends Controller
         $errors = [];
         $admin = auth()->user();
 
-        DB::transaction(function () use ($assets, $admin, $checkin_at, $request, &$errors) {
+        DB::transaction(function () use ($assets, $admin, $checkin_at, $request, $submittedLocation, &$errors) {
             foreach ($assets as $asset) {
                 $this->authorize('checkin', $asset);
 
@@ -851,7 +866,21 @@ class BulkAssetsController extends Controller
                     $asset->status_id = $request->input('status_id');
                 }
 
+                $this->migrateLegacyLocations($asset);
+
                 $asset->location_id = $asset->rtd_location_id;
+
+                if ($request->has('location_id')) {
+                    if ($submittedLocation) {
+                        $asset->location_id = $submittedLocation->id;
+                        if ($request->input('update_default_location') == 0) {
+                            $asset->rtd_location_id = $submittedLocation->id;
+                        }
+                    } else {
+                        $asset->location_id = null;
+                    }
+                }
+
                 $asset->last_checkin = $checkin_at;
 
                 if ($request->boolean('checkin_licenses')) {

--- a/resources/views/hardware/bulk-checkin.blade.php
+++ b/resources/views/hardware/bulk-checkin.blade.php
@@ -74,6 +74,26 @@
                 </div>
             </div>
 
+            <x-input.location-select
+                :label="trans('general.location')"
+                name="location_id"
+                :selected="old('location_id')"
+            />
+
+            <!-- Update actual location -->
+            <div class="form-group">
+                <div class="col-md-9 col-md-offset-3">
+                    <label class="form-control">
+                        <input name="update_default_location" type="radio" value="1" @checked(old('update_default_location', '1') == '1') aria-label="update_default_location" />
+                        {{ trans('admin/hardware/form.asset_location') }}
+                    </label>
+                    <label class="form-control">
+                        <input name="update_default_location" type="radio" value="0" @checked(old('update_default_location') === '0') aria-label="update_default_location" />
+                        {{ trans('admin/hardware/form.asset_location_update_default_current') }}
+                    </label>
+                </div>
+            </div>
+
             <!-- Checkin Date -->
             <div class="form-group {{ $errors->has('checkin_at') ? 'error' : '' }}">
                 <label for="checkin_at" class="col-sm-3 control-label">

--- a/tests/Feature/Checkins/Ui/AssetCheckinTest.php
+++ b/tests/Feature/Checkins/Ui/AssetCheckinTest.php
@@ -6,6 +6,7 @@ use App\Events\CheckoutableCheckedIn;
 use App\Models\Actionlog;
 use App\Models\Asset;
 use App\Models\CheckoutAcceptance;
+use App\Models\Company;
 use App\Models\LicenseSeat;
 use App\Models\Location;
 use App\Models\Statuslabel;
@@ -177,6 +178,45 @@ class AssetCheckinTest extends TestCase
 
         $this->assertTrue($asset->refresh()->location()->is($rtdLocation));
         $this->assertHasTheseActionLogs($asset, ['create', 'checkin from']);
+    }
+
+    public function test_checkin_rejects_nonexistent_location_id()
+    {
+        $rtdLocation = Location::factory()->create();
+        $asset = Asset::factory()->assignedToUser()->create(['rtd_location_id' => $rtdLocation->id]);
+
+        $this->actingAs(User::factory()->checkinAssets()->create())
+            ->post(route('hardware.checkin.store', [$asset]), [
+                'location_id' => PHP_INT_MAX,
+            ])
+            ->assertRedirect()
+            ->assertSessionHas('error');
+
+        $this->assertNotNull($asset->fresh()->assigned_to);
+    }
+
+    public function test_checkin_rejects_location_from_another_company_under_fmcs()
+    {
+        $this->settings->enableMultipleFullCompanySupport();
+
+        [$companyA, $companyB] = Company::factory()->count(2)->create();
+
+        $foreignLocation = Location::factory()->create(['company_id' => $companyB->id]);
+        $rtdLocation = Location::factory()->create(['company_id' => $companyA->id]);
+        $asset = Asset::factory()->assignedToUser()->create([
+            'company_id' => $companyA->id,
+            'rtd_location_id' => $rtdLocation->id,
+        ]);
+        $actor = User::factory()->checkinAssets()->viewAssets()->create(['company_id' => $companyA->id]);
+
+        $this->actingAs($actor)
+            ->post(route('hardware.checkin.store', [$asset]), [
+                'location_id' => $foreignLocation->id,
+            ])
+            ->assertRedirect()
+            ->assertSessionHas('error');
+
+        $this->assertNotNull($asset->fresh()->assigned_to);
     }
 
     public function test_default_location_can_be_updated_upon_checkin()

--- a/tests/Feature/Checkins/Ui/BulkAssetCheckinTest.php
+++ b/tests/Feature/Checkins/Ui/BulkAssetCheckinTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Checkins\Ui;
 use App\Events\CheckoutableCheckedIn;
 use App\Models\Asset;
 use App\Models\CheckoutAcceptance;
+use App\Models\Company;
 use App\Models\LicenseSeat;
 use App\Models\Location;
 use App\Models\Statuslabel;
@@ -135,6 +136,97 @@ class BulkAssetCheckinTest extends TestCase
 
         $assets->each(function (Asset $asset) use ($rtdLocation) {
             $this->assertEquals($rtdLocation->id, $asset->fresh()->location_id);
+        });
+    }
+
+    public function test_bulk_checkin_rejects_nonexistent_location_id()
+    {
+        $rtdLocation = Location::factory()->create();
+        $assets = Asset::factory()->assignedToUser()->count(2)->create(['rtd_location_id' => $rtdLocation->id]);
+
+        $this->actingAs(User::factory()->checkinAssets()->create())
+            ->post(route('hardware.bulkcheckin.store'), [
+                'selected_assets' => $assets->pluck('id')->toArray(),
+                'location_id' => PHP_INT_MAX,
+            ])
+            ->assertRedirectToRoute('hardware.bulkcheckin.show')
+            ->assertSessionHas('error');
+
+        $assets->each(function (Asset $asset) {
+            $this->assertNotNull($asset->fresh()->assigned_to);
+        });
+    }
+
+    public function test_bulk_checkin_rejects_location_from_another_company_under_fmcs()
+    {
+        $this->settings->enableMultipleFullCompanySupport();
+
+        [$companyA, $companyB] = Company::factory()->count(2)->create();
+
+        $foreignLocation = Location::factory()->create(['company_id' => $companyB->id]);
+        $rtdLocation = Location::factory()->create(['company_id' => $companyA->id]);
+        $assets = Asset::factory()->assignedToUser()->count(2)->create([
+            'company_id' => $companyA->id,
+            'rtd_location_id' => $rtdLocation->id,
+        ]);
+        $actor = User::factory()->checkinAssets()->viewAssets()->create(['company_id' => $companyA->id]);
+
+        $this->actingAs($actor)
+            ->post(route('hardware.bulkcheckin.store'), [
+                'selected_assets' => $assets->pluck('id')->toArray(),
+                'location_id' => $foreignLocation->id,
+            ])
+            ->assertRedirectToRoute('hardware.bulkcheckin.show')
+            ->assertSessionHas('error');
+
+        $assets->each(function (Asset $asset) {
+            $this->assertNotNull($asset->fresh()->assigned_to);
+        });
+    }
+
+    public function test_submitted_location_overrides_rtd_location_without_updating_default()
+    {
+        $rtdLocation = Location::factory()->create();
+        $submittedLocation = Location::factory()->create();
+
+        $assets = Asset::factory()->assignedToUser()->count(2)->create([
+            'rtd_location_id' => $rtdLocation->id,
+        ]);
+
+        $this->actingAs(User::factory()->checkinAssets()->create())
+            ->post(route('hardware.bulkcheckin.store'), [
+                'selected_assets' => $assets->pluck('id')->toArray(),
+                'location_id' => $submittedLocation->id,
+                'update_default_location' => '1',
+            ]);
+
+        $assets->each(function (Asset $asset) use ($submittedLocation, $rtdLocation) {
+            $fresh = $asset->fresh();
+            $this->assertEquals($submittedLocation->id, $fresh->location_id);
+            $this->assertEquals($rtdLocation->id, $fresh->rtd_location_id);
+        });
+    }
+
+    public function test_submitted_location_updates_both_current_and_default_when_radio_set_to_zero()
+    {
+        $rtdLocation = Location::factory()->create();
+        $submittedLocation = Location::factory()->create();
+
+        $assets = Asset::factory()->assignedToUser()->count(2)->create([
+            'rtd_location_id' => $rtdLocation->id,
+        ]);
+
+        $this->actingAs(User::factory()->checkinAssets()->create())
+            ->post(route('hardware.bulkcheckin.store'), [
+                'selected_assets' => $assets->pluck('id')->toArray(),
+                'location_id' => $submittedLocation->id,
+                'update_default_location' => '0',
+            ]);
+
+        $assets->each(function (Asset $asset) use ($submittedLocation) {
+            $fresh = $asset->fresh();
+            $this->assertEquals($submittedLocation->id, $fresh->location_id);
+            $this->assertEquals($submittedLocation->id, $fresh->rtd_location_id);
         });
     }
 


### PR DESCRIPTION
This reproduces the same behavior that the single checkin has, allowing the user to change location on bulk checkin.