### PR TITLE
CSV Import: Fixed #13995 - purchase date silently stored as 1970-01-01 for unparseable dates

### DIFF
--- a/app/Importer/ItemImporter.php
+++ b/app/Importer/ItemImporter.php
@@ -89,7 +89,8 @@ class ItemImporter extends Importer
 
         $this->item['purchase_date'] = null;
         if ($this->findCsvMatch($row, 'purchase_date') != '') {
-            $this->item['purchase_date'] = date('Y-m-d', strtotime($this->findCsvMatch($row, 'purchase_date')));
+            $this->item['purchase_date'] = $this->findCsvMatch($row, 'purchase_date');
+            $this->item['purchase_date'] = $this->parseOrNullDate('purchase_date');
         }
 
         // NO need to call this method if we're running the user import.


### PR DESCRIPTION
Refs #13995 (the "purchase date defaults to 1970" part of that report).

### What & why
When importing items, an unparseable **Purchase Date** is silently stored as **`1970-01-01`** rather than left empty. Affects every import through the base importer (assets, accessories, consumables, components) and is easy to hit with common non-US inputs like day-first `31/12/2023`.

### Root cause
`ItemImporter::handle()` used `date('Y-m-d', strtotime($value))`. `strtotime()` returns `false` on failure; `date()` coerces `false` to timestamp `0` (the Unix epoch), so the row imports as `1970-01-01` with no error.

### Fix
Use the importer's existing `parseOrNullDate()` helper — already used in `AssetImporter` for `last_audit_date`, `next_audit_date`, `asset_eol_date`, `last_checkin`, `last_checkout`, and `expected_checkin`. It parses with `CarbonImmutable`, logs `Unable to parse date: …`, and returns `null` on failure. Valid dates are unchanged.

### Testing
Verified the parse behavior side-by-side: valid inputs (`2023-12-31`, `12/31/2023`, `March 5, 2022`) are unchanged; unparseable inputs (`31/12/2023` day-first, `N/A`, `unknown`) go from `1970-01-01` → `null`. It's a one-line swap to an existing, already-used helper (no parser change for valid dates).

> Disclosure: this fix was prepared with AI assistance (Claude) and reviewed and verified by me before submission.
