### PR TITLE
Update GitHub Actions security

### DIFF
--- a/.github/workflows/SA-codeql.yml
+++ b/.github/workflows/SA-codeql.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v7
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Crowdin push
         uses: crowdin/github-action@v2

--- a/.github/workflows/docker-alpine.yml
+++ b/.github/workflows/docker-alpine.yml
@@ -43,6 +43,8 @@ jobs:
       # https://github.com/actions/checkout
       - name: Checkout codebase
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       # https://github.com/docker/setup-buildx-action
       - name: Setup Docker Buildx

--- a/.github/workflows/docker-ubuntu.yml
+++ b/.github/workflows/docker-ubuntu.yml
@@ -43,6 +43,8 @@ jobs:
       # https://github.com/actions/checkout
       - name: Checkout codebase
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       # https://github.com/docker/setup-buildx-action
       - name: Setup Docker Buildx

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Docker Hub Description
         uses: grokability/dockerhub-description@7ea9d275c7cdbe2b676a093a0308c50665e3b8b4

--- a/.github/workflows/tests-mysql.yml
+++ b/.github/workflows/tests-mysql.yml
@@ -39,6 +39,8 @@ jobs:
           coverage: none
 
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Get Composer Cache Directory
         id: composer-cache

--- a/.github/workflows/tests-mysql.yml
+++ b/.github/workflows/tests-mysql.yml
@@ -33,7 +33,7 @@ jobs:
     name: PHP ${{ matrix.php-version }}
 
     steps:
-      - uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: none

--- a/.github/workflows/tests-mysql.yml
+++ b/.github/workflows/tests-mysql.yml
@@ -51,7 +51,7 @@ jobs:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
-            ${{ runner.os }}-composer-
+            ${{ runner.os }}-${{ matrix.php-version }}-composer-
 
       - name: Copy .env
         run: |

--- a/.github/workflows/tests-postgres.yml
+++ b/.github/workflows/tests-postgres.yml
@@ -30,7 +30,7 @@ jobs:
     name: PHP ${{ matrix.php-version }}
 
     steps:
-      - uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: none

--- a/.github/workflows/tests-postgres.yml
+++ b/.github/workflows/tests-postgres.yml
@@ -36,6 +36,8 @@ jobs:
           coverage: none
 
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Get Composer Cache Directory
         id: composer-cache

--- a/.github/workflows/tests-postgres.yml
+++ b/.github/workflows/tests-postgres.yml
@@ -48,7 +48,7 @@ jobs:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
-            ${{ runner.os }}-composer-
+            ${{ runner.os }}-${{ matrix.php-version }}-composer-
 
       - name: Copy .env
         run: |

--- a/.github/workflows/tests-sqlite.yml
+++ b/.github/workflows/tests-sqlite.yml
@@ -38,7 +38,7 @@ jobs:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
-            ${{ runner.os }}-composer-
+            ${{ runner.os }}-${{ matrix.php-version }}-composer-
 
       - name: Copy .env
         run: |

--- a/.github/workflows/tests-sqlite.yml
+++ b/.github/workflows/tests-sqlite.yml
@@ -26,6 +26,8 @@ jobs:
           coverage: none
 
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Get Composer Cache Directory
         id: composer-cache

--- a/.github/workflows/tests-sqlite.yml
+++ b/.github/workflows/tests-sqlite.yml
@@ -20,7 +20,7 @@ jobs:
     name: PHP ${{ matrix.php-version }}
 
     steps:
-      - uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: none


### PR DESCRIPTION
This PR makes some updates to our GitHub actions workflows:

- Adds `persist-credentials: false` for the `action/checkout` step to tighten up security around the token used in the workflows (thanks [Mastering Laravel](https://masteringlaravel.io/daily/2026-06-18-the-security-default-we-change-in-githubs-checkout-action))
- [Pins the setup-php step to a specific commit](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions) (v2.37.2) to help mitigate a supply-chain attack.
- Fixes the restore-keys step so that they actually match the keys set when they are cached (whoops...that's on me...)
