### PR TITLE
User Print All: Fixes #19177 - change license count target to direct licenses

### DIFF
--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -177,9 +177,9 @@
     @endif
 
     @can('view', \App\Models\License::class)
-    @if ($show_user->licenses->count() > 0)
+        @if ($show_user->directlicenses->count() > 0)
         <div id="licenses-toolbar">
-            <h4>{{ trans_choice('general.countable.licenses', $show_user->licenses->count(), ['count' => $show_user->licenses->count()]) }}</h4>
+            <h4>{{ trans_choice('general.countable.licenses', $show_user->directlicenses->count(), ['count' => $show_user->directlicenses->count()]) }}</h4>
         </div>
 
         <table
@@ -372,6 +372,7 @@
     @endif
     @endcan
     @if(($indirectItemsCount ?? 0) > 0 && $settings->show_assigned_assets)
+
         <div id="indirect-assignments-toolbar">
             <h4>{{ $indirectItemsCount.' '.trans('mail.assigned_to_assets') }}</h4>
         </div>
@@ -415,7 +416,7 @@
                         $indirectAssignmentsCounter++
                     @endphp
                 @endforeach
-                @can('view', \App\Models\License::class)
+                    @can('view', \App\Models\License::class)
                 @foreach ($asset->licenses as $indirectLicense)
                     @if($indirectLicense)
                         <tr>


### PR DESCRIPTION
This changes the table of licenses assigned to user to only count licenses directly assigned to user.

Currently it would count the Licenses assigned to assigned assets as well, but not display anything in the table.
Before on the Demo photoshop is assigned to an asset:
<img width="1142" height="970" alt="image" src="https://github.com/user-attachments/assets/f026b0a6-34fe-4a40-a12d-19bc16a53b6e" />

After this correctly shows multiple assigned to assets, and one copy assigned to user:
<img width="1142" height="970" alt="image" src="https://github.com/user-attachments/assets/4dedcbc4-659d-4519-97ec-04179d039990" />

As for Accessories, they seem to populate correctly.

#19177