### PR TITLE
Backups: Fixed #19305 - show tooltip explaining that backup deleting …

### DIFF
--- a/resources/lang/en-US/admin/settings/message.php
+++ b/resources/lang/en-US/admin/settings/message.php
@@ -13,6 +13,7 @@ return [
         'file_not_found' => 'That backup file could not be found on the server.',
         'restore_warning' => 'Yes, restore it. I acknowledge that this will overwrite any existing data currently in the database. This will also log out all of your existing users (including you).',
         'restore_confirm' => 'Are you sure you wish to restore your database from :filename?',
+        'delete_disabled_help' => 'Deleting backups is disabled. Contact your administrator if you wish to enable deleting backups.',
     ],
     'restore' => [
         'success' => 'Your system backup has been restored. Please log in again.',

--- a/resources/views/settings/backups.blade.php
+++ b/resources/views/settings/backups.blade.php
@@ -97,20 +97,24 @@
                   @can('superadmin')
                       @if (config('app.allow_backup_delete')=='true')
                       <a data-html="false"
-                         class="btn delete-asset btn-danger btn-sm {{ (config('app.lock_passwords')) ? ' disabled': '' }}" 
-                         data-toggle="modal" href="{{ route('settings.backups.destroy', $file['filename']) }}" 
-                         data-content="{{ trans('admin/settings/message.backup.delete_confirm') }}" 
+                         class="btn delete-asset btn-danger btn-sm {{ (config('app.lock_passwords')) ? ' disabled': '' }}"
+                         data-toggle="modal" href="{{ route('settings.backups.destroy', $file['filename']) }}"
+                         data-content="{{ trans('admin/settings/message.backup.delete_confirm') }}"
                          data-title="{{ trans('general.delete') }}  {{ e($file['filename']) }}?"
                          onClick="return false;">
                           <i class="fas fa-trash icon-white" aria-hidden="true"></i>
                           <span class="sr-only">{{ trans('general.delete') }}</span>
                       </a>
                       @else
-                          <a href="#"
-                             class="btn delete-asset btn-danger btn-sm disabled">
-                              <i class="fas fa-trash icon-white" aria-hidden="true"></i>
-                              <span class="sr-only">{{ trans('general.delete') }}</span>
-                          </a>
+                          <span data-tooltip="true" title="{{ trans('admin/settings/message.backup.delete_disabled_help') }}">
+                              <a href="#"
+                                 class="btn delete-asset btn-danger btn-sm disabled"
+                                 aria-disabled="true"
+                                 onClick="return false;">
+                                  <i class="fas fa-trash icon-white" aria-hidden="true"></i>
+                                  <span class="sr-only">{{ trans('general.delete') }} ({{ trans('admin/settings/message.backup.delete_disabled_help') }})</span>
+                              </a>
+                          </span>
                       @endif
 
                           <a data-html="true"


### PR DESCRIPTION
This just adds a tooltip if backup deleting is disabled.

<img width="1689" height="1041" alt="Screenshot 2026-07-15 at 12 19 39 PM" src="https://github.com/user-attachments/assets/f38ed791-08b5-4f79-9f79-967355959a4a" />

Fixes #19305