### PR TITLE
Importer: Fixed FD-56113 - scope to user who uploaded

### DIFF
--- a/app/Http/Controllers/Api/ImportController.php
+++ b/app/Http/Controllers/Api/ImportController.php
@@ -28,9 +28,17 @@ class ImportController extends Controller
     public function index(): JsonResponse|array
     {
         $this->authorize('import');
-        $imports = Import::with('adminuser')->latest()->get();
 
-        return (new ImportsTransformer)->transformImports($imports);
+        // Silently scope to the caller's own imports unless they're a superuser.
+        // The `import` permission is grantable to any user, but a stored import
+        // file (and the first CSV row exposed by the transformer) is only meant
+        // for whoever uploaded it. Superusers keep the full view.
+        $query = Import::with('adminuser')->latest();
+        if (! auth()->user()->isSuperUser()) {
+            $query->where('created_by', auth()->id());
+        }
+
+        return (new ImportsTransformer)->transformImports($query->get());
     }
 
     /**
@@ -205,7 +213,11 @@ class ImportController extends Controller
 
         $import = Import::find($import_id);
 
-        if (is_null($import)) {
+        // Non-owners get the same "not found" branch as a missing record so we
+        // don't leak existence of another user's uploaded import file, and so
+        // an attacker with the `import` permission can't replay a stored file
+        // by guessing its (sequential) ID. Superusers can process any import.
+        if (is_null($import) || ($import->created_by !== auth()->id() && ! auth()->user()->isSuperUser())) {
             $error[0][0] = trans('validation.exists', ['attribute' => 'file']);
 
             return response()->json(Helper::formatStandardApiResponse('import-errors', null, $error), 500);

--- a/database/factories/ImportFactory.php
+++ b/database/factories/ImportFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Models\Import;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 use Tests\Support\Importing;
@@ -27,6 +28,13 @@ class ImportFactory extends Factory
             'file_path' => Str::random().'.csv',
             'filesize' => $this->faker->randomDigitNotNull(),
             'field_map' => null,
+            // In production `store()` always sets `created_by = auth()->id()`,
+            // so an import never exists without an owner. Mirror that here:
+            // if the test is already actingAs someone, use them; otherwise
+            // mint a fresh user. This keeps the "actor owns their import"
+            // idiom that existing tests already assume, and lets the API
+            // owner-scope on read/process paths match production behavior.
+            'created_by' => auth()->id() ?? User::factory(),
         ];
     }
 

--- a/tests/Feature/Importing/Api/ImportAssetsTest.php
+++ b/tests/Feature/Importing/Api/ImportAssetsTest.php
@@ -750,9 +750,8 @@ class ImportAssetsTest extends ImportDataTestCase implements TestsPermissionsReq
             'assigneeEmail' => 'phantom@example.org',
         ]);
 
-        $import = Import::factory()->asset()->create(['file_path' => $importFileBuilder->saveToImportsDirectory()]);
-
         $this->actingAsForApi($importer);
+        $import = Import::factory()->asset()->create(['file_path' => $importFileBuilder->saveToImportsDirectory()]);
         $this->importFileResponse(['import' => $import->id])->assertOk();
 
         $this->assertDatabaseMissing('users', ['username' => 'phantom-floater-user']);

--- a/tests/Feature/Importing/Api/ImportOwnershipTest.php
+++ b/tests/Feature/Importing/Api/ImportOwnershipTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Tests\Feature\Importing\Api;
+
+use App\Models\Import;
+use App\Models\Location;
+use App\Models\User;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Support\Importing\CleansUpImportFiles;
+use Tests\Support\Importing\LocationsImportFileBuilder;
+use Tests\TestCase;
+
+/**
+ * The import API endpoints used to expose every uploaded import to any user
+ * holding the flat `import` permission: the index disclosed the first CSV row
+ * of each foreign upload, and the process endpoint would read another user's
+ * file from disk and create records from it under the caller's identity.
+ * These tests pin the owner-only scope on both endpoints, with a superuser
+ * escape hatch for admin-tier maintenance.
+ */
+class ImportOwnershipTest extends TestCase
+{
+    use CleansUpImportFiles;
+
+    #[Test]
+    public function index_only_returns_the_callers_own_imports_for_non_superuser(): void
+    {
+        $mine = Import::factory()->locations()->create(['created_by' => ($me = User::factory()->canImport()->create())->id]);
+        $theirs = Import::factory()->locations()->create(['created_by' => User::factory()->canImport()->create()->id]);
+
+        $this->actingAsForApi($me);
+
+        $response = $this->getJson(route('api.imports.index'))->assertOk()->json();
+
+        $ids = array_column($response['rows'] ?? $response, 'id');
+        $this->assertContains($mine->id, $ids);
+        $this->assertNotContains($theirs->id, $ids, "Non-superuser index leaked another user's import");
+    }
+
+    #[Test]
+    public function index_returns_all_imports_for_superuser(): void
+    {
+        $mine = Import::factory()->locations()->create(['created_by' => ($me = User::factory()->superuser()->create())->id]);
+        $theirs = Import::factory()->locations()->create(['created_by' => User::factory()->canImport()->create()->id]);
+
+        $this->actingAsForApi($me);
+
+        $response = $this->getJson(route('api.imports.index'))->assertOk()->json();
+        $ids = array_column($response['rows'] ?? $response, 'id');
+
+        $this->assertContains($mine->id, $ids);
+        $this->assertContains($theirs->id, $ids);
+    }
+
+    #[Test]
+    public function process_refuses_and_does_not_read_another_users_file(): void
+    {
+        $victim = User::factory()->canImport()->create();
+        $attacker = User::factory()->canImport()->create();
+
+        $importFileBuilder = LocationsImportFileBuilder::new();
+        $row = $importFileBuilder->firstRow();
+        $import = Import::factory()->locations()->create([
+            'file_path' => $importFileBuilder->saveToImportsDirectory(),
+            'created_by' => $victim->id,
+        ]);
+
+        $this->actingAsForApi($attacker);
+
+        $this->postJson(
+            route('api.imports.importFile', ['import' => $import->id]),
+            ['import-type' => 'location']
+        )
+            ->assertStatus(500)
+            ->assertJsonPath('status', 'import-errors');
+
+        // The victim's rows must NOT have been imported under the attacker.
+        $this->assertDatabaseMissing((new Location)->getTable(), ['name' => $row['name']]);
+    }
+
+    #[Test]
+    public function process_works_for_the_owner(): void
+    {
+        $owner = User::factory()->canImport()->create();
+
+        $importFileBuilder = LocationsImportFileBuilder::new();
+        $row = $importFileBuilder->firstRow();
+        $import = Import::factory()->locations()->create([
+            'file_path' => $importFileBuilder->saveToImportsDirectory(),
+            'created_by' => $owner->id,
+        ]);
+
+        $this->actingAsForApi($owner);
+
+        $this->postJson(
+            route('api.imports.importFile', ['import' => $import->id]),
+            ['import-type' => 'location']
+        )->assertOk();
+
+        $this->assertDatabaseHas((new Location)->getTable(), ['name' => $row['name']]);
+    }
+
+    #[Test]
+    public function process_works_for_a_superuser_on_any_import(): void
+    {
+        $victim = User::factory()->canImport()->create();
+        $superuser = User::factory()->superuser()->create();
+
+        $importFileBuilder = LocationsImportFileBuilder::new();
+        $row = $importFileBuilder->firstRow();
+        $import = Import::factory()->locations()->create([
+            'file_path' => $importFileBuilder->saveToImportsDirectory(),
+            'created_by' => $victim->id,
+        ]);
+
+        $this->actingAsForApi($superuser);
+
+        $this->postJson(
+            route('api.imports.importFile', ['import' => $import->id]),
+            ['import-type' => 'location']
+        )->assertOk();
+
+        $this->assertDatabaseHas((new Location)->getTable(), ['name' => $row['name']]);
+    }
+}

--- a/tests/Feature/Importing/Api/ImportUsersTest.php
+++ b/tests/Feature/Importing/Api/ImportUsersTest.php
@@ -405,9 +405,9 @@ class ImportUsersTest extends ImportDataTestCase implements TestsPermissionsRequ
                 'email' => 'hijacked@evil.com',
             ]),
         ]);
-        $import = Import::factory()->users()->create(['file_path' => $importFileBuilder->saveToImportsDirectory()]);
 
         $this->actingAsForApi(User::factory()->canImport()->create());
+        $import = Import::factory()->users()->create(['file_path' => $importFileBuilder->saveToImportsDirectory()]);
         $this->importFileResponse(['import' => $import->id, 'import-update' => true])->assertOk();
 
         $this->assertEquals('original@example.com', $victim->refresh()->email);
@@ -427,9 +427,9 @@ class ImportUsersTest extends ImportDataTestCase implements TestsPermissionsRequ
                 'email' => 'updated@example.com',
             ]),
         ]);
-        $import = Import::factory()->users()->create(['file_path' => $importFileBuilder->saveToImportsDirectory()]);
 
         $this->actingAsForApi(User::factory()->canImport()->editUsers()->create());
+        $import = Import::factory()->users()->create(['file_path' => $importFileBuilder->saveToImportsDirectory()]);
         $this->importFileResponse(['import' => $import->id, 'import-update' => true])->assertOk();
 
         $this->assertEquals('updated@example.com', $target->refresh()->email);

--- a/tests/Feature/Importing/AssetImportCreatedAtTest.php
+++ b/tests/Feature/Importing/AssetImportCreatedAtTest.php
@@ -47,8 +47,11 @@ class AssetImportCreatedAtTest extends TestCase
         $csv = "asset tag,item name,category,status\n";
         $csv .= "TEST-001,Test Asset Updated,{$category->name},{$statusLabel->name}\n";
 
-        // Perform import with update flag
-        $this->actingAsForApi(User::factory()->canImport()->create())
+        // Perform import with update flag. The same user has to upload and
+        // process, because the process endpoint scopes to the file's uploader.
+        $importer = User::factory()->canImport()->create();
+
+        $this->actingAsForApi($importer)
             ->postJson(route('api.imports.store'), [
                 'files' => [
                     $this->createFakeUploadedFile('test.csv', $csv),
@@ -58,7 +61,7 @@ class AssetImportCreatedAtTest extends TestCase
 
         // Import the file
         $import = Import::latest()->first();
-        $this->actingAsForApi(User::factory()->canImport()->create())
+        $this->actingAsForApi($importer)
             ->postJson(route('api.imports.importFile', $import->id), [
                 'import-type' => 'asset',
                 'import-update' => true,
@@ -118,7 +121,11 @@ class AssetImportCreatedAtTest extends TestCase
             $csv .= "{$asset->asset_tag},{$asset->name},{$category->name},{$statusLabel->name}\n";
         }
 
-        $this->actingAsForApi(User::factory()->canImport()->create())
+        // Same user has to upload and process, because the process endpoint
+        // scopes to the file's uploader.
+        $importer = User::factory()->canImport()->create();
+
+        $this->actingAsForApi($importer)
             ->postJson(route('api.imports.store'), [
                 'files' => [
                     $this->createFakeUploadedFile('test1.csv', $csv),
@@ -127,7 +134,7 @@ class AssetImportCreatedAtTest extends TestCase
             ->assertSuccessful();
 
         $import1 = Import::latest()->first();
-        $this->actingAsForApi(User::factory()->canImport()->create())
+        $this->actingAsForApi($importer)
             ->postJson(route('api.imports.importFile', $import1->id), [
                 'import-type' => 'asset',
                 'import-update' => true,
@@ -141,7 +148,7 @@ class AssetImportCreatedAtTest extends TestCase
             ->assertSuccessful();
 
         // Perform second import update
-        $this->actingAsForApi(User::factory()->canImport()->create())
+        $this->actingAsForApi($importer)
             ->postJson(route('api.imports.store'), [
                 'files' => [
                     $this->createFakeUploadedFile('test2.csv', $csv),
@@ -150,7 +157,7 @@ class AssetImportCreatedAtTest extends TestCase
             ->assertSuccessful();
 
         $import2 = Import::latest()->first();
-        $this->actingAsForApi(User::factory()->canImport()->create())
+        $this->actingAsForApi($importer)
             ->postJson(route('api.imports.importFile', $import2->id), [
                 'import-type' => 'asset',
                 'import-update' => true,


### PR DESCRIPTION
Before, the imports were sort of treated as shared property among users. This PR scopes them only to the people who actually uploaded them (and superusers).

This *could* mess with people's workflows, if they have a situation where one person compiles and uploads the data and the next person processed it, but we can address that use-case if it comes up. (I'd hate to have to actually scope this to company as well, but we'll cross that bridge when we get there...)