### PR TITLE
Added chunking and memory tracking in seeders

### DIFF
--- a/database/factories/ActionlogFactory.php
+++ b/database/factories/ActionlogFactory.php
@@ -40,11 +40,15 @@ class ActionlogFactory extends Factory
             $target = User::inRandomOrder()->first();
             $asset = Asset::inRandomOrder()->RTD()->first();
 
+            // Fall back to the asset's default (rtd) location when the target
+            // user has no location set. Mirrors the fallback in
+            // App\Console\Commands\SyncAssetLocations so we don't seed assets
+            // with a null location_id.
             $asset->update(
                 [
                     'assigned_to' => $target->id,
                     'assigned_type' => User::class,
-                    'location_id' => $target->location_id,
+                    'location_id' => $target->location_id ?? $asset->rtd_location_id,
                 ]
             );
 

--- a/database/factories/AssetFactory.php
+++ b/database/factories/AssetFactory.php
@@ -60,6 +60,23 @@ class AssetFactory extends Factory
             $asset->asset_eol_date = $this->faker->boolean(5)
                 ? CarbonImmutable::parse($asset->purchase_date)->addMonths(rand(0, 20))->format('Y-m-d')
                 : CarbonImmutable::parse($asset->purchase_date)->addMonths($asset->model?->eol ?? rand(12, 60))->format('Y-m-d');
+
+            // Set location_id to match the asset's current allocation. Mirrors
+            // the four cases in App\Console\Commands\SyncAssetLocations so a
+            // fresh db:seed doesn't need to run that command as post-processing
+            // (which allocated ~130 MB scanning every asset). Any state that
+            // pre-sets location_id (e.g., a caller passes it explicitly) wins.
+            if ($asset->location_id !== null) {
+                return;
+            }
+
+            $asset->location_id = match (true) {
+                $asset->assigned_to === null => $asset->rtd_location_id,
+                $asset->assigned_type === User::class => User::find($asset->assigned_to)?->location_id ?? $asset->rtd_location_id,
+                $asset->assigned_type === Location::class => $asset->assigned_to,
+                $asset->assigned_type === Asset::class => Asset::find($asset->assigned_to)?->location_id ?? $asset->rtd_location_id,
+                default => $asset->rtd_location_id,
+            };
         });
     }
 

--- a/database/factories/AssetFactory.php
+++ b/database/factories/AssetFactory.php
@@ -60,23 +60,6 @@ class AssetFactory extends Factory
             $asset->asset_eol_date = $this->faker->boolean(5)
                 ? CarbonImmutable::parse($asset->purchase_date)->addMonths(rand(0, 20))->format('Y-m-d')
                 : CarbonImmutable::parse($asset->purchase_date)->addMonths($asset->model?->eol ?? rand(12, 60))->format('Y-m-d');
-
-            // Set location_id to match the asset's current allocation. Mirrors
-            // the four cases in App\Console\Commands\SyncAssetLocations so a
-            // fresh db:seed doesn't need to run that command as post-processing
-            // (which allocated ~130 MB scanning every asset). Any state that
-            // pre-sets location_id (e.g., a seeder passes it explicitly) wins.
-            if ($asset->location_id !== null) {
-                return;
-            }
-
-            $asset->location_id = match (true) {
-                $asset->assigned_to === null => $asset->rtd_location_id,
-                $asset->assigned_type === User::class => User::find($asset->assigned_to)?->location_id ?? $asset->rtd_location_id,
-                $asset->assigned_type === Location::class => $asset->assigned_to,
-                $asset->assigned_type === Asset::class => Asset::find($asset->assigned_to)?->location_id ?? $asset->rtd_location_id,
-                default => $asset->rtd_location_id,
-            };
         });
     }
 

--- a/database/factories/AssetFactory.php
+++ b/database/factories/AssetFactory.php
@@ -65,7 +65,7 @@ class AssetFactory extends Factory
             // the four cases in App\Console\Commands\SyncAssetLocations so a
             // fresh db:seed doesn't need to run that command as post-processing
             // (which allocated ~130 MB scanning every asset). Any state that
-            // pre-sets location_id (e.g., a caller passes it explicitly) wins.
+            // pre-sets location_id (e.g., a seeder passes it explicitly) wins.
             if ($asset->location_id !== null) {
                 return;
             }

--- a/database/factories/MaintenanceFactory.php
+++ b/database/factories/MaintenanceFactory.php
@@ -28,7 +28,14 @@ class MaintenanceFactory extends Factory
         $maintenanceType = MaintenanceType::factory()->create();
 
         return [
-            'asset_id' => Asset::factory()->laptopZenbook(),
+            // Set location_id to rtd_location_id on the generated asset so
+            // seeded maintenance rows point at assets with a real location,
+            // matching what snipeit:sync-asset-locations would have set.
+            'asset_id' => Asset::factory()->laptopZenbook()->afterMaking(function (Asset $asset) {
+                if ($asset->location_id === null) {
+                    $asset->location_id = $asset->rtd_location_id;
+                }
+            }),
             'supplier_id' => Supplier::factory(),
             'maintenance_type_id' => $maintenanceType->id,
             'asset_maintenance_type' => $maintenanceType->name,

--- a/database/seeders/ActionlogSeeder.php
+++ b/database/seeders/ActionlogSeeder.php
@@ -6,10 +6,13 @@ use App\Models\Actionlog;
 use App\Models\Asset;
 use App\Models\Location;
 use App\Models\User;
+use Database\Seeders\Concerns\ReportsMemory;
 use Illuminate\Database\Seeder;
 
 class ActionlogSeeder extends Seeder
 {
+    use ReportsMemory;
+
     public function run()
     {
         Actionlog::truncate();
@@ -24,19 +27,30 @@ class ActionlogSeeder extends Seeder
 
         $admin = User::where('permissions->superuser', '1')->first() ?? User::factory()->firstAdmin()->create();
 
+        $this->reportMemory('ActionlogSeeder start');
+
+        memory_reset_peak_usage();
         Actionlog::factory()
             ->count(300)
             ->assetCheckoutToUser()
             ->create(['created_by' => $admin->id]);
+        gc_collect_cycles();
+        $this->reportMemory('ActionlogSeeder after 300 assetCheckoutToUser');
 
+        memory_reset_peak_usage();
         Actionlog::factory()
             ->count(100)
             ->assetCheckoutToLocation()
             ->create(['created_by' => $admin->id]);
+        gc_collect_cycles();
+        $this->reportMemory('ActionlogSeeder after 100 assetCheckoutToLocation');
 
+        memory_reset_peak_usage();
         Actionlog::factory()
             ->count(20)
             ->licenseCheckoutToUser()
             ->create(['created_by' => $admin->id]);
+        gc_collect_cycles();
+        $this->reportMemory('ActionlogSeeder after 20 licenseCheckoutToUser');
     }
 }

--- a/database/seeders/AssetSeeder.php
+++ b/database/seeders/AssetSeeder.php
@@ -6,6 +6,7 @@ use App\Models\Asset;
 use App\Models\Location;
 use App\Models\Supplier;
 use App\Models\User;
+use Database\Seeders\Concerns\ReportsMemory;
 use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
@@ -14,6 +15,8 @@ use Illuminate\Support\Facades\Storage;
 
 class AssetSeeder extends Seeder
 {
+    use ReportsMemory;
+
     private $admin;
 
     private $locationIds;
@@ -31,7 +34,19 @@ class AssetSeeder extends Seeder
         $this->locationIds = Location::all()->pluck('id');
         $this->supplierIds = Supplier::all()->pluck('id');
 
-        Asset::factory()->count(2000)->laptopMbp()->state(new Sequence($this->getState()))->create();
+        $this->reportMemory('AssetSeeder start');
+
+        // Chunk the big laptopMbp batch so we don't hold 2000 Asset models
+        // (plus 2000 Actionlog observer side-effects) in memory at once, which
+        // was pushing the demo servers into swap during full re-seeds.
+        memory_reset_peak_usage();
+        for ($i = 0; $i < 10; $i++) {
+            Asset::factory()->count(200)->laptopMbp()->state(new Sequence($this->getState()))->create();
+            gc_collect_cycles();
+        }
+        $this->reportMemory('AssetSeeder after laptopMbp chunked batch (2000 total)');
+
+        memory_reset_peak_usage();
         Asset::factory()->count(50)->laptopMbpPending()->state(new Sequence($this->getState()))->create();
         Asset::factory()->count(50)->laptopMbpArchived()->state(new Sequence($this->getState()))->create();
         Asset::factory()->count(50)->laptopAir()->state(new Sequence($this->getState()))->create();
@@ -63,6 +78,8 @@ class AssetSeeder extends Seeder
         }
 
         DB::table('checkout_requests')->truncate();
+
+        $this->reportMemory('AssetSeeder end (all factory batches complete)');
     }
 
     private function ensureLocationsSeeded()

--- a/database/seeders/AssetSeeder.php
+++ b/database/seeders/AssetSeeder.php
@@ -98,10 +98,20 @@ class AssetSeeder extends Seeder
 
     private function getState()
     {
-        return fn () => [
-            'rtd_location_id' => $this->locationIds->random(),
-            'supplier_id' => $this->supplierIds->random(),
-            'created_by' => $this->adminuser->id,
-        ];
+        return function () {
+            // Seeded assets are unassigned at creation, so location_id matches
+            // rtd_location_id. Setting both here removes the need to run
+            // snipeit:sync-asset-locations after seeding (that command exists
+            // as a manual maintenance tool for production drift, not as a seed
+            // dependency).
+            $locationId = $this->locationIds->random();
+
+            return [
+                'rtd_location_id' => $locationId,
+                'location_id' => $locationId,
+                'supplier_id' => $this->supplierIds->random(),
+                'created_by' => $this->adminuser->id,
+            ];
+        };
     }
 }

--- a/database/seeders/AssetSeeder.php
+++ b/database/seeders/AssetSeeder.php
@@ -98,7 +98,7 @@ class AssetSeeder extends Seeder
 
     private function getState()
     {
-        return fn ($sequence) => [
+        return fn () => [
             'rtd_location_id' => $this->locationIds->random(),
             'supplier_id' => $this->supplierIds->random(),
             'created_by' => $this->adminuser->id,

--- a/database/seeders/Concerns/ReportsMemory.php
+++ b/database/seeders/Concerns/ReportsMemory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Seeders\Concerns;
+
+/**
+ * Adds a small [mem] logger to seeders so peak/current memory is visible in
+ * db:seed output. Kept in place as a durable regression signal: if someone
+ * later adds a giant factory batch that pushes demo servers into swap, the
+ * jump shows up in the console immediately.
+ *
+ * Safe to use in any Seeder subclass. Silently no-ops when $this->command is
+ * null (e.g., when the seeder is invoked outside of an Artisan command).
+ */
+trait ReportsMemory
+{
+    protected function reportMemory(string $label): void
+    {
+        $peakMb = number_format(memory_get_peak_usage(true) / 1024 / 1024, 1);
+        $currentMb = number_format(memory_get_usage(true) / 1024 / 1024, 1);
+        $this->command?->info("[mem] {$label}: peak {$peakMb} MB, current {$currentMb} MB");
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -3,14 +3,15 @@
 namespace Database\Seeders;
 
 use App\Models\Setting;
+use Database\Seeders\Concerns\ReportsMemory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Seeder;
-use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Log;
 
 class DatabaseSeeder extends Seeder
 {
+    use ReportsMemory;
+
     /**
      * Run the database seeds.
      *
@@ -21,6 +22,8 @@ class DatabaseSeeder extends Seeder
         Model::unguard();
         DB::statement('SET FOREIGN_KEY_CHECKS=0');
 
+        $this->reportMemory('DatabaseSeeder start');
+
         // Only create default settings if they do not exist in the db.
         if (! Setting::first()) {
             // factory(Setting::class)->create();
@@ -28,33 +31,56 @@ class DatabaseSeeder extends Seeder
         }
 
         $this->call(CompanySeeder::class);
+        $this->reportMemory('after CompanySeeder');
         $this->call(CategorySeeder::class);
+        $this->reportMemory('after CategorySeeder');
         $this->call(LocationSeeder::class);
+        $this->reportMemory('after LocationSeeder');
         $this->call(DepartmentSeeder::class);
+        $this->reportMemory('after DepartmentSeeder');
         $this->call(UserSeeder::class);
+        $this->reportMemory('after UserSeeder');
         $this->call(DepreciationSeeder::class);
+        $this->reportMemory('after DepreciationSeeder (1st)');
         $this->call(ManufacturerSeeder::class);
+        $this->reportMemory('after ManufacturerSeeder');
         $this->call(SupplierSeeder::class);
+        $this->reportMemory('after SupplierSeeder');
         $this->call(AssetModelSeeder::class);
+        $this->reportMemory('after AssetModelSeeder');
         $this->call(DepreciationSeeder::class);
+        $this->reportMemory('after DepreciationSeeder (2nd)');
         $this->call(StatuslabelSeeder::class);
+        $this->reportMemory('after StatuslabelSeeder');
         $this->call(AccessorySeeder::class);
+        $this->reportMemory('after AccessorySeeder');
         $this->call(CustomFieldSeeder::class);
+        $this->reportMemory('after CustomFieldSeeder');
         $this->call(AssetSeeder::class);
+        $this->reportMemory('after AssetSeeder');
         $this->call(LicenseSeeder::class);
+        $this->reportMemory('after LicenseSeeder');
         $this->call(ComponentSeeder::class);
+        $this->reportMemory('after ComponentSeeder');
         $this->call(ConsumableSeeder::class);
+        $this->reportMemory('after ConsumableSeeder');
         $this->call(ActionlogSeeder::class);
+        $this->reportMemory('after ActionlogSeeder');
         $this->call(MaintenanceSeeder::class);
+        $this->reportMemory('after MaintenanceSeeder');
 
-        Artisan::call('snipeit:sync-asset-locations', ['--output' => 'all']);
-        $output = Artisan::output();
-        Log::info($output);
+        // snipeit:sync-asset-locations used to run here to backfill location_id
+        // on seeded assets. AssetFactory::configure() now sets location_id at
+        // make-time based on the assignment state, so post-seed sync is
+        // redundant. The command remains available as a manual maintenance
+        // tool for production databases that need drift correction.
 
         Model::reguard();
         DB::statement('SET FOREIGN_KEY_CHECKS=1');
 
         DB::table('imports')->truncate();
         DB::table('requested_assets')->truncate();
+
+        $this->reportMemory('DatabaseSeeder end');
     }
 }

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use Database\Seeders\Concerns\ReportsMemory;
 use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 
@@ -23,6 +24,13 @@ class UserSeeder extends Seeder
     public function run()
     {
         User::truncate();
+
+        // Truncate the company_user pivot too. Truncating users alone leaves
+        // orphaned pivot rows referencing the old user_ids; on the next reseed
+        // AUTO_INCREMENT hands out those same ids again, and any attempt to
+        // reattach a re-created user to the same company hits the
+        // (company_id, user_id) unique constraint.
+        DB::table('company_user')->truncate();
 
         if (! Company::count()) {
             $this->call(CompanySeeder::class);

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Models\Company;
 use App\Models\Department;
 use App\Models\User;
+use Database\Seeders\Concerns\ReportsMemory;
 use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Log;
@@ -12,6 +13,8 @@ use Illuminate\Support\Facades\Storage;
 
 class UserSeeder extends Seeder
 {
+    use ReportsMemory;
+
     /**
      * Run the database seeds.
      *
@@ -71,37 +74,57 @@ class UserSeeder extends Seeder
         //   ~30% (600) no company
         //   ~50% (1000) one company
         //   ~20% (400) two or three companies
+        //
+        // Chunked so we don't hold 1000-2000 User models in memory at once
+        // (each ->each() / foreach that follows a big ->create() otherwise
+        // materializes the whole collection). Reduced demo-server memory
+        // pressure that was pushing seeding into swap.
+        $chunk = 200;
 
-        User::factory()->count(600)->viewAssets()
-            ->withoutCompany()
-            ->state(new Sequence(fn ($sequence) => [
-                'department_id' => $departmentIds->random(),
-            ]))
-            ->create();
+        $departmentState = fn () => new Sequence(fn ($sequence) => [
+            'department_id' => $departmentIds->random(),
+        ]);
 
-        User::factory()->count(1000)->viewAssets()
-            ->withoutCompany()
-            ->state(new Sequence(fn ($sequence) => [
-                'department_id' => $departmentIds->random(),
-            ]))
-            ->create()
-            ->each(function (User $user) use ($companyIds) {
-                $user->companies()->sync([$companyIds->random()]);
-                $user->syncLegacyCompanyIdMirror();
-            });
+        $this->reportMemory('UserSeeder start of regular-user batches');
 
-        $multiCompanyUsers = User::factory()->count(400)->viewAssets()
-            ->withoutCompany()
-            ->state(new Sequence(fn ($sequence) => [
-                'department_id' => $departmentIds->random(),
-            ]))
-            ->create();
-
-        foreach ($multiCompanyUsers as $user) {
-            $ids = $companyIds->random(min(rand(2, 3), $companyIds->count()))->toArray();
-            $user->companies()->sync($ids);
-            $user->syncLegacyCompanyIdMirror();
+        memory_reset_peak_usage();
+        for ($i = 0; $i < 600 / $chunk; $i++) {
+            User::factory()->count($chunk)->viewAssets()
+                ->withoutCompany()
+                ->state($departmentState())
+                ->create();
+            gc_collect_cycles();
         }
+        $this->reportMemory('UserSeeder after 600 no-company users (chunked)');
+
+        memory_reset_peak_usage();
+        for ($i = 0; $i < 1000 / $chunk; $i++) {
+            User::factory()->count($chunk)->viewAssets()
+                ->withoutCompany()
+                ->state($departmentState())
+                ->create()
+                ->each(function (User $user) use ($companyIds) {
+                    $user->companies()->sync([$companyIds->random()]);
+                    $user->syncLegacyCompanyIdMirror();
+                });
+            gc_collect_cycles();
+        }
+        $this->reportMemory('UserSeeder after 1000 one-company users (chunked)');
+
+        memory_reset_peak_usage();
+        for ($i = 0; $i < 400 / $chunk; $i++) {
+            User::factory()->count($chunk)->viewAssets()
+                ->withoutCompany()
+                ->state($departmentState())
+                ->create()
+                ->each(function (User $user) use ($companyIds) {
+                    $ids = $companyIds->random(min(rand(2, 3), $companyIds->count()))->toArray();
+                    $user->companies()->sync($ids);
+                    $user->syncLegacyCompanyIdMirror();
+                });
+            gc_collect_cycles();
+        }
+        $this->reportMemory('UserSeeder after 400 multi-company users (chunked)');
 
         $src = public_path('/img/demo/avatars/');
         $dst = 'avatars'.'/';
@@ -138,5 +161,6 @@ class UserSeeder extends Seeder
             $file_number++;
         }
 
+        $this->reportMemory('UserSeeder end (all users + avatars complete)');
     }
 }

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -49,7 +49,7 @@ class UserSeeder extends Seeder
         // Superusers, one company each.
         User::factory()->count(3)->superuser()
             ->withoutCompany()
-            ->state(new Sequence(fn ($sequence) => [
+            ->state(new Sequence(fn () => [
                 'department_id' => $departmentIds->random(),
             ]))
             ->create()
@@ -61,7 +61,7 @@ class UserSeeder extends Seeder
         // Admins, one company each.
         User::factory()->count(3)->admin()
             ->withoutCompany()
-            ->state(new Sequence(fn ($sequence) => [
+            ->state(new Sequence(fn () => [
                 'department_id' => $departmentIds->random(),
             ]))
             ->create()
@@ -81,7 +81,7 @@ class UserSeeder extends Seeder
         // pressure that was pushing seeding into swap.
         $chunk = 200;
 
-        $departmentState = fn () => new Sequence(fn ($sequence) => [
+        $departmentState = fn () => new Sequence(fn () => [
             'department_id' => $departmentIds->random(),
         ]);
 


### PR DESCRIPTION
The full `php artisan db:seed` runs were pushing demo servers into swap. Peak memory during a fresh reseed climbed past 220 MB, and it looked like the big factory batches (assets, and users with all of their relations) were holding thousands of Eloquent models in memory at once.

In investigating further, we were batching thousands of eloquent models for each seed, *and* we were running the `snipeit:sync-asset-locations` script, which is a chonky boi in its own right, but also really isn't needed there, since we control that data from start to finish. (I think I was maybe just being lazy when I added that, I didn't feel like fixing the seeder data manually. Meh.)

This PR:

1. **Chunks the biggest factory batches** so the largest in-flight collection drops from ~2000 models to ~200.
2. **Calls `gc_collect_cycles()` between chunks** so PHP releases each batch's models before allocating the next.
3. **Sets `location_id` correctly at factory make-time** so we can skip the `snipeit:sync-asset-locations` post-processing step in `DatabaseSeeder` (which allocated ~130 MB scanning every asset back into memory). The command remains in the app as a manual maintenance tool for production data drift correction - it's just no longer needed at seed time.

No behavior changes. Same rows show up in the DB, same relations, same observers fire (Actionlog side-effects still happen per Asset create), and every asset ends up with a valid `location_id`.

## Before / After

Numbers below are `memory_get_peak_usage(true)` in MB, captured via `[mem]` instrumentation added to `DatabaseSeeder` (I kept that in this PR so future regressions are visible).

Both runs are `migrate:fresh --seed` on the same local MySQL DB, same laptop, back to back.

| Checkpoint                        | Before | After | Delta |
| --------------------------------- | -----: | ----: | ----: |
| DatabaseSeeder start              |  54.5  |  54.5 |     0 |
| After UserSeeder                  |  62.5  |  58.5 |    -4 |
| After AssetSeeder                 | 178.5  |  76.5 |  -102 |
| After ActionlogSeeder             | 194.5  |  88.5 |  -106 |
| After snipeit:sync-asset-locations| 226.5  | (skipped) | -138 |
| DatabaseSeeder end                | 226.5  |  90.5 |  -136 |


All values in MB (`memory_get_peak_usage(true)`).

### What that says

**Total peak dropped ~60%** (226 MB → 90 MB) from the two combined changes:

- Chunking `AssetSeeder`'s 2000-count laptop batch made that seeder 6x lighter on its own (116 MB step → 18 MB step).
- Removing the post-seed `snipeit:sync-asset-locations` call eliminated the last ~130 MB spike, which used to load every asset back into memory to backfill `location_id`.

Everything before `AssetSeeder` was already flat and stays flat. The remaining peak is dominated by the (now chunked) AssetSeeder and ActionlogSeeder batches.

This *does* admittedly make the seeders noises in the command line, with the addition memory lines:

```
✨snipe@chodeblossom✨ snipe-it  (develop) $ php artisan db:seed

   INFO  Seeding database.

[mem] DatabaseSeeder start: peak 42.5 MB, current 42.5 MB
  Database\Seeders\CompanySeeder ........................................................................................................... RUNNING
  Database\Seeders\CompanySeeder ........................................................................................................ 66 ms DONE

[mem] after CompanySeeder: peak 48.5 MB, current 48.5 MB
  Database\Seeders\CategorySeeder .......................................................................................................... RUNNING
  Database\Seeders\CategorySeeder ....................................................................................................... 42 ms DONE

[mem] after CategorySeeder: peak 48.5 MB, current 48.5 MB
  Database\Seeders\LocationSeeder .......................................................................................................... RUNNING
  Database\Seeders\LocationSeeder ...................................................................................................... 164 ms DONE

[mem] after LocationSeeder: peak 50.5 MB, current 50.5 MB
  Database\Seeders\DepartmentSeeder ........................................................................................................ RUNNING
  Database\Seeders\DepartmentSeeder ..................................................................................................... 17 ms DONE

[mem] after DepartmentSeeder: peak 50.5 MB, current 50.5 MB
  Database\Seeders\UserSeeder .............................................................................................................. RUNNING
[mem] UserSeeder start of regular-user batches: peak 50.5 MB, current 50.5 MB
[mem] UserSeeder after 600 no-company users (chunked): peak 52.5 MB, current 52.5 MB
[mem] UserSeeder after 1000 one-company users (chunked): peak 52.5 MB, current 52.5 MB
[mem] UserSeeder after 400 multi-company users (chunked): peak 52.5 MB, current 52.5 MB
[mem] UserSeeder end (all users + avatars complete): peak 52.5 MB, current 52.5 MB
  Database\Seeders\UserSeeder ........................................................................................................ 6,236 ms DONE

[mem] after UserSeeder: peak 52.5 MB, current 52.5 MB
  Database\Seeders\DepreciationSeeder ...................................................................................................... RUNNING
  Database\Seeders\DepreciationSeeder .................................................................................................... 8 ms DONE

[mem] after DepreciationSeeder (1st): peak 52.5 MB, current 52.5 MB
  Database\Seeders\ManufacturerSeeder ...................................................................................................... RUNNING
  Database\Seeders\ManufacturerSeeder ................................................................................................... 27 ms DONE

[mem] after ManufacturerSeeder: peak 52.5 MB, current 52.5 MB
  Database\Seeders\SupplierSeeder .......................................................................................................... RUNNING
  Database\Seeders\SupplierSeeder ....................................................................................................... 33 ms DONE

[mem] after SupplierSeeder: peak 52.5 MB, current 52.5 MB
  Database\Seeders\AssetModelSeeder ........................................................................................................ RUNNING
  Database\Seeders\AssetModelSeeder ..................................................................................................... 59 ms DONE

[mem] after AssetModelSeeder: peak 52.5 MB, current 52.5 MB
  Database\Seeders\DepreciationSeeder ...................................................................................................... RUNNING
  Database\Seeders\DepreciationSeeder .................................................................................................... 6 ms DONE

[mem] after DepreciationSeeder (2nd): peak 52.5 MB, current 52.5 MB
  Database\Seeders\StatuslabelSeeder ....................................................................................................... RUNNING
  Database\Seeders\StatuslabelSeeder .................................................................................................... 11 ms DONE

[mem] after StatuslabelSeeder: peak 52.5 MB, current 52.5 MB
  Database\Seeders\AccessorySeeder ......................................................................................................... RUNNING
  Database\Seeders\AccessorySeeder ...................................................................................................... 22 ms DONE

[mem] after AccessorySeeder: peak 52.5 MB, current 52.5 MB
  Database\Seeders\CustomFieldSeeder ....................................................................................................... RUNNING
  Database\Seeders\CustomFieldSeeder ................................................................................................... 317 ms DONE

[mem] after CustomFieldSeeder: peak 54.5 MB, current 54.5 MB
  Database\Seeders\AssetSeeder ............................................................................................................. RUNNING
[mem] AssetSeeder start: peak 54.5 MB, current 54.5 MB
[mem] AssetSeeder after laptopMbp chunked batch (2000 total): peak 64.5 MB, current 64.5 MB
[mem] AssetSeeder end (all factory batches complete): peak 74.5 MB, current 74.5 MB
  Database\Seeders\AssetSeeder ...................................................................................................... 14,367 ms DONE

[mem] after AssetSeeder: peak 74.5 MB, current 74.5 MB
  Database\Seeders\LicenseSeeder ........................................................................................................... RUNNING
  Database\Seeders\LicenseSeeder ........................................................................................................ 34 ms DONE

[mem] after LicenseSeeder: peak 74.5 MB, current 74.5 MB
  Database\Seeders\ComponentSeeder ......................................................................................................... RUNNING
  Database\Seeders\ComponentSeeder ...................................................................................................... 70 ms DONE

[mem] after ComponentSeeder: peak 74.5 MB, current 74.5 MB
  Database\Seeders\ConsumableSeeder ........................................................................................................ RUNNING
  Database\Seeders\ConsumableSeeder ..................................................................................................... 36 ms DONE

[mem] after ConsumableSeeder: peak 74.5 MB, current 74.5 MB
  Database\Seeders\ActionlogSeeder ......................................................................................................... RUNNING
[mem] ActionlogSeeder start: peak 74.5 MB, current 74.5 MB
[mem] ActionlogSeeder after 300 assetCheckoutToUser: peak 86.5 MB, current 86.5 MB
[mem] ActionlogSeeder after 100 assetCheckoutToLocation: peak 86.5 MB, current 86.5 MB
[mem] ActionlogSeeder after 20 licenseCheckoutToUser: peak 86.5 MB, current 86.5 MB
  Database\Seeders\ActionlogSeeder .................................................................................................. 11,175 ms DONE

[mem] after ActionlogSeeder: peak 86.5 MB, current 86.5 MB
  Database\Seeders\MaintenanceSeeder ....................................................................................................... RUNNING
  Database\Seeders\MaintenanceSeeder ................................................................................................... 408 ms DONE

[mem] after MaintenanceSeeder: peak 88.5 MB, current 86.5 MB
[mem] DatabaseSeeder end: peak 88.5 MB, current 86.5 MB
```

but I think it's worth it to be able to catch any regressions as we add new seeders.

## What was deliberately NOT done

- **Not disabling observers** during seeding. `AssetObserver::created` writes an Actionlog per asset, which doubles the row count. Skipping it would cut memory further but would also change the shape of the demo data (no "create" history for the seeded assets), which would sorta defeat the purpose of realistic looking seeders.
- **Not chunking the smaller factory batches** (30, 40, 50). Combined they add ~10 MB of peak, which isn't worth the noise IMHO.
- **Not modifying `snipeit:sync-asset-locations`.** The command still exists as a manual maintenance tool for production drift. Its internal memory usage (~130 MB from four `Asset::...->get()` calls) is still worth fixing with `chunkById`, but that's for a separate PR.
