### PR TITLE
CSV Import: update mode silently resets requestable and cannot clear byod

### DIFF
--- a/app/Importer/AssetImporter.php
+++ b/app/Importer/AssetImporter.php
@@ -112,11 +112,29 @@ class AssetImporter extends ItemImporter
 
         $this->item['notes'] = trim($this->findCsvMatch($row, 'asset_notes'));
         $this->item['image'] = basename(trim($this->findCsvMatch($row, 'image')));
-        $this->item['requestable'] = trim(($this->fetchHumanBoolean($this->findCsvMatch($row, 'requestable'))) == 1) ? '1' : 0;
-        $asset->requestable = $this->item['requestable'];
+
+        /**
+         * Boolean fields need special handling. On create, a missing or blank value
+         * defaults to 0. On update, only touch the flag when the CSV actually provides
+         * a value — otherwise a file without the column would silently reset the flag
+         * on every updated asset. The coerced value is also assigned directly to the
+         * model because sanitizeItemForUpdating() strips falsy values, which would
+         * make it impossible to explicitly clear a flag in update mode.
+         */
+        $requestable = trim((string) $this->findCsvMatch($row, 'requestable'));
+        if ((! $this->updating) || ($requestable !== '')) {
+            $this->item['requestable'] = ($this->fetchHumanBoolean($requestable) == 1) ? '1' : 0;
+            $asset->requestable = $this->item['requestable'];
+        }
+
+        $byod = trim((string) $this->findCsvMatch($row, 'byod'));
+        if ((! $this->updating) || ($byod !== '')) {
+            $this->item['byod'] = ($this->fetchHumanBoolean($byod) == 1) ? '1' : 0;
+            $asset->byod = $this->item['byod'];
+        }
+
         $this->item['warranty_months'] = intval(trim($this->findCsvMatch($row, 'warranty_months')));
         $this->item['model_id'] = $this->createOrFetchAssetModel($row);
-        $this->item['byod'] = ($this->fetchHumanBoolean(trim($this->findCsvMatch($row, 'byod'))) == 1) ? '1' : 0;
         $this->item['last_checkin'] = trim($this->findCsvMatch($row, 'last_checkin'));
         $this->item['last_checkout'] = trim($this->findCsvMatch($row, 'last_checkout'));
         $this->item['expected_checkin'] = trim($this->findCsvMatch($row, 'expected_checkin'));

--- a/tests/Feature/Importing/Api/ImportAssetsTest.php
+++ b/tests/Feature/Importing/Api/ImportAssetsTest.php
@@ -395,7 +395,7 @@ class ImportAssetsTest extends ImportDataTestCase implements TestsPermissionsReq
             'category', 'manufacturer_id', 'name', 'tag', 'model_id',
             'model_number', 'purchase_date', 'purchase_cost', 'warranty_months', 'supplier_id',
             'location_id', 'company_id', 'serial', 'assigned_to', 'status_id', 'rtd_location_id',
-            'last_checkout', 'requestable', 'updated_at', 'checkout_counter', 'assigned_type',
+            'last_checkout', 'updated_at', 'checkout_counter', 'assigned_type',
         ];
 
         $this->assertEquals($row['assigneeFullName'], "{$assignee->first_name} {$assignee->last_name}");
@@ -419,13 +419,52 @@ class ImportAssetsTest extends ImportDataTestCase implements TestsPermissionsReq
         $this->assertEquals(1, $updatedAsset->checkout_counter);
         $this->assertEquals(User::class, $updatedAsset->assigned_type);
 
-        // RequestAble is always updated regardless of initial value.
-        // $this->assertEquals($asset->requestable, $updatedAsset->requestable);
+        // The import file has no requestable column, so the flag should be untouched.
+        $this->assertEquals($asset->requestable, $updatedAsset->requestable);
 
         $this->assertEquals(
             Arr::except($asset->attributesToArray(), $updatedAttributes),
             Arr::except($updatedAsset->attributesToArray(), $updatedAttributes),
         );
+    }
+
+    #[Test]
+    public function update_mode_preserves_boolean_flags_when_columns_are_not_in_file(): void
+    {
+        $asset = Asset::factory()->create(['requestable' => 1, 'byod' => 1])->refresh();
+
+        // The default import file has no "Requestable" or "BYOD" columns, so an
+        // update import should leave both flags alone.
+        $importFileBuilder = ImportFileBuilder::times(1)->replace(['tag' => $asset->asset_tag]);
+        $import = Import::factory()->asset()->create(['file_path' => $importFileBuilder->saveToImportsDirectory()]);
+
+        $this->actingAsForApi(User::factory()->superuser()->create());
+        $this->importFileResponse(['import' => $import->id, 'import-update' => true])->assertOk();
+
+        $asset->refresh();
+        $this->assertEquals(1, $asset->requestable, 'Update import without a requestable column should not reset the requestable flag.');
+        $this->assertEquals(1, $asset->byod, 'Update import without a byod column should not reset the byod flag.');
+    }
+
+    #[Test]
+    public function update_mode_can_clear_boolean_flags_when_explicitly_false(): void
+    {
+        $asset = Asset::factory()->create(['requestable' => 1, 'byod' => 1])->refresh();
+
+        $row = ImportFileBuilder::new()->definition();
+        $row['tag'] = $asset->asset_tag;
+        $row['Requestable'] = 'FALSE';
+        $row['BYOD'] = 'FALSE';
+
+        $importFileBuilder = new ImportFileBuilder([$row]);
+        $import = Import::factory()->asset()->create(['file_path' => $importFileBuilder->saveToImportsDirectory()]);
+
+        $this->actingAsForApi(User::factory()->superuser()->create());
+        $this->importFileResponse(['import' => $import->id, 'import-update' => true])->assertOk();
+
+        $asset->refresh();
+        $this->assertEquals(0, $asset->requestable, 'Update import with requestable=FALSE should clear the requestable flag.');
+        $this->assertEquals(0, $asset->byod, 'Update import with byod=FALSE should clear the byod flag.');
     }
 
     #[Test]


### PR DESCRIPTION
**Bug 1 - requestable wiped on every update import.** In update mode, `AssetImporter::createAssetIfNotExists()` always coerces the requestable CSV value and assigns it directly to the asset. When the file has no requestable column, `null` coerces to `0`, so an update import (e.g. changing locations in bulk) silently un-flags every requestable asset it touches. The test suite already documented this: `update_asset_from_import` excluded `requestable` from its unchanged-attributes check with the comment "RequestAble is always updated regardless of initial value." and the assertion commented out.

**Bug 2 - byod can never be cleared.** The mirror problem: byod is coerced to int `0` before `sanitizeItemForUpdating()`, which strips falsy values in update mode, so an explicit `byod=FALSE` in the CSV is silently dropped.

**Fix:** in update mode, only touch either flag when the CSV provides a non-blank value; assign the coerced value directly to the model (as the requestable line already did) so an explicit falsy value survives empty-value stripping. Create mode is unchanged - missing/blank still defaults to 0.

**Tests:** two regression tests (preserve-when-absent, clear-when-explicitly-false) - both fail on develop, pass with the fix - and the previously commented-out assertion in `update_asset_from_import` is restored. Full `tests/Feature/Importing` suite passes (153 tests, sqlite).

Disclosure: this fix was developed with the assistance of an AI agent (Claude), with the bug confirmed and tests verified by running the suite locally.
