### PR TITLE
Factories: Manually set non-fillable properties in CheckoutAcceptanceFactory

### DIFF
--- a/database/factories/CheckoutAcceptanceFactory.php
+++ b/database/factories/CheckoutAcceptanceFactory.php
@@ -48,10 +48,10 @@ class CheckoutAcceptanceFactory extends Factory
             }
 
             if ($acceptance->checkoutable instanceof Asset && $acceptance->assignedTo instanceof User) {
-                $acceptance->checkoutable->update([
-                    'assigned_to' => $acceptance->assigned_to_id,
-                    'assigned_type' => get_class($acceptance->assignedTo),
-                ]);
+                $asset = $acceptance->checkoutable;
+                $asset->assigned_to = $acceptance->assigned_to_id;
+                $asset->assigned_type = get_class($acceptance->assignedTo);
+                $asset->save();
             }
         });
     }


### PR DESCRIPTION
`assigned_to` and `assigned_type` recently got removed from the `$fillable` array on the `Asset` model so calling `update` was having no effect. This PR sets those fields individually so that they are actually updated on the model.
