### PR TITLE
SCIM: For empty addresses, we were returning empty arrays instead of skipping

### DIFF
--- a/app/Models/SnipeSCIMConfig.php
+++ b/app/Models/SnipeSCIMConfig.php
@@ -502,8 +502,11 @@ class SnipeSCIMConfig
                                 $address['type'] = 'work';
                                 $address['primary'] = true;
                             }
-
-                            return [$address];
+                            if ($address) {
+                                return [(object) $address]; //cast-to-object forces "squiggly-brackets" in JSON
+                            } else {
+                                return null; //this should remove the addresses block entirely
+                            }
                         }
 
                         public function doWrite($operation, $subop, $value, Model &$object, ?Path $path = null, $removeIfNotSet = false)

--- a/app/Models/SnipeSCIMConfig.php
+++ b/app/Models/SnipeSCIMConfig.php
@@ -377,13 +377,14 @@ class SnipeSCIMConfig
                     {
                         protected function doRead(&$object, $attributes = [])
                         {
-                            return collect([$object->email])->map(function ($email) {
-                                return [
-                                    'value' => $email,
-                                    'type' => 'work', // TODO - is this how we always have done it?
-                                    'primary' => true,
-                                ];
-                            })->toArray();
+                            if (!$object->email) {
+                                return null;
+                            }
+                            return [
+                                'value' => $object->email,
+                                'type' => 'work', // TODO - is this how we always have done it?
+                                'primary' => true,
+                            ];
                         }
 
                         public function doWrite($operation, $subop, $value, Model &$object, ?Path $path = null, $removeIfNotSet = false)


### PR DESCRIPTION
So the problem that we were seeing is two of the SCIM clients we encounter (though not very often) were choking on our Address records. After talking with a customer, we realized why:

For empty addresses, we were returning - 

```json
{
   "addresses": [ [ ] ]
  // ....
}
```

whereas a slightly more correct version of that would be:

```json
{
   "addresses": [ { } ]
  // ...
}
```

But the most correct version would be to return absolutely nothing at all - no addresses 'key' represented at all - like:

```
{
  "schemas": [
    "urn:ietf:params:scim:schemas:core:2.0:User",
    "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
    "urn:ietf:params:scim:schemas:extension:grokability:2.0:User"
  ],
  "id": "1051",
  "meta": {
    "created": "2026-07-13T14:06:10+00:00",
    "lastModified": "2026-07-13T14:06:10+00:00",
    "location": "http://snipe-it.test/scim/v2/Users/1051",
    "resourceType": "User",
    "version": "W/\"b4be0c1c4d5666de713830526dc0c1c872e5fa4f\""
  },
  "userName": "empty",
  "active": false,
  "name": {
    "givenName": "empty name"
  },
  "displayName": "empty name",
  "groups": []
}
```

In addition, we were doing something similar for 'phone' - but I don't think that was tripping up the SCIM clients as badly because the 'shape' of the response was still correct - it was just returning `"value": ""`. I don't _think_ that's an error, but it's a little gauche.