### PR TITLE
Fixed #19302 - add focus to serials if auto increment is on

### DIFF
--- a/resources/views/hardware/edit.blade.php
+++ b/resources/views/hardware/edit.blade.php
@@ -320,7 +320,11 @@
         });
 
         @if (isset($cloned_model))
-        $('input[name="serials[1]"]').trigger('focus');
+            @if ($snipeSettings->auto_increment_assets == '1')
+                $('input[name="serials[1]"]').trigger('focus');
+            @else
+                $('#asset_tag').trigger('focus');
+            @endif
         @endif
     });
 


### PR DESCRIPTION
If auto-incrementing asset tags is enabled, put the focus on the serial field - if it's not, put the focus on the asset tag.

Fixes #19302