### PR TITLE
SCIM Groups: Fixed RB-21764

### DIFF
--- a/app/Models/SnipeSCIMConfig.php
+++ b/app/Models/SnipeSCIMConfig.php
@@ -166,6 +166,25 @@ class SnipeMutableCollection extends MutableCollection
     {
         $this->add($value, $object);
     }
+
+    // POST /scim/v2/Groups with an initial `members` array arrives here with
+    // an unsaved parent: the SCIM library runs attribute mappers before it
+    // calls save() on the new resource. Letting parent::add() fire on an
+    // unsaved model makes Eloquent's pivot INSERT bind NULL for group_id
+    // (since $parent->getKey() is null) and blow up with a MySQL 23000 integrity
+    // violation. Persist first so the pivot row has a real parent id, then
+    // stash the object into the request so the displayName uniqueness closure
+    // (which re-runs after mapping) can recognize its own row instead of
+    // treating it as an existing name collision.
+    public function add($value, Model &$object)
+    {
+        if (! $object->exists) {
+            $object->save();
+            request()->attributes->set('scim_in_flight_resource', $object);
+        }
+
+        parent::add($value, $object);
+    }
 }
 
 class MappedTable extends Attribute
@@ -644,9 +663,23 @@ class SnipeSCIMConfig
                     eloquent('displayName', 'name')->ensure('required', 'min:3', function ($attribute, $value, $fail) {
                         // check if group does not exist or if it exists, it is the same group
                         $group = $this->getGroupClass()::where('name', $value)->first();
-                        if ($group && (request()->route('resourceObject') == null || $group->id != request()->route('resourceObject')->id)) {
-                            $fail('The name has already been taken.');
+                        if (! $group) {
+                            return;
                         }
+                        // PATCH/PUT: the group being edited is route-bound.
+                        $routeResource = request()->route('resourceObject');
+                        if ($routeResource && $group->id == $routeResource->id) {
+                            return;
+                        }
+                        // POST create with an initial members[] triggers SnipeMutableCollection
+                        // to save the parent early (so the pivot INSERT has a valid group_id),
+                        // which puts a row in the DB before this closure re-runs. Recognize the
+                        // just-saved row as ours so validation doesn't false-positive.
+                        $inFlight = request()->attributes->get('scim_in_flight_resource');
+                        if ($inFlight && $group->id == $inFlight->id) {
+                            return;
+                        }
+                        $fail('The name has already been taken.');
                     }),
                     (new SnipeMutableCollection('members'))->withSubAttributes(
                         eloquent('value', 'id')->ensure('required'),

--- a/tests/Feature/Scim/CreateGroupWithMembersTest.php
+++ b/tests/Feature/Scim/CreateGroupWithMembersTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature\Scim;
+
+use App\Models\Group;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Laravel\Passport\Passport;
+use Tests\TestCase;
+
+class CreateGroupWithMembersTest extends TestCase
+{
+    public function test_post_group_with_members_in_initial_body_attaches_pivot_rows()
+    {
+        // Regression for the Rollbar 23000 crash: the SCIM library runs
+        // attribute mappers before saving the parent resource, so a
+        // POST /scim/v2/Groups body that carries `members` alongside
+        // displayName used to write pivot rows with a NULL group_id
+        // and blow up with an integrity-constraint violation. The
+        // SnipeMutableCollection::add override saves the parent first.
+        Passport::actingAs(User::factory()->superuser()->create());
+
+        $memberOne = User::factory()->create();
+        $memberTwo = User::factory()->create();
+
+        $response = $this->postJson('/scim/v2/Groups', [
+            'schemas' => ['urn:ietf:params:scim:schemas:core:2.0:Group'],
+            'displayName' => 'SCIM Group With Members',
+            'members' => [
+                ['value' => $memberOne->id],
+                ['value' => $memberTwo->id],
+            ],
+        ]);
+
+        $response->assertStatus(201);
+        $response->assertJsonPath('displayName', 'SCIM Group With Members');
+
+        $group = Group::where('name', 'SCIM Group With Members')->firstOrFail();
+
+        $this->assertDatabaseHas('users_groups', [
+            'group_id' => $group->id,
+            'user_id' => $memberOne->id,
+        ]);
+        $this->assertDatabaseHas('users_groups', [
+            'group_id' => $group->id,
+            'user_id' => $memberTwo->id,
+        ]);
+        $this->assertSame(0, DB::table('users_groups')
+            ->where('group_id', $group->id)
+            ->whereNull('user_id')
+            ->count());
+    }
+
+    public function test_post_group_without_members_still_works()
+    {
+        // Sanity check that the save-if-unsaved shortcut doesn't break the
+        // ordinary create path where no members are attached.
+        Passport::actingAs(User::factory()->superuser()->create());
+
+        $response = $this->postJson('/scim/v2/Groups', [
+            'schemas' => ['urn:ietf:params:scim:schemas:core:2.0:Group'],
+            'displayName' => 'SCIM Group No Members',
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertDatabaseHas('permission_groups', ['name' => 'SCIM Group No Members']);
+    }
+}


### PR DESCRIPTION
Azure Entra ID provisions groups with POST /scim/v2/Groups and the members array in the initial request body. When a mew group was trying to be created and then synced with members, it was hitting a PDOException: SQLSTATE[23000] Column 'group_id' cannot be null in Rollbar every time:
  
```
PDOException: SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'group_id' cannot be null in /snipe-it/vendor/laravel/framework/src/Illuminate/Database/MySqlConnection.php:53
Stack trace:
...
```

The upstream SCIM library (arietimmerman/laravel-scim-server) runs attribute mappers before saving the new resource. Our `SnipeMutableCollection::add` was calling `syncWithoutDetaching()` on the **unsaved** Group, so Eloquent's pivot `INSERT` was binding `$parent->getKey() (null)` into `group_id`.                               
                                                                                                                                                                                                                                                                                                                             
This PR should fix this by way of:

- `SnipeMutableCollection::add()` now persists the parent before delegating to the upstream implementation. The Groups mapping declares `displayName` before members, so `$group->name` is already set on the in-memory model by the time we save.                                                                               
- After the early save, the object is stashed in `request()->attributes` so the `displayName` uniqueness closure can tell "the row I just persisted" apart from "someone else already had this name". Without that, the SCIM controller's post-mutation re-validation would flag the just-created group as a duplicate (of itself).                                                                                                                                                                                                                                                                                                                    
- The closure now handles all three cases explicitly: no match, `PATCH`/`PUT` route-bound resource, `POST` early-saved resource.  

I also added a few tests to confirm this behavior. 