### PR TITLE
Accessibility: Added aria labels to flash messages and static callouts

### DIFF
--- a/resources/views/accessories/checkin.blade.php
+++ b/resources/views/accessories/checkin.blade.php
@@ -41,7 +41,7 @@
                             :value="old('checkin_at', date('Y-m-d'))"
                             end_date="0d"
                         />
-                        {!! $errors->first('checkin_at', '<span class="alert-msg"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                        {!! $errors->first('checkin_at', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                     </div>
                 </div>
             </div>

--- a/resources/views/accessories/checkout.blade.php
+++ b/resources/views/accessories/checkout.blade.php
@@ -54,7 +54,7 @@
             @if ($accessory->requireAcceptance() || (string) $snipeSettings->require_accept_signature === '1' || $accessory->getEula() || ($snipeSettings->webhook_endpoint != ''))
                 <div class="form-group notification-callout">
                     <div class="col-md-8 col-md-offset-3">
-                        <div class="callout callout-info">
+                        <div class="callout callout-info" role="status" aria-live="polite" aria-atomic="true">
                             @if ($accessory->requireAcceptance())
                                 <i class="far fa-envelope" aria-hidden="true"></i>
                                 {{ trans('admin/categories/general.required_acceptance') }}<br>

--- a/resources/views/accessories/checkout.blade.php
+++ b/resources/views/accessories/checkout.blade.php
@@ -48,7 +48,7 @@
                         <input class="form-control" type="number" name="checkout_qty" id="checkout_qty" value="{{ old('checkout_qty', 1) }}" min="1" max="{{ $accessory->numRemaining() }}" aria-label="{{ trans('general.qty') }}" />
                     </div>
                 </div>
-                {!! $errors->first('checkout_qty', '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
+                {!! $errors->first('checkout_qty', '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
             </div>
 
             @if ($accessory->requireAcceptance() || (string) $snipeSettings->require_accept_signature === '1' || $accessory->getEula() || ($snipeSettings->webhook_endpoint != ''))

--- a/resources/views/accessories/edit.blade.php
+++ b/resources/views/accessories/edit.blade.php
@@ -77,7 +77,7 @@
                         id="purchase_date"
                         :value="old('purchase_date', $item->purchase_date ? date('Y-m-d', strtotime($item->purchase_date)) : '')"
                     />
-                    {!! $errors->first('purchase_date', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                    {!! $errors->first('purchase_date', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                 </div>
             </div>
 

--- a/resources/views/account/change-password.blade.php
+++ b/resources/views/account/change-password.blade.php
@@ -24,7 +24,7 @@
         </label>
         <div class="col-md-5 required">
             <input class="form-control" type="password" name="current_password" id="current_password" required {{ (config('app.lock_passwords') ? ' disabled' : '') }}>
-            {!! $errors->first('current_password', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+            {!! $errors->first('current_password', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
             @if (config('app.lock_passwords')===true)
                 <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
             @endif
@@ -35,7 +35,7 @@
         <label for="password" class="col-md-3 control-label">{{ trans('general.new_password') }}</label>
         <div class="col-md-5 required">
             <input class="form-control" type="password" name="password" id="password" required {{ (config('app.lock_passwords') ? ' disabled' : '') }}>
-            {!! $errors->first('password', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+            {!! $errors->first('password', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
             @if (config('app.lock_passwords')===true)
                 <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
             @endif
@@ -47,7 +47,7 @@
         <label for="password_confirmation" class="col-md-3 control-label">{{ trans('general.new_password') }}</label>
         <div class="col-md-5 required">
             <input class="form-control" type="password" name="password_confirmation" id="password_confirmation"  {{ (config('app.lock_passwords') ? ' disabled' : '') }} aria-label="password_confirmation">
-            {!! $errors->first('password_confirmation', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+            {!! $errors->first('password_confirmation', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
             @if (config('app.lock_passwords')===true)
                 <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
             @endif

--- a/resources/views/account/profile.blade.php
+++ b/resources/views/account/profile.blade.php
@@ -29,7 +29,7 @@
 
                       @if (!config('app.lock_passwords'))
                           <x-input.locale-select name="locale" :selected="old('locale', $user->locale)"/>
-                          {!! $errors->first('locale', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                          {!! $errors->first('locale', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                       @else
                           <p class="help-block">{{ trans('general.feature_disabled') }}</p>
                       @endif
@@ -42,7 +42,7 @@
                   <label for="nav_link_color" class="col-md-3 control-label">{{ trans('admin/settings/general.nav_link_color') }}</label>
                   <div class="col-md-9">
                       <x-input.colorpicker :item="$user" placeholder="#ffffff" div_id="nav-link-color" id="nav-link-color" :value="old('nav_link_color', ($user->nav_link_color ?? '#ffffff'))" name="nav_link_color" />
-                      {!! $errors->first('nav_link_color', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                      {!! $errors->first('nav_link_color', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                       <p class="help-block">{{ trans('admin/settings/general.nav_link_color_help') }}</p>
                   </div>
               </div>
@@ -52,7 +52,7 @@
                   <label for="link_light_color" class="col-md-3 control-label">{{ trans('admin/settings/general.link_light_color') }}</label>
                   <div class="col-md-9">
                       <x-input.colorpicker :item="$user" id="link_light_color" placeholder="{{ $link_light_color }}" :value="old('link_light_color', ($user->link_light_color ?? $link_light_color))" name="link_light_color" />
-                      {!! $errors->first('link_light_color', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                      {!! $errors->first('link_light_color', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                       <p class="help-block">{{ trans('admin/settings/general.link_light_color_help') }}</p>
                   </div>
               </div>
@@ -62,7 +62,7 @@
                   <label for="link_dark_color" class="col-md-3 control-label">{{ trans('admin/settings/general.link_dark_color') }}</label>
                   <div class="col-md-9">
                       <x-input.colorpicker :item="$user" id="link_dark_color" placeholder="{{ $link_light_color }}" :value="old('link_dark_color', $link_light_color)" name="link_dark_color" />
-                      {!! $errors->first('link_dark_color', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                      {!! $errors->first('link_dark_color', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                       <p class="help-block">{{ trans('admin/settings/general.link_dark_color_help') }}</p>
                   </div>
               </div>
@@ -113,7 +113,7 @@
                       </label>
                       <div class="col-md-8 required">
                         <input class="form-control" type="text" name="first_name" id="first_name" value="{{ old('first_name', $user->first_name) }}" required />
-                        {!! $errors->first('first_name', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                        {!! $errors->first('first_name', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                       </div>
                     </div>
 
@@ -124,7 +124,7 @@
                       </label>
                       <div class="col-md-8 required">
                         <input class="form-control" type="text" name="last_name" id="last_name" value="{{ old('last_name', $user->last_name) }}" />
-                        {!! $errors->first('last_name', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                        {!! $errors->first('last_name', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                       </div>
                     </div>
 
@@ -140,7 +140,7 @@
                       <label class="col-md-3 control-label" for="phone">{{ trans('admin/users/table.phone') }}</label>
                       <div class="col-md-4">
                         <input class="form-control" type="text" name="phone" id="phone" value="{{ old('phone', $user->phone) }}" />
-                        {!! $errors->first('phone', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                        {!! $errors->first('phone', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                       </div>
                     </div>
 
@@ -149,7 +149,7 @@
                       <label for="website" class="col-md-3 control-label">{{ trans('general.website') }}</label>
                       <div class="col-md-8">
                         <input class="form-control" type="text" name="website" id="website" value="{{ old('website', $user->website) }}" />
-                        {!! $errors->first('website', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                        {!! $errors->first('website', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                       </div>
                     </div>
 
@@ -163,7 +163,7 @@
                             <input type="checkbox" name="image_delete" id="image_delete" value="1" @checked(old('image_delete')) aria-label="image_delete">
                             {{ trans('general.image_delete') }}
                           </label>
-                          {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
+                          {!! $errors->first('image_delete', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                           @endif
                         </div>
                       </div>
@@ -171,7 +171,7 @@
                       <div class="form-group">
                         <div class="col-md-9 col-md-offset-3">
                           <img src="{{ (($user->isAvatarExternal()) ? $user->avatar : Storage::disk('public')->url(app('users_upload_path').e($user->avatar))) }}" class="img-responsive">
-                          {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
+                          {!! $errors->first('image_delete', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                         </div>
                       </div>
 
@@ -183,7 +183,7 @@
                         </label>
                         <div class="col-md-8">
                           <input class="form-control" type="text" name="gravatar" id="gravatar" value="{{ old('gravatar', $user->gravatar) }}" />
-                          {!! $errors->first('gravatar', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                          {!! $errors->first('gravatar', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                           <p style="padding-top: 3px;">
                             <img src="//secure.gravatar.com/avatar/{{ md5(strtolower(trim($user->gravatar))) }}" width="30" height="30" alt="{{ $user->display_name }} avatar image">
                             {!! trans('general.gravatar_url') !!}

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -62,7 +62,7 @@
                                                 {{ trans('admin/users/table.username')  }}
                                             </label>
                                             <input class="form-control" placeholder="{{ trans('admin/users/table.username')  }}" name="username" type="text" id="username" autocomplete="{{ (config('auth.login_autocomplete') === true) ? 'on' : 'off'  }}" autocapitalize="off" spellcheck="false" autofocus>
-                                            {!! $errors->first('username', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                            {!! $errors->first('username', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                                         </div>
 
 
@@ -80,7 +80,7 @@
                                                 </span>
                                             </div>
 
-                                            {!! $errors->first('password', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                            {!! $errors->first('password', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                                         </div>
 
                                         <div class="form-group">

--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -57,7 +57,7 @@
                                         <div class="col-md-12">
                                             <label for="username"><x-icon type="user" /> {{ trans('admin/users/table.username') }} </label>
                                             <input type="text" class="form-control" name="username" value="{{ old('username') }}" placeholder="{{ trans('admin/users/table.username') }}" aria-label="username">
-                                            {!! $errors->first('username', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}
+                                            {!! $errors->first('username', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times"></i> :message</span>') !!}
                                         </div>
                                     </div>
                             </div>

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -34,7 +34,7 @@
 
                                         <div class="col-md-6">
                                             <input type="text" class="form-control" name="username" value="{{ old('username', $username) }}">
-                                            {!! $errors->first('username', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}
+                                            {!! $errors->first('username', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times"></i> :message</span>') !!}
 
                             </div>
                         </div>
@@ -47,7 +47,7 @@
 
                             <div class="col-md-6">
                                 <input type="password" class="form-control" name="password" aria-label="password">
-                                {!! $errors->first('password', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                {!! $errors->first('password', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                             </div>
                         </div>
 
@@ -57,7 +57,7 @@
                                 {{ trans('admin/users/table.password_confirm')  }}</label>
                             <div class="col-md-6">
                                 <input type="password" class="form-control" name="password_confirmation" aria-label="password_confirmation">
-                                {!! $errors->first('password_confirmation', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                {!! $errors->first('password_confirmation', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
 
                             </div>
                         </div>

--- a/resources/views/auth/two_factor.blade.php
+++ b/resources/views/auth/two_factor.blade.php
@@ -31,7 +31,7 @@
                                     <fieldset>
                                         <div class="form-group{{ $errors->has('secret') ? ' has-error' : '' }}">
                                             <input class="form-control" placeholder="{{ trans('admin/settings/general.two_factor_secret')  }}" name="two_factor_secret" type="text" aria-label="two_factor_secret" autofocus>
-                                            {!! $errors->first('two_factor_secret', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                            {!! $errors->first('two_factor_secret', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                                         </div>
                                     </fieldset>
                                 </div>

--- a/resources/views/auth/two_factor_enroll.blade.php
+++ b/resources/views/auth/two_factor_enroll.blade.php
@@ -41,7 +41,7 @@
                             <fieldset>
                                 <div class="form-group{{ $errors->has('secret') ? ' has-error' : '' }}">
                                     <input class="form-control" placeholder="{{ trans('admin/settings/general.two_factor_secret')  }}" name="two_factor_secret" type="text" aria-label="two_factor_secret" autofocus>
-                                    {!! $errors->first('two_factor_secret', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                    {!! $errors->first('two_factor_secret', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                                 </div>
                             </fieldset>
                                 </div>

--- a/resources/views/blade/form/checkbox-row.blade.php
+++ b/resources/views/blade/form/checkbox-row.blade.php
@@ -126,7 +126,7 @@
 
     @error($name)
         <div class="col-md-8 col-md-offset-3">
-            <span class="alert-msg" aria-hidden="true">
+            <span class="alert-msg" role="alert" aria-live="assertive">
                 <x-icon type="x" />
                 {{ $message }}
             </span>

--- a/resources/views/blade/form/radio-row.blade.php
+++ b/resources/views/blade/form/radio-row.blade.php
@@ -69,7 +69,7 @@
 
     @error($name)
         <div class="col-md-8 col-md-offset-3">
-            <span class="alert-msg" aria-hidden="true">
+            <span class="alert-msg" role="alert" aria-live="assertive">
                 <x-icon type="x" />
                 {{ $message }}
             </span>

--- a/resources/views/blade/form/row.blade.php
+++ b/resources/views/blade/form/row.blade.php
@@ -55,7 +55,7 @@
 
     @error($name)
     <div class="col-md-8 col-md-offset-3">
-        <span class="alert-msg" aria-hidden="true">
+        <span class="alert-msg" role="alert" aria-live="assertive">
             <x-icon type="x" />
             {{ $message }}
         </span>

--- a/resources/views/blade/input/category-select.blade.php
+++ b/resources/views/blade/input/category-select.blade.php
@@ -49,5 +49,5 @@
         </div>
     @endunless
 
-    {!! $errors->first($name, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
+    {!! $errors->first($name, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
 </div>

--- a/resources/views/blade/input/company-select.blade.php
+++ b/resources/views/blade/input/company-select.blade.php
@@ -61,5 +61,5 @@
         @endcan
     @endif
 
-    {!! $errors->first($name, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
+    {!! $errors->first($name, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
 </div>

--- a/resources/views/blade/input/location-select.blade.php
+++ b/resources/views/blade/input/location-select.blade.php
@@ -65,7 +65,7 @@
         @endunless
     </div>
 
-    {!! $errors->first($name, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
+    {!! $errors->first($name, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
 
     @if ($helpText)
         <div class="col-md-7 col-sm-11 col-md-offset-3">

--- a/resources/views/blade/input/manufacturer-select.blade.php
+++ b/resources/views/blade/input/manufacturer-select.blade.php
@@ -48,5 +48,5 @@
         </div>
     @endunless
 
-    {!! $errors->first($name, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
+    {!! $errors->first($name, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
 </div>

--- a/resources/views/blade/input/minimum-quantity.blade.php
+++ b/resources/views/blade/input/minimum-quantity.blade.php
@@ -29,7 +29,7 @@
             <x-form.tooltip>{{ trans('general.min_amt_help') }}</x-form.tooltip>
         </div>
         <div class="col-md-12">
-            {!! $errors->first('min_amt', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+            {!! $errors->first('min_amt', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
         </div>
     </div>
 </div>

--- a/resources/views/blade/input/purchase-cost.blade.php
+++ b/resources/views/blade/input/purchase-cost.blade.php
@@ -34,7 +34,7 @@
             </span>
         </div>
         <div class="col-md-9" style="padding-left: 0">
-            {!! $errors->first('purchase_cost', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+            {!! $errors->first('purchase_cost', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
             <p class="help-block">{{ trans('general.purchase_cost_format_help', ['format' => $snipeSettings->digit_separator]) }}</p>
         </div>
     </div>

--- a/resources/views/blade/input/quantity.blade.php
+++ b/resources/views/blade/input/quantity.blade.php
@@ -35,7 +35,7 @@
             />
         </div>
         <div class="col-md-12" style="padding-left: 0">
-            {!! $errors->first($name, '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+            {!! $errors->first($name, '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
             @if ($help_text)
                 <p class="help-block">{{ $help_text }}</p>
             @endif

--- a/resources/views/blade/input/supplier-select.blade.php
+++ b/resources/views/blade/input/supplier-select.blade.php
@@ -50,5 +50,5 @@
         </div>
     @endunless
 
-    {!! $errors->first($name, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
+    {!! $errors->first($name, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
 </div>

--- a/resources/views/categories/edit.blade.php
+++ b/resources/views/categories/edit.blade.php
@@ -29,7 +29,7 @@
             style="min-width:350px"
             aria-label="category_type"
         />
-        {!! $errors->first('category_type', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first('category_type', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
     <div class="col-md-7 col-md-offset-3">
         <p class="help-block">{!! trans('admin/categories/message.update.cannot_change_category_type') !!} </p>
@@ -58,7 +58,7 @@
                 aria-label="notes"
                 rows="5"
         />
-        {!! $errors->first('notes', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first('notes', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>
 
@@ -95,7 +95,7 @@
             </label>
             <div class="col-md-9">
                 <x-input.colorpicker :item="$item" id="color" :value="old('color', ($item->color ?? '#f4f4f4'))" name="tag_color" id="tag_color" />
-                {!! $errors->first('tag_color', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                {!! $errors->first('tag_color', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
             </div>
         </div>
     </fieldset>

--- a/resources/views/companies/edit.blade.php
+++ b/resources/views/companies/edit.blade.php
@@ -70,7 +70,7 @@
                     <label for="tag_color" class="col-md-3 control-label">{{ trans('general.tag_color') }}</label>
                     <div class="col-md-9">
                         <x-input.colorpicker :item="$item" id="tag_color" :value="old('tag_color', ($item->tag_color ?? '#f4f4f4'))" name="tag_color" />
-                        {!! $errors->first('tag_color', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                        {!! $errors->first('tag_color', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                     </div>
                 </div>
             </fieldset>

--- a/resources/views/components/checkout.blade.php
+++ b/resources/views/components/checkout.blade.php
@@ -36,7 +36,7 @@
             @if ($snipe_component->requireAcceptance() || $snipe_component->getEula() || ($snipeSettings->webhook_endpoint != ''))
                 <div class="form-group notification-callout">
                     <div class="col-md-8 col-md-offset-3">
-                        <div class="callout callout-info">
+                        <div class="callout callout-info" role="status" aria-live="polite" aria-atomic="true">
                             @if ($snipe_component->category->require_acceptance == '1')
                                 <i class="far fa-envelope" aria-hidden="true"></i>
                                 {{ trans('admin/categories/general.required_acceptance') }}<br>

--- a/resources/views/components/edit.blade.php
+++ b/resources/views/components/edit.blade.php
@@ -87,7 +87,7 @@
                         id="purchase_date"
                         :value="old('purchase_date', $item->purchase_date ? date('Y-m-d', strtotime($item->purchase_date)) : '')"
                     />
-                    {!! $errors->first('purchase_date', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                    {!! $errors->first('purchase_date', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                 </div>
             </div>
 

--- a/resources/views/consumables/checkout.blade.php
+++ b/resources/views/consumables/checkout.blade.php
@@ -76,7 +76,7 @@
                         <input class="form-control" type="number" name="checkout_qty" id="checkout_qty" value="{{ old('checkout_qty', 1) }}" min="1" max="{{ $consumable->numRemaining() }}" aria-label="{{ trans('general.qty') }}" />
                     </div>
                 </div>
-                {!! $errors->first('qty', '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
+                {!! $errors->first('qty', '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
             </div>
 
             <x-form.row

--- a/resources/views/consumables/checkout.blade.php
+++ b/resources/views/consumables/checkout.blade.php
@@ -36,7 +36,7 @@
             @if ($consumable->requireAcceptance() || (string) $snipeSettings->require_accept_signature === '1' || $consumable->getEula() || ($snipeSettings->webhook_endpoint != ''))
                 <div class="form-group notification-callout">
                     <div class="col-md-8 col-md-offset-3">
-                        <div class="callout callout-info">
+                        <div class="callout callout-info" role="status" aria-live="polite" aria-atomic="true">
                             @if ($consumable->category->require_acceptance == '1')
                                 <i class="far fa-envelope" aria-hidden="true"></i>
                                 {{ trans('admin/categories/general.required_acceptance') }}<br>

--- a/resources/views/consumables/edit.blade.php
+++ b/resources/views/consumables/edit.blade.php
@@ -87,7 +87,7 @@
                             id="purchase_date"
                             :value="old('purchase_date', $item->purchase_date ? date('Y-m-d', strtotime($item->purchase_date)) : '')"
                         />
-                        {!! $errors->first('purchase_date', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                        {!! $errors->first('purchase_date', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                     </div>
                 </div>
 

--- a/resources/views/custom_fields/fields/edit.blade.php
+++ b/resources/views/custom_fields/fields/edit.blade.php
@@ -39,7 +39,7 @@
             </label>
             <div class="col-md-8 required">
                 <input class="form-control" aria-label="name" name="name" type="text" required value="{{ old('name', $field->name) }}">
-                {!! $errors->first('name', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                {!! $errors->first('name', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
             </div>
           </div>
 
@@ -64,7 +64,7 @@
                     'radio' => trans('admin/custom_fields/general.types.radio'),
                 ]"
             />
-            {!! $errors->first('element', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+            {!! $errors->first('element', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
 
             </div>
           </div>
@@ -82,7 +82,7 @@
                     rows="4"
                     aria-label="field_values"
                 />
-              {!! $errors->first('field_values', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+              {!! $errors->first('field_values', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
               <p class="help-block">{{ trans('admin/custom_fields/general.field_values_help') }}</p>
             </div>
           </div>
@@ -107,7 +107,7 @@
                     style="width:100%"
                     aria-label="format"
                 />
-              {!! $errors->first('format', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+              {!! $errors->first('format', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
             </div>
           </div>
           <!-- Custom Format -->
@@ -119,7 +119,7 @@
                 <input class="form-control" id="custom_format" aria-label="custom_format" maxlength="191" placeholder="regex:/^[0-9]{15}$/" name="custom_format" type="text" value="{{ old('custom_format', (($field->format!='') && (stripos($field->format,'regex')===0)) ? $field->format : '') }}">
                 <p class="help-block">{!! trans('admin/custom_fields/general.field_custom_format_help') !!}</p>
 
-              {!! $errors->first('custom_format', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+              {!! $errors->first('custom_format', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
 
             </div>
           </div>
@@ -132,7 +132,7 @@
               <div class="col-md-8">
                   <input class="form-control" aria-label="help_text" name="help_text" type="text" value=" {{ old('help_text', $field->help_text) }}">
                   <p class="help-block">{{ trans('admin/custom_fields/general.help_text_description') }}</p>
-                  {!! $errors->first('help_text', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                  {!! $errors->first('help_text', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
               </div>
           </div>
 
@@ -257,7 +257,7 @@
           <div class="col-md-4">
 
               <h4>{{ trans('admin/custom_fields/general.fieldsets') }}</h4>
-              {!! $errors->first('associate_fieldsets', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+              {!! $errors->first('associate_fieldsets', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
 
               <label class="form-control">
                   <input type="checkbox" id="checkAll">
@@ -286,7 +286,7 @@
                                      value="{{ $fieldset->id }}"
                                     {{ $checked }}>
                               {{ $fieldset->name }}
-                              {!! $errors->first('associate_fieldsets.'.$fieldset->id, '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                              {!! $errors->first('associate_fieldsets.'.$fieldset->id, '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
 
                           </label>
 

--- a/resources/views/custom_fields/fields/edit.blade.php
+++ b/resources/views/custom_fields/fields/edit.blade.php
@@ -160,7 +160,7 @@
                   </label>
               </div>
               <div class="col-md-9 col-md-offset-3" id="encrypt_warning" style="display:none;">
-                  <div class="callout callout-danger">
+                  <div class="callout callout-danger" role="alert" aria-live="assertive" aria-atomic="true">
                       <p><x-icon type="warning" /> {{ trans('admin/custom_fields/general.encrypt_field_help') }}</p>
                   </div>
               </div>

--- a/resources/views/departments/edit.blade.php
+++ b/resources/views/departments/edit.blade.php
@@ -38,7 +38,7 @@
                     aria-label="notes"
                     rows="5"
             />
-            {!! $errors->first('notes', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+            {!! $errors->first('notes', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
         </div>
     </div>
 
@@ -53,7 +53,7 @@
             </label>
             <div class="col-md-9">
                 <x-input.colorpicker :item="$item" id="color" :value="old('color', ($item->color ?? '#f4f4f4'))" name="tag_color" id="tag_color" />
-                {!! $errors->first('tag_color', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                {!! $errors->first('tag_color', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
             </div>
         </div>
     </fieldset>

--- a/resources/views/depreciations/edit.blade.php
+++ b/resources/views/depreciations/edit.blade.php
@@ -17,7 +17,7 @@
     </label>
     <div class="col-md-9 col-sm-12">
         <input class="form-control" type="number" min="0" max="3600" name="months" id="months" value="{{ old('months', $item->months) }}" style="width: 90px;"{!!  (\App\Helpers\Helper::checkIfRequired($item, 'months')) ? ' required' : '' !!} />
-        {!! $errors->first('months', '<span class="alert-msg" aria-hidden="true"><i class="fa fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first('months', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fa fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>
 

--- a/resources/views/groups/edit.blade.php
+++ b/resources/views/groups/edit.blade.php
@@ -19,7 +19,7 @@
     <label for="name" class="col-md-3 control-label">{{ trans('admin/groups/titles.group_name') }}</label>
     <div class="col-md-8 required">
         <input class="form-control" type="text" name="name" id="name" value="{{ old('name', $group->name) }}" required />
-        {!! $errors->first('name', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first('name', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>
 
@@ -35,7 +35,7 @@
                 rows="2"
         />
 
-        {!! $errors->first('notes', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first('notes', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>
 

--- a/resources/views/hardware/audit.blade.php
+++ b/resources/views/hardware/audit.blade.php
@@ -110,7 +110,7 @@
                                     <input type="text" class="form-control" placeholder="{{ trans('general.next_audit_date') }}" name="next_audit_date" id="next_audit_date" value="{{ old('next_audit_date', $next_audit_date) }}">
                                     <span class="input-group-addon"><x-icon type="calendar" /></span>
                                 </div>
-                                {!! $errors->first('next_audit_date', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                {!! $errors->first('next_audit_date', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                                  <p class="help-block">{!! trans('general.next_audit_date_help') !!}</p>
                             </div>
                         </div>
@@ -123,7 +123,7 @@
                             </label>
                             <div class="col-md-8">
                                 <textarea class="col-md-6 form-control" id="note" name="note">{{ old('note', $asset->note) }}</textarea>
-                                {!! $errors->first('note', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                {!! $errors->first('note', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                             </div>
                         </div>
 

--- a/resources/views/hardware/bulk-checkin.blade.php
+++ b/resources/views/hardware/bulk-checkin.blade.php
@@ -70,7 +70,7 @@
                             style="width: 100%;"
                             aria-label="status_id"
                     />
-                    {!! $errors->first('status_id', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                    {!! $errors->first('status_id', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                 </div>
             </div>
 
@@ -100,7 +100,7 @@
                         <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="checkin_at" id="checkin_at" value="{{ old('checkin_at') }}">
                         <span class="input-group-addon"><x-icon type="calendar" /></span>
                     </div>
-                    {!! $errors->first('checkin_at', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                    {!! $errors->first('checkin_at', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                 </div>
             </div>
 
@@ -111,7 +111,7 @@
                 </label>
                 <div class="col-md-8">
                     <textarea class="col-md-6 form-control" id="note" name="note">{{ old('note') }}</textarea>
-                    {!! $errors->first('note', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                    {!! $errors->first('note', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                 </div>
             </div>
 

--- a/resources/views/hardware/bulk-checkout.blade.php
+++ b/resources/views/hardware/bulk-checkout.blade.php
@@ -72,7 +72,7 @@
                             style="width: 100%;"
                             aria-label="status_id"
                     />
-                    {!! $errors->first('status_id', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                    {!! $errors->first('status_id', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                 </div>
             </div>
 
@@ -92,7 +92,7 @@
                         style="width: 100%;"
                         aria-label="set_not_requestable"
                     />
-                    {!! $errors->first('set_not_requestable', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                    {!! $errors->first('set_not_requestable', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                 </div>
             </div>
 
@@ -116,7 +116,7 @@
                           <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="checkout_at" id="checkout_at" value="{{ old('checkout_at') }}">
                           <span class="input-group-addon"><x-icon type="calendar" /></span>
                       </div>
-                      {!! $errors->first('checkout_at', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                      {!! $errors->first('checkout_at', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                   </div>
               </div>
 
@@ -130,7 +130,7 @@
                           <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="expected_checkin" id="expected_checkin" value="{{ old('expected_checkin') }}">
                           <span class="input-group-addon"><x-icon type="calendar" /></span>
                       </div>
-                      {!! $errors->first('expected_checkin', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                      {!! $errors->first('expected_checkin', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                   </div>
               </div>
 
@@ -142,7 +142,7 @@
               </label>
             <div class="col-md-8">
               <textarea class="col-md-6 form-control" id="note" name="note">{{ old('note') }}</textarea>
-              {!! $errors->first('note', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+              {!! $errors->first('note', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
             </div>
           </div>
 

--- a/resources/views/hardware/bulk-delete.blade.php
+++ b/resources/views/hardware/bulk-delete.blade.php
@@ -19,8 +19,8 @@
 
         <div class="box-body">
 
-            <div class="callout callout-warning">
-                <i class="fas fa-exclamation-triangle"></i>
+            <div class="callout callout-warning" role="alert" aria-live="assertive" aria-atomic="true">
+                <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
                 {{ trans('admin/hardware/form.bulk_delete_warn', ['asset_count' => count($assets)]) }}
             </div>
 

--- a/resources/views/hardware/bulk.blade.php
+++ b/resources/views/hardware/bulk.blade.php
@@ -42,7 +42,7 @@
             </label>
             <div class="col-md-4">
                 <input type="text" class="form-control" name="name" id="name" value="{{ old('name') }}" maxlength="191" style="width:100%">
-              {!! $errors->first('name', '<span class="alert-msg" aria-hidden="true">
+              {!! $errors->first('name', '<span class="alert-msg" role="alert" aria-live="assertive">
                 <i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
             </div>
             <div class="col-md-5">
@@ -64,7 +64,7 @@
                         value="{{ old('purchase_date') }}"
                         placeholder="{{ trans('general.select_date') }}"
                     />
-                    {!! $errors->first('purchase_date', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                    {!! $errors->first('purchase_date', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                 </div>
                 <div class="col-md-5">
                     <x-form.checkbox-inline
@@ -84,7 +84,7 @@
                         value="{{ old('expected_checkin') }}"
                         placeholder="{{ trans('general.select_date') }}"
                     />
-                    {!! $errors->first('expected_checkin', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                    {!! $errors->first('expected_checkin', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                 </div>
                 <div class="col-md-5">
                     <x-form.checkbox-inline
@@ -104,7 +104,7 @@
                         value="{{ old('asset_eol_date') }}"
                         placeholder="{{ trans('general.select_date') }}"
                     />
-                    {!! $errors->first('asset_eol_date', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                    {!! $errors->first('asset_eol_date', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                 </div>
                 <div class="col-md-5">
                     <x-form.checkbox-inline
@@ -140,7 +140,7 @@
               />
               <p class="help-block">{{ trans('general.status_compatibility') }}</p>
                 <p id="selected_status_status" style="display:none;"></p>
-              {!! $errors->first('status_id', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+              {!! $errors->first('status_id', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
             </div>
           </div>
 
@@ -178,7 +178,7 @@
             <div class="input-group col-md-3">
               <span class="input-group-addon">{{ $snipeSettings->default_currency }}</span>
                 <input type="text" class="form-control" pattern="^\d+([.,]\d+)?$" maxlength="10" placeholder="{{ trans('admin/hardware/form.cost') }}" name="purchase_cost" id="purchase_cost" value="{{ old('purchase_cost') }}">
-                {!! $errors->first('purchase_cost', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                {!! $errors->first('purchase_cost', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
             </div>
           </div>
 
@@ -194,7 +194,7 @@
             </label>
             <div class="col-md-7">
               <input class="form-control" type="text" maxlength="200" name="order_number" id="order_number" value="{{ old('order_number') }}" />
-              {!! $errors->first('order_number', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+              {!! $errors->first('order_number', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
             </div>
           </div>
 
@@ -207,7 +207,7 @@
               <div class="input-group">
                 <input class="col-md-3 form-control" maxlength="4" type="text" name="warranty_months" id="warranty_months" value="{{ old('warranty_months') }}" />
                 <span class="input-group-addon">{{ trans('admin/hardware/form.months') }}</span>
-                {!! $errors->first('warranty_months', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                {!! $errors->first('warranty_months', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
               </div>
             </div>
           </div>
@@ -222,7 +222,7 @@
                         value="{{ old('next_audit_date') }}"
                         placeholder="{{ trans('general.select_date') }}"
                     />
-                    {!! $errors->first('next_audit_date', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                    {!! $errors->first('next_audit_date', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                 </div>
                 <div class="col-md-5">
                     <x-form.checkbox-inline

--- a/resources/views/hardware/bulk.blade.php
+++ b/resources/views/hardware/bulk.blade.php
@@ -27,8 +27,8 @@
       <div class="box box-default">
         <div class="box-body">
 
-          <div class="callout callout-warning">
-            <i class="fas fa-exclamation-triangle"></i> {{ trans_choice('admin/hardware/form.bulk_update_warn', count($assets), ['asset_count' => count($assets)]) }}
+          <div class="callout callout-warning" role="alert" aria-live="assertive" aria-atomic="true">
+            <i class="fas fa-exclamation-triangle" aria-hidden="true"></i> {{ trans_choice('admin/hardware/form.bulk_update_warn', count($assets), ['asset_count' => count($assets)]) }}
 
             @if (count($models) > 0)
               {{ trans_choice('admin/hardware/form.bulk_update_with_custom_field', count($models), ['asset_model_count' => count($models)]) }}

--- a/resources/views/hardware/bulk.blade.php
+++ b/resources/views/hardware/bulk.blade.php
@@ -139,7 +139,7 @@
                   aria-label="status_id"
               />
               <p class="help-block">{{ trans('general.status_compatibility') }}</p>
-                <p id="selected_status_status" style="display:none;"></p>
+                <p id="selected_status_status" role="status" aria-live="polite" aria-atomic="true" style="display:none;"></p>
               {!! $errors->first('status_id', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
             </div>
           </div>

--- a/resources/views/hardware/checkin.blade.php
+++ b/resources/views/hardware/checkin.blade.php
@@ -95,7 +95,7 @@
                                             <div class="col-md-8">
                                                 <input class="form-control" type="text" name="name" aria-label="name"
                                                        id="name" value="{{ old('name', $asset->name) }}"/>
-                                                {!! $errors->first('name', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                                {!! $errors->first('name', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                                             </div>
                                         </div>
 
@@ -113,7 +113,7 @@
                                                     style="width: 100%"
                                                     aria-label="status_id"
                                                 />
-                                                {!! $errors->first('status_id', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                                {!! $errors->first('status_id', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                                             </div>
                                         </div>
 
@@ -172,7 +172,7 @@
                                                             <x-icon type="calendar" />
                                                         </span>
                                                     </div>
-                                                    {!! $errors->first('checkin_at', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                                    {!! $errors->first('checkin_at', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                                                 </div>
                                             </div>
                                         </div>
@@ -185,7 +185,7 @@
                                             <div class="col-md-8">
                                                 <textarea class="col-md-6 form-control" id="note" @required($snipeSettings->require_checkinout_notes)
                                                 name="note">{{ old('note', $asset->note) }}</textarea>
-                                                {!! $errors->first('note', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                                {!! $errors->first('note', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                                             </div>
                                         </div>
 

--- a/resources/views/hardware/checkout.blade.php
+++ b/resources/views/hardware/checkout.blade.php
@@ -80,7 +80,7 @@
                             <div class="col-md-7">
                                 <input class="form-control" type="text" name="name" id="name"
                                        value="{{ old('name', $asset->name) }}" tabindex="1">
-                                {!! $errors->first('name', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                {!! $errors->first('name', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                             </div>
                         </div>
 
@@ -97,7 +97,7 @@
                                     style="width: 100%;"
                                     aria-label="status_id"
                                 />
-                                {!! $errors->first('status_id', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                {!! $errors->first('status_id', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                             </div>
                         </div>
 
@@ -139,7 +139,7 @@
                                         placeholder="{{ trans('general.select_date') }}"
                                         required="{{ Helper::checkIfRequired($item, 'checkout_at') }}"
                                 />
-                                {!! $errors->first('checkout_at', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                {!! $errors->first('checkout_at', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                             </div>
                         </div>
 
@@ -157,7 +157,7 @@
                                         placeholder="{{ trans('general.select_date') }}"
                                         required="{{ Helper::checkIfRequired($item, 'expected_checkin') }}"
                                 />
-                                {!! $errors->first('expected_checkin', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                {!! $errors->first('expected_checkin', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                             </div>
                         </div>
 
@@ -170,7 +170,7 @@
                             <div class="col-md-8">
                                 <textarea class="col-md-6 form-control" id="note" @required($snipeSettings->require_checkinout_notes)
                                 name="note">{{ old('note', $asset->note) }}</textarea>
-                                {!! $errors->first('note', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                {!! $errors->first('note', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                             </div>
                         </div>
 

--- a/resources/views/hardware/checkout.blade.php
+++ b/resources/views/hardware/checkout.blade.php
@@ -185,7 +185,7 @@
                         @if ($asset->requireAcceptance() || (string) $snipeSettings->require_accept_signature === '1' || $asset->getEula() || ($snipeSettings->webhook_endpoint!=''))
                             <div class="form-group notification-callout" style="display:none;">
                                 <div class="col-md-8 col-md-offset-3">
-                                    <div class="callout callout-info">
+                                    <div class="callout callout-info" role="status" aria-live="polite" aria-atomic="true">
 
                                         @if ($asset->requireAcceptance())
                                             <x-icon type="email"/>

--- a/resources/views/hardware/edit.blade.php
+++ b/resources/views/hardware/edit.blade.php
@@ -33,8 +33,8 @@
           <div class="col-md-7 col-sm-12">
 
           <input class="form-control" type="text" name="asset_tags[1]" id="asset_tag" value="{{ old('asset_tag', $item->asset_tag) }}" required>
-              {!! $errors->first('asset_tags', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}
-              {!! $errors->first('asset_tag', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}
+              {!! $errors->first('asset_tags', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times"></i> :message</span>') !!}
+              {!! $errors->first('asset_tag', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times"></i> :message</span>') !!}
           </div>
       @else
           <!-- we are creating a new asset - let people use more than one asset tag -->
@@ -42,8 +42,8 @@
               <input class="form-control"
                      type="text" name="asset_tags[1]" id="asset_tag"
                      value="{{ old('asset_tags.1', \App\Models\Asset::autoincrement_asset()) }}" required>
-              {!! $errors->first('asset_tags.1', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}
-              {!! $errors->first('asset_tag', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}
+              {!! $errors->first('asset_tags.1', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times"></i> :message</span>') !!}
+              {!! $errors->first('asset_tag', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times"></i> :message</span>') !!}
           </div>
           <div class="col-md-2 col-sm-12">
               <button class="add_field_button btn btn-sm btn-theme" name="add_field_button">
@@ -83,7 +83,7 @@
                         <input type="text" class="form-control" name="asset_tags[{{ $i }}]"
                                value="{{ old('asset_tags.'.$i) }}"
                                required>
-              {!! $errors->first('asset_tags.'.$i, '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}
+              {!! $errors->first('asset_tags.'.$i, '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times"></i> :message</span>') !!}
                     </div>
                     <div class="col-md-2 col-sm-12">
                         <a href="#" class="remove_field btn btn-sm btn-theme"><x-icon type="minus"/></a>

--- a/resources/views/hardware/history.blade.php
+++ b/resources/views/hardware/history.blade.php
@@ -150,7 +150,7 @@
                         <div class="box-footer text-right">
                             @if (config('app.lock_passwords')===true)
                                 <div class="col-md-12">
-                                    <div class="callout callout-info">
+                                    <div class="callout callout-info" role="status" aria-live="polite" aria-atomic="true">
                                         {{ trans('general.feature_disabled') }}
                                     </div>
                                 </div>

--- a/resources/views/hardware/quickscan-checkin.blade.php
+++ b/resources/views/hardware/quickscan-checkin.blade.php
@@ -37,7 +37,7 @@
                                 <input type="text" class="form-control" name="asset_tag" id="asset_tag" value="{{ old('asset_tag') }}" required>
 
                             </div>
-                            {!! $errors->first('asset_tag', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                            {!! $errors->first('asset_tag', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                         </div>
                     </div>
 
@@ -54,7 +54,7 @@
                                 style="width:100%"
                                 aria-label="status_id"
                             />
-                            {!! $errors->first('status_id', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                            {!! $errors->first('status_id', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                         </div>
                     </div>
 
@@ -66,7 +66,7 @@
                             <label for="note" class="col-md-3 control-label">{{ trans('admin/hardware/form.notes') }}</label>
                             <div class="col-md-8">
                                 <textarea class="col-md-6 form-control" id="note" name="note">{{ old('note') }}</textarea>
-                                {!! $errors->first('note', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                {!! $errors->first('note', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                             </div>
                         </div>
 

--- a/resources/views/hardware/quickscan.blade.php
+++ b/resources/views/hardware/quickscan.blade.php
@@ -34,7 +34,7 @@
                                     <option value="asset_tag">{{ trans('general.asset_tag') }}</option>
                                     <option value="serial" {{ (($settings->unique_serial != '1') ? 'disabled' : '') }}>{{ trans('general.serial_number') }}</option>
                                 </select>
-                                {!! $errors->first('audit_by_field', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                {!! $errors->first('audit_by_field', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
 
                                 <p class="help-block">
                                     <x-icon type="tip"/>
@@ -50,7 +50,7 @@
                             <div class="col-md-8">
                                 <input type="text" class="form-control" name="audit_key" id="audit_key" required
                                        value="{{ old('audit_key') }}">
-                                {!! $errors->first('audit_key', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                {!! $errors->first('audit_key', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                             </div>
                         </div>
 
@@ -81,7 +81,7 @@
                                     <input type="text" class="form-control" placeholder="{{ trans('general.next_audit_date') }}" name="next_audit_date" id="next_audit_date" value="{{ old('next_audit_date', $next_audit_date) }}">
                                     <span class="input-group-addon"><x-icon type="calendar" /></span>
                                 </div>
-                                {!! $errors->first('next_audit_date', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                {!! $errors->first('next_audit_date', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                             </div>
                         </div>
 
@@ -91,7 +91,7 @@
                             <label for="note" class="col-md-3 control-label">{{ trans('admin/hardware/form.notes') }}</label>
                             <div class="col-md-8">
                                 <textarea class="col-md-6 form-control" id="note" name="note">{{ old('note') }}</textarea>
-                                {!! $errors->first('note', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                {!! $errors->first('note', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                             </div>
                         </div>
 

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -18,7 +18,7 @@
 
         @if (!$asset->model)
             <div class="col-md-12">
-                <div class="callout callout-danger">
+                <div class="callout callout-danger" role="alert" aria-live="assertive" aria-atomic="true">
                     <p>
                         <strong>{{ trans('admin/models/message.no_association') }}</strong> {{ trans('admin/models/message.no_association_fix') }}
                     </p>
@@ -28,7 +28,7 @@
 
         @if ($asset->checkInvalidNextAuditDate())
             <div class="col-md-12">
-                <div class="callout callout-warning">
+                <div class="callout callout-warning" role="alert" aria-live="assertive" aria-atomic="true">
                     <p><strong>{{ trans('general.warning',
                         [
                             'warning' => trans('admin/hardware/message.warning_audit_date_mismatch',
@@ -45,7 +45,7 @@
 
         @if ($asset->deleted_at!='')
             <div class="col-md-12">
-                <div class="callout callout-warning">
+                <div class="callout callout-warning" role="alert" aria-live="assertive" aria-atomic="true">
                     <x-icon type="warning"/>
                     {{ trans('general.asset_deleted_warning') }}
                 </div>

--- a/resources/views/kits/accessory-edit.blade.php
+++ b/resources/views/kits/accessory-edit.blade.php
@@ -13,7 +13,7 @@
         <div class="col-md-2" style="padding-left:0px">
             <input class="form-control" type="text" name="quantity" id="quantity" value="{{ old('quantity', $item->quantity) }}" />
         </div>
-        {!! $errors->first('quantity', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}
+        {!! $errors->first('quantity', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times"></i> :message</span>') !!}
     </div>
 </div>
 

--- a/resources/views/kits/checkout.blade.php
+++ b/resources/views/kits/checkout.blade.php
@@ -35,7 +35,7 @@
                           <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="checkout_at" id="checkout_at" value="{{ old('checkout_at') }}">
                           <span class="input-group-addon"><x-icon type="calendar" /></span>
                       </div>
-                      {!! $errors->first('checkout_at', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}
+                      {!! $errors->first('checkout_at', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times"></i> :message</span>') !!}
                   </div>
               </div>
 
@@ -49,7 +49,7 @@
                           <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="expected_checkin" id="expected_checkin" value="{{ old('expected_checkin') }}">
                           <span class="input-group-addon"><x-icon type="calendar" /></span>
                       </div>
-                      {!! $errors->first('expected_checkin', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}
+                      {!! $errors->first('expected_checkin', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times"></i> :message</span>') !!}
                   </div>
               </div>
 
@@ -61,7 +61,7 @@
               </label>
             <div class="col-md-8">
               <textarea class="col-md-6 form-control" id="note" name="note">{{ old('note') }}</textarea>
-              {!! $errors->first('note', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}
+              {!! $errors->first('note', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times"></i> :message</span>') !!}
             </div>
           </div>
 

--- a/resources/views/kits/consumable-edit.blade.php
+++ b/resources/views/kits/consumable-edit.blade.php
@@ -14,7 +14,7 @@
         <div class="col-md-2" style="padding-left:0px">
             <input class="form-control" type="text" name="quantity" id="quantity" value="{{ old('quantity', $item->quantity) }}" />
         </div>
-        {!! $errors->first('quantity', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}
+        {!! $errors->first('quantity', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times"></i> :message</span>') !!}
     </div>
 </div>
 

--- a/resources/views/kits/license-edit.blade.php
+++ b/resources/views/kits/license-edit.blade.php
@@ -13,7 +13,7 @@
         <div class="col-md-2" style="padding-left:0px">
             <input class="form-control" type="text" name="quantity" id="quantity" value="{{ old('quantity', $item->quantity) }}" />
         </div>
-        {!! $errors->first('quantity', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}
+        {!! $errors->first('quantity', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times"></i> :message</span>') !!}
     </div>
 </div>
 

--- a/resources/views/kits/model-edit.blade.php
+++ b/resources/views/kits/model-edit.blade.php
@@ -14,7 +14,7 @@
         <div class="col-md-2" style="padding-left:0px">
             <input class="form-control" type="text" name="quantity" id="quantity" value="{{ old('quantity', $item->quantity) }}" />
         </div>
-        {!! $errors->first('quantity', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}
+        {!! $errors->first('quantity', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times"></i> :message</span>') !!}
     </div>
 </div>
 

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -1530,10 +1530,7 @@
                                         </a>
                                     </li>
 
-                                    <?php
-use App\Models\Statuslabel;
-
-                                    $status_navs = Statuslabel::where('show_in_nav', '=', 1)->withCount('assets as asset_count')->get(); ?>
+                                    <?php $status_navs = \App\Models\Statuslabel::where('show_in_nav', '=', 1)->withCount('assets as asset_count')->get(); ?>
                                     @if (count($status_navs) > 0)
                                         @foreach ($status_navs as $status_nav)
                                             <li{!! (request()->is('statuslabels/'.$status_nav->id) ? ' class="active"' : '') !!}>

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -1533,7 +1533,7 @@
                                     <?php
 use App\Models\Statuslabel;
 
-$status_navs = Statuslabel::where('show_in_nav', '=', 1)->withCount('assets as asset_count')->get(); ?>
+                                    $status_navs = Statuslabel::where('show_in_nav', '=', 1)->withCount('assets as asset_count')->get(); ?>
                                     @if (count($status_navs) > 0)
                                         @foreach ($status_navs as $status_nav)
                                             <li{!! (request()->is('statuslabels/'.$status_nav->id) ? ' class="active"' : '') !!}>
@@ -2342,6 +2342,11 @@ $status_navs = Statuslabel::where('show_in_nav', '=', 1)->withCount('assets as a
                 errorClass: 'alert-msg',
                 errorElement: 'div',
                 errorPlacement: function(error, element) {
+                    // Screen readers only announce inserted error text when the
+                    // error element carries role=alert (aria-live=assertive is
+                    // implied, but set explicitly for older AT compatibility).
+                    error.attr('role', 'alert');
+                    error.attr('aria-live', 'assertive');
 
                     if ($(element).hasClass('select2') || $(element).hasClass('js-data-ajax')) {
                         // If the element is a select2 then append the error to the parent div

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -1530,7 +1530,10 @@
                                         </a>
                                     </li>
 
-                                    <?php $status_navs = \App\Models\Statuslabel::where('show_in_nav', '=', 1)->withCount('assets as asset_count')->get(); ?>
+                                    <?php
+use App\Models\Statuslabel;
+
+$status_navs = Statuslabel::where('show_in_nav', '=', 1)->withCount('assets as asset_count')->get(); ?>
                                     @if (count($status_navs) > 0)
                                         @foreach ($status_navs as $status_nav)
                                             <li{!! (request()->is('statuslabels/'.$status_nav->id) ? ' class="active"' : '') !!}>
@@ -2024,7 +2027,7 @@
                     <div class="row">
                         @if (config('app.lock_passwords'))
                             <div class="col-md-12">
-                                <div class="callout callout-info">
+                                <div class="callout callout-info" role="status" aria-live="polite" aria-atomic="true">
                                     {{ trans('general.some_features_disabled') }}
                                 </div>
                             </div>

--- a/resources/views/licenses/checkin.blade.php
+++ b/resources/views/licenses/checkin.blade.php
@@ -76,7 +76,7 @@
                 <label for="note" class="col-md-3 control-label">{{ trans('general.checkin_note') }}</label>
                 <div class="col-md-8">
                     <textarea class="form-control" id="notes" name="notes" rows="5"></textarea>
-                    {!! $errors->first('notes', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                    {!! $errors->first('notes', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                 </div>
             </div>
                         <x-redirect_submit_options

--- a/resources/views/licenses/checkout.blade.php
+++ b/resources/views/licenses/checkout.blade.php
@@ -91,7 +91,7 @@
                 @if ($license->requireAcceptance() || (string) $snipeSettings->require_accept_signature === '1' || $license->getEula() || ($snipeSettings->webhook_endpoint!=''))
                     <div class="form-group notification-callout">
                         <div class="col-md-8 col-md-offset-3">
-                            <div class="callout callout-info">
+                            <div class="callout callout-info" role="status" aria-live="polite" aria-atomic="true">
 
                                 @if ($license->requireAcceptance())
                                     <i class="far fa-envelope"></i>

--- a/resources/views/licenses/checkout.blade.php
+++ b/resources/views/licenses/checkout.blade.php
@@ -82,7 +82,7 @@
                         <label for="note" class="col-md-3 control-label">{{ trans('general.checkout_note') }}</label>
                         <div class="col-md-8">
                             <textarea class="col-md-6 form-control" id="notes" name="notes" rows="5">{{ old('note') }}</textarea>
-                            {!! $errors->first('note', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                            {!! $errors->first('note', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                         </div>
                     </div>
                 </div>

--- a/resources/views/licenses/edit.blade.php
+++ b/resources/views/licenses/edit.blade.php
@@ -26,7 +26,7 @@
             <input class="form-control" type="number" min="0" name="seats" id="seats" value="{{ old('seats', $item->seats) }}" minlength="1" required style="width: 97px;">
         </div>
     </div>
-    {!! $errors->first('seats', '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
+    {!! $errors->first('seats', '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
 </div>
 @include ('partials.forms.edit.minimum_quantity')
 
@@ -36,7 +36,7 @@
         <label for="serial" class="col-md-3 control-label">{{ trans('admin/licenses/form.license_key') }}</label>
         <div class="col-md-7">
             <textarea class="form-control" type="text" name="serial" id="serial" rows="5"{{  (Helper::checkIfRequired($item, 'serial')) ? ' required' : '' }}>{{ old('serial', $item->serial) }}</textarea>
-            {!! $errors->first('serial', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+            {!! $errors->first('serial', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
         </div>
     </div>
 @endcan
@@ -49,7 +49,7 @@
     <label for="license_name" class="col-md-3 control-label">{{ trans('admin/licenses/form.to_name') }}</label>
     <div class="col-md-7">
         <input class="form-control" type="text" name="license_name" id="license_name" value="{{ old('license_name', $item->license_name) }}" />
-        {!! $errors->first('license_name', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first('license_name', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>
 
@@ -58,7 +58,7 @@
     <label for="license_email" class="col-md-3 control-label">{{ trans('admin/licenses/form.to_email') }}</label>
     <div class="col-md-7">
         <input class="form-control" type="email" name="license_email" id="license_email" value="{{ old('license_email', $item->license_email) }}" />
-        {!! $errors->first('license_email', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first('license_email', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>
 
@@ -90,7 +90,7 @@
             <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="expiration_date" id="expiration_date" value="{{ old('expiration_date', ($item->expiration_date) ? $item->expiration_date->format('Y-m-d') : '') }}" maxlength="10">
             <span class="input-group-addon"><x-icon type="calendar" /></span>
         </div>
-        {!! $errors->first('expiration_date', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first('expiration_date', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 
 </div>
@@ -104,7 +104,7 @@
             <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="termination_date" id="termination_date" value="{{ old('termination_date', ($item->termination_date) ? $item->termination_date->format('Y-m-d') : '') }}" maxlength="10">
             <span class="input-group-addon"><x-icon type="calendar" /></span>
         </div>
-        {!! $errors->first('termination_date', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first('termination_date', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>
 
@@ -114,7 +114,7 @@
     <label for="purchase_order" class="col-md-3 control-label">{{ trans('admin/licenses/form.purchase_order') }}</label>
     <div class="col-md-3 text-right">
         <input class="form-control" type="text" name="purchase_order" id="purchase_order" value="{{ old('purchase_order', $item->purchase_order) }}" maxlength="191" />
-        {!! $errors->first('purchase_order', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first('purchase_order', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>
 

--- a/resources/views/livewire/category-edit-form.blade.php
+++ b/resources/views/livewire/category-edit-form.blade.php
@@ -11,7 +11,7 @@
             />
             <p class="help-block">{!! trans('admin/categories/general.eula_text_help') !!} </p>
             <p class="help-block">{!! trans('admin/settings/general.eula_markdown') !!} </p>
-            {!! $errors->first('eula_text', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+            {!! $errors->first('eula_text', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
         </div>
         @if ($this->eulaTextDisabled)
             <input type="hidden" name="eula_text" wire:model.live="eulaText" />

--- a/resources/views/livewire/category-edit-form.blade.php
+++ b/resources/views/livewire/category-edit-form.blade.php
@@ -105,8 +105,8 @@
                 @endif
             </label>
             @if ($this->emailWillBeSendDueToEula)
-                <div class="callout callout-info">
-                    <i class="far fa-envelope"></i>
+                <div class="callout callout-info" role="status" aria-live="polite" aria-atomic="true">
+                    <i class="far fa-envelope" aria-hidden="true"></i>
                     <span>{{ $this->emailMessage }}</span>
                 </div>
             @endif

--- a/resources/views/livewire/custom-field-set-default-values-for-model.blade.php
+++ b/resources/views/livewire/custom-field-set-default-values-for-model.blade.php
@@ -14,7 +14,7 @@
                  style="width:100%; min-width:350px;"
                  aria-label="custom_fieldset"
              />
-            {!! $errors->first('custom_fieldset', '<span class="alert-msg" aria-hidden="true"><br><i class="fas fa-times"></i> :message</span>') !!}
+            {!! $errors->first('custom_fieldset', '<span class="alert-msg" role="alert" aria-live="assertive"><br><i class="fas fa-times"></i> :message</span>') !!}
         </div>
         <div class="col-md-3">
             @if ($fieldset_id)
@@ -143,7 +143,7 @@
                                         <?php
                                         $errormessage = $errors->first($field->db_column_name());
                                         if ($errormessage) {
-                                            print('<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> '.$errormessage.'</span>');
+                                            print('<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> '.$errormessage.'</span>');
                                         }
                                         ?>
                         </div>

--- a/resources/views/livewire/slack-settings-form.blade.php
+++ b/resources/views/livewire/slack-settings-form.blade.php
@@ -92,7 +92,7 @@
                             </div>
                             <div class="col-md-9 required">
                                     <input type="url" wire:model.change.live="webhook_endpoint" class="form-control" placeholder="{{$webhook_placeholder}}" value="{{old('webhook_endpoint', $webhook_endpoint)}}"{{ Helper::isDemoMode() ? ' disabled' : ''}}>
-                                {!! $errors->first('webhook_endpoint', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                {!! $errors->first('webhook_endpoint', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                             </div>
                         </div>
 
@@ -110,7 +110,7 @@
                                 <div class="col-md-9 required">
                                         <input type="text" wire:model.change.live="webhook_channel" class="form-control" placeholder="#IT-Ops" value="{{ old('webhook_channel', $webhook_channel) }}"{{ Helper::isDemoMode() ? ' disabled' : ''}}>
 
-                                    {!! $errors->first('webhook_channel', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                    {!! $errors->first('webhook_channel', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                 </div>
                             </div>
                         @endif
@@ -127,7 +127,7 @@
                                 </div>
                                 <div class="col-md-9">
                                         <input type="text" wire:model.change.live="webhook_botname" class='form-control' placeholder="Snipe-Bot" {{ old('webhook_botname', $webhook_botname)}}{{ Helper::isDemoMode() ? ' disabled' : ''}}>
-                                    {!! $errors->first('webhook_botname', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                    {!! $errors->first('webhook_botname', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                 </div><!--col-md-10-->
                             </div>
                         @endif

--- a/resources/views/locations/edit.blade.php
+++ b/resources/views/locations/edit.blade.php
@@ -42,7 +42,7 @@
     <div class="col-md-7">
         <input class="form-control" style="width:100px" type="text" name="currency" aria-label="currency" id="currency" value="{{ old('currency', $item->currency) }}"{!!  (Helper::checkIfRequired($item, 'currency')) ? ' required' : '' !!} maxlength="3" />
         @error('currency')
-        <span class="alert-msg">
+        <span class="alert-msg" role="alert" aria-live="assertive">
             <x-icon type="x" />
             {{ $message }}
         </span>
@@ -62,7 +62,7 @@
         <div class="col-md-7">
             <input class="form-control" type="text" name="ldap_ou" aria-label="ldap_ou" id="ldap_ou" value="{{ old('ldap_ou', $item->ldap_ou) }}"{!!  (Helper::checkIfRequired($item, 'ldap_ou')) ? ' required' : '' !!} maxlength="191" />
             @error('ldap_ou')
-            <span class="alert-msg">
+            <span class="alert-msg" role="alert" aria-live="assertive">
                 <x-icon type="x" />
                 {{ $message }}
         </span>
@@ -85,7 +85,7 @@
                 aria-label="notes"
                 rows="5"
         />
-        {!! $errors->first('notes', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first('notes', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>
 
@@ -100,7 +100,7 @@
         </label>
         <div class="col-md-9">
             <x-input.colorpicker :item="$item" id="color" :value="old('color', ($item->color ?? '#f4f4f4'))" name="tag_color" id="tag_color" />
-            {!! $errors->first('tag_color', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+            {!! $errors->first('tag_color', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
         </div>
     </div>
 </fieldset>

--- a/resources/views/locations/view.blade.php
+++ b/resources/views/locations/view.blade.php
@@ -20,7 +20,7 @@
 
         @if ($location->deleted_at!='')
             <div class="col-md-12">
-                <div class="callout callout-warning">
+                <div class="callout callout-warning" role="alert" aria-live="assertive" aria-atomic="true">
                     <x-icon type="warning" />
                     {{ trans('admin/locations/message.deleted_warning') }}
                 </div>

--- a/resources/views/maintenances/edit.blade.php
+++ b/resources/views/maintenances/edit.blade.php
@@ -131,7 +131,7 @@
                           </option>
                       @endif
                   </select>
-                  {!! $errors->first('responsible_party_id', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                  {!! $errors->first('responsible_party_id', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
               </div>
           </div>
 
@@ -148,7 +148,7 @@
                     placeholder="{{ trans('general.select_date') }}"
                     required="{{ Helper::checkIfRequired($item, 'start_date') }}"
             />
-            {!! $errors->first('start_date', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+            {!! $errors->first('start_date', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
           </div>
         </div>
 
@@ -165,7 +165,7 @@
                     placeholder="{{ trans('general.select_date') }}"
                     required="Helper::checkIfRequired($item, 'completion_date')"
             />
-            {!! $errors->first('completion_date', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+            {!! $errors->first('completion_date', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
           </div>
         </div>
 
@@ -198,7 +198,7 @@
               </span>
                 </div>
                 <div class="col-md-9" style="padding-left: 0px;">
-              {!! $errors->first('cost', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+              {!! $errors->first('cost', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
               <p class="help-block">{{ trans('general.purchase_cost_format_help', ['format' => $snipeSettings->digit_separator]) }}</p>
             </div>
           </div>
@@ -208,7 +208,7 @@
           <label for="url" class="col-md-3 control-label">{{ trans('general.url') }}</label>
           <div class="col-md-7">
             <input class="form-control" name="url" type="url" id="url" value="{{ old('url', $item->url) }}" placeholder="https://example.com">
-            {!! $errors->first('url', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+            {!! $errors->first('url', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
           </div>
         </div>
 
@@ -223,7 +223,7 @@
           <div class="col-md-7">
             <textarea class="col-md-6 form-control" id="notes" name="notes">{{ old('notes', $item->notes) }}</textarea>
             <p class="help-block">{!! trans('general.markdown') !!}</p>
-            {!! $errors->first('notes', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+            {!! $errors->first('notes', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
           </div>
         </div>
       </div> <!-- .box-body -->

--- a/resources/views/manufacturers/edit.blade.php
+++ b/resources/views/manufacturers/edit.blade.php
@@ -105,7 +105,7 @@
                         </label>
                         <div class="col-md-9">
                             <x-input.colorpicker :item="$item" id="color" :value="old('color', ($item->color ?? '#f4f4f4'))" name="tag_color" id="tag_color" />
-                            {!! $errors->first('tag_color', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                            {!! $errors->first('tag_color', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                         </div>
                     </div>
                 </fieldset>

--- a/resources/views/manufacturers/index.blade.php
+++ b/resources/views/manufacturers/index.blade.php
@@ -15,7 +15,7 @@
 
                     <form action="{{ route('manufacturers.seed') }}" method="POST">
                       {{ csrf_field() }}
-                    <div class="callout callout-info">
+                    <div class="callout callout-info" role="status" aria-live="polite" aria-atomic="true">
                       <p>
                           {{ trans('general.seeding.manufacturers.prompt') }}
                         <button class="btn btn-sm btn-theme hidden-print" rel="noopener">

--- a/resources/views/modals/add-note.blade.php
+++ b/resources/views/modals/add-note.blade.php
@@ -21,7 +21,7 @@
                     <div class="row">
                         <div class="col-md-12">
                             <textarea class="form-control" id="note" name="note" required>{{ old('note') }}</textarea>
-                            {!! $errors->first('note', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                            {!! $errors->first('note', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                         </div>
                     </div>
                 </div>

--- a/resources/views/models/bulk-edit.blade.php
+++ b/resources/views/models/bulk-edit.blade.php
@@ -18,8 +18,8 @@
                 <div class="box box-default">
                     <div class="box-body">
 
-                        <div class="callout callout-warning">
-                            <i class="fas fa-exclamation-triangle"></i>
+                        <div class="callout callout-warning" role="alert" aria-live="assertive" aria-atomic="true">
+                            <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
                             {{ trans_choice('admin/models/message.bulkedit.warn', count($models), ['model_count' => count($models)]) }}
                         </div>
 

--- a/resources/views/models/bulk-edit.blade.php
+++ b/resources/views/models/bulk-edit.blade.php
@@ -63,7 +63,7 @@
                                         class="js-fieldset-field"
                                         style="width:350px"
                                     />
-                                    {!! $errors->first('fieldset_id', '<span class="alert-msg" aria-hidden="true"><br><i class="fas fa-times"></i> :message</span>') !!}
+                                    {!! $errors->first('fieldset_id', '<span class="alert-msg" role="alert" aria-live="assertive"><br><i class="fas fa-times"></i> :message</span>') !!}
                                 </div>
                             </div>
 
@@ -80,7 +80,7 @@
                                         :selected="old('depreciation_id', 'NC')"
                                         style="width:350px"
                                     />
-                                    {!! $errors->first('depreciation_id', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                    {!! $errors->first('depreciation_id', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                                 </div>
                             </div>
 

--- a/resources/views/models/custom_fields_form.blade.php
+++ b/resources/views/models/custom_fields_form.blade.php
@@ -115,7 +115,7 @@
                   $errormessage = $errors->first($field->db_column_name());
                   if ($errormessage) {
                       $errormessage = preg_replace('/ snipeit /', '', $errormessage);
-                      print('<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> '.$errormessage.'</span>');
+                      print('<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> '.$errormessage.'</span>');
                   }
                   ?>
       </div>

--- a/resources/views/models/custom_fields_form_bulk_edit.blade.php
+++ b/resources/views/models/custom_fields_form_bulk_edit.blade.php
@@ -161,7 +161,7 @@
           $errormessage=$errors->first($field->db_column_name());
           if ($errormessage) {
               $errormessage=preg_replace('/ snipeit /', '', $errormessage);
-              print('<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> '.$errormessage.'</span>');
+              print('<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> '.$errormessage.'</span>');
           }
             ?>
       </div>

--- a/resources/views/models/edit.blade.php
+++ b/resources/views/models/edit.blade.php
@@ -50,7 +50,7 @@
         </div>
     </div>
     <div class="col-md-9 col-md-offset-3">
-        {!! $errors->first('eol', '<span class="alert-msg" aria-hidden="true"><br><i class="fas fa-times"></i> :message</span>') !!}
+        {!! $errors->first('eol', '<span class="alert-msg" role="alert" aria-live="assertive"><br><i class="fas fa-times"></i> :message</span>') !!}
     </div>
 </div>
 

--- a/resources/views/models/view.blade.php
+++ b/resources/views/models/view.blade.php
@@ -17,7 +17,7 @@
 
         @if ($model->deleted_at!='')
             <div class="col-md-12">
-                <div class="callout callout-warning">
+                <div class="callout callout-warning" role="alert" aria-live="assertive" aria-atomic="true">
                     <x-icon type="warning" />
                     {{ trans('admin/models/general.deleted') }}
                 </div>

--- a/resources/views/notifications.blade.php
+++ b/resources/views/notifications.blade.php
@@ -1,8 +1,8 @@
 @if ($errors->any())
 <div class="col-md-12" id="error-notification">
-    <div class="alert alert-danger fade in">
-        <button type="button" class="close" data-dismiss="alert">&times;</button>
-        <i class="fas fa-exclamation-triangle faa-pulse animated"></i>
+    <div class="alert alert-danger fade in" role="alert" aria-live="assertive" aria-atomic="true">
+        <button type="button" class="close" data-dismiss="alert" aria-label="{{ trans('general.close') }}"><span aria-hidden="true">&times;</span></button>
+        <i class="fas fa-exclamation-triangle faa-pulse animated" aria-hidden="true"></i>
         <strong>{{ trans('general.notification_error') }}:</strong>
          {{ trans('general.notification_error_hint') }}
     </div>
@@ -13,9 +13,9 @@
 
 @if ($message = session()->get('status'))
     <div class="col-md-12" id="success-notification">
-        <div class="alert alert-success fade in">
-            <button type="button" class="close" data-dismiss="alert">&times;</button>
-            <i class="fas fa-check faa-pulse animated"></i>
+        <div class="alert alert-success fade in" role="status" aria-live="polite" aria-atomic="true">
+            <button type="button" class="close" data-dismiss="alert" aria-label="{{ trans('general.close') }}"><span aria-hidden="true">&times;</span></button>
+            <i class="fas fa-check faa-pulse animated" aria-hidden="true"></i>
             <strong>{{ trans('general.notification_success') }}: </strong>
             {{ $message }}
         </div>
@@ -25,9 +25,9 @@
 
 @if ($message = session()->get('success'))
 <div class="col-md-12" id="success-notification">
-    <div class="alert alert-success fade in">
-        <button type="button" class="close" data-dismiss="alert">&times;</button>
-        <i class="fas fa-check faa-pulse animated"></i>
+    <div class="alert alert-success fade in" role="status" aria-live="polite" aria-atomic="true">
+        <button type="button" class="close" data-dismiss="alert" aria-label="{{ trans('general.close') }}"><span aria-hidden="true">&times;</span></button>
+        <i class="fas fa-check faa-pulse animated" aria-hidden="true"></i>
         <strong>{{ trans('general.notification_success') }}: </strong>
         {{ $message }}
     </div>
@@ -38,9 +38,9 @@
 
 @if ($message = session()->get('success-unescaped'))
     <div class="col-md-12" id="success-notification">
-        <div class="alert alert-success fade in">
-            <button type="button" class="close" data-dismiss="alert">&times;</button>
-            <i class="fas fa-check faa-pulse animated"></i>
+        <div class="alert alert-success fade in" role="status" aria-live="polite" aria-atomic="true">
+            <button type="button" class="close" data-dismiss="alert" aria-label="{{ trans('general.close') }}"><span aria-hidden="true">&times;</span></button>
+            <i class="fas fa-check faa-pulse animated" aria-hidden="true"></i>
             <strong>{{ trans('general.notification_success') }}: </strong>
             {!!  $message !!}
         </div>
@@ -52,9 +52,9 @@
 @if ($assets = session()->get('assets'))
     @foreach ($assets as $asset)
         <div class="col-md-12" id="multi-error-notification">
-            <div class="alert alert-info fade in">
-                <button type="button" class="close" data-dismiss="alert">&times;</button>
-                <i class="fas fa-info-circle faa-pulse animated"></i>
+            <div class="alert alert-info fade in" role="status" aria-live="polite" aria-atomic="true">
+                <button type="button" class="close" data-dismiss="alert" aria-label="{{ trans('general.close') }}"><span aria-hidden="true">&times;</span></button>
+                <i class="fas fa-info-circle faa-pulse animated" aria-hidden="true"></i>
                 <strong>{{ trans('general.asset_information') }}:</strong>
                 <ul>
                     @isset ($asset->model->name)
@@ -78,9 +78,9 @@
 @if ($consumables = session()->get('consumables'))
     @foreach ($consumables as $consumable)
         <div class="col-md-12" id="success-notification">
-            <div class="alert alert-info fade in">
-                <button type="button" class="close" data-dismiss="alert">&times;</button>
-                <i class="fas fa-info-circle faa-pulse animated"></i>
+            <div class="alert alert-info fade in" role="status" aria-live="polite" aria-atomic="true">
+                <button type="button" class="close" data-dismiss="alert" aria-label="{{ trans('general.close') }}"><span aria-hidden="true">&times;</span></button>
+                <i class="fas fa-info-circle faa-pulse animated" aria-hidden="true"></i>
                 <strong>{{ trans('general.consumable_information') }}: </strong>
                 <ul><li><b>{{ trans('general.consumable_name') }}</b> {{ $consumable->name }}</li></ul>
             </div>
@@ -92,9 +92,9 @@
 @if ($accessories = session()->get('accessories'))
     @foreach ($accessories as $accessory)
         <div class="col-md-12">
-            <div class="alert alert-info fade in">
-                <button type="button" class="close" data-dismiss="alert">&times;</button>
-                <i class="fas fa-info-circle faa-pulse animated"></i>
+            <div class="alert alert-info fade in" role="status" aria-live="polite" aria-atomic="true">
+                <button type="button" class="close" data-dismiss="alert" aria-label="{{ trans('general.close') }}"><span aria-hidden="true">&times;</span></button>
+                <i class="fas fa-info-circle faa-pulse animated" aria-hidden="true"></i>
                 <strong>{{ trans('general.accessory_information') }}:</strong>
                 <ul><li><b>{{ trans('general.accessory_name') }}</b> {{ $accessory->name }}</li></ul>
             </div>
@@ -105,9 +105,9 @@
 
 @if ($message = session()->get('error'))
 <div class="col-md-12">
-    <div class="alert alert alert-danger fade in">
-        <button type="button" class="close" data-dismiss="alert">&times;</button>
-        <i class="fas fa-exclamation-triangle faa-pulse animated"></i>
+    <div class="alert alert alert-danger fade in" role="alert" aria-live="assertive" aria-atomic="true">
+        <button type="button" class="close" data-dismiss="alert" aria-label="{{ trans('general.close') }}"><span aria-hidden="true">&times;</span></button>
+        <i class="fas fa-exclamation-triangle faa-pulse animated" aria-hidden="true"></i>
         <strong>{{ trans('general.error') }}: </strong>
         {{ $message }}
     </div>
@@ -116,11 +116,11 @@
 
 
 @if ($messages = session()->get('error_messages'))
-@foreach ($messages as $message)        
+@foreach ($messages as $message)
 <div class="col-md-12">
-    <div class="alert alert alert-danger fade in">
-        <button type="button" class="close" data-dismiss="alert">&times;</button>
-        <i class="fas fa-exclamation-triangle faa-pulse animated"></i>
+    <div class="alert alert alert-danger fade in" role="alert" aria-live="assertive" aria-atomic="true">
+        <button type="button" class="close" data-dismiss="alert" aria-label="{{ trans('general.close') }}"><span aria-hidden="true">&times;</span></button>
+        <i class="fas fa-exclamation-triangle faa-pulse animated" aria-hidden="true"></i>
         <strong>{{ trans('general.notification_error') }}: </strong>
         {{ $message }}
     </div>
@@ -131,9 +131,9 @@
 
 @if ($messages = session()->get('bulk_asset_errors'))
 <div class="col-md-12">
-    <div class="alert alert alert-danger fade in">
-        <button type="button" class="close" data-dismiss="alert">&times;</button>
-        <i class="fas fa-exclamation-triangle faa-pulse animated"></i>
+    <div class="alert alert alert-danger fade in" role="alert" aria-live="assertive" aria-atomic="true">
+        <button type="button" class="close" data-dismiss="alert" aria-label="{{ trans('general.close') }}"><span aria-hidden="true">&times;</span></button>
+        <i class="fas fa-exclamation-triangle faa-pulse animated" aria-hidden="true"></i>
         <strong>{{ trans('general.notification_error') }}: </strong>
        {{ trans('general.notification_bulk_error_hint') }}
             @foreach($messages as $key => $message)
@@ -149,9 +149,9 @@
 
 @if ($messages = session()->get('multi_error_messages'))
     <div class="col-md-12">
-        <div class="alert alert alert-warning fade in">
-            <button type="button" class="close" data-dismiss="alert">&times;</button>
-            <i class="fas fa-exclamation-triangle faa-pulse animated"></i>
+        <div class="alert alert alert-warning fade in" role="alert" aria-live="assertive" aria-atomic="true">
+            <button type="button" class="close" data-dismiss="alert" aria-label="{{ trans('general.close') }}"><span aria-hidden="true">&times;</span></button>
+            <i class="fas fa-exclamation-triangle faa-pulse animated" aria-hidden="true"></i>
             <strong>{{ trans('general.notification_error') }}: </strong>
             <ul>
                 @foreach(array_splice($messages, 0,3) as $key => $message)
@@ -173,9 +173,9 @@
 
 @if ($message = session()->get('warning'))
 <div class="col-md-12">
-    <div class="alert alert-warning fade in">
-        <button type="button" class="close" data-dismiss="alert">&times;</button>
-        <i class="fas fa-exclamation-triangle faa-pulse animated"></i>
+    <div class="alert alert-warning fade in" role="alert" aria-live="assertive" aria-atomic="true">
+        <button type="button" class="close" data-dismiss="alert" aria-label="{{ trans('general.close') }}"><span aria-hidden="true">&times;</span></button>
+        <i class="fas fa-exclamation-triangle faa-pulse animated" aria-hidden="true"></i>
         <strong>{{ trans('general.notification_warning') }}: </strong>
         {{ $message }}
     </div>
@@ -185,9 +185,9 @@
 
 @if ($message = session()->get('info'))
 <div class="col-md-12">
-    <div class="alert alert-info fade in">
-        <button type="button" class="close" data-dismiss="alert">&times;</button>
-        <i class="fas fa-info-circle faa-pulse animated"></i>
+    <div class="alert alert-info fade in" role="status" aria-live="polite" aria-atomic="true">
+        <button type="button" class="close" data-dismiss="alert" aria-label="{{ trans('general.close') }}"><span aria-hidden="true">&times;</span></button>
+        <i class="fas fa-info-circle faa-pulse animated" aria-hidden="true"></i>
         <strong>{{ trans('general.notification_info') }}: </strong>
         {{ $message }}
     </div>

--- a/resources/views/partials/forms/checkout-selector.blade.php
+++ b/resources/views/partials/forms/checkout-selector.blade.php
@@ -28,7 +28,7 @@
             </label>
             @endif
 
-            {!! $errors->first('checkout_to_type', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+            {!! $errors->first('checkout_to_type', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
         </div>
     </div>
 </div>

--- a/resources/views/partials/forms/edit/accessory-select.blade.php
+++ b/resources/views/partials/forms/edit/accessory-select.blade.php
@@ -23,6 +23,6 @@
         @endcannot
     @endif
 
-    {!! $errors->first($fieldname, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg"><i class="fas fa-times"></i> :message</span></div>') !!}
+    {!! $errors->first($fieldname, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times"></i> :message</span></div>') !!}
 
 </div>

--- a/resources/views/partials/forms/edit/address.blade.php
+++ b/resources/views/partials/forms/edit/address.blade.php
@@ -2,7 +2,7 @@
     <label for="address" class="col-md-3 control-label">{{ trans('general.address') }}</label>
     <div class="col-md-7">
         <input class="form-control" aria-label="address" maxlength="191" name="address" type="text" id="address" value="{{ old('address', $item->address) }}">
-        {!! $errors->first('address', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first('address', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>
 
@@ -10,7 +10,7 @@
     <label class="sr-only " for="address2">{{  trans('general.address')  }}</label>
     <div class="col-md-7 col-md-offset-3">
         <input class="form-control" aria-label="address2" maxlength="191" name="address2" type="text" value="{{ old('address2', $item->address2) }}">
-        {!! $errors->first('address2', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first('address2', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>
 
@@ -18,7 +18,7 @@
     <label for="city" class="col-md-3 control-label">{{ trans('general.city') }}</label>
     <div class="col-md-7">
         <input class="form-control" aria-label="city" maxlength="191" name="city" type="text" id="city" value="{{ old('city', $item->city) }}">
-        {!! $errors->first('city', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first('city', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>
 
@@ -26,7 +26,7 @@
     <label for="state" class="col-md-3 control-label">{{ trans('general.state') }}</label>
     <div class="col-md-7">
         <input class="form-control" aria-label="state" maxlength="191" name="state" type="text" id="state" value="{{ old('state', $item->state) }}">
-        {!! $errors->first('state', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first('state', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
 
     </div>
 </div>
@@ -39,7 +39,7 @@
             :selected="old('country', $item->country)"
         />
         <p class="help-block">{{ trans('general.countries_manually_entered_help') }}</p>
-        {!! $errors->first('country', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first('country', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>
 
@@ -47,6 +47,6 @@
     <label for="zip" class="col-md-3 control-label" maxlength="10">{{ trans('general.zip') }}</label>
     <div class="col-md-7">
         <input class="form-control" name="zip" type="text" id="zip" value="{{ old('zip', $item->zip) }}">
-        {!! $errors->first('zip', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first('zip', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>

--- a/resources/views/partials/forms/edit/asset-select.blade.php
+++ b/resources/views/partials/forms/edit/asset-select.blade.php
@@ -45,6 +45,6 @@
         @endcannot
     @endif
 
-    {!! $errors->first($fieldname, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
+    {!! $errors->first($fieldname, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
 
 </div>

--- a/resources/views/partials/forms/edit/category-select.blade.php
+++ b/resources/views/partials/forms/edit/category-select.blade.php
@@ -34,7 +34,7 @@
     </div>
 
 
-    {!! $errors->first($fieldname, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
+    {!! $errors->first($fieldname, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
 
-    {!! $errors->first('category_type', '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
+    {!! $errors->first('category_type', '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
 </div>

--- a/resources/views/partials/forms/edit/company-select.blade.php
+++ b/resources/views/partials/forms/edit/company-select.blade.php
@@ -39,5 +39,5 @@
         @endcan
     @endif
 
-    {!! $errors->first($fieldname, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
+    {!! $errors->first($fieldname, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
 </div>

--- a/resources/views/partials/forms/edit/consumable-select.blade.php
+++ b/resources/views/partials/forms/edit/consumable-select.blade.php
@@ -23,6 +23,6 @@
         @endcannot
     @endif
 
-    {!! $errors->first($fieldname, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg"><i class="fas fa-times"></i> :message</span></div>') !!}
+    {!! $errors->first($fieldname, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times"></i> :message</span></div>') !!}
 
 </div>

--- a/resources/views/partials/forms/edit/datepicker.blade.php
+++ b/resources/views/partials/forms/edit/datepicker.blade.php
@@ -8,7 +8,7 @@
                 placeholder="{{ trans('general.select_date') }}"
                 required="{{ Helper::checkIfRequired($item, 'start_date') }}"
         />
-        {!! $errors->first($fieldname, '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first($fieldname, '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
     @if  (isset($help_text))
         <div class="col-md-8 col-md-offset-3">

--- a/resources/views/partials/forms/edit/department-select.blade.php
+++ b/resources/views/partials/forms/edit/department-select.blade.php
@@ -25,6 +25,6 @@
     </div>
 
 
-    {!! $errors->first($fieldname, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
+    {!! $errors->first($fieldname, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
 
 </div>

--- a/resources/views/partials/forms/edit/depreciation.blade.php
+++ b/resources/views/partials/forms/edit/depreciation.blade.php
@@ -10,6 +10,6 @@
             style="width:350px;"
             aria-label="depreciation_id"
         />
-        {!! $errors->first('depreciation_id', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first('depreciation_id', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>

--- a/resources/views/partials/forms/edit/email.blade.php
+++ b/resources/views/partials/forms/edit/email.blade.php
@@ -2,6 +2,6 @@
     <label for="email" class="col-md-3 col-xs-12 control-label">{{ trans('admin/suppliers/table.email') }}</label>
     <div class="col-md-8 col-xs-12">
         <input type="email" name="email" id="email" value="{{ old('email', $item->email ?? null) }}" class="form-control"  maxlength="191" style="width:100%; display:flex;">
-        {!! $errors->first('email', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first('email', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>

--- a/resources/views/partials/forms/edit/fax.blade.php
+++ b/resources/views/partials/forms/edit/fax.blade.php
@@ -2,6 +2,6 @@
     <label for="fax" class="col-md-3 control-label">{{ trans('admin/suppliers/table.fax') }}</label>
     <div class="col-md-7">
         <input class="form-control" type="text" name="fax" aria-label="fax" id="fax" value="{{ old('fax', $item->fax) }}"  maxlength="34"  />
-        {!! $errors->first('fax', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first('fax', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>

--- a/resources/views/partials/forms/edit/file-upload.blade.php
+++ b/resources/views/partials/forms/edit/file-upload.blade.php
@@ -25,7 +25,7 @@
 
         @foreach ($errors->get('file.*') as $messages)
             @foreach ($messages as $message)
-                <span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> {{ $message }}</span><br>
+                <span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> {{ $message }}</span><br>
             @endforeach
         @endforeach
         

--- a/resources/views/partials/forms/edit/image-upload.blade.php
+++ b/resources/views/partials/forms/edit/image-upload.blade.php
@@ -15,13 +15,13 @@
                         {{ trans('general.use_cloned_image_help') }}
                     </p>
 
-                    {!! $errors->first('use_cloned_image', '<span class="alert-msg">:message</span>') !!}
+                    {!! $errors->first('use_cloned_image', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                 @else
                     <!-- Image Delete -->
                     <label class="form-control">
                         <input type="checkbox" name="image_delete" value="1" @checked(old('image_delete')) aria-label="image_delete" id="image_delete">
                         {{ trans('general.image_delete') }}
-                        {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
+                        {!! $errors->first('image_delete', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                     </label>
                 @endif
 
@@ -32,7 +32,7 @@
     <div class="form-group" id="existing-image">
         <div class="col-md-8 col-md-offset-3">
             <img src="{{ Storage::disk('public')->url($image_path.e($item->{($fieldname ?? 'image')})) }}" class="img-responsive">
-            {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
+            {!! $errors->first('image_delete', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
         </div>
     </div>
    @elseif (isset($item) && (isset($item->model)) && ($item->model->image != ''))
@@ -62,7 +62,7 @@
 
         <p class="help-block" id="uploadFile-status">{{ trans('general.image_filetypes_help', ['size' => Helper::file_upload_max_size_readable()]) }} {{ $help_text ?? '' }}</p>
 
-        {!! $errors->first('image', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+        {!! $errors->first('image', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
     </div>
 <div class="col-md-4 col-md-offset-3" aria-hidden="true">
     <img id="uploadFile-imagePreview" style="max-width: 300px; display: none;" alt="{{ trans('general.alt_uploaded_image_thumbnail') }}">

--- a/resources/views/partials/forms/edit/item_number.blade.php
+++ b/resources/views/partials/forms/edit/item_number.blade.php
@@ -3,6 +3,6 @@
    <label for="item_no" class="col-md-3 control-label">{{ trans('admin/consumables/general.item_no') }}</label>
    <div class="col-md-7 col-sm-12">
        <input class="form-control" type="text" name="item_no" id="item_no" value="{{ old('item_no', $item->item_no) }}"{{  (Helper::checkIfRequired($item, 'item_no')) ? ' required' : '' }}/>
-       {!! $errors->first('item_no', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+       {!! $errors->first('item_no', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
    </div>
 </div>

--- a/resources/views/partials/forms/edit/kit-select.blade.php
+++ b/resources/views/partials/forms/edit/kit-select.blade.php
@@ -22,6 +22,6 @@
         @endcan
     </div>
 
-    {!! $errors->first($fieldname, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg"><i class="fas fa-times"></i> :message</span></div>') !!}
+    {!! $errors->first($fieldname, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times"></i> :message</span></div>') !!}
 
 </div>

--- a/resources/views/partials/forms/edit/license-select.blade.php
+++ b/resources/views/partials/forms/edit/license-select.blade.php
@@ -23,6 +23,6 @@
         @endcannot
     @endif
 
-    {!! $errors->first($fieldname, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg"><i class="fas fa-times"></i> :message</span></div>') !!}
+    {!! $errors->first($fieldname, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times"></i> :message</span></div>') !!}
 
 </div>

--- a/resources/views/partials/forms/edit/location-profile-select.blade.php
+++ b/resources/views/partials/forms/edit/location-profile-select.blade.php
@@ -14,7 +14,7 @@
         </select>
     </div>
 
-    {!! $errors->first('location_id', '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
+    {!! $errors->first('location_id', '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
 
     @if ($snipeSettings->full_multiple_companies_support == '1' && $snipeSettings->scope_locations_fmcs == '1')
         @cannot('superadmin')

--- a/resources/views/partials/forms/edit/location-select.blade.php
+++ b/resources/views/partials/forms/edit/location-select.blade.php
@@ -27,7 +27,7 @@
         @endcan
     </div>
 
-    {!! $errors->first($fieldname, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
+    {!! $errors->first($fieldname, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
 
     @if ($snipeSettings->full_multiple_companies_support == '1' && $snipeSettings->scope_locations_fmcs == '1')
         @cannot('superadmin')

--- a/resources/views/partials/forms/edit/maintenance_type.blade.php
+++ b/resources/views/partials/forms/edit/maintenance_type.blade.php
@@ -30,7 +30,7 @@
                           aria-label="asset_maintenance_type"
                       />
                   @endif
-                  {!! $errors->first('maintenance_type_id', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                  {!! $errors->first('maintenance_type_id', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
               </div>
 
               <div class="col-md-1 col-sm-1 text-left">

--- a/resources/views/partials/forms/edit/manufacturer-select.blade.php
+++ b/resources/views/partials/forms/edit/manufacturer-select.blade.php
@@ -37,5 +37,5 @@
     </div>
 
 
-    {!! $errors->first($fieldname, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
+    {!! $errors->first($fieldname, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
 </div>

--- a/resources/views/partials/forms/edit/minimum_quantity.blade.php
+++ b/resources/views/partials/forms/edit/minimum_quantity.blade.php
@@ -15,7 +15,7 @@
             </x-form.tooltip>
         </div>
         <div class="col-md-12">
-           {!! $errors->first('min_amt', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+           {!! $errors->first('min_amt', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
         </div>
     </div>
 </div>

--- a/resources/views/partials/forms/edit/model-select.blade.php
+++ b/resources/views/partials/forms/edit/model-select.blade.php
@@ -36,5 +36,5 @@
         @endcan
     </div>
 
-    {!! $errors->first($fieldname, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
+    {!! $errors->first($fieldname, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
 </div>

--- a/resources/views/partials/forms/edit/model_number.blade.php
+++ b/resources/views/partials/forms/edit/model_number.blade.php
@@ -3,6 +3,6 @@
     <label for="model_number" class="col-md-3 control-label">{{ trans('general.model_no') }}</label>
     <div class="col-md-7">
     <input class="form-control" type="text" name="model_number" aria-label="model_number" id="model_number" value="{{ old('model_number', $item->model_number) }}" />
-        {!! $errors->first('model_number', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first('model_number', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>

--- a/resources/views/partials/forms/edit/name-first.blade.php
+++ b/resources/views/partials/forms/edit/name-first.blade.php
@@ -9,7 +9,7 @@
     <label class="col-md-3 control-label" for="first_name">{{ trans('general.first_name') }}</label>
     <div class="{{$class ? $class : 'col-md-6'}}" style= "{{$style}}">
         <input class="form-control" type="text" name="first_name" id="first_name" value="{{ old('first_name', ($value ?? $user->first_name)) }}" {{$required ? 'required' : ''}} maxlength="191" {{  (Helper::checkIfRequired($user, 'first_name')) ? ' required' : '' }}/>
-        {!! $errors->first('first_name', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+        {!! $errors->first('first_name', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
     </div>
 </div>
 <!-- partials/forms/edit/name-first.blade.php -->

--- a/resources/views/partials/forms/edit/name-last.blade.php
+++ b/resources/views/partials/forms/edit/name-last.blade.php
@@ -9,7 +9,7 @@
     <label class="col-md-3 control-label" for="last_name">{{ trans('general.last_name') }} </label>
     <div class="{{$class}}" style= "{{$style ? $style : ''}}">
         <input class="form-control" type="text" name="last_name" id="last_name"  value="{{ old('last_name', ($value ?? $user->last_name)) }}" maxlength="191"{{  (Helper::checkIfRequired($user, 'last_name')) ? ' required' : '' }} />
-        {!! $errors->first('last_name', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+        {!! $errors->first('last_name', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
     </div>
 </div>
 <!-- partials/forms/edit/name-last.blade.php -->

--- a/resources/views/partials/forms/edit/name.blade.php
+++ b/resources/views/partials/forms/edit/name.blade.php
@@ -3,6 +3,6 @@
     <label for="name" class="col-md-3 control-label">{{ $translated_name }}</label>
     <div class="col-md-8 col-sm-12">
         <input class="form-control" style="width:100%;" type="text" name="name" aria-label="name" id="name" value="{{ old('name', $item->name) }}"{!!  (Helper::checkIfRequired($item, 'name')) ? ' required' : '' !!} maxlength="191" />
-        {!! $errors->first('name', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first('name', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>

--- a/resources/views/partials/forms/edit/notes.blade.php
+++ b/resources/views/partials/forms/edit/notes.blade.php
@@ -3,6 +3,6 @@
     <label for="notes" class="col-md-3 control-label">{{ trans('general.notes') }}</label>
     <div class="col-md-7 col-sm-12">
         <textarea class="col-md-6 form-control" id="notes" aria-label="notes" name="notes" style="min-width:100%;">{{ old('notes', (isset($item) ? $item->notes : '')) }}</textarea>
-        {!! $errors->first('notes', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first('notes', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>

--- a/resources/views/partials/forms/edit/order_number.blade.php
+++ b/resources/views/partials/forms/edit/order_number.blade.php
@@ -3,6 +3,6 @@
    <label for="order_number" class="col-md-3 control-label">{{ trans('general.order_number') }}</label>
    <div class="col-md-7 col-sm-12">
        <input class="form-control" type="text" name="order_number" aria-label="order_number" id="order_number" value="{{ old('order_number', $item->order_number) }}"  maxlength="191"  />
-       {!! $errors->first('order_number', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+       {!! $errors->first('order_number', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
    </div>
 </div>

--- a/resources/views/partials/forms/edit/phone.blade.php
+++ b/resources/views/partials/forms/edit/phone.blade.php
@@ -2,6 +2,6 @@
     <label for="phone" class="col-md-3 control-label">{{ trans('admin/suppliers/table.phone') }}</label>
     <div class="col-md-7">
         <input class="form-control" aria-label="phone" maxlength="191" name="phone" type="text" id="phone" value="{{ old('phone', $item->phone) }}">
-        {!! $errors->first('phone', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first('phone', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>

--- a/resources/views/partials/forms/edit/purchase_cost.blade.php
+++ b/resources/views/partials/forms/edit/purchase_cost.blade.php
@@ -13,7 +13,7 @@
             </span>
         </div>
         <div class="col-md-9" style="padding-left: 0px;">
-            {!! $errors->first('purchase_cost', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+            {!! $errors->first('purchase_cost', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
             <p class="help-block">{{ trans('general.purchase_cost_format_help', ['format' => $snipeSettings->digit_separator]) }}</p>
         </div>
     </div>

--- a/resources/views/partials/forms/edit/quantity.blade.php
+++ b/resources/views/partials/forms/edit/quantity.blade.php
@@ -7,7 +7,7 @@
            <input class="form-control" maxlength="5" min="{{ (isset($qty)) ? $qty : '0' }}" type="number" name="qty" aria-label="qty" id="qty" value="{{ old('qty', $item->qty) }}" {!!  (Helper::checkIfRequired($item, 'qty')) ? ' required ' : '' !!}/>
        </div>
         <div class="col-md-12" style="padding-left:0">
-       {!! $errors->first('qty', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+       {!! $errors->first('qty', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
         </div>
    </div>
 </div>

--- a/resources/views/partials/forms/edit/serial.blade.php
+++ b/resources/views/partials/forms/edit/serial.blade.php
@@ -4,7 +4,7 @@
     <div class="col-md-7 col-sm-12">
         <input class="form-control" type="text" name="{{ $fieldname }}" id="{{ $fieldname }}" value="{{ old((isset($old_val_name) ? $old_val_name : $fieldname), $item->serial) }}" {{  (Helper::checkIfRequired($item, 'serial') || ($item->model && $item->model->require_serial)) ? ' required' : '' }} maxlength="191" />
         @error($old_val_name ?? $fieldname)
-        <span class="alert-msg" aria-hidden="true">
+        <span class="alert-msg" role="alert" aria-live="assertive">
                 <i class="fas fa-times" aria-hidden="true"></i> {{ $message }}
             </span>
         @enderror

--- a/resources/views/partials/forms/edit/status-select.blade.php
+++ b/resources/views/partials/forms/edit/status-select.blade.php
@@ -30,5 +30,5 @@
     </div>
 
 
-    {!! $errors->first($fieldname, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
+    {!! $errors->first($fieldname, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
 </div>

--- a/resources/views/partials/forms/edit/status.blade.php
+++ b/resources/views/partials/forms/edit/status.blade.php
@@ -12,7 +12,7 @@
             style="width:100%;"
             aria-label="status_id"
         />
-        {!! $errors->first('status_id', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first('status_id', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
     <div class="col-md-2 col-sm-2 text-left">
 

--- a/resources/views/partials/forms/edit/status.blade.php
+++ b/resources/views/partials/forms/edit/status.blade.php
@@ -25,7 +25,7 @@
     </div>
 
     <div class="col-md-7 col-sm-11 col-md-offset-3" id="status_helptext">
-        <p id="selected_status_status" style="display:none;"></p>
+        <p id="selected_status_status" role="status" aria-live="polite" aria-atomic="true" style="display:none;"></p>
     </div>
 
 </div>

--- a/resources/views/partials/forms/edit/supplier-select.blade.php
+++ b/resources/views/partials/forms/edit/supplier-select.blade.php
@@ -27,6 +27,6 @@
         @endcan
     </div>
 
-    {!! $errors->first($fieldname, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
+    {!! $errors->first($fieldname, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
 
 </div>

--- a/resources/views/partials/forms/edit/uploadLogo.blade.php
+++ b/resources/views/partials/forms/edit/uploadLogo.blade.php
@@ -17,7 +17,7 @@
 
         <span class='label label-default' id="{{ $logoId }}-info"></span>
 
-        {!! $errors->first($logoVariable, '<span class="alert-msg">:message</span>') !!}
+        {!! $errors->first($logoVariable, '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
 
 
         <p class="help-block" style="!important" id="{{ $logoId }}-status">

--- a/resources/views/partials/forms/edit/user-select.blade.php
+++ b/resources/views/partials/forms/edit/user-select.blade.php
@@ -30,6 +30,6 @@
         @endcannot
     @endif
 
-    {!! $errors->first($fieldname, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
+    {!! $errors->first($fieldname, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
 
 </div>

--- a/resources/views/partials/forms/edit/warranty.blade.php
+++ b/resources/views/partials/forms/edit/warranty.blade.php
@@ -7,7 +7,7 @@
             <span class="input-group-addon">{{ trans('admin/hardware/form.months') }}</span>
         </div>
         <div class="col-md-9" style="padding-left: 0px;">
-            {!! $errors->first('warranty_months', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+            {!! $errors->first('warranty_months', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
         </div>
     </div>
 </div>

--- a/resources/views/partials/labels-legacy-engine.blade.php
+++ b/resources/views/partials/labels-legacy-engine.blade.php
@@ -32,7 +32,7 @@
             :selected="old('label2_1d_type', $setting->label2_1d_type)"
             class="col-md-4"
         />
-        {!! $errors->first('label2_1d_type', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first('label2_1d_type', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
         <p class="help-block">
             {{ trans('admin/settings/general.label2_1d_type_help') }}.
             {!!
@@ -73,7 +73,7 @@
             :selected="old('label2_2d_type', $setting->label2_2d_type)"
             class="col-md-4"
         />
-        {!! $errors->first('label2_2d_type', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first('label2_2d_type', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
         <p class="help-block">
             {{ trans('admin/settings/general.label2_2d_type_help', ['current' => $setting->barcode_type]) }}.
             {!! trans('admin/settings/general.help_default_will_use') !!}
@@ -112,7 +112,7 @@
             <p class="help-block">{{ trans('admin/settings/general.qr_help') }}</p>
         @endif
 
-        {!! $errors->first('qr_text', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first('qr_text', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>
 
@@ -127,7 +127,7 @@
         <span id="purgebarcodesicon"></span>
         <span id="purgebarcodesresult"></span>
         <span id="purgebarcodesstatus"></span>
-        {!! $errors->first('purgebarcodes', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first('purgebarcodes', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
         <p class="help-block">{{ trans('admin/settings/general.barcodes_help') }}</p>
     </div>
 </div>
@@ -138,7 +138,7 @@
     </div>
     <div class="col-md-9">
         <input class="form-control" style="width: 100px;" name="labels_per_page" type="text" value="{{ old('labels_per_page', $setting->labels_per_page) }}" id="labels_per_page">
-        {!! $errors->first('labels_per_page', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+        {!! $errors->first('labels_per_page', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
     </div>
 </div>
 
@@ -153,7 +153,7 @@
         </div>
     </div>
     <div class="col-md-9 col-md-offset-3">
-        {!! $errors->first('labels_fontsize', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+        {!! $errors->first('labels_fontsize', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
     </div>
 </div>
 
@@ -166,14 +166,14 @@
             <input class="form-control" name="labels_width" type="text" value="{{ old('labels_width', $setting->labels_width) }}" id="labels_width">
             <div class="input-group-addon">{{ trans('admin/settings/general.width_w') }}</div>
         </div>
-        {!! $errors->first('labels_width', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+        {!! $errors->first('labels_width', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
     </div>
     <div class="col-md-3 text-right">
         <div class="input-group">
             <input class="form-control" name="labels_height" type="text" value="{{ old('labels_height', $setting->labels_height) }}" id="labels_height">
             <div class="input-group-addon">{{ trans('admin/settings/general.height_h') }}</div>
         </div>
-        {!! $errors->first('labels_height', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+        {!! $errors->first('labels_height', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
     </div>
 </div>
 
@@ -194,8 +194,8 @@
         </div>
     </div>
     <div class="col-md-9 col-md-offset-3">
-        {!! $errors->first('labels_display_sgutter', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
-        {!! $errors->first('labels_display_bgutter', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+        {!! $errors->first('labels_display_sgutter', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
+        {!! $errors->first('labels_display_bgutter', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
     </div>
 </div>
 
@@ -242,8 +242,8 @@
         </div>
     </div>
     <div class="col-md-9 col-md-offset-3">
-        {!! $errors->first('labels_pagewidth', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
-        {!! $errors->first('labels_pageheight', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+        {!! $errors->first('labels_pagewidth', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
+        {!! $errors->first('labels_pageheight', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
     </div>
 </div>
 

--- a/resources/views/partials/labels-new-engine.blade.php
+++ b/resources/views/partials/labels-new-engine.blade.php
@@ -57,7 +57,7 @@
         </div>
         <div class="col-md-7">
             <input class="form-control" name="label2_title" type="text" id="label2_title" value="{{ old('label2_title', $setting->label2_title) }}">
-            {!! $errors->first('label2_title', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+            {!! $errors->first('label2_title', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
             <p class="help-block">{!! trans('admin/settings/general.label2_title_help') !!}</p>
             <p class="help-block">
                 {!! trans('admin/settings/general.label2_title_help_phold') !!}.<br />
@@ -106,7 +106,7 @@
                 :selected="old('label2_1d_type', $setting->label2_1d_type)"
                 class="col-md-4"
             />
-            {!! $errors->first('label2_1d_type', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+            {!! $errors->first('label2_1d_type', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
             <p class="help-block">
                 {{ trans('admin/settings/general.label2_1d_type_help') }}.
                 {!!
@@ -139,7 +139,7 @@
                 :selected="old('label2_2d_type', $setting->label2_2d_type)"
                 class="col-md-4"
             />
-            {!! $errors->first('label2_2d_type', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+            {!! $errors->first('label2_2d_type', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
             <p class="help-block">
                 {{ trans('admin/settings/general.label2_2d_type_help', ['current' => $setting->barcode_type]) }}.
                 {!! trans('admin/settings/general.help_default_will_use') !!}
@@ -153,7 +153,7 @@
         </div>
         <div class="col-md-7">
             <input class="form-control" name="label2_2d_prefix" type="text" id="label2_2d_prefix" value="{{ old('label2_2d_prefix', $setting->label2_2d_prefix) }}">
-            {!! $errors->first('label2_2d_prefix', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+            {!! $errors->first('label2_2d_prefix', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
             <p class="help-block">{!! trans('admin/settings/general.label2_2d_prefix_help') !!}</p>
         </div>
     </div>
@@ -182,7 +182,7 @@
                 :selected="old('label2_2d_target', $setting->label2_2d_target)"
                 class="col-md-4"
             />
-            {!! $errors->first('label2_2d_target', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+            {!! $errors->first('label2_2d_target', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
             <p class="help-block">{{ trans('admin/settings/general.label2_2d_target_help') }}</p>
         </div>
     </div>
@@ -204,7 +204,7 @@
         </div>
         <div class="col-md-9 col-md-offset-3">
             <p class="help-block">{!! trans('admin/settings/general.empty_row_count_help') !!}</p>
-            {!! $errors->first('label2_empty_row_count', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+            {!! $errors->first('label2_empty_row_count', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
         </div>
     </div>
 </fieldset>
@@ -221,7 +221,7 @@
                 'customFields' => $customFields,
                 'template' => $setting->label2_template,
             ])
-            {!! $errors->first('label2_fields', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+            {!! $errors->first('label2_fields', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
         </div>
     </div>
 </fieldset>

--- a/resources/views/reports/custom/asset.blade.php
+++ b/resources/views/reports/custom/asset.blade.php
@@ -72,7 +72,7 @@
                                 value="{{ $template->name }}"
                                 required
                             >
-                            {!! $errors->first('name', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                            {!! $errors->first('name', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                         </div>
                         @if ($template->created_by == auth()->id())
                             <div class="col-md-3">
@@ -443,8 +443,8 @@
 
                 @if ($errors->has('purchase_start') || $errors->has('purchase_end'))
                     <div class="col-md-9 col-lg-offset-3">
-                        {!! $errors->first('purchase_start', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
-                        {!! $errors->first('purchase_end', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                        {!! $errors->first('purchase_start', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                        {!! $errors->first('purchase_end', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                     </div>
                 @endif
 
@@ -461,8 +461,8 @@
 
               @if ($errors->has('purchase_cost_start') || $errors->has('purchase_cost_end'))
                   <div class="col-md-9 col-lg-offset-3">
-                      {!! $errors->first('purchase_cost_start', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
-                      {!! $errors->first('purchase_cost_end', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                      {!! $errors->first('purchase_cost_start', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                      {!! $errors->first('purchase_cost_end', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                   </div>
               @endif
 
@@ -479,8 +479,8 @@
 
                 @if ($errors->has('created_start') || $errors->has('created_end'))
                     <div class="col-md-9 col-lg-offset-3">
-                        {!! $errors->first('created_start', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
-                        {!! $errors->first('created_end', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                        {!! $errors->first('created_start', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                        {!! $errors->first('created_end', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                     </div>
                 @endif
             </div>
@@ -496,8 +496,8 @@
 
               @if ($errors->has('checkout_date_start') || $errors->has('checkout_date_end'))
                   <div class="col-md-9 col-lg-offset-3">
-                      {!! $errors->first('checkout_date_start', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
-                      {!! $errors->first('checkout_date_end', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                      {!! $errors->first('checkout_date_start', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                      {!! $errors->first('checkout_date_end', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                   </div>
               @endif
 
@@ -514,8 +514,8 @@
 
               @if ($errors->has('checkin_date_start') || $errors->has('checkin_date_end'))
                   <div class="col-md-9 col-lg-offset-3">
-                      {!! $errors->first('checkin_date_start', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
-                      {!! $errors->first('checkin_date_end', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                      {!! $errors->first('checkin_date_start', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                      {!! $errors->first('checkin_date_end', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                   </div>
               @endif
           </div>
@@ -531,8 +531,8 @@
 
                 @if ($errors->has('expected_checkin_start') || $errors->has('expected_checkin_end'))
                     <div class="col-md-9 col-lg-offset-3">
-                        {!! $errors->first('expected_checkin_start', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
-                        {!! $errors->first('expected_checkin_end', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                        {!! $errors->first('expected_checkin_start', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                        {!! $errors->first('expected_checkin_end', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                     </div>
                 @endif
 
@@ -549,8 +549,8 @@
 
                   @if ($errors->has('asset_eol_date_start') || $errors->has('asset_eol_date_end'))
                       <div class="col-md-9 col-lg-offset-3">
-                          {!! $errors->first('asset_eol_date_start', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
-                          {!! $errors->first('asset_eol_date_end', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                          {!! $errors->first('asset_eol_date_start', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                          {!! $errors->first('asset_eol_date_end', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                       </div>
                   @endif
               </div>
@@ -566,8 +566,8 @@
 
                   @if ($errors->has('last_audit_start') || $errors->has('last_audit_end'))
                       <div class="col-md-9 col-lg-offset-3">
-                          {!! $errors->first('last_audit_start', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
-                          {!! $errors->first('last_audit_end', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                          {!! $errors->first('last_audit_start', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                          {!! $errors->first('last_audit_end', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                       </div>
                   @endif
               </div>
@@ -583,8 +583,8 @@
 
                   @if ($errors->has('next_audit_start') || $errors->has('next_audit_end'))
                       <div class="col-md-9 col-lg-offset-3">
-                          {!! $errors->first('next_audit_start', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
-                          {!! $errors->first('next_audit_end', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                          {!! $errors->first('next_audit_start', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                          {!! $errors->first('next_audit_end', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                       </div>
                   @endif
               </div>
@@ -600,8 +600,8 @@
 
                   @if ($errors->has('last_updated_start') || $errors->has('last_updated_end'))
                       <div class="col-md-9 col-lg-offset-3">
-                          {!! $errors->first('last_updated_start', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
-                          {!! $errors->first('last_updated_end', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                          {!! $errors->first('last_updated_start', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                          {!! $errors->first('last_updated_end', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                       </div>
                   @endif
               </div>
@@ -616,7 +616,7 @@
 
                   @if ($errors->has('last_updated_before'))
                       <div class="col-md-9 col-lg-offset-3">
-                          {!! $errors->first('last_updated_before', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                          {!! $errors->first('last_updated_before', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                       </div>
                   @endif
               </div>
@@ -790,7 +790,7 @@
                             value="{{ $template->name }}"
                             required
                         >
-                        {!! $errors->first('name', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                        {!! $errors->first('name', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                     </div>
                     <button class="btn btn-primary" style="width: 100%">
                         {{ trans('admin/reports/general.save_template') }}

--- a/resources/views/reports/custom/component.blade.php
+++ b/resources/views/reports/custom/component.blade.php
@@ -72,7 +72,7 @@
                                         value="{{ $template->name }}"
                                         required
                                     >
-                                    {!! $errors->first('name', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                    {!! $errors->first('name', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                                 </div>
                                 @if ($template->created_by == auth()->id())
                                     <div class="col-md-3">
@@ -290,8 +290,8 @@
 
                                 @if ($errors->has('purchase_start') || $errors->has('purchase_end'))
                                     <div class="col-md-9 col-lg-offset-3">
-                                        {!! $errors->first('purchase_start', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
-                                        {!! $errors->first('purchase_end', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                        {!! $errors->first('purchase_start', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                        {!! $errors->first('purchase_end', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                                     </div>
                                 @endif
                             </div>
@@ -307,8 +307,8 @@
 
                                 @if ($errors->has('quantity_start') || $errors->has('quantity_end'))
                                     <div class="col-md-9 col-lg-offset-3">
-                                        {!! $errors->first('quantity_start', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
-                                        {!! $errors->first('quantity_end', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                        {!! $errors->first('quantity_start', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                        {!! $errors->first('quantity_end', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                                     </div>
                                 @endif
                             </div>
@@ -324,8 +324,8 @@
 
                                 @if ($errors->has('min_quantity_start') || $errors->has('min_quantity_end'))
                                     <div class="col-md-9 col-lg-offset-3">
-                                        {!! $errors->first('min_quantity_start', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
-                                        {!! $errors->first('min_quantity_end', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                        {!! $errors->first('min_quantity_start', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                        {!! $errors->first('min_quantity_end', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                                     </div>
                                 @endif
                             </div>
@@ -341,8 +341,8 @@
 
                                 @if ($errors->has('unit_cost_start') || $errors->has('unit_cost_end'))
                                     <div class="col-md-9 col-lg-offset-3">
-                                        {!! $errors->first('unit_cost_start', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
-                                        {!! $errors->first('unit_cost_end', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                        {!! $errors->first('unit_cost_start', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                        {!! $errors->first('unit_cost_end', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                                     </div>
                                 @endif
                             </div>
@@ -358,8 +358,8 @@
 
                                 @if ($errors->has('checkout_date_start') || $errors->has('checkout_date_end'))
                                     <div class="col-md-9 col-lg-offset-3">
-                                        {!! $errors->first('checkout_date_start', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
-                                        {!! $errors->first('checkout_date_end', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                        {!! $errors->first('checkout_date_start', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                        {!! $errors->first('checkout_date_end', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                                     </div>
                                 @endif
                             </div>
@@ -375,8 +375,8 @@
 
                                 @if ($errors->has('created_start') || $errors->has('created_end'))
                                     <div class="col-md-9 col-lg-offset-3">
-                                        {!! $errors->first('created_start', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
-                                        {!! $errors->first('created_end', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                        {!! $errors->first('created_start', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                        {!! $errors->first('created_end', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                                     </div>
                                 @endif
                             </div>
@@ -392,8 +392,8 @@
 
                                 @if ($errors->has('last_updated_start') || $errors->has('last_updated_end'))
                                     <div class="col-md-9 col-lg-offset-3">
-                                        {!! $errors->first('last_updated_start', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
-                                        {!! $errors->first('last_updated_end', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                        {!! $errors->first('last_updated_start', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                        {!! $errors->first('last_updated_end', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                                     </div>
                                 @endif
                             </div>
@@ -408,7 +408,7 @@
 
                                 @if ($errors->has('last_updated_before'))
                                     <div class="col-md-9 col-lg-offset-3">
-                                        {!! $errors->first('last_updated_before', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                        {!! $errors->first('last_updated_before', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                                     </div>
                                 @endif
                             </div>
@@ -515,7 +515,7 @@
                                 value="{{ $template->name }}"
                                 required
                             >
-                            {!! $errors->first('name', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                            {!! $errors->first('name', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                         </div>
                         <button class="btn btn-primary" style="width: 100%">
                             {{ trans('admin/reports/general.save_template') }}

--- a/resources/views/settings/alerts.blade.php
+++ b/resources/views/settings/alerts.blade.php
@@ -80,7 +80,7 @@
                                 </div>
                                 <div class="col-md-8 col-md-offset-3">
                                     <p class="help-block">{{ trans('admin/settings/general.alert_email_help') }}</p>
-                                    {!! $errors->first('alert_email', '<span class="alert-msg" aria-hidden="true">:message</span><br>') !!}
+                                    {!! $errors->first('alert_email', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span><br>') !!}
                                 </div>
                             </div>
 
@@ -97,7 +97,7 @@
                                 </div>
                                 <div class="col-md-8 col-md-offset-3">
                                     <p class="help-block">{{ trans('admin/settings/general.admin_cc_email_help') }}</p>
-                                    {!! $errors->first('admin_cc_email', '<span class="alert-msg" aria-hidden="true">:message</span><br>') !!}
+                                    {!! $errors->first('admin_cc_email', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span><br>') !!}
                                 </div>
                             </div>
                             <x-form.radio-row
@@ -123,7 +123,7 @@
 
                                 <div class="col-md-8">
                                     <input class="form-control" placeholder="5" maxlength="3" style="width: 100px;" name="alert_threshold" type="number" value="{{ old('alert_threshold', $setting->alert_threshold) }}" id="alert_threshold">
-                                    {!! $errors->first('alert_threshold', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                    {!! $errors->first('alert_threshold', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                 </div>
                             </div>
 
@@ -135,7 +135,7 @@
                                 <div class="input-group col-xs-10 col-sm-6 col-md-4 col-lg-3 col-xl-3">
                                     <input class="form-control" placeholder="30" maxlength="3" name="alert_interval" type="number" value="{{ old('alert_interval', $setting->alert_interval) }}" id="alert_interval">
                                     <span class="input-group-addon">{{ trans('general.days') }}</span>
-                                    {!! $errors->first('alert_interval', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                    {!! $errors->first('alert_interval', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                 </div>
                             </div>
 
@@ -149,7 +149,7 @@
                                     <span class="input-group-addon">{{ trans('general.days') }}</span>
                                 </div>
                                 <div class="col-md-8 col-md-offset-3">
-                                    {!! $errors->first('due_checkin_days', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                    {!! $errors->first('due_checkin_days', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                     <p class="help-block">{{ trans('admin/settings/general.due_checkin_days_help') }}</p>
                                 </div>
                             </div>
@@ -163,7 +163,7 @@
                                     <span class="input-group-addon">{{ trans('general.days') }}</span>
                                 </div>
                                 <div class="col-md-8 col-md-offset-3">
-                                    {!! $errors->first('audit_warning_days', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                    {!! $errors->first('audit_warning_days', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                     <p class="help-block">{{ trans('admin/settings/general.audit_warning_days_help') }}</p>
                                 </div>
                             </div>
@@ -178,7 +178,7 @@
                                     <span class="input-group-addon">{{ trans('general.months') }}</span>
                                 </div>
                                 <div class="col-md-8 col-md-offset-3">
-                                    {!! $errors->first('audit_interval', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                    {!! $errors->first('audit_interval', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                     <p class="help-block">
                                         {{ trans('admin/settings/general.audit_interval_help') }}
                                     </p>

--- a/resources/views/settings/api.blade.php
+++ b/resources/views/settings/api.blade.php
@@ -52,7 +52,7 @@
                                         <p class="help-block">
                                             {{ trans('admin/settings/general.block_api_user_agents_help') }}
                                         </p>
-                                        {!! $errors->first('block_api_user_agents', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                        {!! $errors->first('block_api_user_agents', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                     </div>
                                 </div>
 
@@ -68,7 +68,7 @@
                                             aria-describedby="blocked_api_user_agents_help"
                                             @disabled(! $blockApiUserAgents)
                                         >{{ $blockedApiUserAgents }}</textarea>
-                                        {!! $errors->first('blocked_api_user_agents', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                        {!! $errors->first('blocked_api_user_agents', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
 
                                     </div>
                                     <div class="col-md-offset-3 col-md-8">
@@ -89,7 +89,7 @@
                                         <p class="help-block">
                                             {!! trans('admin/settings/general.block_blank_api_user_agents_help') !!}
                                         </p>
-                                        {!! $errors->first('block_blank_api_user_agents', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                        {!! $errors->first('block_blank_api_user_agents', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                     </div>
                                 </div>
 

--- a/resources/views/settings/asset_tags.blade.php
+++ b/resources/views/settings/asset_tags.blade.php
@@ -56,7 +56,7 @@
 
                             <div class="col-md-8">
                                 <input class="form-control" style="width: 200px;" aria-label="next_auto_tag_base" name="next_auto_tag_base" type="text" value="{{ old('next_auto_tag_base', $setting->next_auto_tag_base) }}" id="next_auto_tag_base">
-                                {!! $errors->first('next_auto_tag_base', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                {!! $errors->first('next_auto_tag_base', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                             </div>
                         </div>
 
@@ -68,7 +68,7 @@
 
                             <div class="col-md-8">
                                 <input class="form-control" disabled maxlength="100" style="width: 200px;" aria-label="auto_increment_prefix" name="auto_increment_prefix" type="text" id="auto_increment_prefix" value="{{ old('auto_increment_prefix', $setting->auto_increment_prefix) }}">
-                                {!! $errors->first('auto_increment_prefix', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                {!! $errors->first('auto_increment_prefix', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
 
                             </div>
                         </div>
@@ -80,7 +80,7 @@
 
                             <div class="col-md-7">
                                 <input class="form-control" maxlength="100" style="width: 200px;" aria-label="zerofill_count" name="zerofill_count" type="text" value="{{ old('zerofill_count', $setting->zerofill_count) }}" id="zerofill_count">
-                                {!! $errors->first('zerofill_count', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                {!! $errors->first('zerofill_count', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                             </div>
                         </div>
 

--- a/resources/views/settings/backups.blade.php
+++ b/resources/views/settings/backups.blade.php
@@ -182,7 +182,7 @@
           
           <p class="label label-default col-md-12" style="font-size: 120%!important; margin-top: 10px; margin-bottom: 10px;" id="uploadFile-info"></p>
           <p class="help-block" style="margin-top: 10px;" id="uploadFile-status">{{ trans_choice('general.filetypes_accepted_help', 1, ['size' => Helper::file_upload_max_size_readable(), 'types' => '.zip']) }}</p>     
-          {!! $errors->first('file', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+          {!! $errors->first('file', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
             
         </div>  
             

--- a/resources/views/settings/branding.blade.php
+++ b/resources/views/settings/branding.blade.php
@@ -68,7 +68,7 @@
                                     @else
                                         <input maxlength="191" class="form-control" placeholder="Snipe-IT Asset Management" required="required" name="site_name" type="text" value="{{ old('site_name', $setting->site_name) }}" id="site_name">
                                     @endif
-                                    {!! $errors->first('site_name', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                    {!! $errors->first('site_name', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                 </div>
                             </div>
 
@@ -83,7 +83,7 @@
                                 <div class="col-md-9">
                                     <x-input.colorpicker :item="$setting" placeholder="#3c8dbc" div_id="header-color" id="header_color" :value="old('header_color', ($setting->header_color ?? '#3c8dbc'))" name="header_color" />
                                     <p class="help-block">{{ trans('admin/settings/general.header_color_help') }}</p>
-                                    {!! $errors->first('header_color', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                    {!! $errors->first('header_color', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                 </div>
                             </div>
 
@@ -92,7 +92,7 @@
                             <label for="nav_link_color" class="col-md-3 control-label">{{ trans('admin/settings/general.nav_link_color') }}</label>
                             <div class="col-md-9">
                                 <x-input.colorpicker :item="$setting" placeholder="#ffffff" div_id="nav-link-color" id="nav_link_color" :value="old('nav_link_color', ($setting->nav_link_color ?? '#ffffff'))" name="nav_link_color" />
-                                {!! $errors->first('nav_link_color', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                {!! $errors->first('nav_link_color', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                 <p class="help-block">{{ trans('admin/settings/general.nav_link_color_help') }}</p>
                             </div>
                         </div>
@@ -102,7 +102,7 @@
                             <label for="link_light_color" class="col-md-3 control-label">{{ trans('admin/settings/general.link_light_color') }}</label>
                             <div class="col-md-9">
                                 <x-input.colorpicker :item="$setting" id="link_light_color" placeholder="#296282" :value="old('link_light_color', ($setting->link_light_color ?? '#296282'))" name="link_light_color" />
-                                {!! $errors->first('link_light_color', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                {!! $errors->first('link_light_color', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                 <p class="help-block">{{ trans('admin/settings/general.link_light_color_help') }}</p>
                             </div>
                         </div>
@@ -112,7 +112,7 @@
                             <label for="link_dark_color" class="col-md-3 control-label">{{ trans('admin/settings/general.link_dark_color') }}</label>
                             <div class="col-md-9">
                                 <x-input.colorpicker :item="$setting" id="link_dark_color" placeholder="#5fa4cc" :value="old('link_dark_color', ($setting->link_dark_color ?? '#5fa4cc'))" name="link_dark_color" />
-                                {!! $errors->first('link_dark_color', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                {!! $errors->first('link_dark_color', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                 <p class="help-block">{{ trans('admin/settings/general.link_dark_color_help') }}</p>
                             </div>
                         </div>
@@ -155,7 +155,7 @@
                                         class="form-control"
                                         style="width: 150px"
                                     />
-                                    {!! $errors->first('brand', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                    {!! $errors->first('brand', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                 </div>
                             </div>
 
@@ -243,7 +243,7 @@
                                     <label class="form-control">
                                         <input type="checkbox" name="load_remote" value="1" @checked(old('load_remote', $setting->load_remote)) />
                                         {{ trans('general.yes') }}
-                                        {!! $errors->first('load_remote', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                        {!! $errors->first('load_remote', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                     </label>
 
                                     <p class="help-block">
@@ -303,7 +303,7 @@
                                             aria-label="custom_css"
                                             disabled
                                         />
-                                        {!! $errors->first('custom_css', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                        {!! $errors->first('custom_css', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                         <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
                                     @else
                                         <x-input.textarea
@@ -312,7 +312,7 @@
                                             placeholder="{{ trans('admin/settings/general.custom_css_placeholder') }}"
                                             aria-label="custom_css"
                                         />
-                                        {!! $errors->first('custom_css', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                        {!! $errors->first('custom_css', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                     @endif
                                     <p class="help-block">{!! trans('admin/settings/general.custom_css_help') !!}</p>
                                 </div>
@@ -357,7 +357,7 @@
                                         @endif
 
 
-                                        {!! $errors->first('support_footer', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                        {!! $errors->first('support_footer', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                     </div>
                                 </div>
 
@@ -391,7 +391,7 @@
                                         @endif
 
                                         <p class="help-block">{{ trans('admin/settings/general.version_footer_help') }}</p>
-                                        {!! $errors->first('version_footer', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                        {!! $errors->first('version_footer', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                     </div>
                                 </div>
 
@@ -420,7 +420,7 @@
                                             />
                                         @endif
                                         <p class="help-block">{!! trans('admin/settings/general.footer_text_help') !!}</p>
-                                        {!! $errors->first('footer_text', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                        {!! $errors->first('footer_text', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
 
                                     </div>
                                 </div>

--- a/resources/views/settings/general.blade.php
+++ b/resources/views/settings/general.blade.php
@@ -79,7 +79,7 @@
                                <div class="col-md-8">
                                    <input class="form-control" placeholder="example.com" name="email_domain" type="text" value="{{ old('email_domain', $setting->email_domain) }}" id="email_domain">
                                    <span class="help-block">{{ trans('general.email_domain_help')  }}</span>
-                                   {!! $errors->first('email_domain', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                   {!! $errors->first('email_domain', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                </div>
                            </div>
 
@@ -96,7 +96,7 @@
                                        style="width: 100%"
                                        aria-label="email_format"
                                    />
-                                   {!! $errors->first('email_format', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                   {!! $errors->first('email_format', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                </div>
                            </div>
 
@@ -112,7 +112,7 @@
                                        style="width: 100%"
                                        aria-label="username_format"
                                    />
-                                   {!! $errors->first('username_format', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                   {!! $errors->first('username_format', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
 
                                    <p class="help-block">
                                        {{ trans('admin/settings/general.username_format_help') }}
@@ -163,7 +163,7 @@
                                            :value="old('default_eula_text', $setting->default_eula_text)"
                                            placeholder="{{ trans('admin/settings/general.default_eula_text_placeholder') }}"
                                    />
-                                   {!! $errors->first('default_eula_text', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                   {!! $errors->first('default_eula_text', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                    <p class="help-block">{{ trans('admin/settings/general.default_eula_help_text') }}</p>
                                    <p class="help-block">{!! trans('admin/settings/general.eula_markdown') !!}</p>
                                </div>
@@ -184,7 +184,7 @@
                                <div class="col-md-8">
                                    <input class="form-control" style="max-width: 100px;" placeholder="50" maxlength="3" name="thumbnail_max_h" type="number" value="{{ old('thumbnail_max_h', ($setting->thumbnail_max_h ?? '25')) }}" id="thumbnail_max_h">
                                    <p class="help-block">{{ trans('admin/settings/general.thumbnail_max_h_help') }}</p>
-                                   {!! $errors->first('thumbnail_max_h', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                   {!! $errors->first('thumbnail_max_h', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                </div>
                            </div>
 
@@ -226,7 +226,7 @@
                                        {{ trans('admin/settings/general.show_assigned_assets') }}
                                    </label>
                                    <p class="help-block">{{ trans('admin/settings/general.show_assigned_assets_help') }}</p>
-                                   {!! $errors->first('show_assigned_assets', '<span class="alert-msg">:message</span>') !!}
+                                   {!! $errors->first('show_assigned_assets', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                </div>
                            </div>
 
@@ -276,7 +276,7 @@
                                    <label class="form-control">
                                        <input type="checkbox" name="show_images_in_email" value="1" @checked(old('show_images_in_email', $setting->show_images_in_email)) />
                                        {{ trans('admin/settings/general.show_images_in_email') }}
-                                       {!! $errors->first('show_images_in_email', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                       {!! $errors->first('show_images_in_email', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                    </label>
 
                                </div>
@@ -320,11 +320,11 @@
                                    @if (config('app.lock_passwords'))
 
                                        <textarea class="form-control disabled" name="login_note" placeholder="{{trans('admin/settings/general.login_note_placeholder')}}" rows="2" aria-label="login_note" readonly>{{ old('login_note', $setting->login_note) }}</textarea>
-                                       {!! $errors->first('login_note', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                       {!! $errors->first('login_note', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                        <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
                                    @else
                                        <textarea class="form-control" name="login_note" aria-label="login_note" placeholder="{{trans('admin/settings/general.login_note_placeholder')}}" rows="2">{{ old('login_note', $setting->login_note) }}</textarea>
-                                       {!! $errors->first('login_note', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                       {!! $errors->first('login_note', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                    @endif
                                    <p class="help-block">{!!  trans('admin/settings/general.login_note_help') !!}</p>
                                </div>
@@ -354,11 +354,11 @@
                                        @if (config('app.lock_passwords'))
 
                                            <textarea class="form-control disabled" name="login_note" placeholder="{{ trans('admin/settings/general.login_note_placeholder') }}" rows="2" aria-label="dashboard_message" readonly>{{ old('dashboard_message', $setting->login_note) }}</textarea>
-                                           {!! $errors->first('dashboard_message', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                           {!! $errors->first('dashboard_message', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                            <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
                                        @else
                                            <textarea class="form-control" aria-label="dashboard_message" name="dashboard_message" rows="2">{{ old('login_note', $setting->dashboard_message) }}</textarea>
-                                           {!! $errors->first('dashboard_message', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                           {!! $errors->first('dashboard_message', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                        @endif
                                        <p class="help-block">
                                            {{ trans('admin/settings/general.dashboard_message_help') }}
@@ -389,7 +389,7 @@
                                    @endif
 
                                    <span class="help-block">{{ trans('admin/settings/general.privacy_policy_link_help')  }}</span>
-                                   {!! $errors->first('privacy_policy_link', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                   {!! $errors->first('privacy_policy_link', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
 
                                    @if (config('app.lock_passwords')===true)
                                        <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
@@ -421,7 +421,7 @@
                                        <label class="form-control">
                                            <input type="checkbox" name="unique_serial" value="1" @checked(old('unique_serial', $setting->unique_serial)) />
                                            {{ trans('admin/settings/general.unique_serial') }}
-                                           {!! $errors->first('unique_serial', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                           {!! $errors->first('unique_serial', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                        </label>
 
                                        <p class="help-block">
@@ -441,7 +441,7 @@
                                    <p class="help-block">
                                        {{ trans('admin/settings/general.manager_view_enabled_help') }}
                                    </p>
-                                   {!! $errors->first('manager_view_enabled', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                   {!! $errors->first('manager_view_enabled', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                </div>
                            </div>
                            <!-- /.form-group -->

--- a/resources/views/settings/google.blade.php
+++ b/resources/views/settings/google.blade.php
@@ -77,7 +77,7 @@
                                     value="{{ old('google_client_id', $setting->google_client_id) }}"
                                     @disabled(config('app.lock_passwords')===true)
                                 >
-                                {!! $errors->first('google_client_id', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                {!! $errors->first('google_client_id', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
                                     <p class="text-warning"><i class="fas fa-lock" aria-hidden="true"></i> {{ trans('general.feature_disabled') }}</p>
                                 @endif
@@ -97,7 +97,7 @@
                                     <input class="form-control" placeholder="{{ trans('general.example') .'XXXXXXXXXXXX' }}" name="google_client_secret" type="text" id="google_client_secret" value="{{ old('google_client_secret', $setting->google_client_secret) }}">
                                 @endif
 
-                                {!! $errors->first('google_client_secret', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                {!! $errors->first('google_client_secret', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
                                     <p class="text-warning"><i class="fas fa-lock" aria-hidden="true"></i> {{ trans('general.feature_disabled') }}</p>
                                 @endif

--- a/resources/views/settings/labels.blade.php
+++ b/resources/views/settings/labels.blade.php
@@ -41,7 +41,7 @@
                                     {{ trans('admin/settings/general.label2_enable') }}
                                 </label>
 
-                                {!! $errors->first('label2_enable', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                {!! $errors->first('label2_enable', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
 
                                 <p class="help-block">
                                     {!! trans('admin/settings/general.label2_enable_help') !!}

--- a/resources/views/settings/ldap.blade.php
+++ b/resources/views/settings/ldap.blade.php
@@ -130,7 +130,7 @@
                                         {{ trans('admin/settings/general.is_ad') }}
                                         </label>
                                         @error('is_ad')
-                                            <span class="alert-msg">
+                                            <span class="alert-msg" role="alert" aria-live="assertive">
                                                  <x-icon type="x" />
                                                 {{ $message }}
                                             </span>
@@ -158,7 +158,7 @@
 
                                         <p class="help-block">{{ trans('admin/settings/general.ldap_pw_sync_help') }}</p>
                                         @error('ldap_pw_sync')
-                                            <span class="alert-msg">
+                                            <span class="alert-msg" role="alert" aria-live="assertive">
                                                  <x-icon type="x" />
                                                 {{ $message }}
                                             </span>
@@ -183,7 +183,7 @@
                                         <input class="form-control" placeholder="{{ trans('general.example') .'example.com' }}" name="ad_domain" type="text" id="ad_domain" value="{{ old('ad_domain', $setting->ad_domain) }}">
                                         <p class="help-block">{{ trans('admin/settings/general.ad_domain_help') }}</p>
                                         @error('ad_domain')
-                                            <span class="alert-msg">
+                                            <span class="alert-msg" role="alert" aria-live="assertive">
                                                  <x-icon type="x" />
                                                 {{ $message }}
                                             </span>
@@ -212,7 +212,7 @@
                                             :placeholder="sprintf('%s-----BEGIN RSA PRIVATE KEY-----%s1234567890%s-----END RSA PRIVATE KEY-----', trans('general.example'), PHP_EOL, PHP_EOL)"
                                         />
                                         @error('ldap_client_tls_key')
-                                            <span class="alert-msg">
+                                            <span class="alert-msg" role="alert" aria-live="assertive">
                                                  <x-icon type="x" />
                                                 {{ $message }}
                                             </span>
@@ -240,7 +240,7 @@
                                         />
                                         <p class="help-block">{{ trans('admin/settings/general.ldap_client_tls_cert_help') }}</p>
                                         @error('ldap_client_tls_cert')
-                                            <span class="alert-msg">
+                                            <span class="alert-msg" role="alert" aria-live="assertive">
                                                <x-icon type="x" />
                                                 {{ $message }}
                                             </span>
@@ -263,7 +263,7 @@
                                     <div class="col-md-8">
                                         <input class="form-control" placeholder="{{ trans('general.example') .'ldap://ldap.example.com' }}" name="ldap_server" type="text" id="ldap_server" value="{{ old('ldap_server', $setting->ldap_server) }}">
                                         @error('ldap_server')
-                                            <span class="alert-msg">
+                                            <span class="alert-msg" role="alert" aria-live="assertive">
                                                 <x-icon type="x" />
                                                 {{ $message }}
                                             </span>
@@ -291,7 +291,7 @@
                                             {{ trans('admin/settings/general.ldap_tls_help') }}
                                         </label>
                                         @error('ldap_tls')
-                                            <span class="alert-msg">
+                                            <span class="alert-msg" role="alert" aria-live="assertive">
                                                  <x-icon type="x" />
                                                 {{ $message }}
                                             </span>
@@ -317,7 +317,7 @@
                                             {{ trans('admin/settings/general.ldap_server_cert_ignore') }}
                                         </label>
                                         @error('ldap_server_cert_ignore')
-                                            <span class="alert-msg">
+                                            <span class="alert-msg" role="alert" aria-live="assertive">
                                                  <x-icon type="x" />
                                                 {{ $message }}
                                             </span>
@@ -343,7 +343,7 @@
                                     <div class="col-md-8">
                                         <input class="form-control" autocomplete="off" placeholder="{{ trans('general.example') .'binduser@example.com' }}" name="ldap_uname" type="text" id="ldap_uname" value="{{ old('ldap_uname', $setting->ldap_uname) }}">
                                         @error('ldap_uname')
-                                            <span class="alert-msg">
+                                            <span class="alert-msg" role="alert" aria-live="assertive">
                                                  <x-icon type="x" />
                                                 {{ $message }}
                                             </span>
@@ -366,7 +366,7 @@
                                     <div class="col-md-8">
                                         <input class="form-control" type="password" name="ldap_pword" id="ldap_pword" value="" autocomplete="off" onfocus="this.removeAttribute('readonly');" readonly>
                                         @error('ldap_pword')
-                                            <span class="alert-msg">
+                                            <span class="alert-msg" role="alert" aria-live="assertive">
                                                  <x-icon type="x" />
                                                 {{ $message }}
                                             </span>
@@ -389,7 +389,7 @@
                                     <div class="col-md-8">
                                         <input class="form-control" placeholder="{{ trans('general.example') .'cn=users/authorized,dc=example,dc=com' }}" name="ldap_basedn" type="text" id="ldap_basedn" value="{{ old('ldap_basedn', $setting->ldap_basedn) }}">
                                         @error('ldap_basedn')
-                                            <span class="alert-msg">
+                                            <span class="alert-msg" role="alert" aria-live="assertive">
                                                 <x-icon type="x" />
                                                 {{ $message }}
                                             </span>
@@ -412,7 +412,7 @@
                                     <div class="col-md-8">
                                         <input type="text" name="ldap_filter" id="ldap_filter" value="{{  old('ldap_filter', $setting->ldap_filter) }}" class="form-control" placeholder="{{  trans('general.example') .'&(cn=*)' }}">
                                         @error('ldap_filter')
-                                            <span class="alert-msg">
+                                            <span class="alert-msg" role="alert" aria-live="assertive">
                                                 <x-icon type="x" />
                                                 {{ $message }}
                                             </span>
@@ -436,7 +436,7 @@
 
                                     <input type="text" name="ldap_auth_filter_query" id="ldap_auth_filter_query" value="{{  old('ldap_auth_filter_query', $setting->ldap_auth_filter_query) }}" class="form-control" placeholder="{{ trans('general.example') .'uid='  }}">
                                     @error('ldap_auth_filter_query')
-                                    <span class="alert-msg">
+                                    <span class="alert-msg" role="alert" aria-live="assertive">
                                                 <x-icon type="x" />
                                                 {!! $message !!}
                                             </span>
@@ -510,7 +510,7 @@
                                 <div class="col-md-8">
                                     <input type="text" name="ldap_username_field" id="ldap_username_field" value="{{  old('ldap_username_field', $setting->ldap_username_field) }}" class="form-control" placeholder="{{  trans('general.example') .'samaccountname' }}">
                                     @error('ldap_username_field')
-                                    <span class="alert-msg">
+                                    <span class="alert-msg" role="alert" aria-live="assertive">
                                                 <x-icon type="x" />
                                                 {!! $message !!}
                                             </span>
@@ -527,7 +527,7 @@
                                 <div class="col-md-8">
                                     <input type="text" name="ldap_lname_field" id="ldap_lname_field" value="{{  old('ldap_lname_field', $setting->ldap_lname_field) }}" class="form-control" placeholder="{{  trans('general.example') .'sn' }}">
                                     @error('ldap_lname_field')
-                                    <span class="alert-msg">
+                                    <span class="alert-msg" role="alert" aria-live="assertive">
                                                 <x-icon type="x" />
                                                 {{ $message }}
                                             </span>
@@ -544,7 +544,7 @@
                                 <div class="col-md-8">
                                     <input type="text" name="ldap_fname_field" id="ldap_fname_field" value="{{  old('ldap_fname_field', $setting->ldap_fname_field) }}" class="form-control" placeholder="{{ trans('general.example') .'givenname'  }}">
                                     @error('ldap_fname_field')
-                                    <span class="alert-msg">
+                                    <span class="alert-msg" role="alert" aria-live="assertive">
                                                 <x-icon type="x" />
                                                 {{ $message }}
                                             </span>
@@ -562,7 +562,7 @@
                                     <input type="text" name="ldap_display_name" id="ldap_display_name" value="{{  old('ldap_display_name', $setting->ldap_display_name) }}" class="form-control" placeholder="{{  trans('general.example') .'displayname' }}">
                                     <p class="help-block">{{ trans('admin/settings/general.ldap_display_name_help') }}</p>
                                     @error('ldap_display_name')
-                                    <span class="alert-msg">
+                                    <span class="alert-msg" role="alert" aria-live="assertive">
                                                     <x-icon type="x" />
                                                     {{ $message }}
                                                 </span>
@@ -579,7 +579,7 @@
                                 <div class="col-md-8">
                                     <input class="form-control" placeholder="{{ trans('general.example') .'employeenumber/employeeid' }}" name="ldap_emp_num" type="text" id="ldap_emp_num" value="{{ old('ldap_emp_num', $setting->ldap_emp_num) }}">
                                     @error('ldap_emp_num')
-                                    <span class="alert-msg">
+                                    <span class="alert-msg" role="alert" aria-live="assertive">
                                                 <x-icon type="x" />
                                                 {{ $message }}
                                             </span>
@@ -602,7 +602,7 @@
                                     <input class="form-control" placeholder="{{ trans('general.example') .'department' }}" name="ldap_dept" type="text" id="ldap_dept" value="{{ old('ldap_dept', $setting->ldap_dept) }}">
 
                                     @error('ldap_dept')
-                                    <span class="alert-msg">
+                                    <span class="alert-msg" role="alert" aria-live="assertive">
                                                 <x-icon type="x" />
                                                 {{ $message }}
                                             </span>
@@ -624,7 +624,7 @@
                                 <div class="col-md-8">
                                     <input class="form-control" placeholder=" {{ trans('general.example') .'manager' }}" name="ldap_manager" type="text" value="{{ old('ldap_manager', $setting->ldap_manager) }}">
                                     @error('ldap_manager')
-                                    <span class="alert-msg">
+                                    <span class="alert-msg" role="alert" aria-live="assertive">
                                                 <x-icon type="x" />
                                                 {{ $message }}
                                             </span>
@@ -647,7 +647,7 @@
                                 <div class="col-md-8">
                                     <input class="form-control" placeholder="{{ trans('general.example') .'mail' }}" name="ldap_email" type="text" id="ldap_email" value="{{ old('ldap_email', $setting->ldap_email) }}">
                                     @error('ldap_email')
-                                    <span class="alert-msg">
+                                    <span class="alert-msg" role="alert" aria-live="assertive">
                                                 <x-icon type="x" />
                                                 {{ $message }}
                                             </span>
@@ -670,7 +670,7 @@
                                 <div class="col-md-8">
                                     <input class="form-control" placeholder="{{ trans('general.example') .'telephonenumber' }}" name="ldap_phone" type="text" id="ldap_phone" value="{{ old('ldap_phone', $setting->ldap_phone_field) }}">
                                     @error('ldap_phone')
-                                    <span class="alert-msg">
+                                    <span class="alert-msg" role="alert" aria-live="assertive">
                                                 <x-icon type="x" />
                                                 {{ $message }}
                                             </span>
@@ -693,7 +693,7 @@
                                 <div class="col-md-8">
                                     <input class="form-control" placeholder="{{ trans('general.example') .'mobile' }}" name="ldap_mobile" type="text" id="ldap_mobile" value="{{ old('ldap_mobile', $setting->ldap_mobile) }}">
                                     @error('ldap_mobile')
-                                    <span class="alert-msg">
+                                    <span class="alert-msg" role="alert" aria-live="assertive">
                                                 <x-icon type="x" />
                                                 {{ $message }}
                                             </span>
@@ -709,7 +709,7 @@
                                 <div class="col-md-8">
                                     <input class="form-control" placeholder="{{ trans('general.example') .'title' }}" name="ldap_jobtitle" type="text" id="ldap_jobtitle" value="{{ old('ldap_jobtitle', $setting->ldap_jobtitle) }}">
                                     @error('ldap_jobtitle')
-                                    <span class="alert-msg">
+                                    <span class="alert-msg" role="alert" aria-live="assertive">
                                                 <x-icon type="x" />
                                                 {{ $message }}
                                             </span>
@@ -732,7 +732,7 @@
                                 <div class="col-md-8">
                                     <input class="form-control" name="ldap_address" placeholder="{{ trans('general.example') .'streetaddress' }}"  type="text" id="ldap_address" value="{{ old('ldap_address', $setting->ldap_address) }}">
                                     @error('ldap_address')
-                                    <span class="alert-msg">
+                                    <span class="alert-msg" role="alert" aria-live="assertive">
                                                 <x-icon type="x" />
                                                 {{ $message }}
                                             </span>
@@ -748,7 +748,7 @@
                                 <div class="col-md-8">
                                     <input class="form-control" placeholder="{{ trans('general.example') .'l' }}" name="ldap_city" type="text" id="ldap_city" value="{{ old('ldap_city', $setting->ldap_city) }}">
                                     @error('ldap_city')
-                                    <span class="alert-msg">
+                                    <span class="alert-msg" role="alert" aria-live="assertive">
                                                 <x-icon type="x" />
                                                 {{ $message }}
                                             </span>
@@ -764,7 +764,7 @@
                                 <div class="col-md-8">
                                     <input class="form-control" placeholder="{{ trans('general.example') .'st' }}"  name="ldap_state" type="text" id="ldap_state" value="{{ old('ldap_state', $setting->ldap_state) }}">
                                     @error('ldap_state')
-                                    <span class="alert-msg">
+                                    <span class="alert-msg" role="alert" aria-live="assertive">
                                                 <x-icon type="x" />
                                                 {{ $message }}
                                             </span>
@@ -780,7 +780,7 @@
                                 <div class="col-md-8">
                                     <input class="form-control" name="ldap_zip" type="text" id="ldap_zip" placeholder="{{ trans('general.example') .'postalcode' }}"  value="{{ old('ldap_zip', $setting->ldap_zip) }}">
                                     @error('ldap_zip')
-                                    <span class="alert-msg">
+                                    <span class="alert-msg" role="alert" aria-live="assertive">
                                                 <x-icon type="x" />
                                                 {{ $message }}
                                             </span>
@@ -797,7 +797,7 @@
                                 <div class="col-md-8">
                                     <input class="form-control" placeholder="{{ trans('general.example') .'co' }}" name="ldap_country" type="text" id="ldap_country" value="{{ old('ldap_country', $setting->ldap_country) }}">
                                     @error('ldap_country')
-                                    <span class="alert-msg">
+                                    <span class="alert-msg" role="alert" aria-live="assertive">
                                                 <x-icon type="x" />
                                                 {{ $message }}
                                             </span>
@@ -821,7 +821,7 @@
                                     <input class="form-control" placeholder="{{ trans('general.example') .'physicaldeliveryofficename' }}" name="ldap_location" type="text" id="ldap_location" value="{{ old('ldap_location', $setting->ldap_location) }}">
                                     <p class="help-block">{!! trans('admin/settings/general.ldap_location_help') !!}</p>
                                     @error('ldap_location')
-                                    <span class="alert-msg">
+                                    <span class="alert-msg" role="alert" aria-live="assertive">
                                                  <x-icon type="x" />
                                                 {{ $message }}
                                             </span>
@@ -846,7 +846,7 @@
                                     <p class="help-block">{!! trans('admin/settings/general.ldap_activated_flag_help') !!}</p>
 
                                     @error('ldap_active_flag')
-                                    <span class="alert-msg">
+                                    <span class="alert-msg" role="alert" aria-live="assertive">
                                                 <x-icon type="x" />
                                                 {{ $message }}
                                             </span>
@@ -874,7 +874,7 @@
                                         {{ trans('general.yes') }}
                                     </label>
                                     @error('ldap_invert_active_flag')
-                                    <span class="alert-msg">
+                                    <span class="alert-msg" role="alert" aria-live="assertive">
                                                  <x-icon type="x" />
                                                 {{ $message }}
                                             </span>
@@ -972,7 +972,7 @@
                                         <input class="form-control" placeholder="{{ trans('general.example') .'https://my.ldapserver-forgotpass.com' }}" name="custom_forgot_pass_url" type="url" id="custom_forgot_pass_url" value="{{ old('custom_forgot_pass_url', $setting->custom_forgot_pass_url) }}">
                                         <p class="help-block">{{ trans('admin/settings/general.custom_forgot_pass_url_help') }}</p>
                                         @error('custom_forgot_pass_url')
-                                            <span class="alert-msg">
+                                            <span class="alert-msg" role="alert" aria-live="assertive">
                                                 <x-icon type="x" />
                                                 {{ $message }}
                                             </span>

--- a/resources/views/settings/localization.blade.php
+++ b/resources/views/settings/localization.blade.php
@@ -48,7 +48,7 @@
                             <div class="col-md-5 col-xs-12">
                                 <x-input.locale-select name="locale" :selected="old('locale', $setting->locale)" />
 
-                                {!! $errors->first('locale', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                {!! $errors->first('locale', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                             </div>
                         </div>
 
@@ -64,7 +64,7 @@
                                     :selected="old('name_display_format', $setting->name_display_format)"
                                     style="width: 100%"
                                 />
-                                {!! $errors->first('name_display_format', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                {!! $errors->first('name_display_format', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                             </div>
                         </div>
 
@@ -82,7 +82,7 @@
                                 <x-input.time-display-format name="time_display_format" :selected="old('time_display_format', $setting->time_display_format)" style="min-width:150px" />
                             </div>
                             
-                            {!! $errors->first('time_display_format', '<div class="col-md-9 col-md-offset-3"><span class="alert-msg" aria-hidden="true">:message</span> </div>') !!}
+                            {!! $errors->first('time_display_format', '<div class="col-md-9 col-md-offset-3"><span class="alert-msg" role="alert" aria-live="assertive">:message</span> </div>') !!}
 
                         </div>
 
@@ -119,7 +119,7 @@
 
                             </div>
 
-                            {!! $errors->first('week_start', '<div class="col-md-9 col-md-offset-3"><span class="alert-msg" aria-hidden="true">:message</span> </div>') !!}
+                            {!! $errors->first('week_start', '<div class="col-md-9 col-md-offset-3"><span class="alert-msg" role="alert" aria-live="assertive">:message</span> </div>') !!}
 
                         </div>
 
@@ -147,7 +147,7 @@
                                     style="min-width:120px"
                                 />
 
-                                {!! $errors->first('default_currency', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                {!! $errors->first('default_currency', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                             </div>
                         </div>
 

--- a/resources/views/settings/partials/labels-legacy-engine.blade.php
+++ b/resources/views/settings/partials/labels-legacy-engine.blade.php
@@ -32,7 +32,7 @@
             :selected="old('label2_1d_type', $setting->label2_1d_type)"
             class="col-md-4"
         />
-        {!! $errors->first('label2_1d_type', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first('label2_1d_type', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
         <p class="help-block">
             {{ trans('admin/settings/general.label2_1d_type_help') }}.
             {!!
@@ -73,7 +73,7 @@
             :selected="old('label2_2d_type', $setting->label2_2d_type)"
             class="col-md-4"
         />
-        {!! $errors->first('label2_2d_type', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first('label2_2d_type', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
         <p class="help-block">
             {{ trans('admin/settings/general.label2_2d_type_help', ['current' => $setting->barcode_type]) }}.
             {!! trans('admin/settings/general.help_default_will_use') !!}
@@ -112,7 +112,7 @@
             <p class="help-block">{{ trans('admin/settings/general.qr_help') }}</p>
         @endif
 
-        {!! $errors->first('qr_text', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first('qr_text', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>
 
@@ -127,7 +127,7 @@
         <span id="purgebarcodesicon"></span>
         <span id="purgebarcodesresult"></span>
         <span id="purgebarcodesstatus"></span>
-        {!! $errors->first('purgebarcodes', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first('purgebarcodes', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
         <p class="help-block">{{ trans('admin/settings/general.barcodes_help') }}</p>
     </div>
 </div>
@@ -138,7 +138,7 @@
     </div>
     <div class="col-md-9">
         <input class="form-control" style="width: 100px;" name="labels_per_page" type="text" value="{{ old('labels_per_page', $setting->labels_per_page) }}" id="labels_per_page">
-        {!! $errors->first('labels_per_page', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+        {!! $errors->first('labels_per_page', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
     </div>
 </div>
 
@@ -153,7 +153,7 @@
         </div>
     </div>
     <div class="col-md-9 col-md-offset-3">
-        {!! $errors->first('labels_fontsize', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+        {!! $errors->first('labels_fontsize', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
     </div>
 </div>
 
@@ -166,14 +166,14 @@
             <input class="form-control" name="labels_width" type="text" value="{{ old('labels_width', $setting->labels_width) }}" id="labels_width">
             <div class="input-group-addon">{{ trans('admin/settings/general.width_w') }}</div>
         </div>
-        {!! $errors->first('labels_width', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+        {!! $errors->first('labels_width', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
     </div>
     <div class="col-md-3 text-right">
         <div class="input-group">
             <input class="form-control" name="labels_height" type="text" value="{{ old('labels_height', $setting->labels_height) }}" id="labels_height">
             <div class="input-group-addon">{{ trans('admin/settings/general.height_h') }}</div>
         </div>
-        {!! $errors->first('labels_height', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+        {!! $errors->first('labels_height', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
     </div>
 </div>
 
@@ -194,8 +194,8 @@
         </div>
     </div>
     <div class="col-md-9 col-md-offset-3">
-        {!! $errors->first('labels_display_sgutter', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
-        {!! $errors->first('labels_display_bgutter', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+        {!! $errors->first('labels_display_sgutter', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
+        {!! $errors->first('labels_display_bgutter', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
     </div>
 </div>
 
@@ -242,8 +242,8 @@
         </div>
     </div>
     <div class="col-md-9 col-md-offset-3">
-        {!! $errors->first('labels_pagewidth', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
-        {!! $errors->first('labels_pageheight', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+        {!! $errors->first('labels_pagewidth', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
+        {!! $errors->first('labels_pageheight', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
     </div>
 </div>
 

--- a/resources/views/settings/partials/labels-new-engine.blade.php
+++ b/resources/views/settings/partials/labels-new-engine.blade.php
@@ -47,7 +47,7 @@
         </div>
         <div class="col-md-7">
             <input class="form-control" name="label2_title" type="text" id="label2_title" value="{{ old('label2_title', $setting->label2_title) }}">
-            {!! $errors->first('label2_title', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+            {!! $errors->first('label2_title', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
             <p class="help-block">{!! trans('admin/settings/general.label2_title_help') !!}</p>
             <p class="help-block">
                 {!! trans('admin/settings/general.label2_title_help_phold') !!}.<br />
@@ -96,7 +96,7 @@
                 :selected="old('label2_1d_type', $setting->label2_1d_type)"
                 class="col-md-4"
             />
-            {!! $errors->first('label2_1d_type', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+            {!! $errors->first('label2_1d_type', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
             <p class="help-block">
                 {{ trans('admin/settings/general.label2_1d_type_help') }}.
                 {!!
@@ -129,7 +129,7 @@
                 :selected="old('label2_2d_type', $setting->label2_2d_type)"
                 class="col-md-4"
             />
-            {!! $errors->first('label2_2d_type', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+            {!! $errors->first('label2_2d_type', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
             <p class="help-block">
                 {{ trans('admin/settings/general.label2_2d_type_help', ['current' => $setting->barcode_type]) }}.
                 {!! trans('admin/settings/general.help_default_will_use') !!}
@@ -143,7 +143,7 @@
         </div>
         <div class="col-md-7">
             <input class="form-control" name="label2_2d_prefix" type="text" id="label2_2d_prefix" value="{{ old('label2_2d_prefix', $setting->label2_2d_prefix) }}">
-            {!! $errors->first('label2_2d_prefix', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+            {!! $errors->first('label2_2d_prefix', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
             <p class="help-block">{!! trans('admin/settings/general.label2_2d_prefix_help') !!}</p>
         </div>
     </div>
@@ -172,7 +172,7 @@
                 :selected="old('label2_2d_target', $setting->label2_2d_target)"
                 class="col-md-4"
             />
-            {!! $errors->first('label2_2d_target', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+            {!! $errors->first('label2_2d_target', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
             <p class="help-block">{{ trans('admin/settings/general.label2_2d_target_help') }}</p>
         </div>
     </div>
@@ -194,7 +194,7 @@
         </div>
         <div class="col-md-9 col-md-offset-3">
             <p class="help-block">{!! trans('admin/settings/general.empty_row_count_help') !!}</p>
-            {!! $errors->first('label2_empty_row_count', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+            {!! $errors->first('label2_empty_row_count', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
         </div>
     </div>
 </fieldset>
@@ -211,7 +211,7 @@
                 'customFields' => $customFields,
                 'template' => $setting->label2_template,
             ])
-            {!! $errors->first('label2_fields', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+            {!! $errors->first('label2_fields', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
         </div>
     </div>
 </fieldset>

--- a/resources/views/settings/saml.blade.php
+++ b/resources/views/settings/saml.blade.php
@@ -49,7 +49,7 @@
                                     {{ trans('admin/settings/general.saml_enabled') }}
                                 </label>
 
-                                {!! $errors->first('saml_integration', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                {!! $errors->first('saml_integration', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                 @if (config('app.lock_passwords') === true)
                                     <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
                                 @endif
@@ -141,7 +141,7 @@
 
                                 </div>
                                 @endif
-                                {!! $errors->first('saml_enabled', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                {!! $errors->first('saml_enabled', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
 
                         </div>
 
@@ -160,7 +160,7 @@
                                     placeholder="https://example.com/idp/metadata"
                                     wrap="off"
                                 />
-                                {!! $errors->first('saml_idp_metadata', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}<br>
+                                {!! $errors->first('saml_idp_metadata', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}<br>
                                 <button type="button" class="btn btn-theme" id="saml_idp_metadata_upload_btn" {{ $setting->demoMode }}>{{ trans('button.select_file') }}</button>
                                 <input type="file" class="js-uploadFile" id="saml_idp_metadata_upload" @disabled(config('app.lock_passwords'))
                                     data-maxsize="{{ Helper::file_upload_max_size() }}"
@@ -183,7 +183,7 @@
                             <div class="col-md-8">
                                 <input class="form-control" name="saml_attr_mapping_username" type="text" id="saml_attr_mapping_username" value="{{ old('saml_attr_mapping_username', $setting->saml_attr_mapping_username) }}" @disabled(config('app.lock_passwords'))>
                                 <p class="help-block">{{ trans('admin/settings/general.saml_attr_mapping_username_help') }}</p>
-                                {!! $errors->first('saml_attr_mapping_username', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                {!! $errors->first('saml_attr_mapping_username', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
 
                                 @if (config('app.lock_passwords') === true)
                                     <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
@@ -203,7 +203,7 @@
                                     {{ trans('admin/settings/general.saml_forcelogin') }}
                                 </label>
                                 <p class="help-block">{{ trans('admin/settings/general.saml_forcelogin_help') }}</p>
-                                {!! $errors->first('saml_forcelogin', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                {!! $errors->first('saml_forcelogin', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
 
                                 @if (config('app.lock_passwords') === true)
                                     <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
@@ -223,7 +223,7 @@
                                     {{ trans('admin/settings/general.saml_slo') }}
                                 </label>
                                 <p class="help-block">{{ trans('admin/settings/general.saml_slo_help') }}</p>
-                                {!! $errors->first('saml_slo', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                {!! $errors->first('saml_slo', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
 
                                 @if (config('app.lock_passwords') === true)
                                     <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
@@ -244,7 +244,7 @@
                                 wrap="off"
                             />
                             <p class="help-block">{{ trans('admin/settings/general.saml_custom_settings_help') }}</p>
-                            {!! $errors->first('saml_custom_settings', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                            {!! $errors->first('saml_custom_settings', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
 
                             @if (config('app.lock_passwords') === true)
                                 <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>

--- a/resources/views/settings/security.blade.php
+++ b/resources/views/settings/security.blade.php
@@ -63,7 +63,7 @@
                                         <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
                                     @endif
 
-                                    {!! $errors->first('two_factor_enabled', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                    {!! $errors->first('two_factor_enabled', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                 </div>
                             </div>
 
@@ -78,7 +78,7 @@
 
                                 <div class="col-md-9">
                                     <input class="form-control" style="width: 60px;" name="pwd_secure_min" type="number" value="{{ old('pwd_secure_min', $setting->pwd_secure_min) }}" id="pwd_secure_min" maxlength="2" min="8">
-                                    {!! $errors->first('pwd_secure_min', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                    {!! $errors->first('pwd_secure_min', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                     <p class="help-block">
                                         {{ trans('admin/settings/general.pwd_secure_min_help') }}
                                     </p>
@@ -119,7 +119,7 @@
                                     </label>
 
                                     @if ($errors->has('pwd_secure_complexity.*'))
-                                        <span class="alert-msg">{{ trans('validation.generic.invalid_value_in_field') }}</span>
+                                        <span class="alert-msg" role="alert" aria-live="assertive">{{ trans('validation.generic.invalid_value_in_field') }}</span>
                                     @endif
                                     <p class="help-block">
                                         {{ trans('admin/settings/general.pwd_secure_complexity_help') }}
@@ -147,7 +147,7 @@
                                             <label for="login_remote_user_enabled">{{ trans('admin/settings/general.login_remote_user_enabled_text') }}</label>
                                         </label>
 
-                                        {!! $errors->first('login_remote_user_enabled', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                        {!! $errors->first('login_remote_user_enabled', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                         <p class="help-block">
                                             {{ trans('admin/settings/general.login_remote_user_enabled_help') }}
                                         </p>
@@ -161,7 +161,7 @@
 
                                 <div class="col-md-8">
                                         <input class="form-control" name="login_remote_user_header_name" type="text" value="{{ old('login_remote_user_header_name', $setting->login_remote_user_header_name) }}" id="login_remote_user_header_name">
-                                        {!! $errors->first('login_remote_user_header_name', '<span class="alert-msg">:message</span>') !!}
+                                        {!! $errors->first('login_remote_user_header_name', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                         <p class="help-block">
                                             <x-icon type="warning" class="text-danger"/>
                                             {!! trans('admin/settings/general.login_remote_user_header_name_help') !!}
@@ -175,7 +175,7 @@
 
                                 <div class="col-md-8">
                                         <input class="form-control" aria-label="login_remote_user_custom_logout_url" name="login_remote_user_custom_logout_url" type="url" value="{{ old('login_remote_user_custom_logout_url', $setting->login_remote_user_custom_logout_url) }}" id="login_remote_user_custom_logout_url">
-                                        {!! $errors->first('login_remote_user_custom_logout_url', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                        {!! $errors->first('login_remote_user_custom_logout_url', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                         <p class="help-block">
                                             {{ trans('admin/settings/general.login_remote_user_custom_logout_url_help') }}
                                         </p>
@@ -191,7 +191,7 @@
                                             {{ trans('admin/settings/general.login_common_disabled_text') }}
                                         </label>
 
-                                        {!! $errors->first('login_common_disabled', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                        {!! $errors->first('login_common_disabled', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                         <p class="help-block">
                                             {{ trans('admin/settings/general.login_common_disabled_help') }}
                                         </p>

--- a/resources/views/setup/user.blade.php
+++ b/resources/views/setup/user.blade.php
@@ -27,7 +27,7 @@
         </label>
         <input class="form-control" placeholder="Snipe-IT Asset Management" required="" name="site_name" type="text" value="{{ old('site_name') }}">
 
-        {!! $errors->first('site_name', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+        {!! $errors->first('site_name', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
       </div>
     </div>
 
@@ -37,14 +37,14 @@
           <div class="form-group col-lg-6">
               <label for="first_name">{{ trans('general.first_name') }}</label>
               <input class="form-control" placeholder="Jane" required="" name="first_name" type="text" id="first_name" value="{{ old('first_name') }}">
-              {!! $errors->first('first_name', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+              {!! $errors->first('first_name', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
           </div>
 
           <!-- last name -->
           <div class="form-group col-lg-6 required {{ $errors->has('last_name') ? 'error' : '' }}">
               <label for="last_name">{{ trans('general.last_name') }}</label>
               <input class="form-control" placeholder="Smith" required="" name="last_name" type="text" id="last_name" value="{{ old('last_name') }}">
-              {!! $errors->first('last_name', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+              {!! $errors->first('last_name', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
           </div>
       </div>
 
@@ -53,14 +53,14 @@
           <div class="form-group col-lg-6{{ $errors->has('email') ? ' error' : '' }}">
               <label for="email">{{ trans('admin/users/table.email') }}</label>
               <input class="form-control" type="email" name="email" id="email" value="{{ old('email', config('mail.from.address')) }}" placeholder="you@example.com" required>
-              {!! $errors->first('email', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+              {!! $errors->first('email', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
           </div>
 
           <!-- username -->
           <div class="form-group col-lg-6 {{ $errors->has('username') ? 'error' : '' }}">
               <label for="username">{{ trans('admin/users/table.username') }}</label>
               <input class="form-control" placeholder="jsmith" required="" name="username" type="text" id="username" value="{{ old('username') }}" required>
-              {!! $errors->first('username', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+              {!! $errors->first('username', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
           </div>
 
       </div>
@@ -70,14 +70,14 @@
           <div class="form-group col-lg-6{{  (Helper::checkIfRequired(\App\Models\User::class, 'password')) ? ' required' : '' }} {{ $errors->has('password') ? 'error' : '' }}">
               <label for="password">{{ trans('admin/users/table.password') }}</label>
               <input class="form-control" type="password" name="password" id="password" value="" required>
-              {!! $errors->first('password', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+              {!! $errors->first('password', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
           </div>
 
           <!-- password confirm -->
           <div class="form-group col-lg-6{{  (Helper::checkIfRequired(\App\Models\User::class, 'password')) ? ' required' : '' }} {{ $errors->has('password_confirm') ? 'error' : '' }}">
               <label for="password_confirmation">{{ trans('admin/users/table.password_confirm') }}</label>
               <input class="form-control" type="password" name="password_confirmation" id="password_confirmation" value="" required>
-              {!! $errors->first('password_confirmation', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+              {!! $errors->first('password_confirmation', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
           </div>
 
           <!-- Email credentials -->
@@ -96,14 +96,14 @@
               <label for="auto_increment_prefix">{{ trans('admin/settings/general.auto_increment_prefix') }}</label>
               <input class="form-control" name="auto_increment_prefix" type="text" id="auto_increment_prefix" value="{{ old('auto_increment_prefix') }}">
 
-              {!! $errors->first('auto_increment_prefix', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+              {!! $errors->first('auto_increment_prefix', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
           </div>
 
           <div class="form-group col-lg-6{{ $errors->has('zerofill_count') ? ' error' : '' }}">
               <label for="zerofill_count">{{ trans('admin/settings/general.zerofill_count') }}</label>
               <input class="form-control" name="zerofill_count" type="text" value="{{ old('zerofill_count', 5) }}" id="zerofill_count">
 
-              {!! $errors->first('zerofill_count', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+              {!! $errors->first('zerofill_count', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
           </div>
       </div>
 
@@ -135,7 +135,7 @@
         {{ trans('admin/settings/general.default_language') }}
       </label>
       <x-input.locale-select name="locale" :selected="old('locale', 'en-US')" />
-      {!! $errors->first('locale', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+      {!! $errors->first('locale', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
     </div>
 
     <!-- Currency -->
@@ -143,7 +143,7 @@
       <label for="default_currency">{{ trans('admin/settings/general.default_currency') }}</label>
       <input class="form-control" placeholder="USD" maxlength="3" style="width: 60px;" name="default_currency" type="text" id="default_currency" value="{{ old('default_currency') }}">
 
-      {!! $errors->first('default_currency', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+      {!! $errors->first('default_currency', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
     </div>
 
   </div>

--- a/resources/views/statuslabels/edit.blade.php
+++ b/resources/views/statuslabels/edit.blade.php
@@ -34,7 +34,7 @@
             style="width: 100%; min-width:400px"
             aria-label="statuslabel_types"
         />
-        {!! $errors->first('statuslabel_types', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first('statuslabel_types', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>
 
@@ -43,7 +43,7 @@
     <label for="color" class="col-md-3 control-label">{{ trans('admin/statuslabels/table.color') }}</label>
     <div class="col-md-9">
         <x-input.colorpicker :item="$item" id="color" :value="old('color', ($item->color ?? '#f4f4f4'))" name="color" id="color" />
-        {!! $errors->first('color', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+        {!! $errors->first('color', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
     </div>
 </div>
 

--- a/resources/views/suppliers/edit.blade.php
+++ b/resources/views/suppliers/edit.blade.php
@@ -17,7 +17,7 @@
     <label for="contact" class="col-md-3 control-label">{{ trans('admin/suppliers/table.contact') }}</label>
     <div class="col-md-7">
         <input class="form-control" name="contact" type="text" id="contact" value="{{ old('contact', $item->contact) }}">
-        {!! $errors->first('contact', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first('contact', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>
 
@@ -29,7 +29,7 @@
     <label for="url" class="col-md-3 control-label">{{ trans('general.url') }}</label>
     <div class="col-md-7">
         <input class="form-control" name="url" type="url" id="url" value="{{ old('url', $item->url) }}">
-        {!! $errors->first('url', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        {!! $errors->first('url', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>
 
@@ -47,7 +47,7 @@
         </label>
         <div class="col-md-9">
             <x-input.colorpicker :item="$item" id="color" :value="old('color', ($item->color ?? '#f4f4f4'))" name="tag_color" id="tag_color" />
-            {!! $errors->first('tag_color', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+            {!! $errors->first('tag_color', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
         </div>
     </div>
 </fieldset>

--- a/resources/views/users/bulk-edit.blade.php
+++ b/resources/views/users/bulk-edit.blade.php
@@ -24,8 +24,8 @@
 
             <p>{{ trans('admin/users/general.bulk_update_help') }}</p>
 
-            <div class="callout callout-warning">
-                <i class="fas fa-exclamation-triangle"></i> {{ trans('admin/users/general.bulk_update_warn', ['user_count' => count($users)]) }}
+            <div class="callout callout-warning" role="alert" aria-live="assertive" aria-atomic="true">
+                <i class="fas fa-exclamation-triangle" aria-hidden="true"></i> {{ trans('admin/users/general.bulk_update_warn', ['user_count' => count($users)]) }}
             </div>
 
             <form class="form-horizontal" method="post" action="{{ route('users/bulkeditsave') }}" autocomplete="off" role="form">

--- a/resources/views/users/bulk-edit.blade.php
+++ b/resources/views/users/bulk-edit.blade.php
@@ -95,7 +95,7 @@
                             <label class="col-md-3 control-label" for="locale">{{ trans('general.language') }}</label>
                             <div class="col-md-8">
                                 <x-input.locale-select name="locale" :selected="old('locale', '')"/>
-                                {!! $errors->first('locale', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                {!! $errors->first('locale', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                             </div>
                         </div>
 
@@ -113,7 +113,7 @@
                             <label class="col-md-3 control-label" for="city">{{ trans('general.city') }}</label>
                             <div class="col-md-4">
                                 <input class="form-control" type="text" name="city" id="city" aria-label="city" />
-                                {!! $errors->first('city', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                {!! $errors->first('city', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                             </div>
                         </div>
 
@@ -131,7 +131,7 @@
                             <label class="col-md-3 control-label" for="state">{{ trans('general.state') }}</label>
                             <div class="col-md-4">
                                 <input class="form-control" type="text" name="state" id="state" aria-label="state" maxlength="191" />
-                                {!! $errors->first('state', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                {!! $errors->first('state', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                             </div>
                         </div>
 
@@ -149,7 +149,7 @@
                             <label class="col-md-3 control-label" for="country">{{ trans('general.country') }}</label>
                             <div class="col-md-4">
                                 <x-input.country-select name="country" :selected="old('country', '')" />
-                                {!! $errors->first('country', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                {!! $errors->first('country', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                             </div>
                         </div>
 
@@ -167,7 +167,7 @@
                             <label class="col-md-3 control-label" for="zip">{{ trans('general.zip') }}</label>
                             <div class="col-md-4">
                                 <input class="form-control" type="text" name="zip" id="zip" aria-label="zip" maxlength="10" />
-                                {!! $errors->first('zip', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                {!! $errors->first('zip', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                             </div>
                         </div>
 
@@ -185,7 +185,7 @@
                             <label class="col-md-3 control-label" for="address">{{ trans('general.address') }}</label>
                             <div class="col-md-4">
                                 <input class="form-control" type="text" name="address" id="address" aria-label="address" maxlength="191" />
-                                {!! $errors->first('address', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                {!! $errors->first('address', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                             </div>
                         </div>
 
@@ -203,7 +203,7 @@
                             <label class="col-md-3 control-label" for="phone">{{ trans('admin/users/table.phone') }}</label>
                             <div class="col-md-4">
                                 <input class="form-control" type="text" name="phone" id="phone" aria-label="phone" maxlength="191" />
-                                {!! $errors->first('phone', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                {!! $errors->first('phone', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                             </div>
                         </div>
 
@@ -221,7 +221,7 @@
                             <label class="col-md-3 control-label" for="jobtitle">{{ trans('admin/users/table.title') }}</label>
                             <div class="col-md-4">
                                 <input class="form-control" type="text" name="jobtitle" id="jobtitle" aria-label="jobtitle" maxlength="191" />
-                                {!! $errors->first('jobtitle', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                {!! $errors->first('jobtitle', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                             </div>
                         </div>
 
@@ -250,7 +250,7 @@
                             <label class="col-md-3 control-label" for="website">{{ trans('general.website') }}</label>
                             <div class="col-md-4">
                                 <input class="form-control" type="url" name="website" id="website" aria-label="website" maxlength="191" />
-                                {!! $errors->first('website', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                {!! $errors->first('website', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                             </div>
                         </div>
 
@@ -361,7 +361,7 @@
                             <label class="col-md-3 control-label" for="email">{{ trans('admin/users/table.email') }}</label>
                             <div class="col-md-4">
                                 <input class="form-control" type="email" name="email" id="email" aria-label="email" maxlength="191" />
-                                {!! $errors->first('email', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                {!! $errors->first('email', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                             </div>
                         </div>
 
@@ -403,7 +403,7 @@
                             <label for="display_name" class="col-md-3 control-label">{{ trans('admin/users/table.display_name') }}</label>
                             <div class="col-md-4">
                                     <input type="text" class="form-control" placeholder="{{ trans('admin/users/table.display_name') }}" name="display_name" id="display_name" value="{{ old('display_name') }}">
-                                {!! $errors->first('display_name', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}
+                                {!! $errors->first('display_name', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times"></i> :message</span>') !!}
                             </div>
                             <div class="col-md-5">
                                 <label class="form-control">
@@ -423,7 +423,7 @@
                                     value="{{ old('start_date') }}"
                                     placeholder="{{ trans('general.select_date') }}"
                                 />
-                                {!! $errors->first('start_date', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                {!! $errors->first('start_date', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                             </div>
                             <div class="col-md-5">
                                 <label class="form-control">
@@ -443,7 +443,7 @@
                                     value="{{ old('end_date') }}"
                                     placeholder="{{ trans('general.select_date') }}"
                                 />
-                                {!! $errors->first('end_date', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                {!! $errors->first('end_date', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                             </div>
                             <div class="col-md-5">
                                 <label class="form-control">
@@ -459,7 +459,7 @@
                             <label class="col-md-3 control-label" for="notes">{{ trans('general.notes') }}</label>
                             <div class="col-md-6">
                                 <textarea class="form-control" rows="4" id="notes" name="notes" aria-label="notes"></textarea>
-                                {!! $errors->first('notes', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                {!! $errors->first('notes', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                             </div>
                         </div>
 

--- a/resources/views/users/confirm-bulk-delete.blade.php
+++ b/resources/views/users/confirm-bulk-delete.blade.php
@@ -16,8 +16,8 @@
           <!-- CSRF Token -->
           {{csrf_field()}}
           <div class="col-md-12">
-            <div class="callout callout-danger">
-              <i class="fas fa-exclamation-triangle"></i>
+            <div class="callout callout-danger" role="alert" aria-live="assertive" aria-atomic="true">
+              <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
               <strong>{{ trans('admin/users/general.warning_deletion_information', array('count' => count($users))) }} </strong>
 
             </div>
@@ -25,7 +25,7 @@
 
           @if (config('app.lock_passwords'))
             <div class="col-md-12">
-              <div class="callout callout-warning">
+              <div class="callout callout-warning" role="alert" aria-live="assertive" aria-atomic="true">
                 <p>{{ trans('general.feature_disabled') }}</p>
               </div>
             </div>

--- a/resources/views/users/confirm-merge.blade.php
+++ b/resources/views/users/confirm-merge.blade.php
@@ -23,8 +23,8 @@
                         {{csrf_field()}}
                         <div class="row">
                             <div class="col-md-12">
-                                <div class="callout callout-danger">
-                                    <i class="fas fa-exclamation-triangle"></i>
+                                <div class="callout callout-danger" role="alert" aria-live="assertive" aria-atomic="true">
+                                    <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
                                     {{ trans('general.warning_merge_information') }}
                                 </div>
                             </div>
@@ -33,7 +33,7 @@
                         @if (config('app.lock_passwords'))
                             <div class="row">
                                 <div class="col-md-12">
-                                    <div class="callout callout-info">
+                                    <div class="callout callout-info" role="status" aria-live="polite" aria-atomic="true">
                                         <p>{{ trans('general.feature_disabled') }}</p>
                                     </div>
                                 </div>

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -115,7 +115,7 @@
 
                 @if ($errors->first('username'))
                     <div class="col-md-8 col-md-offset-3">
-                        {!! $errors->first('username', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                        {!! $errors->first('username', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                     </div>
                 @endif
 
@@ -137,7 +137,7 @@
                               <span class="sr-only">{{ trans('general.toggle_password_visibility') }}</span>
                             </span>
                           </div>
-                              {!! $errors->first('password', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                              {!! $errors->first('password', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                         @else
                               <p class="form-control-static">
                               {{ trans('general.managed_ldap') }}
@@ -198,7 +198,7 @@
                                 {{ trans('admin/users/table.lock_passwords') }}
                               </p>
                         @endif
-                        {!! $errors->first('password_confirmation', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                        {!! $errors->first('password_confirmation', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                       </div>
                     </div>
                 @endif
@@ -275,7 +275,7 @@
                               </p>
                           @endif
 
-                        {!! $errors->first('email', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                        {!! $errors->first('email', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
 
 
                   </div>
@@ -338,7 +338,7 @@
                                               id="display_name"
                                               value="{{ old('display_name', $user->getRawOriginal('display_name')) }}"
                                       />
-                                      {!! $errors->first('display_name', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                      {!! $errors->first('display_name', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                   </div>
                               </div>
 
@@ -409,7 +409,7 @@
                                       @endif
                                   </div>
 
-                                  {!! $errors->first('company_ids', '<div class="col-md-8 col-md-offset-3"><span class="alert-msg"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
+                                  {!! $errors->first('company_ids', '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
                               </div>
 
 
@@ -418,7 +418,7 @@
                                   <label class="col-md-3 control-label" for="locale">{{ trans('general.language') }}</label>
                                   <div class="col-md-6">
                                       <x-input.locale-select name="locale" :selected="old('locale', $user->locale)" />
-                                      {!! $errors->first('locale', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                      {!! $errors->first('locale', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                   </div>
                               </div>
 
@@ -435,7 +435,7 @@
                                               id="employee_num"
                                               value="{{ old('employee_num', $user->employee_num) }}"
                                       />
-                                      {!! $errors->first('employee_num', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                      {!! $errors->first('employee_num', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                   </div>
                               </div>
 
@@ -452,7 +452,7 @@
                                               id="jobtitle"
                                               value="{{ old('jobtitle', $user->jobtitle) }}"
                                       />
-                                      {!! $errors->first('jobtitle', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                      {!! $errors->first('jobtitle', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                   </div>
                               </div>
 
@@ -517,7 +517,7 @@
                                   <label class="col-md-3 control-label" for="phone">{{ trans('admin/users/table.phone') }}</label>
                                   <div class="col-md-6">
                                       <input class="form-control" type="text" name="phone" id="phone" value="{{ old('phone', $user->phone) }}" maxlength="191" />
-                                      {!! $errors->first('phone', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                      {!! $errors->first('phone', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                   </div>
                               </div>
 
@@ -526,7 +526,7 @@
                                   <label class="col-md-3 control-label" for="phone">{{ trans('admin/users/table.mobile') }}</label>
                                   <div class="col-md-6">
                                       <input class="form-control" type="text" name="mobile" id="mobile" value="{{ old('mobile', $user->mobile) }}" maxlength="191" />
-                                      {!! $errors->first('mobile', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                      {!! $errors->first('mobile', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                   </div>
                               </div>
 
@@ -535,7 +535,7 @@
                                   <label for="website" class="col-md-3 control-label">{{ trans('general.website') }}</label>
                                   <div class="col-md-6">
                                       <input class="form-control" type="url" name="website" id="website" value="{{ old('website', $user->website) }}" maxlength="191" />
-                                      {!! $errors->first('website', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                      {!! $errors->first('website', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                                   </div>
                               </div>
 
@@ -544,7 +544,7 @@
                                   <label class="col-md-3 control-label" for="address">{{ trans('general.address') }}</label>
                                   <div class="col-md-6">
                                       <input class="form-control" type="text" name="address" id="address" value="{{ old('address', $user->address) }}" maxlength="191" />
-                                      {!! $errors->first('address', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                      {!! $errors->first('address', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                   </div>
                               </div>
 
@@ -553,7 +553,7 @@
                                   <label class="col-md-3 control-label" for="city">{{ trans('general.city') }}</label>
                                   <div class="col-md-6">
                                       <input class="form-control" type="text" name="city" id="city" aria-label="city" value="{{ old('city', $user->city) }}" maxlength="191" />
-                                      {!! $errors->first('city', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                      {!! $errors->first('city', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                   </div>
                               </div>
 
@@ -562,7 +562,7 @@
                                   <label class="col-md-3 control-label" for="state">{{ trans('general.state') }}</label>
                                   <div class="col-md-6">
                                       <input class="form-control" type="text" name="state" id="state" value="{{ old('state', $user->state) }}" maxlength="191" />
-                                      {!! $errors->first('state', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                      {!! $errors->first('state', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                   </div>
                               </div>
 
@@ -577,7 +577,7 @@
                                       />
 
                                       <p class="help-block">{{ trans('general.countries_manually_entered_help') }}</p>
-                                      {!! $errors->first('country', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                      {!! $errors->first('country', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                   </div>
                               </div>
 
@@ -586,7 +586,7 @@
                                   <label class="col-md-3 control-label" for="zip">{{ trans('general.zip') }}</label>
                                   <div class="col-md-3 text-right">
                                       <input class="form-control" type="text" name="zip" id="zip" value="{{ old('zip', $user->zip) }}" maxlength="10" />
-                                      {!! $errors->first('zip', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                      {!! $errors->first('zip', '<span class="alert-msg" role="alert" aria-live="assertive">:message</span>') !!}
                                   </div>
                               </div>
 
@@ -595,7 +595,7 @@
                                   <label for="notes" class="col-md-3 control-label">{{ trans('admin/users/table.notes') }}</label>
                                   <div class="col-md-6">
                                       <textarea class="form-control" rows="5" id="notes" name="notes">{{ old('notes', $user->notes) }}</textarea>
-                                      {!! $errors->first('notes', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                      {!! $errors->first('notes', '<span class="alert-msg" role="alert" aria-live="assertive"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                                   </div>
                               </div>
 

--- a/resources/views/users/ldap.blade.php
+++ b/resources/views/users/ldap.blade.php
@@ -100,7 +100,7 @@
                                 @if ($entry['status']=='success')
                                 <span class="text-success"><i class="fas fa-check"></i> {!! $entry['note'] !!}</span>
                                 @else
-                                <span class="alert-msg" aria-hidden="true">{!! $entry['note'] !!}</span>
+                                <span class="alert-msg" role="alert" aria-live="assertive">{!! $entry['note'] !!}</span>
                                 @endif
                                 </td>
                             </tr>

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -17,7 +17,7 @@
 
         @if ($user->deleted_at!='')
             <div class="col-md-12">
-                <div class="callout callout-warning">
+                <div class="callout callout-warning" role="alert" aria-live="assertive" aria-atomic="true">
                     <x-icon type="warning"/>
                     {{ trans('admin/users/message.user_deleted_warning') }}
                 </div>


### PR DESCRIPTION
This adds some accessibility tags to our callout alerts. (We could probably convert those callouts into a blade component too.)

### aria-live

`aria-live="polite"` tells screen readers to announce content changes when the user is idle -  after they finish reading the current thing, pausing, or between navigation actions. It doesn't interrupt.                                                                                                                     
                                                                                                                                                                                                                                                                                                                   
`aria-live="assertive"` preempts whatever the screen reader is currently saying and announces immediately.                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                   
For example: a user is reading a form label out loud via screen reader when a "Saved" confirmation appears.                                                                                                                                                                                                          
- With polite: screen reader finishes reading the label, then says "Saved."                                                                                                                                                                                                                                                
- With assertive: screen reader cuts off mid-word to say "Saved."                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                   
**Rule of thumb:**                                                                                                                                                                                                                                                                                                             
- Polite: success messages, status updates, non-critical info ("3 results loaded", "Draft saved")                                                                                                                                                                                                                          
- Assertive: errors, validation failures, time-sensitive warnings ("Session expiring in 30 seconds", "Payment failed")                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                   
**Assertive is disruptive, so overusing it makes the interface feel like it's shouting**. We should default to polite and reserve assertive for things the user genuinely needs to know right now (JS Validation errors, for example).       

### aria-atomic

`aria-atomic` controls how much of a live region gets re-announced when any part of it changes.                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                         
- `aria-atomic="false"` (the default): the screen reader announces only the specific node that changed.                                                                                                                                                                                                                  
- `aria-atomic="true"`: the screen reader re-announces the entire contents of the live region, treating it as one atomic unit.                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                         
For flash notifications and callouts where the label + message form one coherent statement, `aria-atomic="true"` is the right choice, which is why it's paired with role="alert" / role="status" on those blocks. For long live regions where you only care about diffs (like a chat log or a stock ticker), you'd leave it false so the whole log doesn't re-read every update.      

More info:

- https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-atomic
- https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-live
- https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles