### PR TITLE
Added form help text component

### DIFF
--- a/resources/views/blade/form/checkbox-row.blade.php
+++ b/resources/views/blade/form/checkbox-row.blade.php
@@ -8,6 +8,7 @@
     'required' => null,
     'disabled' => false,
     'help_text' => null,
+    'help_icon' => null,
     'info_tooltip_text' => null,
     // Default input column: only skip the offset when a left-hand label
     // column is being rendered (i.e. multi mode with a label). Single mode
@@ -134,7 +135,7 @@
 
     @if ($help_text)
         <div class="col-md-8 col-md-offset-3">
-            <x-form.help :name="$name">{!! $help_text !!}</x-form.help>
+            <x-form.help :name="$name" :icon="$help_icon">{!! $help_text !!}</x-form.help>
         </div>
     @endif
 

--- a/resources/views/blade/form/checkbox-row.blade.php
+++ b/resources/views/blade/form/checkbox-row.blade.php
@@ -87,6 +87,7 @@
                     :required="$really_required"
                     :disabled="$disabled"
                     :aria-label="$name"
+                    :aria-describedby="$help_text ? $name.'-help' : null"
                 />
                 {{ $label }}
             </label>
@@ -108,6 +109,7 @@
                         :checked="$is_checked($option_value)"
                         :disabled="$disabled"
                         :aria-label="$name"
+                        :aria-describedby="$help_text ? $name.'-help' : null"
                     />
                     {{ $option_label }}
                 </label>
@@ -132,9 +134,7 @@
 
     @if ($help_text)
         <div class="col-md-8 col-md-offset-3">
-            <p class="help-block">
-                {!! $help_text !!}
-            </p>
+            <x-form.help :name="$name">{!! $help_text !!}</x-form.help>
         </div>
     @endif
 

--- a/resources/views/blade/form/help.blade.php
+++ b/resources/views/blade/form/help.blade.php
@@ -1,0 +1,7 @@
+@props(['name', 'icon' => null])
+<p class="help-block" id="{{ $name }}-help">
+    @if ($icon)
+        <x-icon :type="$icon" />
+    @endif
+    {{ $slot }}
+</p>

--- a/resources/views/blade/form/radio-row.blade.php
+++ b/resources/views/blade/form/radio-row.blade.php
@@ -53,6 +53,7 @@
                     :required="$really_required && $loop->first"
                     :disabled="$disabled"
                     :aria-label="$name"
+                    :aria-describedby="$help_text ? $name.'-help' : null"
                 />
                 {{ $option_label }}
             </label>
@@ -75,9 +76,7 @@
 
     @if ($help_text)
         <div class="col-md-8 col-md-offset-3">
-            <p class="help-block">
-                {!! $help_text !!}
-            </p>
+            <x-form.help :name="$name">{!! $help_text !!}</x-form.help>
         </div>
     @endif
 

--- a/resources/views/blade/form/radio-row.blade.php
+++ b/resources/views/blade/form/radio-row.blade.php
@@ -7,6 +7,7 @@
     'required' => null,
     'disabled' => false,
     'help_text' => null,
+    'help_icon' => null,
     'info_tooltip_text' => null,
     // Default input column depends on whether the row has a left-hand label.
     // With a label, the row already spends col-md-3 on the left; without one
@@ -76,7 +77,7 @@
 
     @if ($help_text)
         <div class="col-md-8 col-md-offset-3">
-            <x-form.help :name="$name">{!! $help_text !!}</x-form.help>
+            <x-form.help :name="$name" :icon="$help_icon">{!! $help_text !!}</x-form.help>
         </div>
     @endif
 

--- a/resources/views/blade/form/row.blade.php
+++ b/resources/views/blade/form/row.blade.php
@@ -31,6 +31,7 @@
                     :$name
                     :$type
                     :aria-label="$name"
+                    :aria-describedby="$help_text ? $name.'-help' : null"
                     :component="'input.'.$blade_type"
                     :id="$name"
                     :required="Helper::checkIfRequired($item, $name)"
@@ -60,9 +61,7 @@
     @if ($help_text)
         <!-- Help Text -->
         <div class="col-md-8 col-md-offset-3">
-            <p class="help-block">
-                {!! $help_text !!}
-            </p>
+            <x-form.help :name="$name">{!! $help_text !!}</x-form.help>
         </div>
     @endif
 

--- a/resources/views/blade/form/row.blade.php
+++ b/resources/views/blade/form/row.blade.php
@@ -5,6 +5,7 @@
     'item' => null,
     'info_tooltip_text' => null,
     'help_text' => null,
+    'help_icon' => null,
     'label' => null,
     'input_div_class' => 'col-md-8',
     'errors_class' => $errors->has('support_url') ? ' has-error' : '',
@@ -61,7 +62,7 @@
     @if ($help_text)
         <!-- Help Text -->
         <div class="col-md-8 col-md-offset-3">
-            <x-form.help :name="$name">{!! $help_text !!}</x-form.help>
+            <x-form.help :name="$name" :icon="$help_icon">{!! $help_text !!}</x-form.help>
         </div>
     @endif
 

--- a/resources/views/blade/input/quantity.blade.php
+++ b/resources/views/blade/input/quantity.blade.php
@@ -8,6 +8,7 @@
     'max' => null,
     'value' => null,
     'help_text' => null,
+    'help_icon' => null,
 ])
 
 <div
@@ -38,7 +39,7 @@
         <div class="col-md-12" style="padding-left: 0">
             <x-form.error :name="$name" />
             @if ($help_text)
-                <x-form.help :name="$name">{{ $help_text }}</x-form.help>
+                <x-form.help :name="$name" :icon="$help_icon">{{ $help_text }}</x-form.help>
             @endif
         </div>
     </div>

--- a/resources/views/blade/input/quantity.blade.php
+++ b/resources/views/blade/input/quantity.blade.php
@@ -27,6 +27,7 @@
                 name="{{ $name }}"
                 id="{{ $name }}"
                 aria-label="{{ $label ?? trans('general.quantity') }}"
+                @if ($help_text) aria-describedby="{{ $name }}-help" @endif
                 value="{{ old($name, $value ?? $item?->{$name} ?? '') }}"
                 min="{{ $min }}"
                 @if ($max) max="{{ $max }}" @endif
@@ -37,7 +38,7 @@
         <div class="col-md-12" style="padding-left: 0">
             <x-form.error :name="$name" />
             @if ($help_text)
-                <p class="help-block">{{ $help_text }}</p>
+                <x-form.help :name="$name">{{ $help_text }}</x-form.help>
             @endif
         </div>
     </div>


### PR DESCRIPTION
This adds a small `<x-form.help>` blade component and wires it into the form-row wrappers so help text under a form input is properly linked to its input via [`aria-describedby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby). Before this, help text was visually _adjacent_ but semantically _orphaned_. Screen reader users focusing an input heard the label and any errors but never the guidance underneath.

`resources/views/blade/form/help.blade.php` takes two props:

* `name` (required). Used to generate `id="{name}-help"` so the input can point at the block.
* `icon` (optional). If set, the icon is prepended via `<x-icon :type="$icon" />`. Common value is `tip` for the lightbulb pattern already used on the FMCS select notes.

Slot content is rendered as HTML, so callers can pass `{!! trans(...) !!}` with embedded markup, matching how the existing `$help_text` prop already worked.

## Example usage

Direct use in a hand-authored form (a form row that hasn't been converted into the form-row component yet, a process that's big and ongoing):

```blade
<input class="form-control" name="site_name" id="site_name" aria-describedby="site_name-help" ... >

<x-form.help name="site_name">
    Enter the name shown in the top navigation.
</x-form.help>
```

With an icon:

```blade
<x-form.help name="ldap_server" icon="tip">
    Reachable from your Snipe-IT container.
</x-form.help>
```

Via a row wrapper (zero caller changes needed for forms already using the wrappers, the wrapper handles the wiring internally):

```blade
<x-form.row
    name="site_name"
    :label="trans('admin/settings/general.site_name')"
    :item="$setting"
    :help_text="trans('admin/settings/general.site_name_help')"
/>
```

The row wrapper detects the presence of `:help_text`, adds `aria-describedby="site_name-help"` on the input it generates, and renders the help slot inside `<x-form.help>` with the matching id. Same thing is in place for `<x-form.checkbox-row>`, `<x-form.radio-row>`, and `<x-input.quantity>`.

An icon can also be passed through the row wrappers via the `help_icon` prop, so forms migrating away from raw HTML can still get the lightbulb-tip pattern:

```blade
<x-form.row
    name="ldap_server"
    :label="trans('...')"
    :item="$setting"
    :help_text="trans('admin/settings/general.ldap_server_help')"
    help_icon="tip"
/>
```

## Why it matters

Help text and instructions attached to form fields are covered by [WCAG SC 1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html) and [WCAG SC 3.3.2 Labels or Instructions](https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.html). When the text sits next to a field visually but is not programmatically associated, screen readers announce the field name and any errors but skip the guidance. Wiring `aria-describedby` fixes that so the help text is spoken as part of the field's description on focus.

Wiring this through the row wrappers also supports the broader plan of moving hand-authored forms onto the wrapper components, which is what will make future Bootstrap / AdminLTE upgrades easier. Every form that adopts the wrapper picks up the accessibility for free, which is what we've been trying to accomplish with all of these refactors.