### PR TITLE
Fixes #19235: use total var to avoid multiple database queries

### DIFF
--- a/app/Http/Controllers/Api/AccessoriesController.php
+++ b/app/Http/Controllers/Api/AccessoriesController.php
@@ -111,7 +111,8 @@ class AccessoriesController extends Controller
         }
 
         // Make sure the offset and limit are actually integers and do not exceed system limits
-        $offset = ($request->input('offset') > $accessories->count()) ? $accessories->count() : app('api_offset_value');
+        $total = $accessories->count();
+        $offset = ($request->input('offset') > $total) ? $total : app('api_offset_value');
         $limit = app('api_limit_value');
 
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
@@ -145,7 +146,6 @@ class AccessoriesController extends Controller
                 break;
         }
 
-        $total = $accessories->count();
         $accessories = $accessories->skip($offset)->take($limit)->get();
 
         return (new AccessoriesTransformer)->transformAccessories($accessories, $total);

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -491,8 +491,7 @@ class AssetsController extends Controller
             $assets = $assets->withTrashed();
         }
 
-        $total = $assets->count();
-        if (($assets = $assets->get()) && $total > 0) {
+        if (($assets = $assets->get()) && ($total = $assets->count()) > 0) {
 
             // If there is exactly one result and the deleted parameter is not passed, we should pull the first (and only)
             // asset from the returned collection, since transformAsset() expects an Asset object, NOT a collection
@@ -548,7 +547,7 @@ class AssetsController extends Controller
 
         $assets = $assets->skip($offset)->take($limit)->get();
 
-        if (($assets) && $total > 0) {
+        if (($assets) && ($assets->count()) > 0) {
             return (new AssetsTransformer)->transformAssets($assets, $total);
         }
 

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -454,10 +454,10 @@ class AssetsController extends Controller
         }
 
         // Make sure the offset and limit are actually integers and do not exceed system limits
-        $offset = ($request->input('offset') > $assets->count()) ? $assets->count() : app('api_offset_value');
+        $total = $assets->count();
+        $offset = ($request->input('offset') > $total) ? $total : app('api_offset_value');
         $limit = app('api_limit_value');
 
-        $total = $assets->count();
         $assets = $assets->skip($offset)->take($limit)->get();
 
         /**
@@ -491,17 +491,18 @@ class AssetsController extends Controller
             $assets = $assets->withTrashed();
         }
 
-        if (($assets = $assets->get()) && ($assets->count()) > 0) {
+        $total = $assets->count();
+        if (($assets = $assets->get()) && $total > 0) {
 
             // If there is exactly one result and the deleted parameter is not passed, we should pull the first (and only)
             // asset from the returned collection, since transformAsset() expects an Asset object, NOT a collection
-            if (($assets->count() == 1) && ($request->input('deleted') != 'true')) {
+            if (($total == 1) && ($request->input('deleted') != 'true')) {
                 return (new AssetsTransformer)->transformAsset($assets->first());
 
                 // If there is more than one result OR if the endpoint is requesting deleted items (even if there is only one
                 // match, return the normal collection transformed.
             } else {
-                return (new AssetsTransformer)->transformAssets($assets, $assets->count());
+                return (new AssetsTransformer)->transformAssets($assets, $total);
             }
         }
 
@@ -541,13 +542,13 @@ class AssetsController extends Controller
             $assets = $assets->withTrashed();
         }
 
-        $offset = ($request->input('offset') > $assets->count()) ? $assets->count() : app('api_offset_value');
+        $total = $assets->count();
+        $offset = ($request->input('offset') > $total) ? $total : app('api_offset_value');
         $limit = app('api_limit_value');
 
-        $total = $assets->count();
         $assets = $assets->skip($offset)->take($limit)->get();
 
-        if (($assets) && ($assets->count()) > 0) {
+        if (($assets) && $total > 0) {
             return (new AssetsTransformer)->transformAssets($assets, $total);
         }
 
@@ -1453,10 +1454,10 @@ class AssetsController extends Controller
         $assets->requestableAssets();
 
         // Make sure the offset and limit are actually integers and do not exceed system limits
-        $offset = ($request->input('offset') > $assets->count()) ? $assets->count() : app('api_offset_value');
+        $total = $assets->count();
+        $offset = ($request->input('offset') > $total) ? $total : app('api_offset_value');
         $limit = app('api_limit_value');
 
-        $total = $assets->count();
         $assets = $assets->skip($offset)->take($limit)->get();
 
         return (new AssetsTransformer)->transformRequestedAssets($assets, $total);
@@ -1487,10 +1488,10 @@ class AssetsController extends Controller
             ->with('adminuser')
             ->with('accessories');
 
-        $offset = ($request->input('offset') > $accessory_checkouts->count()) ? $accessory_checkouts->count() : app('api_offset_value');
+        $total = $accessory_checkouts->count();
+        $offset = ($request->input('offset') > $total) ? $total : app('api_offset_value');
         $limit = app('api_limit_value');
 
-        $total = $accessory_checkouts->count();
         $accessory_checkouts = $accessory_checkouts->skip($offset)->take($limit)->get();
 
         return (new AssetsTransformer)->transformCheckedoutAccessories($accessory_checkouts, $total);
@@ -1525,8 +1526,8 @@ class AssetsController extends Controller
                 break;
         }
 
-        $offset = ($request->input('offset') > $component_checkouts->count()) ? $component_checkouts->count() : app('api_offset_value');
         $total = $component_checkouts->count();
+        $offset = ($request->input('offset') > $total) ? $total : app('api_offset_value');
         $limit = app('api_limit_value');
         $component_checkouts = $component_checkouts->skip($offset)->take($limit)->get();
 

--- a/app/Http/Controllers/Api/CategoriesController.php
+++ b/app/Http/Controllers/Api/CategoriesController.php
@@ -119,7 +119,8 @@ class CategoriesController extends Controller
         }
 
         // Make sure the offset and limit are actually integers and do not exceed system limits
-        $offset = ($request->input('offset') > $categories->count()) ? $categories->count() : app('api_offset_value');
+        $total = $categories->count();
+        $offset = ($request->input('offset') > $total) ? $total : app('api_offset_value');
         $limit = app('api_limit_value');
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $sort_override = $request->input('sort');
@@ -139,7 +140,6 @@ class CategoriesController extends Controller
                 break;
         }
 
-        $total = $categories->count();
         $categories = $categories->skip($offset)->take($limit)->get();
 
         return (new CategoriesTransformer)->transformCategories($categories, $total);

--- a/app/Http/Controllers/Api/CompaniesController.php
+++ b/app/Http/Controllers/Api/CompaniesController.php
@@ -73,7 +73,8 @@ class CompaniesController extends Controller
         }
 
         // Make sure the offset and limit are actually integers and do not exceed system limits
-        $offset = ($request->input('offset') > $companies->count()) ? $companies->count() : app('api_offset_value');
+        $total = $companies->count();
+        $offset = ($request->input('offset') > $total) ? $total : app('api_offset_value');
         $limit = app('api_limit_value');
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $sort_override = $request->input('sort');
@@ -88,7 +89,6 @@ class CompaniesController extends Controller
                 break;
         }
 
-        $total = $companies->count();
 
         $companies = $companies->skip($offset)->take($limit)->get();
 

--- a/app/Http/Controllers/Api/ConsumablesController.php
+++ b/app/Http/Controllers/Api/ConsumablesController.php
@@ -105,7 +105,8 @@ class ConsumablesController extends Controller
         }
 
         // Make sure the offset and limit are actually integers and do not exceed system limits
-        $offset = ($request->input('offset') > $consumables->count()) ? $consumables->count() : app('api_offset_value');
+        $total = $consumables->count();
+        $offset = ($request->input('offset') > $total) ? $total : app('api_offset_value');
         $limit = app('api_limit_value');
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
 
@@ -137,7 +138,6 @@ class ConsumablesController extends Controller
                 break;
         }
 
-        $total = $consumables->count();
         $consumables = $consumables->skip($offset)->take($limit)->get();
 
         return (new ConsumablesTransformer)->transformConsumables($consumables, $total);

--- a/app/Http/Controllers/Api/DepreciationsController.php
+++ b/app/Http/Controllers/Api/DepreciationsController.php
@@ -46,7 +46,8 @@ class DepreciationsController extends Controller
         }
 
         // Make sure the offset and limit are actually integers and do not exceed system limits
-        $offset = ($request->input('offset') > $depreciations->count()) ? $depreciations->count() : app('api_offset_value');
+        $total = $depreciations->count();
+        $offset = ($request->input('offset') > $total) ? $total : app('api_offset_value');
         $limit = app('api_limit_value');
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $sort_override = $request->input('sort');
@@ -61,7 +62,6 @@ class DepreciationsController extends Controller
                 break;
         }
 
-        $total = $depreciations->count();
         $depreciations = $depreciations->skip($offset)->take($limit)->get();
 
         return (new DepreciationsTransformer)->transformDepreciations($depreciations, $total);

--- a/app/Http/Controllers/Api/GroupsController.php
+++ b/app/Http/Controllers/Api/GroupsController.php
@@ -37,7 +37,8 @@ class GroupsController extends Controller
             $groups->where('name', '=', $request->input('name'));
         }
 
-        $offset = ($request->input('offset') > $groups->count()) ? $groups->count() : app('api_offset_value');
+        $total = $groups->count();
+        $offset = ($request->input('offset') > $total) ? $total : app('api_offset_value');
         $limit = app('api_limit_value');
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
 
@@ -61,7 +62,6 @@ class GroupsController extends Controller
                 break;
         }
 
-        $total = $groups->count();
         $groups = $groups->skip($offset)->take($limit)->get();
 
         return (new GroupsTransformer)->transformGroups($groups, $total);

--- a/app/Http/Controllers/Api/LicenseSeatsController.php
+++ b/app/Http/Controllers/Api/LicenseSeatsController.php
@@ -55,7 +55,7 @@ class LicenseSeatsController extends Controller
             $total = $seats->count();
 
             // Make sure the offset and limit are actually integers and do not exceed system limits
-            $offset = ($request->input('offset') > $seats->count()) ? $seats->count() : app('api_offset_value');
+            $offset = ($request->input('offset') > $total) ? $total : app('api_offset_value');
 
             if ($offset >= $total) {
                 $offset = 0;

--- a/app/Http/Controllers/Api/LocationsController.php
+++ b/app/Http/Controllers/Api/LocationsController.php
@@ -384,10 +384,10 @@ class LocationsController extends Controller
         $this->authorize('view', $location);
         $accessory_checkouts = AccessoryCheckout::LocationAssigned()->where('assigned_to', $location->id)->with('adminuser')->with('accessories');
 
-        $offset = ($request->input('offset') > $accessory_checkouts->count()) ? $accessory_checkouts->count() : app('api_offset_value');
+        $total = $accessory_checkouts->count();
+        $offset = ($request->input('offset') > $total) ? $total : app('api_offset_value');
         $limit = app('api_limit_value');
 
-        $total = $accessory_checkouts->count();
         $accessory_checkouts = $accessory_checkouts->skip($offset)->take($limit)->get();
 
         return (new LocationsTransformer)->transformCheckedoutAccessories($accessory_checkouts, $total);

--- a/app/Http/Controllers/Api/MaintenanceTypesController.php
+++ b/app/Http/Controllers/Api/MaintenanceTypesController.php
@@ -30,12 +30,12 @@ class MaintenanceTypesController extends Controller
             $types->where('name', '=', $request->input('name'));
         }
 
-        $offset = ($request->input('offset') > $types->count()) ? $types->count() : app('api_offset_value');
+        $total = $types->count();
+        $offset = ($request->input('offset') > $total) ? $total : app('api_offset_value');
         $limit = app('api_limit_value');
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $sort = in_array($request->input('sort'), ['id', 'name', 'created_at', 'updated_at']) ? $request->input('sort') : 'name';
 
-        $total = $types->count();
         $types = $types->orderBy($sort, $order)->skip($offset)->take($limit)->get();
 
         return (new MaintenanceTypesTransformer)->transformMaintenanceTypes($types, $total);

--- a/app/Http/Controllers/Api/MaintenancesController.php
+++ b/app/Http/Controllers/Api/MaintenancesController.php
@@ -102,7 +102,8 @@ class MaintenancesController extends Controller
         }
 
         // Make sure the offset and limit are actually integers and do not exceed system limits
-        $offset = ($request->input('offset') > $maintenances->count()) ? $maintenances->count() : app('api_offset_value');
+        $total = $maintenances->count();
+        $offset = ($request->input('offset') > $total) ? $total : app('api_offset_value');
         $limit = app('api_limit_value');
 
         $allowed_columns = [
@@ -169,7 +170,6 @@ class MaintenancesController extends Controller
                 break;
         }
 
-        $total = $maintenances->count();
         $maintenances = $maintenances->skip($offset)->take($limit)->get();
 
         if (request()->input('format') == 'flat') {

--- a/app/Http/Controllers/Api/ManufacturersController.php
+++ b/app/Http/Controllers/Api/ManufacturersController.php
@@ -117,7 +117,8 @@ class ManufacturersController extends Controller
         }
 
         // Make sure the offset and limit are actually integers and do not exceed system limits
-        $offset = ($request->input('offset') > $manufacturers->count()) ? $manufacturers->count() : app('api_offset_value');
+        $total = $manufacturers->count();
+        $offset = ($request->input('offset') > $total) ? $total : app('api_offset_value');
         $limit = app('api_limit_value');
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $sort_override = $request->input('sort');
@@ -132,7 +133,6 @@ class ManufacturersController extends Controller
                 break;
         }
 
-        $total = $manufacturers->count();
         $manufacturers = $manufacturers->skip($offset)->take($limit)->get();
 
         return (new ManufacturersTransformer)->transformManufacturers($manufacturers, $total);

--- a/app/Http/Controllers/Api/PredefinedKitsController.php
+++ b/app/Http/Controllers/Api/PredefinedKitsController.php
@@ -35,7 +35,8 @@ class PredefinedKitsController extends Controller
         }
 
         // Make sure the offset and limit are actually integers and do not exceed system limits
-        $offset = ($request->input('offset') > $kits->count()) ? $kits->count() : app('api_offset_value');
+        $total = $kits->count();
+        $offset = ($request->input('offset') > $total) ? $total : app('api_offset_value');
         $limit = app('api_limit_value');
 
         $order = $request->input('order') === 'desc' ? 'desc' : 'asc';
@@ -59,7 +60,6 @@ class PredefinedKitsController extends Controller
                 break;
         }
 
-        $total = $kits->count();
         $kits = $kits->skip($offset)->take($limit)->get();
 
         return (new PredefinedKitsTransformer)->transformPredefinedKits($kits, $total);

--- a/app/Http/Controllers/Api/StatuslabelsController.php
+++ b/app/Http/Controllers/Api/StatuslabelsController.php
@@ -63,7 +63,8 @@ class StatuslabelsController extends Controller
         }
 
         // Make sure the offset and limit are actually integers and do not exceed system limits
-        $offset = ($request->input('offset') > $statuslabels->count()) ? $statuslabels->count() : app('api_offset_value');
+        $total = $statuslabels->count();
+        $offset = ($request->input('offset') > $total) ? $total : app('api_offset_value');
         $limit = app('api_limit_value');
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $sort_override = $request->input('sort');
@@ -78,7 +79,6 @@ class StatuslabelsController extends Controller
                 break;
         }
 
-        $total = $statuslabels->count();
         $statuslabels = $statuslabels->skip($offset)->take($limit)->get();
 
         return (new StatuslabelsTransformer)->transformStatuslabels($statuslabels, $total);

--- a/app/Http/Controllers/Api/SuppliersController.php
+++ b/app/Http/Controllers/Api/SuppliersController.php
@@ -114,7 +114,8 @@ class SuppliersController extends Controller
         }
 
         // Make sure the offset and limit are actually integers and do not exceed system limits
-        $offset = ($request->input('offset') > $suppliers->count()) ? $suppliers->count() : app('api_offset_value');
+        $total = $suppliers->count();
+        $offset = ($request->input('offset') > $total) ? $total : app('api_offset_value');
         $limit = app('api_limit_value');
 
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
@@ -129,7 +130,6 @@ class SuppliersController extends Controller
                 break;
         }
 
-        $total = $suppliers->count();
         $suppliers = $suppliers->skip($offset)->take($limit)->get();
 
         return (new SuppliersTransformer)->transformSuppliers($suppliers, $total);

--- a/app/Http/Controllers/Api/UploadedFilesController.php
+++ b/app/Http/Controllers/Api/UploadedFilesController.php
@@ -52,7 +52,8 @@ class UploadedFilesController extends Controller
         $uploads = self::$map_object_type[$object_type]::withTrashed()->find($id)->uploads()
             ->with('adminuser');
 
-        $offset = ($request->input('offset') > $uploads->count()) ? $uploads->count() : app('api_offset_value');
+        $total = $uploads->count();
+        $offset = ($request->input('offset') > $total) ? $total : app('api_offset_value');
         $limit = app('api_limit_value');
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $sort = in_array($request->input('sort'), $allowed_columns) ? $request->input('sort') : 'created_at';
@@ -70,7 +71,6 @@ class UploadedFilesController extends Controller
             );
         }
 
-        $total = $uploads->count();
         $uploads = $uploads->skip($offset)->take($limit)->orderBy($sort, $order)->get();
 
         return (new UploadedFilesTransformer)->transformFiles($uploads, $total);

--- a/app/Http/Controllers/Api/UploadedFilesController.php
+++ b/app/Http/Controllers/Api/UploadedFilesController.php
@@ -52,8 +52,7 @@ class UploadedFilesController extends Controller
         $uploads = self::$map_object_type[$object_type]::withTrashed()->find($id)->uploads()
             ->with('adminuser');
 
-        $total = $uploads->count();
-        $offset = ($request->input('offset') > $total) ? $total : app('api_offset_value');
+        $offset = ($request->input('offset') > $uploads->count()) ? $uploads->count() : app('api_offset_value');
         $limit = app('api_limit_value');
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $sort = in_array($request->input('sort'), $allowed_columns) ? $request->input('sort') : 'created_at';
@@ -71,6 +70,7 @@ class UploadedFilesController extends Controller
             );
         }
 
+        $total = $uploads->count();
         $uploads = $uploads->skip($offset)->take($limit)->orderBy($sort, $order)->get();
 
         return (new UploadedFilesTransformer)->transformFiles($uploads, $total);

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -361,10 +361,10 @@ class UsersController extends Controller
         }
 
         // Make sure the offset and limit are actually integers and do not exceed system limits
-        $offset = ($request->input('offset') > $users->count()) ? $users->count() : app('api_offset_value');
+        $total = $users->count();
+        $offset = ($request->input('offset') > $total) ? $total : app('api_offset_value');
         $limit = app('api_limit_value');
 
-        $total = $users->count();
         $users = $users->skip($offset)->take($limit)->get();
 
         return (new UsersTransformer)->transformUsers($users, $total);


### PR DESCRIPTION
fixes ##19235

We were seeing multiple count queries (two or three) against our database when using the API. With this change we are now seeing one query and, for us, it saves on average 300ms.