### PR TITLE
Webhooks: Update validation to only http/https only, optional internal config flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -256,3 +256,8 @@ ARGON_TIME=2
 # --------------------------------------------
 SCIM_TRACE=false
 SCIM_STANDARDS_COMPLIANCE=false
+
+# --------------------------------------------
+# OPTIONAL: WEBHOOK SETTINGS
+# --------------------------------------------
+WEBHOOK_ALLOW_INTERNAL_TARGETS=false

--- a/app/Livewire/SlackSettingsForm.php
+++ b/app/Livewire/SlackSettingsForm.php
@@ -4,8 +4,11 @@ namespace App\Livewire;
 
 use App\Helpers\Helper;
 use App\Models\Setting;
+use App\Rules\ExternalUrl;
 use GuzzleHttp\Client;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 use Livewire\Component;
 use Osama\LaravelTeamsNotification\TeamsNotification;
@@ -42,11 +45,19 @@ class SlackSettingsForm extends Component
 
     public $webhook_endpoint_rules;
 
-    protected $rules = [
-        'webhook_endpoint' => 'required_with:webhook_channel|starts_with:http://,https://,ftp://,irc://,https://hooks.slack.com/services/|url|nullable',
-        'webhook_channel' => 'required_with:webhook_endpoint|starts_with:#|nullable',
-        'webhook_botname' => 'string|nullable',
-    ];
+    protected function rules(): array
+    {
+        return [
+            'webhook_endpoint' => [
+                'nullable',
+                'required_with:webhook_channel',
+                'url',
+                new ExternalUrl,
+            ],
+            'webhook_channel' => 'required_with:webhook_endpoint|starts_with:#|nullable',
+            'webhook_botname' => 'string|nullable',
+        ];
+    }
 
     public function mount()
     {
@@ -109,7 +120,7 @@ class SlackSettingsForm extends Component
     public function updated($field)
     {
 
-        $this->validateOnly($field, $this->rules);
+        $this->validateOnly($field);
 
     }
 
@@ -157,6 +168,9 @@ class SlackSettingsForm extends Component
 
     public function testWebhook()
     {
+        if ($fail = $this->guardWebhookEndpoint()) {
+            return $fail;
+        }
 
         $webhook = new Client([
             'base_url' => e($this->webhook_endpoint),
@@ -187,11 +201,7 @@ class SlackSettingsForm extends Component
             return session()->flash('success', trans('admin/settings/message.webhook.success', ['webhook_name' => $this->webhook_name]));
 
         } catch (\Exception $e) {
-
-            $this->isDisabled = 'disabled';
-            $this->save_button = trans('admin/settings/general.webhook_presave');
-
-            return session()->flash('error', trans('admin/settings/message.webhook.error', ['error_message' => $e->getMessage(), 'app' => $this->webhook_name]));
+            return $this->handleWebhookFailure($e);
         }
 
         return session()->flash('error', trans('admin/settings/message.webhook.error_misc'));
@@ -222,7 +232,7 @@ class SlackSettingsForm extends Component
         if (Helper::isDemoMode()) {
             session()->flash('error', trans('general.feature_disabled'));
         } else {
-            $this->validate($this->rules);
+            $this->validate();
 
             $this->setting->webhook_selected = $this->webhook_selected;
             $this->setting->webhook_endpoint = $this->webhook_endpoint;
@@ -238,6 +248,9 @@ class SlackSettingsForm extends Component
 
     public function googleWebhookTest()
     {
+        if ($fail = $this->guardWebhookEndpoint()) {
+            return $fail;
+        }
 
         $payload = [
             'text' => trans('general.webhook_test_msg', ['app' => $this->webhook_name]),
@@ -246,8 +259,9 @@ class SlackSettingsForm extends Component
         try {
             $response = Http::withHeaders([
                 'content-type' => 'application/json',
-            ])->post($this->webhook_endpoint,
-                $payload)->throw();
+            ])->withOptions(['allow_redirects' => false])
+                ->post($this->webhook_endpoint, $payload)
+                ->throw();
 
             if (($response->getStatusCode() == 302) || ($response->getStatusCode() == 301)) {
                 return session()->flash('error', trans('admin/settings/message.webhook.error_redirect', ['endpoint' => $this->webhook_endpoint]));
@@ -259,16 +273,15 @@ class SlackSettingsForm extends Component
             return session()->flash('success', trans('admin/settings/message.webhook.success', ['webhook_name' => $this->webhook_name]));
 
         } catch (\Exception $e) {
-
-            $this->isDisabled = 'disabled';
-            $this->save_button = trans('admin/settings/general.webhook_presave');
-
-            return session()->flash('error', trans('admin/settings/message.webhook.error', ['error_message' => $e->getMessage(), 'app' => $this->webhook_name]));
+            return $this->handleWebhookFailure($e);
         }
     }
 
     public function msTeamTestWebhook()
     {
+        if ($fail = $this->guardWebhookEndpoint()) {
+            return $fail;
+        }
 
         try {
 
@@ -284,8 +297,9 @@ class SlackSettingsForm extends Component
                     ];
                 $response = Http::withHeaders([
                     'content-type' => 'application/json',
-                ])->post($this->webhook_endpoint,
-                    $payload)->throw();
+                ])->withOptions(['allow_redirects' => false])
+                    ->post($this->webhook_endpoint, $payload)
+                    ->throw();
             } else {
                 $notification = new TeamsNotification($this->webhook_endpoint);
                 $message = trans('general.webhook_test_msg', ['app' => $this->webhook_name]);
@@ -293,7 +307,8 @@ class SlackSettingsForm extends Component
 
                 $response = Http::withHeaders([
                     'content-type' => 'application/json',
-                ])->post($this->webhook_endpoint);
+                ])->withOptions(['allow_redirects' => false])
+                    ->post($this->webhook_endpoint);
             }
 
             if (($response->getStatusCode() == 302) || ($response->getStatusCode() == 301)) {
@@ -305,13 +320,57 @@ class SlackSettingsForm extends Component
             return session()->flash('success', trans('admin/settings/message.webhook.success', ['webhook_name' => $this->webhook_name]));
 
         } catch (\Exception $e) {
-
-            $this->isDisabled = 'disabled';
-            $this->save_button = trans('admin/settings/general.webhook_presave');
-
-            return session()->flash('error', trans('admin/settings/message.webhook.error', ['error_message' => $e->getMessage(), 'app' => $this->webhook_name]));
+            return $this->handleWebhookFailure($e);
         }
 
         return session()->flash('error', trans('admin/settings/message.webhook.error_misc'));
+    }
+
+    /**
+     * Re-validate the currently-entered endpoint immediately before an
+     * outbound request. This is defense-in-depth on top of the save-time
+     * ExternalUrl rule: it stops a super-admin from typing an internal
+     * URL, clicking Test, and having the server dial it before the value
+     * is ever persisted. Returns a flash-response on failure, null on pass.
+     */
+    private function guardWebhookEndpoint()
+    {
+        $validator = Validator::make(
+            ['webhook_endpoint' => $this->webhook_endpoint],
+            ['webhook_endpoint' => ['required', 'url', new ExternalUrl]],
+        );
+
+        if ($validator->fails()) {
+            $this->isDisabled = 'disabled';
+            $this->save_button = trans('admin/settings/general.webhook_presave');
+
+            return session()->flash('error', $validator->errors()->first('webhook_endpoint'));
+        }
+
+        return null;
+    }
+
+    /**
+     * Uniform failure path for outbound webhook tests. The exception message
+     * is logged server-side but never reflected into the UI, because Guzzle
+     * error strings leak connect-refused / timeout / DNS details that turn
+     * this feature into a port-scanning oracle for internal hosts.
+     */
+    private function handleWebhookFailure(\Throwable $e)
+    {
+        Log::warning('Webhook test failed', [
+            'endpoint' => $this->webhook_endpoint,
+            'app' => $this->webhook_name,
+            'exception' => $e::class,
+            'message' => $e->getMessage(),
+        ]);
+
+        $this->isDisabled = 'disabled';
+        $this->save_button = trans('admin/settings/general.webhook_presave');
+
+        return session()->flash('error', trans('admin/settings/message.webhook.error', [
+            'error_message' => trans('admin/settings/message.webhook.error_misc'),
+            'app' => $this->webhook_name,
+        ]));
     }
 }

--- a/app/Livewire/SlackSettingsForm.php
+++ b/app/Livewire/SlackSettingsForm.php
@@ -352,9 +352,13 @@ class SlackSettingsForm extends Component
 
     /**
      * Uniform failure path for outbound webhook tests. The exception message
-     * is logged server-side but never reflected into the UI, because Guzzle
-     * error strings leak connect-refused / timeout / DNS details that turn
-     * this feature into a port-scanning oracle for internal hosts.
+     * used to be a port-scanning oracle back when the endpoint field accepted
+     * internal URLs; now that the ExternalUrl rule rejects those before we
+     * ever dial anything, the connect-level error can only describe an
+     * external host the admin explicitly typed, so we surface it back into
+     * the flash. Full exception context still lands in the log for audit
+     * and for cases where the flash message is too short to be useful (SSL
+     * chain problems, proxy failures, etc.).
      */
     private function handleWebhookFailure(\Throwable $e)
     {
@@ -363,13 +367,15 @@ class SlackSettingsForm extends Component
             'app' => $this->webhook_name,
             'exception' => $e::class,
             'message' => $e->getMessage(),
+            'file' => $e->getFile(),
+            'line' => $e->getLine(),
         ]);
 
         $this->isDisabled = 'disabled';
         $this->save_button = trans('admin/settings/general.webhook_presave');
 
         return session()->flash('error', trans('admin/settings/message.webhook.error', [
-            'error_message' => trans('admin/settings/message.webhook.error_misc'),
+            'error_message' => $e->getMessage(),
             'app' => $this->webhook_name,
         ]));
     }

--- a/app/Rules/ExternalUrl.php
+++ b/app/Rules/ExternalUrl.php
@@ -44,6 +44,13 @@ class ExternalUrl implements ValidationRule
             return;
         }
 
+        // Operators who legitimately need to point at an on-LAN webhook
+        // receiver flip WEBHOOK_ALLOW_INTERNAL_TARGETS in .env. Scheme
+        // restrictions above still apply; only the IP-range check is skipped.
+        if (config('app.webhook_allow_internal_targets')) {
+            return;
+        }
+
         $host = $parts['host'];
 
         if (str_starts_with($host, '[') && str_ends_with($host, ']')) {
@@ -89,25 +96,31 @@ class ExternalUrl implements ValidationRule
     {
         $ips = [];
 
-        $records = @dns_get_record($host, DNS_A + DNS_AAAA);
-        if (is_array($records)) {
-            foreach ($records as $r) {
-                if (! empty($r['ip'])) {
-                    $ips[] = $r['ip'];
-                }
+        // gethostbynamel goes through nsswitch (/etc/hosts, mDNS, DNS) —
+        // the same lookup path the outbound HTTP client will use. dns_get_record
+        // alone is a pure DNS query that ignores /etc/hosts and may apply
+        // search suffixes, which would let "localhost" resolve to a public IP
+        // under "localhost.<search-domain>" and slip past the check.
+        $v4 = @gethostbynamel($host);
+        if (is_array($v4)) {
+            foreach ($v4 as $ip) {
+                $ips[] = $ip;
+            }
+        }
+
+        // There is no stdlib nsswitch equivalent for IPv6, so this leg is
+        // best-effort DNS. The IPv4 leg above already catches the common
+        // "localhost" / hosts-file cases, so a missed AAAA record here
+        // can't silently pass a name we would have otherwise rejected.
+        $v6 = @dns_get_record($host, DNS_AAAA);
+        if (is_array($v6)) {
+            foreach ($v6 as $r) {
                 if (! empty($r['ipv6'])) {
                     $ips[] = $r['ipv6'];
                 }
             }
         }
 
-        if ($ips === []) {
-            $resolved = @gethostbyname($host);
-            if ($resolved !== $host && filter_var($resolved, FILTER_VALIDATE_IP)) {
-                $ips[] = $resolved;
-            }
-        }
-
-        return $ips;
+        return array_values(array_unique($ips));
     }
 }

--- a/app/Rules/ExternalUrl.php
+++ b/app/Rules/ExternalUrl.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+/**
+ * Reject URLs that point at loopback, link-local, private-network, or
+ * otherwise-non-public addresses so a super-admin can't be tricked (or
+ * accidentally) turn the outbound webhook path into an SSRF primitive
+ * against 169.254.169.254, 127.0.0.1, RFC-1918, [::1], and friends.
+ *
+ * The rule is intentionally scheme-strict (http/https only): the previous
+ * webhook validator accepted ftp:// and irc://, which have no legitimate
+ * webhook use and expand the attack surface.
+ *
+ * Between this check and the outbound request there is still a DNS
+ * rebinding window; that is acceptable given the super-admin threat
+ * model. If we ever need to close it, pin the resolved IP into Guzzle
+ * via CURLOPT_RESOLVE on the actual request.
+ */
+class ExternalUrl implements ValidationRule
+{
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! is_string($value) || $value === '') {
+            $fail(trans('validation.external_url'));
+
+            return;
+        }
+
+        $parts = parse_url($value);
+
+        if ($parts === false || empty($parts['scheme']) || empty($parts['host'])) {
+            $fail(trans('validation.external_url'));
+
+            return;
+        }
+
+        if (! in_array(strtolower($parts['scheme']), ['http', 'https'], true)) {
+            $fail(trans('validation.external_url'));
+
+            return;
+        }
+
+        $host = $parts['host'];
+
+        if (str_starts_with($host, '[') && str_ends_with($host, ']')) {
+            $host = substr($host, 1, -1);
+        }
+
+        $ips = filter_var($host, FILTER_VALIDATE_IP) ? [$host] : $this->resolveHost($host);
+
+        if ($ips === []) {
+            $fail(trans('validation.external_url'));
+
+            return;
+        }
+
+        foreach ($ips as $ip) {
+            if (! $this->isPublicIp($ip)) {
+                $fail(trans('validation.external_url'));
+
+                return;
+            }
+        }
+    }
+
+    private function isPublicIp(string $ip): bool
+    {
+        // Unwrap IPv4-mapped IPv6 so ::ffff:127.0.0.1 doesn't sneak past
+        // the IPv4 private/reserved checks.
+        if (stripos($ip, '::ffff:') === 0) {
+            $ipv4 = substr($ip, 7);
+            if (filter_var($ipv4, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+                $ip = $ipv4;
+            }
+        }
+
+        return (bool) filter_var(
+            $ip,
+            FILTER_VALIDATE_IP,
+            FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE
+        );
+    }
+
+    private function resolveHost(string $host): array
+    {
+        $ips = [];
+
+        $records = @dns_get_record($host, DNS_A + DNS_AAAA);
+        if (is_array($records)) {
+            foreach ($records as $r) {
+                if (! empty($r['ip'])) {
+                    $ips[] = $r['ip'];
+                }
+                if (! empty($r['ipv6'])) {
+                    $ips[] = $r['ipv6'];
+                }
+            }
+        }
+
+        if ($ips === []) {
+            $resolved = @gethostbyname($host);
+            if ($resolved !== $host && filter_var($resolved, FILTER_VALIDATE_IP)) {
+                $ips[] = $resolved;
+            }
+        }
+
+        return $ips;
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -234,6 +234,26 @@ return [
 
     /*
    |--------------------------------------------------------------------------
+   | ALLOW INTERNAL WEBHOOK TARGETS
+   |--------------------------------------------------------------------------
+   |
+   | By default the webhook endpoint validator refuses URLs that resolve to
+   | loopback, link-local, RFC-1918, or otherwise-non-public IPs. This
+   | prevents a super-admin (or someone who has taken over a super-admin
+   | account) from turning the outbound notification path into an SSRF
+   | primitive against internal services or cloud metadata endpoints.
+   |
+   | Some operators legitimately run their own webhook receiver on the same
+   | private network as Snipe-IT (self-hosted Mattermost, Rocket.Chat, an
+   | internal ChatOps bot, etc.). Setting this to true re-enables outbound
+   | requests to those addresses. Scheme restrictions (http/https only) are
+   | still enforced. Leave this off unless you know you need it.
+   |
+   */
+    'webhook_allow_internal_targets' => env('WEBHOOK_ALLOW_INTERNAL_TARGETS', false),
+
+    /*
+   |--------------------------------------------------------------------------
    | LOG AUTHED USER HEADER
    |--------------------------------------------------------------------------
    |

--- a/database/migrations/2026_07_01_000001_clear_unsafe_webhook_endpoints.php
+++ b/database/migrations/2026_07_01_000001_clear_unsafe_webhook_endpoints.php
@@ -1,0 +1,53 @@
+<?php
+
+use App\Rules\ExternalUrl;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Validator;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // The webhook endpoint used to accept ftp:// and irc:// schemes and did
+        // no host validation at all, so upgrading instances may already have a
+        // value pointing at loopback, RFC-1918, or a metadata service. The new
+        // ExternalUrl rule blocks new saves in that shape, but the runtime
+        // notification senders read the stored value directly on every checkout
+        // / checkin, so a bad value sitting in the DB stays exploitable until
+        // it's cleared. This migration walks the settings rows once and blanks
+        // anything the rule rejects, logging the previous value so an operator
+        // who was intentionally pointing at an internal receiver can see what
+        // was removed and put it back through a reverse proxy if they want.
+        $rows = DB::table('settings')
+            ->whereNotNull('webhook_endpoint')
+            ->where('webhook_endpoint', '!=', '')
+            ->get(['id', 'webhook_endpoint']);
+
+        foreach ($rows as $row) {
+            $fails = Validator::make(
+                ['webhook_endpoint' => $row->webhook_endpoint],
+                ['webhook_endpoint' => [new ExternalUrl]],
+            )->fails();
+
+            if (! $fails) {
+                continue;
+            }
+
+            Log::warning('Clearing unsafe webhook_endpoint during migration', [
+                'settings_id' => $row->id,
+                'previous_endpoint' => $row->webhook_endpoint,
+            ]);
+
+            DB::table('settings')
+                ->where('id', $row->id)
+                ->update(['webhook_endpoint' => null]);
+        }
+    }
+
+    public function down(): void
+    {
+        // No-op: cleared endpoints are logged during up(); we can't restore them.
+    }
+};

--- a/resources/lang/en-US/validation.php
+++ b/resources/lang/en-US/validation.php
@@ -171,6 +171,7 @@ return [
     'uploaded' => 'The :attribute failed to upload.',
     'uppercase' => 'The :attribute field must be uppercase.',
     'url' => 'The :attribute field must be a valid URL.',
+    'external_url' => 'The :attribute field must be a valid external URL (http:// or https://) that does not point at a private or local address.',
     'ulid' => 'The :attribute field must be a valid ULID.',
     'uuid' => 'The :attribute field must be a valid UUID.',
     'valid_css_color' => 'The :attribute field must be a valid CSS color (hex, rgb, rgba, hsl, or hsla).',

--- a/tests/Unit/Rules/ExternalUrlTest.php
+++ b/tests/Unit/Rules/ExternalUrlTest.php
@@ -55,7 +55,6 @@ class ExternalUrlTest extends TestCase
             'v4-mapped rfc1918' => ['http://[::ffff:10.0.0.1]/'],
 
             // Malformed.
-            'empty' => [''],
             'no scheme' => ['example.com'],
             'no host' => ['http:///'],
         ];
@@ -78,5 +77,26 @@ class ExternalUrlTest extends TestCase
     public function test_accepts_public_ipv6_literal()
     {
         $this->assertTrue($this->passes('http://[2606:2800:220:1:248:1893:25c8:1946]/'));
+    }
+
+    public function test_internal_targets_pass_when_escape_hatch_is_enabled()
+    {
+        config(['app.webhook_allow_internal_targets' => true]);
+
+        $this->assertTrue($this->passes('http://127.0.0.1/hook'));
+        $this->assertTrue($this->passes('http://10.0.0.1/hook'));
+        $this->assertTrue($this->passes('http://192.168.1.50:8080/hook'));
+        $this->assertTrue($this->passes('http://169.254.169.254/'));
+        $this->assertTrue($this->passes('http://[::1]/hook'));
+    }
+
+    public function test_escape_hatch_still_blocks_non_http_schemes()
+    {
+        config(['app.webhook_allow_internal_targets' => true]);
+
+        $this->assertFalse($this->passes('ftp://example.com/'));
+        $this->assertFalse($this->passes('irc://example.com/'));
+        $this->assertFalse($this->passes('javascript:alert(1)'));
+        $this->assertFalse($this->passes('file:///etc/passwd'));
     }
 }

--- a/tests/Unit/Rules/ExternalUrlTest.php
+++ b/tests/Unit/Rules/ExternalUrlTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Unit\Rules;
+
+use App\Rules\ExternalUrl;
+use Illuminate\Support\Facades\Validator;
+use Tests\TestCase;
+
+class ExternalUrlTest extends TestCase
+{
+    private function passes(string $url): bool
+    {
+        return Validator::make(
+            ['url' => $url],
+            ['url' => [new ExternalUrl]],
+        )->passes();
+    }
+
+    public static function rejectedProvider(): array
+    {
+        return [
+            // Non-http schemes are gone even if the URL is otherwise well-formed.
+            'ftp scheme' => ['ftp://example.com/'],
+            'irc scheme' => ['irc://example.com/'],
+            'javascript scheme' => ['javascript:alert(1)'],
+            'file scheme' => ['file:///etc/passwd'],
+            'gopher scheme' => ['gopher://example.com/'],
+
+            // IMDS / cloud metadata.
+            'aws metadata' => ['http://169.254.169.254/latest/meta-data/'],
+            'aws metadata https' => ['https://169.254.169.254/'],
+
+            // Loopback.
+            'ipv4 loopback' => ['http://127.0.0.1/'],
+            'ipv4 loopback alt' => ['http://127.0.0.53/'],
+            'ipv6 loopback' => ['http://[::1]/'],
+            'localhost host' => ['http://localhost/'],
+
+            // RFC-1918.
+            'rfc1918 10' => ['http://10.0.0.1/'],
+            'rfc1918 172' => ['http://172.16.5.5/'],
+            'rfc1918 192' => ['http://192.168.1.1/'],
+
+            // Link-local / unspecified / broadcast.
+            'link local v4' => ['http://169.254.1.1/'],
+            'link local v6' => ['http://[fe80::1]/'],
+            'unspecified v4' => ['http://0.0.0.0/'],
+
+            // IPv6 unique-local.
+            'unique local v6' => ['http://[fc00::1]/'],
+            'unique local v6 fd' => ['http://[fd12:3456::1]/'],
+
+            // IPv4-mapped IPv6 sneak-in.
+            'v4-mapped loopback' => ['http://[::ffff:127.0.0.1]/'],
+            'v4-mapped rfc1918' => ['http://[::ffff:10.0.0.1]/'],
+
+            // Malformed.
+            'empty' => [''],
+            'no scheme' => ['example.com'],
+            'no host' => ['http:///'],
+        ];
+    }
+
+    /**
+     * @dataProvider rejectedProvider
+     */
+    public function test_rejects_dangerous_or_malformed_urls(string $url)
+    {
+        $this->assertFalse($this->passes($url), 'Should have been rejected: '.$url);
+    }
+
+    public function test_accepts_public_ipv4_literal()
+    {
+        // Public IP literal — no DNS lookup required.
+        $this->assertTrue($this->passes('http://93.184.216.34/'));
+    }
+
+    public function test_accepts_public_ipv6_literal()
+    {
+        $this->assertTrue($this->passes('http://[2606:2800:220:1:248:1893:25c8:1946]/'));
+    }
+}


### PR DESCRIPTION
This locks down the webhooks to http/https requests and disallows things like ftp, etc, since anything other than http/https doesn't really make sense in a webhook context ("web" being the operative word.)

This also added `WEBHOOK_ALLOW_INTERNAL_TARGETS` (defaulting to false) to the example env, so that folks hosting internal chat systems (Mattermost, etc) can still have their internal integrations work if they enable this. 

The migration to clear out the existing potentially bad values could possibly be overkill. I'd be okay with removing that if reviewers felt it was a little too much.