### PR TITLE
Adds `parent::prepareForValidation` to `UpdateAssetRequest`

### DIFF
--- a/app/Http/Requests/UpdateAssetRequest.php
+++ b/app/Http/Requests/UpdateAssetRequest.php
@@ -25,6 +25,8 @@ class UpdateAssetRequest extends ImageUploadRequest
 
     public function prepareForValidation(): void
     {
+        parent::prepareForValidation();
+
         if ($this->filled('purchase_cost') && ! is_float($this->input('purchase_cost')) && preg_match('/^[\d.,]+$/', (string) $this->input('purchase_cost'))) {
             $this->merge(['purchase_cost' => Helper::ParseCurrency($this->input('purchase_cost'))]);
         }

--- a/app/Rules/BooleanEncrypted.php
+++ b/app/Rules/BooleanEncrypted.php
@@ -22,7 +22,7 @@ class BooleanEncrypted implements ValidationRule
             $attributeName = trim(preg_replace('/_+|snipeit|\d+/', ' ', $attribute));
             $decrypted = Crypt::decrypt($value);
 
-            if (!$this->validateBoolean($attributeName, $decrypted) && !is_null($decrypted)) {
+            if (!$this->validateBoolean($attributeName, $decrypted, []) && !is_null($decrypted)) {
                 $fail(trans('validation.ipv6', ['attribute' => $attributeName]));
             }
         } catch (\Exception $e) {


### PR DESCRIPTION
This adds `parent::prepareForValidation` to `UpdateAssetRequest` so that the image processing stuff all runs, fixes a bug in the mobile app. Seems like it was working before because `UpdateAssetRequest` didn't have a `prepareForValidation()` method, so because it extends `ImageUploadRequest` it ran the parent method automatically, this just adds that functionality back. 

Also fixes a small bug with the `BooleanEncrypted` rule by passing an empty array in as the third argument.  