### PR TITLE
EULA PDF: Fixed #18176 - preserve nested markdown lists in acceptance PDF

### DIFF
--- a/app/Models/CheckoutAcceptance.php
+++ b/app/Models/CheckoutAcceptance.php
@@ -267,13 +267,18 @@ class CheckoutAcceptance extends Model
         $pdf->Ln();
         $pdf->writeHTML('<hr>', true, 0, true, 0, '');
 
-        // Break the EULA into lines based on newlines, and check each line for RTL or CJK characters
-        $eula_lines = preg_split("/\r\n|\n|\r/", $data['eula']);
+        // Break the EULA into markdown blocks separated by blank lines (rather than splitting on every
+        // newline), and check each block for RTL or CJK characters. Splitting on blank lines keeps
+        // multi-line markdown constructs - e.g. nested lists - together in a single block, so Parsedown
+        // can render them correctly. Blank lines are Parsedown's own block boundaries, so rendering
+        // block-by-block matches the whole-document rendering used for the acceptance email; splitting
+        // on every newline previously flattened nested lists into a single flat list (#18176).
+        $eula_blocks = preg_split('/\R(?:[ \t]*\R)+/', $data['eula']);
 
-        foreach ($eula_lines as $eula_line) {
-            Helper::hasRtl($eula_line) ? $pdf->setRTL(true) : $pdf->setRTL(false);
-            Helper::isCjk($eula_line) ? $pdf->SetFont('cid0cs', '', 9) : $pdf->SetFont('dejavusans', '', 8, '', true);
-            $pdf->writeHTML(Helper::parseEscapedMarkedown($eula_line), true, 0, true, 0, '');
+        foreach ($eula_blocks as $eula_block) {
+            Helper::hasRtl($eula_block) ? $pdf->setRTL(true) : $pdf->setRTL(false);
+            Helper::isCjk($eula_block) ? $pdf->SetFont('cid0cs', '', 9) : $pdf->SetFont('dejavusans', '', 8, '', true);
+            $pdf->writeHTML(Helper::parseEscapedMarkedown($eula_block), true, 0, true, 0, '');
         }
         $pdf->Ln();
         $pdf->Ln();


### PR DESCRIPTION
Fixes #18176

### What & why

Nested markdown lists in an EULA render correctly in the acceptance **email** but are flattened to a single top-level list in the acceptance **PDF**.

### Root cause

`CheckoutAcceptance::generateAcceptancePdf()` split the EULA on every newline and ran each line through Parsedown individually (so it could set the font / RTL direction per line). Parsedown is a block-level parser, so feeding it one line at a time turns:

```
- item 1
- item 2
  - item 2.1
  - item 2.2
- item 3
```

into several independent single-item `<ul>` blocks — every sub-item is promoted to the top level. The email path renders the whole `eula_text` at once (`{!! $eula !!}`), which is why the two outputs diverged.

### Fix

Split the EULA on **blank lines** (markdown block boundaries) instead of on every newline, so multi-line constructs like nested lists stay in one block and Parsedown renders them correctly. Blank lines are Parsedown's own block boundaries, so rendering block-by-block produces the same HTML as the whole-document rendering the email already uses — while the existing per-block RTL/CJK font detection is preserved. No behavior change for single-line or single-language EULAs.

### Testing

Ran the two approaches through the actual Parsedown library on the nested list above:

- **Before (per-line):** five separate single-item `<ul>` blocks — `item 2.1` / `item 2.2` become top-level lists (the reported flattening).
- **After (per-block):** one list where `item 2` contains a nested `<ul>` with `item 2.1` / `item 2.2`.

Also checked the block-splitting regex against CRLF, whitespace-only blank lines, and an indented code block after a blank line (indentation preserved).

No automated test added: `generateAcceptancePdf()` renders to a live TCPDF instance and returns PDF bytes, which isn't practical to assert on, and the markdown→HTML step (the actual bug) is what's verified above. Happy to add one if you'd prefer.

> Disclosure: this fix was prepared with AI assistance (Claude) and reviewed and verified by me before submission.
