### PR TITLE
Branding Uploads: Fixed #18267 branding s3 empty path

### DIFF
--- a/app/Http/Requests/ImageUploadRequest.php
+++ b/app/Http/Requests/ImageUploadRequest.php
@@ -95,9 +95,9 @@ class ImageUploadRequest extends Request
         // never HEAD an empty key (which S3's HeadObject validator rejects
         // outright — the bug behind #18267).
         $path = trim((string) $path, '/');
-        $prefix = $path === '' ? '' : $path . '/';
+        $prefix = $path === '' ? '' : $path.'/';
 
-        if ($path !== '' && !Storage::disk('public')->exists($path)) {
+        if ($path !== '' && ! Storage::disk('public')->exists($path)) {
             Storage::disk('public')->makeDirectory($path);
         }
 
@@ -115,7 +115,7 @@ class ImageUploadRequest extends Request
             if (($image->getMimeType() == 'image/vnd.microsoft.icon') || ($image->getMimeType() == 'image/x-icon') || ($image->getMimeType() == 'image/avif') || ($image->getMimeType() == 'image/webp')) {
                 // If the file is an icon, webp or avif, we need to just move it since gd doesn't support resizing
                 // icons or avif, and webp support and needs to be compiled into gd for resizing to be available
-                Storage::disk('public')->put($prefix . $file_name, file_get_contents($image));
+                Storage::disk('public')->put($prefix.$file_name, file_get_contents($image));
 
             } elseif ($image->getMimeType() == 'image/svg+xml') {
                 // If the file is an SVG, we need to clean it and NOT encode it
@@ -124,7 +124,7 @@ class ImageUploadRequest extends Request
                 $cleanSVG = $sanitizer->sanitize($dirtySVG);
 
                 try {
-                    Storage::disk('public')->put($prefix . $file_name, $cleanSVG);
+                    Storage::disk('public')->put($prefix.$file_name, $cleanSVG);
                 } catch (\Exception $e) {
                     Log::debug($e);
                 }
@@ -145,7 +145,7 @@ class ImageUploadRequest extends Request
                 }
 
                 // This requires a string instead of an object, so we use ($string)
-                Storage::disk('public')->put($prefix . $file_name, (string) $upload->encode());
+                Storage::disk('public')->put($prefix.$file_name, (string) $upload->encode());
 
             }
 
@@ -170,7 +170,7 @@ class ImageUploadRequest extends Request
                 // pass '' for the disk root, and we don't want to produce a
                 // leading-slash key on S3.
                 $path = trim((string) $path, '/');
-                $key = $path === '' ? $item->{$db_fieldname} : $path . '/' . $item->{$db_fieldname};
+                $key = $path === '' ? $item->{$db_fieldname} : $path.'/'.$item->{$db_fieldname};
                 Storage::disk('public')->delete($key);
                 $item->{$db_fieldname} = null;
             } catch (\Exception $e) {

--- a/app/Http/Requests/ImageUploadRequest.php
+++ b/app/Http/Requests/ImageUploadRequest.php
@@ -89,7 +89,15 @@ class ImageUploadRequest extends Request
 
         }
 
-        if (! Storage::disk('public')->exists($path)) {
+        // SettingsController passes '' to mean "disk root".
+        // Normalize and use a single prefix so we never have a leading-slash
+        // key (S3 stores `/foo.png` and `foo.png` as distinct objects) and
+        // never HEAD an empty key (which S3's HeadObject validator rejects
+        // outright — the bug behind #18267).
+        $path = trim((string) $path, '/');
+        $prefix = $path === '' ? '' : $path . '/';
+
+        if ($path !== '' && !Storage::disk('public')->exists($path)) {
             Storage::disk('public')->makeDirectory($path);
         }
 
@@ -107,7 +115,7 @@ class ImageUploadRequest extends Request
             if (($image->getMimeType() == 'image/vnd.microsoft.icon') || ($image->getMimeType() == 'image/x-icon') || ($image->getMimeType() == 'image/avif') || ($image->getMimeType() == 'image/webp')) {
                 // If the file is an icon, webp or avif, we need to just move it since gd doesn't support resizing
                 // icons or avif, and webp support and needs to be compiled into gd for resizing to be available
-                Storage::disk('public')->put($path.'/'.$file_name, file_get_contents($image));
+                Storage::disk('public')->put($prefix . $file_name, file_get_contents($image));
 
             } elseif ($image->getMimeType() == 'image/svg+xml') {
                 // If the file is an SVG, we need to clean it and NOT encode it
@@ -116,7 +124,7 @@ class ImageUploadRequest extends Request
                 $cleanSVG = $sanitizer->sanitize($dirtySVG);
 
                 try {
-                    Storage::disk('public')->put($path.'/'.$file_name, $cleanSVG);
+                    Storage::disk('public')->put($prefix . $file_name, $cleanSVG);
                 } catch (\Exception $e) {
                     Log::debug($e);
                 }
@@ -137,7 +145,7 @@ class ImageUploadRequest extends Request
                 }
 
                 // This requires a string instead of an object, so we use ($string)
-                Storage::disk('public')->put($path.'/'.$file_name, (string) $upload->encode());
+                Storage::disk('public')->put($prefix . $file_name, (string) $upload->encode());
 
             }
 
@@ -158,7 +166,12 @@ class ImageUploadRequest extends Request
 
         if ($item->{$db_fieldname} != '') {
             try {
-                Storage::disk('public')->delete($path.'/'.$item->{$db_fieldname});
+                // Same path normalization as handleImages — branding callers
+                // pass '' for the disk root, and we don't want to produce a
+                // leading-slash key on S3.
+                $path = trim((string) $path, '/');
+                $key = $path === '' ? $item->{$db_fieldname} : $path . '/' . $item->{$db_fieldname};
+                Storage::disk('public')->delete($key);
                 $item->{$db_fieldname} = null;
             } catch (\Exception $e) {
                 Log::debug($e);

--- a/tests/Feature/Settings/BrandingSettingsTest.php
+++ b/tests/Feature/Settings/BrandingSettingsTest.php
@@ -121,6 +121,60 @@ class BrandingSettingsTest extends TestCase
         $this->followRedirects($response)->assertSee('alert-success');
     }
 
+    public function test_branding_upload_does_not_check_existence_of_empty_disk_root()
+    {
+        // Regression for #18267: SettingsController passes '' as the storage
+        // path for branding images (logo/email_logo/label_logo/favicon/etc.)
+        // to mean "disk root". The old code called
+        //     Storage::disk('public')->exists('')
+        // which the local driver tolerated but the S3 adapter translated into
+        // a HeadObject with an empty Key, which the AWS SDK rejects outright
+        // with UnableToCheckFileExistence.
+        Storage::fake('public');
+        $publicDisk = Storage::disk('public');
+
+        $proxy = \Mockery::mock($publicDisk);
+        $proxy->shouldReceive('exists')->with('')->never();
+        $proxy->shouldReceive('exists')->andReturnUsing(fn($p) => $publicDisk->exists($p));
+        $proxy->shouldReceive('put')->andReturnUsing(fn(...$a) => $publicDisk->put(...$a));
+        $proxy->shouldReceive('delete')->andReturnUsing(fn(...$a) => $publicDisk->delete(...$a));
+        $proxy->shouldReceive('makeDirectory')->andReturnUsing(fn(...$a) => $publicDisk->makeDirectory(...$a));
+        Storage::shouldReceive('disk')->with('public')->andReturn($proxy);
+
+        $this->actingAs(User::factory()->superuser()->create())
+            ->post(route('settings.branding.save'), [
+                'logo' => UploadedFile::fake()->image('regression_logo.png'),
+            ])
+            ->assertValid('logo')
+            ->assertStatus(302);
+    }
+
+    public function test_branding_upload_stores_file_without_leading_slash_key()
+    {
+        // Companion to #18267: even after skipping the empty-path existence
+        // check, the put() call must not produce a leading-slash object key
+        // (S3 stores `/logo.png` distinctly from `logo.png`, and the DB only
+        // tracks the filename — references would mismatch).
+        Storage::fake('public');
+
+        $this->actingAs(User::factory()->superuser()->create())
+            ->post(route('settings.branding.save'), [
+                'logo' => UploadedFile::fake()->image('keyshape_logo.png'),
+            ])
+            ->assertValid('logo')
+            ->assertStatus(302);
+
+        // The Flysystem local adapter silently normalizes leading slashes,
+        // so we can't distinguish '/foo.png' from 'foo.png' at the disk
+        // level here. The S3-relevant assertion is that the DB-stored
+        // filename (which is what we use to build URLs later) is a clean
+        // filename with no leading slash and resolves on disk as-is.
+        $stored = Setting::getSettings()->logo;
+        $this->assertNotEmpty($stored);
+        $this->assertStringStartsNotWith('/', $stored);
+        Storage::disk('public')->assertExists($stored);
+    }
+
     public function test_logo_can_be_uploaded()
     {
         Storage::fake('public');

--- a/tests/Feature/Settings/BrandingSettingsTest.php
+++ b/tests/Feature/Settings/BrandingSettingsTest.php
@@ -135,10 +135,10 @@ class BrandingSettingsTest extends TestCase
 
         $proxy = \Mockery::mock($publicDisk);
         $proxy->shouldReceive('exists')->with('')->never();
-        $proxy->shouldReceive('exists')->andReturnUsing(fn($p) => $publicDisk->exists($p));
-        $proxy->shouldReceive('put')->andReturnUsing(fn(...$a) => $publicDisk->put(...$a));
-        $proxy->shouldReceive('delete')->andReturnUsing(fn(...$a) => $publicDisk->delete(...$a));
-        $proxy->shouldReceive('makeDirectory')->andReturnUsing(fn(...$a) => $publicDisk->makeDirectory(...$a));
+        $proxy->shouldReceive('exists')->andReturnUsing(fn ($p) => $publicDisk->exists($p));
+        $proxy->shouldReceive('put')->andReturnUsing(fn (...$a) => $publicDisk->put(...$a));
+        $proxy->shouldReceive('delete')->andReturnUsing(fn (...$a) => $publicDisk->delete(...$a));
+        $proxy->shouldReceive('makeDirectory')->andReturnUsing(fn (...$a) => $publicDisk->makeDirectory(...$a));
         Storage::shouldReceive('disk')->with('public')->andReturn($proxy);
 
         $this->actingAs(User::factory()->superuser()->create())


### PR DESCRIPTION
The `SettingsController` passes `''` to mean "disk root" (we use the `ImageUploadRequest` in lots of other places, but we always have a prefix - `assets`, `users`, etc - for those). This PR normalizes and uses a single prefix so we never have a leading-slash key (S3 stores `/foo.png` and `foo.png` as distinct objects) and never HEAD an empty key (which S3's HeadObject validator rejects outright - the bug behind #18267).

We could arguably also just create a `settings` directory and use that, but it would touch a lot more places. 