### PR TITLE
FMCS scoping: drop unique DB constraint, scope in the importer

### DIFF
--- a/app/Importer/ItemImporter.php
+++ b/app/Importer/ItemImporter.php
@@ -5,6 +5,7 @@ namespace App\Importer;
 use App\Models\AssetModel;
 use App\Models\Category;
 use App\Models\Company;
+use App\Models\CompanyableScope;
 use App\Models\Location;
 use App\Models\Manufacturer;
 use App\Models\Statuslabel;
@@ -337,7 +338,14 @@ class ItemImporter extends Importer
      */
     public function createOrFetchCompany($asset_company_name)
     {
-        $company = Company::where(['name' => $asset_company_name])->first();
+        // Bypass CompanyableScope so the lookup can see companies the
+        // importer's user isn't FMCS-allowed to see — otherwise the
+        // SELECT misses an existing row, the code falls through to the
+        // INSERT path, and the unique index on companies.name rejects
+        // it (which is what the customer's stack trace shows).
+        $company = Company::withoutGlobalScope(CompanyableScope::class)
+            ->where('name', $asset_company_name)
+            ->first();
         if ($company) {
             $this->log('A matching Company '.$asset_company_name.' already exists');
 
@@ -490,7 +498,14 @@ class ItemImporter extends Importer
             return null;
         }
 
-        $location = Location::where(['name' => $asset_location])->first();
+        // Bypass CompanyableScope so the lookup can see locations the
+        // importer's user isn't FMCS-allowed to see — same shape as the
+        // Company fix in createOrFetchCompany(). Without this, a hidden
+        // existing location forces the INSERT path and trips the unique
+        // index on locations.name.
+        $location = Location::withoutGlobalScope(CompanyableScope::class)
+            ->where('name', $asset_location)
+            ->first();
 
         if ($location) {
             $this->log('Location '.$asset_location.' already exists');

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Http\Traits\UniqueUndeletedTrait;
 use App\Models\Traits\CompanyableTrait;
 use App\Models\Traits\HasUploads;
 use App\Models\Traits\Loggable;
@@ -30,12 +31,13 @@ final class Company extends SnipeModel
     use HasUploads;
     use Loggable;
     use SoftDeletes;
+    use UniqueUndeletedTrait;
 
     protected $table = 'companies';
 
     // Declare the rules for the model validation
     protected $rules = [
-        'name' => 'required|max:255|unique:companies,name',
+        'name' => 'required|max:255|unique_undeleted',
         'fax' => 'min:7|max:35|nullable',
         'phone' => 'min:7|max:35|nullable',
         'email' => 'email|max:150|nullable',

--- a/database/migrations/2026_06_30_000001_drop_company_name_unique_index.php
+++ b/database/migrations/2026_06_30_000001_drop_company_name_unique_index.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Drops the DB-level unique constraint on `companies.name`. Uniqueness is
+ * enforced at the application layer via the `unique_undeleted` validation
+ * rule, which (unlike the DB index) correctly excludes soft-deleted rows —
+ * so a company that was trashed can have its name reused without leaving a
+ * stale schema constraint to trip over.
+ *
+ * Same pattern as the historical 2015_07_25_055415_remove_email_unique_constraint
+ * migration that dropped the equivalent constraint on `users.email`. The
+ * down() is intentionally a no-op because re-adding a unique index on a
+ * table that may by then have legitimate duplicates would fail.
+ *
+ * Background: the asset importer was tripping this index when a
+ * company *existed* but was hidden by CompanyableScope from the importer's
+ * user — the lookup missed it, the code fell through to INSERT, and the
+ * DB rejected the row. This migration removes the underlying foot-gun so the
+ * same shape of bug can't bonk an import run again.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('companies', function (Blueprint $table) {
+            $table->dropUnique('companies_name_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        // Intentionally empty — see header comment.
+    }
+};

--- a/tests/Feature/Companies/Api/CreateCompaniesTest.php
+++ b/tests/Feature/Companies/Api/CreateCompaniesTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Companies\Api;
 
+use App\Models\Company;
 use App\Models\User;
 use Tests\Concerns\TestsPermissionsRequirement;
 use Tests\TestCase;
@@ -41,6 +42,27 @@ class CreateCompaniesTest extends TestCase implements TestsPermissionsRequiremen
         $this->assertDatabaseHas('companies', [
             'name' => 'My Cool Company',
             'notes' => 'A Cool Note',
+        ]);
+    }
+
+    public function test_can_reuse_name_of_soft_deleted_company()
+    {
+        // Previously a DB-level unique index on companies.name made this
+        // impossible — even if the original row was trashed, the schema
+        // constraint matched it and the INSERT failed. The unique_undeleted
+        // validation rule respects deleted_at, so the trashed row no
+        // longer blocks creating a new one with the same name.
+        $trashed = Company::factory()->create(['name' => 'Phoenix Co']);
+        $trashed->delete();
+
+        $this->actingAsForApi(User::factory()->createCompanies()->create())
+            ->postJson(route('api.companies.store'), ['name' => 'Phoenix Co'])
+            ->assertStatus(200)
+            ->assertStatusMessageIs('success');
+
+        $this->assertDatabaseHas('companies', [
+            'name' => 'Phoenix Co',
+            'deleted_at' => null,
         ]);
     }
 }


### PR DESCRIPTION
This fixes the asset importer when a customer has FMCS enabled and a CSV references a company name the importer's user isn't allowed to see, for example "LG" exists in the database, but it lives under a company branch this user can't reach. The importer was throwing a database-level error and crashing out mid-batch, throwing rollbars.                                                              
                                                                                                                                                                                      
Two problems were stacking on top of each other:                                                                                                                                                
                                                                                                                                                                                      
- `createOrFetchCompany()` and `createOrFetchLocation()` in the importer were running the "do we already have one named X?" lookup through normal Eloquent, which inherits  `CompanyableScope` -  the FMCS visibility filter. If the existing row was outside the importer user's reach, the SELECT came up empty, the code fell through to creating a new row, and  then the unique index on the `companies` table rejected it with a raw SQL error.                                                                                                        
- That unique index was itself a leftover. We already enforce name uniqueness at the application layer with the `unique_undeleted` validation rule, which (unlike the DB index) correctly understands soft-deletes. The other comparable tables - `users.email`, statuslabels, locations, suppliers - had their DB unique constraints dropped years ago for the same reason. Companies never got that cleanup, and nobody had (yet) triggered it in the importer so we didn't catch it when we changed the com. 
                                                                                                                                        
- The importer lookups now skip `CompanyableScope` so they actually find what's already there, regardless of FMCS visibility.                                                           
- Dropped the unique index on `companies.name`.                                                                                                                                         
- Swapped the Company model's validation rule from `unique:companies,name` to `unique_undeleted`, and added the `UniqueUndeletedTrait` so the rule resolves properly. Now matches every other similar model in the codebase.  

Now, the importer no longer dies on companies (or locations) it can't FMCS-see. Existing rows get reused like the code was always trying to do. You can now reuse the name of a soft-deleted company without the database rejecting it. 

As a general policy, we don't enforce unique or FK database constraints in Snipe-IT, because old data can cause issues if we suddenly change the rules. This one is my bad - I created that companies migration. 😩