### PR TITLE
General Settings: Fix alignment of model dropdown label

### DIFF
--- a/resources/views/settings/general.blade.php
+++ b/resources/views/settings/general.blade.php
@@ -205,9 +205,9 @@
 
                            <!-- Model List prefs -->
                            <div class="form-group {{ $errors->has('show_in_model_list') ? 'error' : '' }}">
-                               <div class="col-md-3 control-label">
+                               <x-form.label class="col-md-3">
                                    <strong>{{ trans('admin/settings/general.show_in_model_list') }}</strong>
-                               </div>
+                               </x-form.label>
                                <div class="col-md-8">
                                    <label class="form-control">
                                        <input type="checkbox" name="show_in_model_list[]" value="image" @checked(old('show_in_model_list', $snipeSettings->modellistCheckedValue('image'))) aria-label="show_in_model_list"/>

--- a/resources/views/settings/general.blade.php
+++ b/resources/views/settings/general.blade.php
@@ -205,7 +205,7 @@
 
                            <!-- Model List prefs -->
                            <div class="form-group {{ $errors->has('show_in_model_list') ? 'error' : '' }}">
-                               <div class="col-md-3">
+                               <div class="col-md-3 control-label">
                                    <strong>{{ trans('admin/settings/general.show_in_model_list') }}</strong>
                                </div>
                                <div class="col-md-8">


### PR DESCRIPTION
Before:
<img width="765" height="486" alt="image" src="https://github.com/user-attachments/assets/8e701538-90f5-408d-8c3d-3f39cd85347b" />
After:
<img width="765" height="486" alt="image" src="https://github.com/user-attachments/assets/36f179e9-a0fe-4d7a-8004-bb84c577f3d0" />
