### PR TITLE
CSV Import: User importer rejects the entire row when start/end dates aren't exactly Y-m-d

### DIFF
--- a/app/Importer/UserImporter.php
+++ b/app/Importer/UserImporter.php
@@ -90,7 +90,9 @@ class UserImporter extends ItemImporter
         $this->item['state'] = trim($this->findCsvMatch($row, 'state'));
         $this->item['country'] = trim($this->findCsvMatch($row, 'country'));
         $this->item['start_date'] = trim($this->findCsvMatch($row, 'start_date'));
+        $this->item['start_date'] = $this->parseOrNullDate('start_date');
         $this->item['end_date'] = trim($this->findCsvMatch($row, 'end_date'));
+        $this->item['end_date'] = $this->parseOrNullDate('end_date');
         $this->item['zip'] = trim($this->findCsvMatch($row, 'zip'));
         $this->item['activated'] = ($this->fetchHumanBoolean(trim($this->findCsvMatch($row, 'activated'))) == 1) ? '1' : 0;
         $this->item['employee_num'] = trim($this->findCsvMatch($row, 'employee_num'));
@@ -99,8 +101,6 @@ class UserImporter extends ItemImporter
         $this->item['remote'] = ($this->fetchHumanBoolean(trim($this->findCsvMatch($row, 'remote'))) == 1) ? '1' : 0;
         $this->item['vip'] = ($this->fetchHumanBoolean(trim($this->findCsvMatch($row, 'vip'))) == 1) ? '1' : 0;
         $this->item['autoassign_licenses'] = ($this->fetchHumanBoolean(trim($this->findCsvMatch($row, 'autoassign_licenses'))) == 1) ? '1' : 0;
-
-        $this->handleEmptyStringsForDates();
 
         $user_department = trim($this->findCsvMatch($row, 'department'));
         if ($this->shouldUpdateField($user_department)) {
@@ -333,16 +333,5 @@ class UserImporter extends ItemImporter
         }
 
         return in_array($location->company_id, $companyIds);
-    }
-
-    private function handleEmptyStringsForDates(): void
-    {
-        if ($this->item['start_date'] === '') {
-            $this->item['start_date'] = null;
-        }
-
-        if ($this->item['end_date'] === '') {
-            $this->item['end_date'] = null;
-        }
     }
 }

--- a/tests/Feature/Importing/Api/ImportUsersTest.php
+++ b/tests/Feature/Importing/Api/ImportUsersTest.php
@@ -119,6 +119,44 @@ class ImportUsersTest extends ImportDataTestCase implements TestsPermissionsRequ
     }
 
     #[Test]
+    public function parses_non_iso_start_and_end_dates(): void
+    {
+        $row = ImportFileBuilder::new()->definition();
+        $row['start_date'] = '07/28/2025';
+        $row['end_date'] = '12/31/2025';
+
+        $importFileBuilder = new ImportFileBuilder([$row]);
+        $import = Import::factory()->users()->create(['file_path' => $importFileBuilder->saveToImportsDirectory()]);
+
+        $this->actingAsForApi(User::factory()->superuser()->create());
+        $this->importFileResponse(['import' => $import->id])->assertOk();
+
+        $newUser = User::query()->where('username', $row['username'])->sole();
+
+        $this->assertEquals('2025-07-28', $newUser->start_date);
+        $this->assertEquals('2025-12-31', $newUser->end_date);
+    }
+
+    #[Test]
+    public function stores_null_when_start_or_end_date_is_unparseable(): void
+    {
+        $row = ImportFileBuilder::new()->definition();
+        $row['start_date'] = 'not-a-date';
+        $row['end_date'] = 'also-not-a-date';
+
+        $importFileBuilder = new ImportFileBuilder([$row]);
+        $import = Import::factory()->users()->create(['file_path' => $importFileBuilder->saveToImportsDirectory()]);
+
+        $this->actingAsForApi(User::factory()->superuser()->create());
+        $this->importFileResponse(['import' => $import->id])->assertOk();
+
+        $newUser = User::query()->where('username', $row['username'])->sole();
+
+        $this->assertNull($newUser->start_date);
+        $this->assertNull($newUser->end_date);
+    }
+
+    #[Test]
     public function will_ignore_unknown_columns_when_file_contains_unknown_columns(): void
     {
         $row = ImportFileBuilder::new()->definition();


### PR DESCRIPTION
Sibling follow-up to #19306 / #19310 (user side of the importer date-parsing family). Refs #15141 / #19294.

### What & why
Importing users with a **Start Date** or **End Date** in any format other than exactly `Y-m-d` - e.g. `07/28/2025`, `28-12-2025`, or `2025-07-28 00:00:00` - fails validation and **rejects the whole user row**, while the identical date imports fine for assets, licenses, accessories, consumables and components.

### Root cause
`UserImporter` passes the raw CSV value straight into the `User` model, whose rules require `nullable|date_format:Y-m-d`. #19294 fixed the empty-string symptom of this same validation failure (#15141), but any non-ISO representation of a valid date still hard-fails the row.

### Fix
Run `start_date`/`end_date` through the importer's existing `parseOrNullDate()` helper - the same one used everywhere else after #19306/#19310. It parses with `CarbonImmutable`, normalizes to `Y-m-d`, logs `Unable to parse date: ...` and returns `null` on failure. Since it already returns `null` for empty input, the `handleEmptyStringsForDates()` helper from #19294 becomes redundant and is removed. Already-ISO dates are unchanged.

### Testing
Two regression tests in `ImportUsersTest`: a non-ISO date now imports as the normalized `Y-m-d` value (previously: 500 + row rejected), and an unparseable date imports as `null` instead of rejecting the row. Both fail before the fix and pass after; the full ImportUsersTest file passes (17 tests, 128 assertions, sqlite like CI).

Disclosure: prepared with AI assistance (Claude) and reviewed and verified by me before submission.
