### PR TITLE
CSV Import: License importer stores 1970-01-01 for unparseable expiration & termination dates

### DIFF
--- a/app/Importer/LicenseImporter.php
+++ b/app/Importer/LicenseImporter.php
@@ -58,7 +58,8 @@ class LicenseImporter extends ItemImporter
 
         $this->item['expiration_date'] = null;
         if ($this->findCsvMatch($row, 'expiration_date') != '') {
-            $this->item['expiration_date'] = date('Y-m-d 00:00:01', strtotime(trim($this->findCsvMatch($row, 'expiration_date'))));
+            $this->item['expiration_date'] = $this->findCsvMatch($row, 'expiration_date');
+            $this->item['expiration_date'] = $this->parseOrNullDate('expiration_date');
         }
         $this->item['license_email'] = trim($this->findCsvMatch($row, 'license_email'));
         $this->item['license_name'] = trim($this->findCsvMatch($row, 'license_name'));
@@ -76,7 +77,8 @@ class LicenseImporter extends ItemImporter
 
         $this->item['termination_date'] = null;
         if ($this->findCsvMatch($row, 'termination_date') != '') {
-            $this->item['termination_date'] = date('Y-m-d 00:00:01', strtotime($this->findCsvMatch($row, 'termination_date')));
+            $this->item['termination_date'] = $this->findCsvMatch($row, 'termination_date');
+            $this->item['termination_date'] = $this->parseOrNullDate('termination_date');
         }
 
         if ($editingLicense) {


### PR DESCRIPTION
Sibling follow-up to #19306 (Refs #13995 — same root cause, license side).

### What & why
Importing a license with an unparseable **Expiration Date** or **Termination Date** silently stores **`1970-01-01`** instead of leaving it empty — easy to hit with day-first inputs like `31/12/2023` or values like `N/A`.

### Root cause
`LicenseImporter` used `date('Y-m-d 00:00:01', strtotime($value))`. `strtotime()` returns `false` on failure; `date()` coerces `false` to timestamp `0` (Unix epoch), so the row imports as `1970-01-01` with no error.

### Fix
Swap to the importer's existing `parseOrNullDate()` helper — the same one #19306 used for `purchase_date`, and already used across `AssetImporter`. It parses with `CarbonImmutable`, logs `Unable to parse date: …`, and returns `null` on failure. Both columns are cast `'date'` with `toDateString()` setters, so valid dates are byte-identical to before; only unparseable input changes (`1970-01-01` → `null`).

### Testing
Side-by-side harness on the verbatim old/new logic with real Carbon: valid inputs (`2024-05-14`, `05/14/2024`) unchanged; unparseable inputs (`N/A`, day-first, `not-a-date`) go `1970-01-01` → `null`.

> Disclosure: prepared with AI assistance (Claude) and reviewed and verified by me before submission.
