### PR TITLE
Custom Asset Report: Fixed #18281 - isolate asset tag in “checked out to"

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -616,6 +616,10 @@ class ReportsController extends Controller
                 $header[] = trans('general.type');
             }
 
+            if ($request->filled('assigned_asset_tag')) {
+                $header[] = trans('admin/reports/general.custom_export.assigned_asset_tag');
+            }
+
             if ($request->filled('username')) {
                 $header[] = 'Username';
             }
@@ -970,6 +974,14 @@ class ReportsController extends Controller
                     if ($request->filled('assigned_to')) {
                         $row[] = ($asset->assigned) ? $asset->assigned->display_name : '';
                         $row[] = ($asset->assigned) ? $asset->assignedType() : '';
+                    }
+
+                    if ($request->filled('assigned_asset_tag')) {
+                        // #18281: only populated when the assignee is another
+                        // Asset — empty for user/location assignees and for
+                        // unassigned rows, matching how username/email already
+                        // behave when the assignee isn't a user.
+                        $row[] = ($asset->assigned instanceof Asset) ? $asset->assigned->asset_tag : '';
                     }
 
                     if ($request->filled('username')) {

--- a/resources/lang/en-US/admin/reports/general.php
+++ b/resources/lang/en-US/admin/reports/general.php
@@ -11,6 +11,7 @@ return [
     'custom_export' => [
         'asset_company' => 'Asset Company',
         'asset_serial' => 'Asset Serial',
+        'assigned_asset_tag' => 'Checked Out Asset Tag',
         'user_address' => 'User Address',
         'user_company' => 'User Company',
         'user_city' => 'User City',

--- a/resources/views/reports/custom/asset.blade.php
+++ b/resources/views/reports/custom/asset.blade.php
@@ -256,6 +256,11 @@
                 {{ trans('admin/licenses/table.assigned_to') }}
               </label>
 
+                <label class="form-control">
+                    <input type="checkbox" name="assigned_asset_tag" value="1" @checked($template->checkmarkValue('assigned_asset_tag', '0')) />
+                    {{ trans('admin/reports/general.custom_export.assigned_asset_tag') }}
+                </label>
+
 
               <label class="form-control">
                   <input type="checkbox" name="username" value="1" @checked($template->checkmarkValue('username')) />

--- a/tests/Feature/Reporting/Custom/CustomAssetReportTest.php
+++ b/tests/Feature/Reporting/Custom/CustomAssetReportTest.php
@@ -157,6 +157,64 @@ class CustomAssetReportTest extends TestCase
             ->assertSeeTextInStreamedResponse('Unassigned Asset');
     }
 
+    public function test_assigned_asset_tag_column_emits_parent_tag_only_when_opted_in(): void
+    {
+        // #18281: opt-in column that emits the parent asset's tag in its own
+        // cell when an asset is checked out to another asset. Users/locations
+        // /unassigned rows leave the cell empty. Header must not appear when
+        // the checkbox isn't submitted, so existing templates are unchanged.
+        $parent = Asset::factory()->create(['asset_tag' => 'PARENT-001']);
+        Asset::factory()->assignedToAsset()->create([
+            'name' => 'Child Asset',
+            'assigned_to' => $parent->id,
+            'assigned_type' => Asset::class,
+        ]);
+        Asset::factory()->assignedToUser()->create(['name' => 'User-Assigned Asset']);
+        Asset::factory()->create(['name' => 'Unassigned Asset']);
+
+        $reporter = User::factory()->canViewReports()->create();
+
+        // With the checkbox: column appears, parent tag in the asset-to-asset
+        // row, empty cell everywhere else.
+        $response = $this->actingAs($reporter)
+            ->post('reports/custom', [
+                'asset_name' => '1',
+                'assigned_asset_tag' => '1',
+            ])
+            ->assertOk()
+            ->assertHeader('content-type', 'text/csv; charset=utf-8');
+
+        $rows = collect(Reader::createFromString($response->streamedContent())->getRecords())->values();
+        $header = $rows->first();
+        $body = $rows->slice(1)->values();
+
+        $columnIndex = array_search(
+            trans('admin/reports/general.custom_export.assigned_asset_tag'),
+            $header,
+            true,
+        );
+        $this->assertNotFalse($columnIndex, 'Checked Out Asset Tag header should be present when checkbox is submitted');
+
+        $byName = $body->keyBy(fn ($row) => $row[array_search(trans('general.name'), $header, true)] ?? null);
+
+        $this->assertSame('PARENT-001', $byName['Child Asset'][$columnIndex] ?? null);
+        $this->assertSame('', $byName['User-Assigned Asset'][$columnIndex] ?? null);
+        $this->assertSame('', $byName['Unassigned Asset'][$columnIndex] ?? null);
+
+        // Without the checkbox: column header is absent entirely.
+        $responseWithout = $this->actingAs($reporter)
+            ->post('reports/custom', ['asset_name' => '1'])
+            ->assertOk();
+
+        $headerWithout = collect(Reader::createFromString($responseWithout->streamedContent())->getRecords())
+            ->first();
+
+        $this->assertFalse(
+            array_search(trans('admin/reports/general.custom_export.assigned_asset_tag'), $headerWithout, true),
+            'Checked Out Asset Tag column must not appear when checkbox is unchecked',
+        );
+    }
+
     public function test_custom_report_decrypts_encrypted_custom_fields_when_user_has_permission(): void
     {
         $customField = CustomField::factory()->encrypt()->create();


### PR DESCRIPTION
This adds a checkbox that allows the user to separate the asset tags in the "checked out to" instead of using our default formatter. Fixes #18281.