### PR TITLE
Added bulk delete accessories

### DIFF
--- a/app/Http/Controllers/BulkAccessoriesController.php
+++ b/app/Http/Controllers/BulkAccessoriesController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Accessory;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+
+class BulkAccessoriesController extends Controller
+{
+    public function destroy(Request $request)
+    {
+        $this->authorize('delete', Accessory::class);
+
+        $errors = [];
+        $success_count = 0;
+
+        foreach ((array) $request->input('ids', []) as $id) {
+            $accessory = Accessory::find($id);
+            if (is_null($accessory)) {
+                $errors[] = trans('admin/accessories/message.does_not_exist', ['id' => $id]);
+
+                continue;
+            }
+
+            $accessory->loadCount('checkouts as checkouts_count');
+            if (! $accessory->isDeletable()) {
+                $errors[] = trans('general.bulk_delete_associations.assoc_checkouts_no_count', [
+                    'item_name' => $accessory->name,
+                    'item' => trans('general.accessory'),
+                ]);
+
+                continue;
+            }
+
+            if ($accessory->image) {
+                try {
+                    Storage::disk('public')->delete('accessories/'.$accessory->image);
+                } catch (\Exception $e) {
+                    Log::debug($e);
+                }
+            }
+
+            $accessory->delete();
+            $success_count++;
+        }
+
+        if (count($errors) > 0) {
+            if ($success_count > 0) {
+                return redirect()->route('accessories.index')
+                    ->with('success', trans_choice('admin/accessories/message.delete.partial_success', $success_count, ['count' => $success_count]))
+                    ->with('multi_error_messages', $errors);
+            }
+
+            return redirect()->route('accessories.index')->with('multi_error_messages', $errors);
+        }
+
+        return redirect()->route('accessories.index')
+            ->with('success', trans_choice('admin/accessories/message.delete.bulk_success', $success_count, ['count' => $success_count]));
+    }
+}

--- a/app/Http/Controllers/BulkAccessoriesController.php
+++ b/app/Http/Controllers/BulkAccessoriesController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Accessory;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 
@@ -17,9 +18,23 @@ class BulkAccessoriesController extends Controller
         $success_count = 0;
 
         foreach ((array) $request->input('ids', []) as $id) {
+            // Accessory uses CompanyableTrait, so Accessory::find() is
+            // filtered by CompanyableScope — cross-company rows return null
+            // and fall into the "does_not_exist" bucket without ever
+            // reaching authorization.
             $accessory = Accessory::find($id);
             if (is_null($accessory)) {
                 $errors[] = trans('admin/accessories/message.does_not_exist', ['id' => $id]);
+
+                continue;
+            }
+
+            // Per-row auth as belt-and-braces on top of the query scope.
+            // Catches FMCS mismatches that a superuser scope-bypass could
+            // let through, plus any future policy tightening (e.g. per-role
+            // company-based delete gating).
+            if (! Gate::allows('delete', $accessory)) {
+                $errors[] = trans('general.unauthorized');
 
                 continue;
             }

--- a/app/Http/Transformers/AccessoriesTransformer.php
+++ b/app/Http/Transformers/AccessoriesTransformer.php
@@ -80,7 +80,9 @@ class AccessoriesTransformer
             'update' => Gate::allows('update', Accessory::class),
             'delete' => $accessory->checkouts_count === 0 && Gate::allows('delete', Accessory::class),
             'clone' => Gate::allows('create', Accessory::class),
-
+            'bulk_selectable' => [
+                'delete' => $accessory->checkouts_count === 0,
+            ],
         ];
 
         $permissions_array['user_can_checkout'] = false;

--- a/app/Presenters/AccessoryPresenter.php
+++ b/app/Presenters/AccessoryPresenter.php
@@ -16,6 +16,13 @@ class AccessoryPresenter extends Presenter
     {
         $layout = [
             [
+                'field' => 'checkbox',
+                'checkbox' => true,
+                'formatter' => 'checkboxEnabledFormatter',
+                'titleTooltip' => trans('general.select_all_none'),
+                'printIgnore' => true,
+                'class' => 'hidden-print',
+            ], [
                 'field' => 'id',
                 'searchable' => false,
                 'sortable' => true,

--- a/resources/lang/en-US/admin/accessories/message.php
+++ b/resources/lang/en-US/admin/accessories/message.php
@@ -20,6 +20,8 @@ return [
         'confirm' => 'Are you sure you wish to delete this accessory?',
         'error' => 'There was an issue deleting the accessory. Please try again.',
         'success' => 'The accessory was deleted successfully.',
+        'bulk_success' => 'Accessory deleted successfully.|:count accessories were deleted successfully.',
+        'partial_success' => ':count accessory was deleted successfully, but others could not be deleted. See below for details.|:count accessories were deleted successfully, but others could not be deleted. See below for details.',
     ],
 
     'checkout' => [

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -743,6 +743,7 @@ return [
         'assoc_licenses_no_count' => ':item_name is currently associated with other licenses and cannot be deleted. Please update your licenses to no longer reference this :item and try again.',
         'assoc_users_no_count' => ':item_name is currently associated with other users and cannot be deleted. Please update your users to no longer reference this :item and try again.',
         'assoc_child_companies_no_count' => ':item_name is currently a parent to other companies and cannot be deleted. Please reassign or delete the child companies before trying again.',
+        'assoc_checkouts_no_count' => ':item_name is currently checked out. Please check in all items before deleting this :item.',
     ],
 
     'breadcrumb_button_actions' => [

--- a/resources/views/accessories/index.blade.php
+++ b/resources/views/accessories/index.blade.php
@@ -10,7 +10,7 @@
 {{-- Page content --}}
 @section('content')
     <x-container>
-        <x-box>
+        <x-box name="accessory">
             <x-table.accessories name="accessories" :route="route('api.accessories.index')" fixed_right_number="3" />
         </x-box>
     </x-container>

--- a/resources/views/blade/table/accessories.blade.php
+++ b/resources/views/blade/table/accessories.blade.php
@@ -3,7 +3,7 @@
     'name' => 'default',
     'presenter' => \App\Presenters\AccessoryPresenter::dataTableLayout(),
     'fixed_right_number' => 2,
-    'fixed_number' => 1,
+    'fixed_number' => 2,
     'table_header' => trans('general.accessories'),
 ])
 
@@ -15,7 +15,18 @@
     <x-slot:table_header>
         {{ $table_header }}
     </x-slot:table_header>
-    
+
+    <x-slot:bulkactions>
+        <x-table.bulk-actions
+            name='accessory'
+            action_route="{{ route('accessories.bulk.delete') }}"
+            model_name="accessory">
+            @can('delete', App\Models\Accessory::class)
+                <option>{{ trans('general.delete') }}</option>
+            @endcan
+        </x-table.bulk-actions>
+    </x-slot:bulkactions>
+
     <x-table
         :$presenter
         :$fixed_right_number

--- a/routes/web/accessories.php
+++ b/routes/web/accessories.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Accessories;
+use App\Http\Controllers\BulkAccessoriesController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -28,8 +29,8 @@ Route::group(['prefix' => 'accessories', 'middleware' => ['auth']], function () 
     )->name('accessories.checkin.store');
 
     Route::get('{accessory}/clone',
-            [Accessories\AccessoriesController::class, 'getClone']
-        )->name('clone/accessories');
+        [Accessories\AccessoriesController::class, 'getClone']
+    )->name('clone/accessories');
 
     Route::post('{accessory}/clone',
         [Accessories\AccessoriesController::class, 'postCreate']
@@ -38,5 +39,9 @@ Route::group(['prefix' => 'accessories', 'middleware' => ['auth']], function () 
 });
 
 Route::resource('accessories', Accessories\AccessoriesController::class, [
-    'middleware' => ['auth']
+    'middleware' => ['auth'],
 ]);
+
+Route::post('accessories/bulk/delete', [BulkAccessoriesController::class, 'destroy'])
+    ->middleware(['auth'])
+    ->name('accessories.bulk.delete');

--- a/tests/Feature/Accessories/Api/BulkSelectableTest.php
+++ b/tests/Feature/Accessories/Api/BulkSelectableTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature\Accessories\Api;
+
+use App\Models\Accessory;
+use App\Models\AccessoryCheckout;
+use App\Models\User;
+use Tests\TestCase;
+
+/**
+ * Verifies the JS-visible flag that drives the bulk-delete checkbox on the
+ * accessories index. The bootstrap-table `checkboxEnabledFormatter` reads
+ * `available_actions.bulk_selectable.delete` and disables the row's checkbox
+ * when every entry there is false. An accessory that has any active checkout
+ * must therefore report `bulk_selectable.delete === false`; a clean accessory
+ * must report `true`.
+ */
+class BulkSelectableTest extends TestCase
+{
+    public function test_clean_accessory_is_bulk_selectable()
+    {
+        $accessory = Accessory::factory()->create();
+
+        $this->actingAsForApi(User::factory()->superuser()->create())
+            ->getJson(route('api.accessories.show', $accessory))
+            ->assertOk()
+            ->assertJsonPath('available_actions.bulk_selectable.delete', true);
+    }
+
+    public function test_checked_out_accessory_is_not_bulk_selectable()
+    {
+        $accessory = Accessory::factory()->create();
+        AccessoryCheckout::factory()->create(['accessory_id' => $accessory->id]);
+
+        $this->actingAsForApi(User::factory()->superuser()->create())
+            ->getJson(route('api.accessories.show', $accessory))
+            ->assertOk()
+            ->assertJsonPath('available_actions.bulk_selectable.delete', false);
+    }
+}

--- a/tests/Feature/Accessories/Ui/BulkDeleteAccessoriesTest.php
+++ b/tests/Feature/Accessories/Ui/BulkDeleteAccessoriesTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Tests\Feature\Accessories\Ui;
+
+use App\Models\Accessory;
+use App\Models\AccessoryCheckout;
+use App\Models\User;
+use Tests\TestCase;
+
+class BulkDeleteAccessoriesTest extends TestCase
+{
+    public function test_requires_permission()
+    {
+        $this->actingAs(User::factory()->create())
+            ->post(route('accessories.bulk.delete'), [
+                'ids' => [1, 2, 3],
+            ])
+            ->assertForbidden();
+    }
+
+    public function test_checked_out_accessory_is_not_bulk_deleted()
+    {
+        $accessory = Accessory::factory()->create();
+        AccessoryCheckout::factory()->create(['accessory_id' => $accessory->id]);
+
+        $this->actingAs(User::factory()->deleteAccessories()->create())
+            ->post(route('accessories.bulk.delete'), [
+                'ids' => [$accessory->id],
+            ])
+            ->assertSessionHas('multi_error_messages');
+
+        $this->assertDatabaseHas('accessories', ['id' => $accessory->id, 'deleted_at' => null]);
+    }
+
+    public function test_deletable_accessories_are_bulk_deleted()
+    {
+        $accessory1 = Accessory::factory()->create();
+        $accessory2 = Accessory::factory()->create();
+        $accessory3 = Accessory::factory()->create();
+
+        $this->actingAs(User::factory()->deleteAccessories()->create())
+            ->post(route('accessories.bulk.delete'), [
+                'ids' => [$accessory1->id, $accessory2->id, $accessory3->id],
+            ])
+            ->assertRedirect(route('accessories.index'));
+
+        // Accessories are soft-deleted.
+        $this->assertSoftDeleted('accessories', ['id' => $accessory1->id]);
+        $this->assertSoftDeleted('accessories', ['id' => $accessory2->id]);
+        $this->assertSoftDeleted('accessories', ['id' => $accessory3->id]);
+    }
+
+    public function test_partial_success_deletes_the_clean_ones_and_reports_the_rest()
+    {
+        $deletable = Accessory::factory()->create();
+        $blocked = Accessory::factory()->create();
+        AccessoryCheckout::factory()->create(['accessory_id' => $blocked->id]);
+
+        $this->actingAs(User::factory()->deleteAccessories()->create())
+            ->post(route('accessories.bulk.delete'), [
+                'ids' => [$deletable->id, $blocked->id],
+            ])
+            ->assertRedirect(route('accessories.index'))
+            ->assertSessionHas('success')
+            ->assertSessionHas('multi_error_messages');
+
+        $this->assertSoftDeleted('accessories', ['id' => $deletable->id]);
+        $this->assertDatabaseHas('accessories', ['id' => $blocked->id, 'deleted_at' => null]);
+    }
+
+    public function test_nonexistent_ids_are_reported_and_do_not_break_the_batch()
+    {
+        $deletable = Accessory::factory()->create();
+
+        $this->actingAs(User::factory()->deleteAccessories()->create())
+            ->post(route('accessories.bulk.delete'), [
+                'ids' => [$deletable->id, 999999],
+            ])
+            ->assertRedirect(route('accessories.index'))
+            ->assertSessionHas('multi_error_messages');
+
+        $this->assertSoftDeleted('accessories', ['id' => $deletable->id]);
+    }
+
+    public function test_bulk_success_message_pluralizes_by_count()
+    {
+        $solo = Accessory::factory()->create();
+
+        $this->actingAs(User::factory()->deleteAccessories()->create())
+            ->post(route('accessories.bulk.delete'), [
+                'ids' => [$solo->id],
+            ])
+            ->assertSessionHas('success', trans_choice('admin/accessories/message.delete.bulk_success', 1, ['count' => 1]));
+
+        $a = Accessory::factory()->create();
+        $b = Accessory::factory()->create();
+        $c = Accessory::factory()->create();
+
+        $this->actingAs(User::factory()->deleteAccessories()->create())
+            ->post(route('accessories.bulk.delete'), [
+                'ids' => [$a->id, $b->id, $c->id],
+            ])
+            ->assertSessionHas('success', trans_choice('admin/accessories/message.delete.bulk_success', 3, ['count' => 3]));
+    }
+}

--- a/tests/Feature/Accessories/Ui/BulkDeleteAccessoriesTest.php
+++ b/tests/Feature/Accessories/Ui/BulkDeleteAccessoriesTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Accessories\Ui;
 
 use App\Models\Accessory;
 use App\Models\AccessoryCheckout;
+use App\Models\Company;
 use App\Models\User;
 use Tests\TestCase;
 
@@ -80,6 +81,54 @@ class BulkDeleteAccessoriesTest extends TestCase
             ->assertSessionHas('multi_error_messages');
 
         $this->assertSoftDeleted('accessories', ['id' => $deletable->id]);
+    }
+
+    public function test_respects_fmcs_scoping_for_non_superuser()
+    {
+        // Caller scoped to company A asking to bulk delete [A-owned, B-owned]
+        // sees the B-owned row hidden by CompanyableScope (Accessory::find()
+        // returns null), which falls into the "does_not_exist" error bucket.
+        // The A-owned row deletes normally, so the request is a partial success.
+        $this->settings->enableMultipleFullCompanySupport();
+
+        [$companyA, $companyB] = Company::factory()->count(2)->create();
+        $accessoryA = Accessory::factory()->for($companyA)->create();
+        $accessoryB = Accessory::factory()->for($companyB)->create();
+        $userA = User::factory()->for($companyA)->deleteAccessories()->create();
+
+        $this->actingAs($userA)
+            ->post(route('accessories.bulk.delete'), [
+                'ids' => [$accessoryA->id, $accessoryB->id],
+            ])
+            ->assertRedirect(route('accessories.index'))
+            ->assertSessionHas('success')
+            ->assertSessionHas('multi_error_messages');
+
+        $this->assertSoftDeleted('accessories', ['id' => $accessoryA->id]);
+        $this->assertDatabaseHas('accessories', ['id' => $accessoryB->id, 'deleted_at' => null]);
+    }
+
+    public function test_superuser_bypasses_fmcs_and_deletes_accessories_in_any_company()
+    {
+        // FMCS on, but a superuser is exempt from CompanyableScope. A bulk
+        // delete touching accessories in two different companies should
+        // remove both without any "does_not_exist" errors.
+        $this->settings->enableMultipleFullCompanySupport();
+
+        [$companyA, $companyB] = Company::factory()->count(2)->create();
+        $accessoryA = Accessory::factory()->for($companyA)->create();
+        $accessoryB = Accessory::factory()->for($companyB)->create();
+
+        $this->actingAs(User::factory()->superuser()->create())
+            ->post(route('accessories.bulk.delete'), [
+                'ids' => [$accessoryA->id, $accessoryB->id],
+            ])
+            ->assertRedirect(route('accessories.index'))
+            ->assertSessionHas('success')
+            ->assertSessionMissing('multi_error_messages');
+
+        $this->assertSoftDeleted('accessories', ['id' => $accessoryA->id]);
+        $this->assertSoftDeleted('accessories', ['id' => $accessoryB->id]);
     }
 
     public function test_bulk_success_message_pluralizes_by_count()


### PR DESCRIPTION
This works the same as other bulk deletions. Checkbox is unselectable if it cannot be deleted because it has accessories already checked out.