### PR TITLE
2FA: Fixed FD-56499 - Stricter 2FA enforcement for existing PATs on API

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -10,6 +10,7 @@ use App\Http\Middleware\CheckLocale;
 use App\Http\Middleware\CheckPermissions;
 use App\Http\Middleware\CheckUserIsActivated;
 use App\Http\Middleware\EncryptCookies;
+use App\Http\Middleware\EnforceApiTwoFactorEnrollment;
 use App\Http\Middleware\EnforceApiUserAgent;
 use App\Http\Middleware\IssueFreshApiTokenIfTwoFactorComplete;
 use App\Http\Middleware\LogAuthedUserHeader;
@@ -82,6 +83,7 @@ class Kernel extends HttpKernel
 
         'api' => [
             'auth:api',
+            EnforceApiTwoFactorEnrollment::class,
             EnforceApiUserAgent::class,
             CheckLocale::class,
             LogAuthedUserHeader::class,

--- a/app/Http/Middleware/EnforceApiTwoFactorEnrollment.php
+++ b/app/Http/Middleware/EnforceApiTwoFactorEnrollment.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Helpers\Helper;
+use App\Models\Setting;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnforceApiTwoFactorEnrollment
+{
+    public function handle(Request $request, Closure $next)
+    {
+        // If auth:api didn't populate a user (bad token, no token), let it
+        // produce the standard 401 rather than emitting a 403 here.
+        $user = $request->user();
+        if ($user === null) {
+            return $next($request);
+        }
+
+        $settings = Setting::getSettings();
+        if ($settings === null) {
+            return $next($request);
+        }
+
+        // Normalize the same way CheckForTwoFactor does: only '1' (optional)
+        // and '2' (required for all) count as on. Empty, '0', null all mean
+        // 2FA is disabled and we don't gate the API.
+        $mode = (string) $settings->two_factor_enabled;
+        if ($mode !== '1' && $mode !== '2') {
+            return $next($request);
+        }
+
+        // Optional mode only gates users who opted in; matches the web-side
+        // semantics so an install can't accidentally break every legacy PAT
+        // by flipping optional 2FA on.
+        if ($mode === '1' && (string) $user->two_factor_optin !== '1') {
+            return $next($request);
+        }
+
+        // Stateless bearer tokens can't prompt for a live TOTP code, so the
+        // strongest guarantee we can enforce is that the token's owner has
+        // provisioned and confirmed a TOTP secret. A PAT owned by a not-yet-
+        // enrolled user gets refused so that setting two_factor_enabled = 2
+        // actually gates the API surface (previously it only gated the web
+        // group, leaving already-issued PATs fully live). Web session auth
+        // still flows through CheckForTwoFactor and remains untouched.
+        if ((string) $user->two_factor_enrolled !== '1') {
+            return response()->json(
+                Helper::formatStandardApiResponse('error', null, trans('auth/message.two_factor.please_enroll')),
+                Response::HTTP_FORBIDDEN,
+            );
+        }
+
+        return $next($request);
+    }
+}

--- a/tests/Feature/Authentication/EnforceApiTwoFactorEnrollmentTest.php
+++ b/tests/Feature/Authentication/EnforceApiTwoFactorEnrollmentTest.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Tests\Feature\Authentication;
+
+use App\Models\User;
+use Laravel\Passport\Passport;
+use Tests\TestCase;
+
+/**
+ * Confirms that Personal Access Tokens (or any Passport-authenticated API
+ * request) can't be used to call the API when the token's owner hasn't
+ * satisfied the org's 2FA policy. Complements
+ * PersonalAccessTokenTwoFactorGuardTest, which covers the acquisition step
+ * (can't mint a PAT without clearing 2FA in-session); this file covers the
+ * usage step (can't use a PAT when the owner isn't 2FA-enrolled and the org
+ * setting requires enrollment).
+ */
+class EnforceApiTwoFactorEnrollmentTest extends TestCase
+{
+    public function test_disabled_two_factor_lets_any_pat_through()
+    {
+        // '' == disabled globally. Even an unenrolled superuser's PAT works,
+        // matching the behavior of installs that haven't turned 2FA on.
+        $this->settings->set(['two_factor_enabled' => '']);
+        $user = User::factory()->superuser()->create([
+            'two_factor_enrolled' => '0',
+            'two_factor_optin' => '0',
+        ]);
+
+        Passport::actingAs($user);
+
+        $this->getJson(route('api.users.me'))->assertOk();
+    }
+
+    public function test_optional_two_factor_lets_non_optin_users_through()
+    {
+        // Mode 1: 2FA optional. A user who hasn't opted in must not be forced
+        // into 403 territory by this middleware — that would break every
+        // legacy PAT the moment an admin flips optional 2FA on.
+        $this->settings->set(['two_factor_enabled' => '1']);
+        $user = User::factory()->superuser()->create([
+            'two_factor_enrolled' => '0',
+            'two_factor_optin' => '0',
+        ]);
+
+        Passport::actingAs($user);
+
+        $this->getJson(route('api.users.me'))->assertOk();
+    }
+
+    public function test_optional_two_factor_blocks_optin_users_who_are_not_enrolled()
+    {
+        // Mode 1 + opted in but never finished enrollment = same policy state
+        // as required mode: token owner has committed to 2FA but the second
+        // factor isn't actually usable yet.
+        $this->settings->set(['two_factor_enabled' => '1']);
+        $user = User::factory()->superuser()->create([
+            'two_factor_enrolled' => '0',
+            'two_factor_optin' => '1',
+        ]);
+
+        Passport::actingAs($user);
+
+        $this->getJson(route('api.users.me'))
+            ->assertForbidden()
+            ->assertJson(['status' => 'error']);
+    }
+
+    public function test_optional_two_factor_lets_optin_enrolled_users_through()
+    {
+        $this->settings->set(['two_factor_enabled' => '1']);
+        $user = User::factory()->superuser()->create([
+            'two_factor_enrolled' => '1',
+            'two_factor_optin' => '1',
+            'two_factor_secret' => 'TESTSECRET',
+        ]);
+
+        Passport::actingAs($user);
+
+        $this->getJson(route('api.users.me'))->assertOk();
+    }
+
+    /**
+     * The core regression pin: an unenrolled user's PAT is blocked when the
+     * install is set to require 2FA for everyone. This closes the reported
+     * vulnerability where two_factor_enabled=2 only affected the web group
+     * and left already-issued PATs fully usable.
+     */
+    public function test_required_two_factor_blocks_unenrolled_pat()
+    {
+        $this->settings->set(['two_factor_enabled' => '2']);
+        $user = User::factory()->superuser()->create([
+            'two_factor_enrolled' => '0',
+            'two_factor_optin' => '0',
+        ]);
+
+        Passport::actingAs($user);
+
+        $this->getJson(route('api.users.me'))
+            ->assertForbidden()
+            ->assertJson(['status' => 'error']);
+    }
+
+    public function test_required_two_factor_lets_enrolled_pat_through()
+    {
+        $this->settings->set(['two_factor_enabled' => '2']);
+        $user = User::factory()->superuser()->create([
+            'two_factor_enrolled' => '1',
+            'two_factor_optin' => '1',
+            'two_factor_secret' => 'TESTSECRET',
+        ]);
+
+        Passport::actingAs($user);
+
+        $this->getJson(route('api.users.me'))->assertOk();
+    }
+
+    /**
+     * Required mode blocks even opted-in-but-unenrolled users, since "opted
+     * in" alone doesn't mean the account can accept a code. Mirrors the
+     * required-mode branch that ignores the optin flag entirely.
+     */
+    public function test_required_two_factor_blocks_optin_but_unenrolled_pat()
+    {
+        $this->settings->set(['two_factor_enabled' => '2']);
+        $user = User::factory()->superuser()->create([
+            'two_factor_enrolled' => '0',
+            'two_factor_optin' => '1',
+        ]);
+
+        Passport::actingAs($user);
+
+        $this->getJson(route('api.users.me'))->assertForbidden();
+    }
+
+    /**
+     * The middleware must not emit its 2FA-enrollment 403 in place of whatever
+     * auth:api does for a missing/bad token; otherwise clients can't tell
+     * "unauthenticated" from "authenticated but blocked by policy." We don't
+     * pin the exact unauthenticated status code (Laravel's fallback may vary
+     * by config), only that our middleware didn't override it.
+     */
+    public function test_no_token_response_is_not_our_403()
+    {
+        $this->settings->set(['two_factor_enabled' => '2']);
+
+        $response = $this->getJson(route('api.users.me'));
+
+        $this->assertNotEquals(403, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
This adds a new piece of API middleware called `EnforceApiTwoFactorEnrollment`. The existing `CheckForTwoFactor` asks "did this session prove second factor?", while this new one asks "does this token's owner have a second factor set up at all?". 

`EnforceApiTwoFactorEnrollment.php`:

                                                
- Runs after auth:api, reads the authenticated user.      
- Passes through if there's no user (lets `auth:api`'s 401 stand).  
- Passes through if two_factor_enabled is disabled ('', '0', null).          
- Under optional mode ('1'), only enforces on users who `set two_factor_optin = '1'` (mirrors web; keeps legacy Personal Access Tokens (PATs) alive for users who never opted in).              
- Under required mode ('2'), enforces regardless of optin.      
- Blocks with 403 + `Helper::formatStandardApiResponse('error', null, trans('auth/message.two_factor.please_enroll'))` when the token owner's `two_factor_enrolled != '1'`.                                                                                                             																					 
`app/Http/Kernel.php: added EnforceApiTwoFactorEnrollment::class` to the `api` group immediately after `auth:api` so it runs once auth has populated the user and before any endpoint logic.                                                                                                                     																					 


### Tests:                                                                             
- Disabled → PAT works even for unenrolled user.    
- Optional + not opted in → PAT works (legacy compat).                                                  
- Optional + opted in + not enrolled → blocked.                                                       
- Optional + opted in + enrolled → works.                                                                
- Required + not enrolled → blocked (the reported bug).
- Required + enrolled → works. 
- Required + opted-in-but-unenrolled → blocked (optin alone isn't enough).                              
- No token → does not receive our 403 (framework's unauthenticated response is preserved).           

A few notes on why this was needed. 

1. Session vs stateless. A PAT request has no session, so CheckForTwoFactor's session()->get('2fa_authed') always returns null. If you put it on the api group, it'd 403 (or redirect) every PAT request universally, even for fully-enrolled users. `isComplete()` handles this correctly for token management (which really does require an interactive browser session), but it's the wrong check for regular API data endpoints where PATs are the intended auth path.                                                                                                                                                                          
2. Redirect vs JSON envelope. Browsers follow 302 to a login page; `curl -H "Authorization: Bearer …"` doesn't. The api group needs a 4xx JSON response with the `Helper::formatStandardApiResponse` envelope so clients can programmatically detect and report the failure. 
3. Live 2FA challenge is impossible with a stateless bearer token. The web middleware can gate on "did the user actually type a TOTP code this session." A PAT is a persistent secret that isn't tied to a live 2FA transaction - the strongest thing the middleware can enforce is that the token's owner has completed enrollment (i.e. has a provisioned TOTP secret they've validated at least once). That's a materially weaker guarantee than the web-session gate, but it's the strongest one available for stateless bearer tokens. Trying to shoehorn the web-session check into the api group would be checking for the wrong thing. 


																																                      