### PR TITLE
File Uploads: Fixed FD-56588 - tighter controls on model files

### DIFF
--- a/app/Http/Controllers/Api/UploadedFilesController.php
+++ b/app/Http/Controllers/Api/UploadedFilesController.php
@@ -89,9 +89,12 @@ class UploadedFilesController extends Controller
     public function store(UploadFileRequest $request, $object_type, $id): JsonResponse
     {
 
-        // Check the permissions to make sure the user can view the object
+        // Check the permissions to make sure the user is allowed to upload
+        // to the object. `manageFiles` is stricter than `files` (used by
+        // index/show below) so a read-only cascade like the one on
+        // AssetModelPolicy does not accidentally grant write access.
         $object = self::$map_object_type[$object_type]::withTrashed()->find($id);
-        $this->authorize('files', $object);
+        $this->authorize('manageFiles', $object);
 
         if (! $object) {
             return response()->json(Helper::formatStandardApiResponse('error', null, trans('general.file_upload_status.invalid_object')));
@@ -192,9 +195,10 @@ class UploadedFilesController extends Controller
     public function destroy($object_type, $id, $file_id): JsonResponse
     {
 
-        // Check the permissions to make sure the user can view the object
+        // See store(): `manageFiles` is the strict write ability so a
+        // read-only cascade in files() does not authorize deletion.
         $object = self::$map_object_type[$object_type]::withTrashed()->find($id);
-        $this->authorize('files', $object);
+        $this->authorize('manageFiles', $object);
 
         if (! $object) {
             return response()->json(Helper::formatStandardApiResponse('error', null, trans('general.file_upload_status.invalid_object')));

--- a/app/Http/Controllers/UploadedFilesController.php
+++ b/app/Http/Controllers/UploadedFilesController.php
@@ -35,9 +35,12 @@ class UploadedFilesController extends Controller
     public function store(UploadFileRequest $request, $object_type, $id): RedirectResponse
     {
 
-        // Check the permissions to make sure the user can view the object
+        // Check the permissions to make sure the user is allowed to upload
+        // to the object. `manageFiles` is stricter than `files` (used by
+        // show/download) so a read-only cascade like the one on
+        // AssetModelPolicy does not accidentally grant write access.
         $object = self::$map_object_type[$object_type]::withTrashed()->find($id);
-        $this->authorize('files', $object);
+        $this->authorize('manageFiles', $object);
 
         if (! $object) {
             return redirect()->back()->withFragment('files')->with('error', trans('general.file_upload_status.invalid_object'));
@@ -129,9 +132,10 @@ class UploadedFilesController extends Controller
     public function destroy($object_type, $id, $file_id): RedirectResponse
     {
 
-        // Check the permissions to make sure the user can view the object
+        // See store(): `manageFiles` is the strict write ability so a
+        // read-only cascade in files() does not authorize deletion.
         $object = self::$map_object_type[$object_type]::withTrashed()->find($id);
-        $this->authorize('files', $object);
+        $this->authorize('manageFiles', $object);
 
         if (! $object) {
             return redirect()->back()->withFragment('files')->with('error', trans('general.file_upload_status.invalid_object'));

--- a/app/Policies/AssetModelPolicy.php
+++ b/app/Policies/AssetModelPolicy.php
@@ -11,13 +11,30 @@ class AssetModelPolicy extends SnipePermissionsPolicy
         return 'models';
     }
 
+    /**
+     * READ ability for model files (index / show / download). Cascades from
+     * assets.files because a model's file attachments (user manuals, spec
+     * sheets, etc.) show up on the asset detail page and are legitimately
+     * useful to anyone who can see the asset itself.
+     */
     public function files(User $user, $item = null)
     {
-        // Set this to true so that users who can see the asset can also see the associated model files
         if ($user->hasAccess('assets.files')) {
             return true;
         }
 
+        return $user->hasAccess($this->columnName().'.files');
+    }
+
+    /**
+     * WRITE ability for model files (upload / delete). Strict: requires the
+     * dedicated `models.files` grant. The read cascade above must NOT
+     * short-circuit here or an admin who withheld `models.files` while
+     * granting `assets.files` to routine technicians would still see them
+     * mutating the shared model file catalog.
+     */
+    public function manageFiles(User $user, $item = null)
+    {
         return $user->hasAccess($this->columnName().'.files');
     }
 }

--- a/app/Policies/AssetModelPolicy.php
+++ b/app/Policies/AssetModelPolicy.php
@@ -13,13 +13,14 @@ class AssetModelPolicy extends SnipePermissionsPolicy
 
     /**
      * READ ability for model files (index / show / download). Cascades from
-     * assets.files because a model's file attachments (user manuals, spec
-     * sheets, etc.) show up on the asset detail page and are legitimately
-     * useful to anyone who can see the asset itself.
+     * asset visibility: model file attachments (user manuals, spec sheets,
+     * etc.) apply to every asset of a given model, so anyone who can view
+     * assets can see them. Managing (upload/delete) still requires the
+     * dedicated `models.files` grant via manageFiles() below.
      */
     public function files(User $user, $item = null)
     {
-        if ($user->hasAccess('assets.files')) {
+        if ($user->hasAccess('assets.view')) {
             return true;
         }
 

--- a/app/Policies/MaintenancePolicy.php
+++ b/app/Policies/MaintenancePolicy.php
@@ -80,10 +80,22 @@ final class MaintenancePolicy
     }
 
     /**
-     * Determine whether the user can upload or manage files attached to a maintenance record.
+     * Determine whether the user can view files attached to a maintenance record.
      * Allowed if the user can edit the associated asset.
      */
     public function files(User $user, Maintenance $maintenance): bool
+    {
+        return Gate::allows('update', $maintenance->asset);
+    }
+
+    /**
+     * Determine whether the user can upload or delete files attached to a
+     * maintenance record. Mirrors files() here because maintenance file
+     * management follows the same asset-edit gate for both read and write.
+     * MaintenancePolicy is standalone (does not extend SnipePermissionsPolicy)
+     * so the base class fallback for manageFiles does not apply.
+     */
+    public function manageFiles(User $user, Maintenance $maintenance): bool
     {
         return Gate::allows('update', $maintenance->asset);
     }

--- a/app/Policies/SnipePermissionsPolicy.php
+++ b/app/Policies/SnipePermissionsPolicy.php
@@ -108,6 +108,21 @@ abstract class SnipePermissionsPolicy
     }
 
     /**
+     * Determine whether the user can upload or delete files on the resource.
+     * Callers should use this for write actions (POST/DELETE on the files
+     * endpoint) and `files()` for read actions (index/show). Defaults to the
+     * same check as `files()` so most resources need no override. Subclasses
+     * override this when the read ability is deliberately broader than the
+     * write ability, e.g. AssetModelPolicy where asset viewers can see model
+     * files inline but must not be able to upload or delete them without the
+     * dedicated `models.files` grant.
+     */
+    public function manageFiles(User $user, $item = null)
+    {
+        return $this->files($user, $item);
+    }
+
+    /**
      * Determine whether the user can create model.
      *
      * @return mixed

--- a/app/Presenters/UploadedFilesPresenter.php
+++ b/app/Presenters/UploadedFilesPresenter.php
@@ -8,11 +8,16 @@ namespace App\Presenters;
 class UploadedFilesPresenter extends Presenter
 {
     /**
-     * Json Column Layout for bootstrap table
+     * Json Column Layout for bootstrap table.
      *
+     * @param  array  $hide_fields  Column field names to omit from the layout.
+     *                              Callers pass `['available_actions']` for
+     *                              read-only views (e.g. the model files tab
+     *                              for users without models.files) so the
+     *                              delete button doesn't render at all.
      * @return string
      */
-    public static function dataTableLayout()
+    public static function dataTableLayout($hide_fields = [])
     {
 
         $layout = [
@@ -94,7 +99,11 @@ class UploadedFilesPresenter extends Presenter
                 'title' => trans('general.created_at'),
                 'visible' => true,
                 'formatter' => 'dateDisplayFormatter',
-            ], [
+            ],
+        ];
+
+        if (! in_array('available_actions', $hide_fields)) {
+            $layout[] = [
                 'field' => 'available_actions',
                 'scope' => 'col',
                 'searchable' => false,
@@ -105,8 +114,8 @@ class UploadedFilesPresenter extends Presenter
                 'formatter' => 'deleteUploadFormatter',
                 'printIgnore' => true,
                 'class' => 'hidden-print',
-            ],
-        ];
+            ];
+        }
 
         return json_encode($layout);
     }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -551,6 +551,11 @@ class UserFactory extends Factory
         return $this->appendPermission(['assets.audit' => '1']);
     }
 
+    public function manageAssetFiles()
+    {
+        return $this->appendPermission(['assets.files' => '1']);
+    }
+
     public function manageModelFiles()
     {
         return $this->appendPermission(['models.files' => '1']);

--- a/resources/lang/en-US/permissions.php
+++ b/resources/lang/en-US/permissions.php
@@ -36,11 +36,12 @@ return [
 
     'assets' => [
         'name' => 'Assets',
-        'note' => 'Grants access to the Assets section of the application.',
+        'note' => 'Grants access to the Assets section of the application. ',
     ],
 
     'assetsview' => [
         'name' => 'View Assets',
+        'note' => 'Note that users with this permission will also be able to see (not modify or delete) files uploaded to the asset model as well. This is to make it easier to share common documents like user manuals across assets without having to upload them to every asset, and to avoid having to grant the user permission to modify asset files.',
     ],
 
     'assetscreate' => [

--- a/resources/views/blade/table/files.blade.php
+++ b/resources/views/blade/table/files.blade.php
@@ -12,7 +12,7 @@
 
 @if(isset($object))
     <table
-        data-columns="{{ \App\Presenters\UploadedFilesPresenter::dataTableLayout() }}"
+        data-columns="{{ \App\Presenters\UploadedFilesPresenter::dataTableLayout(Gate::allows('manageFiles', $object) ? [] : ['available_actions']) }}"
         data-cookie-id-table="{{ $object_type }}-FileUploadsTable"
         data-id-table="{{ $object_type }}-FileUploadsTable"
         id="{{ $object_type }}-FileUploadsTable"

--- a/resources/views/blade/tabs/model-files-tab.blade.php
+++ b/resources/views/blade/tabs/model-files-tab.blade.php
@@ -1,13 +1,16 @@
 @props([
     'count' => null,
     'class' => false,
+    'item' => null,
 ])
 
-<x-tabs.nav-item
-    :$class
-    name="model-files"
-    icon_type="more-files"
-    label="{{ trans('general.additional_files') }}"
-    count="{{ $count }}"
-    tooltip="{{ trans('general.additional_files') }}"
-/>
+@can('files', $item)
+    <x-tabs.nav-item
+        :$class
+        name="model-files"
+        icon_type="more-files"
+        label="{{ trans('general.additional_files') }}"
+        count="{{ $count }}"
+        tooltip="{{ trans('general.additional_files') }}"
+    />
+@endcan

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -69,7 +69,7 @@
                     />
                     <x-tabs.note-tab :item="$asset" count="{{ $asset->journal->count() }}"/>
                     <x-tabs.files-tab :item="$asset" count="{{ $asset->uploads()->count() }}"/>
-                    <x-tabs.model-files-tab count="{{ $asset->model?->uploads()->count() }}"/>
+                    <x-tabs.model-files-tab :item="$asset->model" count="{{ $asset->model?->uploads()->count() }}"/>
                     <x-tabs.history-tab count="{{ $asset->history()->count() }}" :model="$asset"/>
                     <x-tabs.upload-tab :item="$asset"/>
                 </x-slot:tabnav>

--- a/tests/Feature/AssetModels/Api/AssetModelFilesPolicyBypassTest.php
+++ b/tests/Feature/AssetModels/Api/AssetModelFilesPolicyBypassTest.php
@@ -22,16 +22,16 @@ use Tests\TestCase;
  */
 class AssetModelFilesPolicyBypassTest extends TestCase
 {
-    public function test_read_cascade_from_assets_files_is_preserved_for_index()
+    public function test_asset_viewer_can_list_model_files()
     {
         // Seed one file on the model as a superuser so there is something to see.
         $model = AssetModel::factory()->create();
         $this->uploadFileAs(User::factory()->superuser()->create(), $model);
 
-        // A user with only assets.files (no models.files) can still see model files
-        // because the model's files show up on the asset detail page and blocking
-        // that read would be a UX regression.
-        $reader = User::factory()->manageAssetFiles()->create();
+        // Anyone who can view assets can see the model's file attachments
+        // (user manuals, spec sheets) because they show up on the asset
+        // detail page and apply to every asset of that model.
+        $reader = User::factory()->viewAssets()->create();
 
         $this->actingAsForApi($reader)
             ->getJson(route('api.files.index', ['object_type' => 'models', 'id' => $model->id]))
@@ -39,21 +39,49 @@ class AssetModelFilesPolicyBypassTest extends TestCase
             ->assertJsonPath('total', 1);
     }
 
-    public function test_read_cascade_from_assets_files_is_preserved_for_show()
+    public function test_asset_viewer_can_download_model_file()
     {
         // Seed one file as superuser.
         $model = AssetModel::factory()->create();
         $fileId = $this->uploadFileAndReturnId(User::factory()->superuser()->create(), $model);
 
-        $reader = User::factory()->manageAssetFiles()->create();
+        $reader = User::factory()->viewAssets()->create();
 
         $this->actingAsForApi($reader)
             ->get(route('api.files.show', ['object_type' => 'models', 'id' => $model->id, 'file_id' => $fileId]))
             ->assertOk();
     }
 
+    public function test_asset_viewer_cannot_upload_to_model()
+    {
+        $model = AssetModel::factory()->create();
+        $writer = User::factory()->viewAssets()->create();
+
+        $this->actingAsForApi($writer)
+            ->post(
+                route('api.files.store', ['object_type' => 'models', 'id' => $model->id]),
+                ['file' => [UploadedFile::fake()->create('test.jpg', 100)]]
+            )
+            ->assertForbidden();
+    }
+
+    public function test_asset_viewer_cannot_delete_model_file()
+    {
+        // Seed a file as superuser so there is something for the low-priv user to try to delete.
+        $model = AssetModel::factory()->create();
+        $fileId = $this->uploadFileAndReturnId(User::factory()->superuser()->create(), $model);
+
+        $writer = User::factory()->viewAssets()->create();
+
+        $this->actingAsForApi($writer)
+            ->delete(route('api.files.destroy', ['object_type' => 'models', 'id' => $model->id, 'file_id' => $fileId]))
+            ->assertForbidden();
+    }
+
     public function test_user_with_only_assets_files_cannot_upload_to_model()
     {
+        // The originally-reported bypass scenario: assets.files alone used to
+        // grant model file upload/delete. It must not anymore.
         $model = AssetModel::factory()->create();
         $writer = User::factory()->manageAssetFiles()->create();
 
@@ -67,7 +95,6 @@ class AssetModelFilesPolicyBypassTest extends TestCase
 
     public function test_user_with_only_assets_files_cannot_delete_model_file()
     {
-        // Seed a file as superuser so there is something for the low-priv user to try to delete.
         $model = AssetModel::factory()->create();
         $fileId = $this->uploadFileAndReturnId(User::factory()->superuser()->create(), $model);
 

--- a/tests/Feature/AssetModels/Api/AssetModelFilesPolicyBypassTest.php
+++ b/tests/Feature/AssetModels/Api/AssetModelFilesPolicyBypassTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Tests\Feature\AssetModels\Api;
+
+use App\Models\AssetModel;
+use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use Tests\TestCase;
+
+/**
+ * Regression tests for a broken-access-control bug where a user with only
+ * `assets.files` (and not `models.files`) could upload and delete files on
+ * any asset model instance-wide. The `AssetModelPolicy::files()` method
+ * short-circuited on `assets.files`, and the controller used the same
+ * `files` ability for both read and write actions, so the intended write
+ * gate `models.files` was bypassable.
+ *
+ * Fix: added `manageFiles()` as the write ability. AssetModelPolicy overrides
+ * it to require `models.files` strictly. The read cascade on `files()` is
+ * preserved so anyone who can view an asset can still see its model's file
+ * attachments inline on the asset detail page.
+ */
+class AssetModelFilesPolicyBypassTest extends TestCase
+{
+    public function test_read_cascade_from_assets_files_is_preserved_for_index()
+    {
+        // Seed one file on the model as a superuser so there is something to see.
+        $model = AssetModel::factory()->create();
+        $this->uploadFileAs(User::factory()->superuser()->create(), $model);
+
+        // A user with only assets.files (no models.files) can still see model files
+        // because the model's files show up on the asset detail page and blocking
+        // that read would be a UX regression.
+        $reader = User::factory()->manageAssetFiles()->create();
+
+        $this->actingAsForApi($reader)
+            ->getJson(route('api.files.index', ['object_type' => 'models', 'id' => $model->id]))
+            ->assertOk()
+            ->assertJsonPath('total', 1);
+    }
+
+    public function test_read_cascade_from_assets_files_is_preserved_for_show()
+    {
+        // Seed one file as superuser.
+        $model = AssetModel::factory()->create();
+        $fileId = $this->uploadFileAndReturnId(User::factory()->superuser()->create(), $model);
+
+        $reader = User::factory()->manageAssetFiles()->create();
+
+        $this->actingAsForApi($reader)
+            ->get(route('api.files.show', ['object_type' => 'models', 'id' => $model->id, 'file_id' => $fileId]))
+            ->assertOk();
+    }
+
+    public function test_user_with_only_assets_files_cannot_upload_to_model()
+    {
+        $model = AssetModel::factory()->create();
+        $writer = User::factory()->manageAssetFiles()->create();
+
+        $this->actingAsForApi($writer)
+            ->post(
+                route('api.files.store', ['object_type' => 'models', 'id' => $model->id]),
+                ['file' => [UploadedFile::fake()->create('test.jpg', 100)]]
+            )
+            ->assertForbidden();
+    }
+
+    public function test_user_with_only_assets_files_cannot_delete_model_file()
+    {
+        // Seed a file as superuser so there is something for the low-priv user to try to delete.
+        $model = AssetModel::factory()->create();
+        $fileId = $this->uploadFileAndReturnId(User::factory()->superuser()->create(), $model);
+
+        $writer = User::factory()->manageAssetFiles()->create();
+
+        $this->actingAsForApi($writer)
+            ->delete(route('api.files.destroy', ['object_type' => 'models', 'id' => $model->id, 'file_id' => $fileId]))
+            ->assertForbidden();
+    }
+
+    public function test_user_with_models_files_can_upload_to_model()
+    {
+        $model = AssetModel::factory()->create();
+        $writer = User::factory()->manageModelFiles()->create();
+
+        $this->actingAsForApi($writer)
+            ->post(
+                route('api.files.store', ['object_type' => 'models', 'id' => $model->id]),
+                ['file' => [UploadedFile::fake()->create('test.jpg', 100)]]
+            )
+            ->assertOk();
+    }
+
+    public function test_user_with_models_files_can_delete_model_file()
+    {
+        $model = AssetModel::factory()->create();
+        $fileId = $this->uploadFileAndReturnId(User::factory()->superuser()->create(), $model);
+
+        $writer = User::factory()->manageModelFiles()->create();
+
+        $this->actingAsForApi($writer)
+            ->delete(route('api.files.destroy', ['object_type' => 'models', 'id' => $model->id, 'file_id' => $fileId]))
+            ->assertOk();
+    }
+
+    public function test_user_with_no_file_permissions_is_forbidden_on_all_actions()
+    {
+        $model = AssetModel::factory()->create();
+        $fileId = $this->uploadFileAndReturnId(User::factory()->superuser()->create(), $model);
+
+        $noPerms = User::factory()->create();
+
+        $this->actingAsForApi($noPerms)
+            ->getJson(route('api.files.index', ['object_type' => 'models', 'id' => $model->id]))
+            ->assertForbidden();
+
+        $this->actingAsForApi($noPerms)
+            ->get(route('api.files.show', ['object_type' => 'models', 'id' => $model->id, 'file_id' => $fileId]))
+            ->assertForbidden();
+
+        $this->actingAsForApi($noPerms)
+            ->post(
+                route('api.files.store', ['object_type' => 'models', 'id' => $model->id]),
+                ['file' => [UploadedFile::fake()->create('test.jpg', 100)]]
+            )
+            ->assertForbidden();
+
+        $this->actingAsForApi($noPerms)
+            ->delete(route('api.files.destroy', ['object_type' => 'models', 'id' => $model->id, 'file_id' => $fileId]))
+            ->assertForbidden();
+    }
+
+    private function uploadFileAs(User $user, AssetModel $model): void
+    {
+        $this->actingAsForApi($user)
+            ->post(
+                route('api.files.store', ['object_type' => 'models', 'id' => $model->id]),
+                ['file' => [UploadedFile::fake()->create('test.jpg', 100)]]
+            )
+            ->assertOk();
+    }
+
+    private function uploadFileAndReturnId(User $user, AssetModel $model): int
+    {
+        $this->uploadFileAs($user, $model);
+
+        return $this->actingAsForApi($user)
+            ->getJson(route('api.files.index', ['object_type' => 'models', 'id' => $model->id]))
+            ->assertOk()
+            ->decodeResponseJson()
+            ->json()['rows'][0]['id'];
+    }
+}

--- a/tests/Unit/Presenters/UploadedFilesPresenterTest.php
+++ b/tests/Unit/Presenters/UploadedFilesPresenterTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Unit\Presenters;
+
+use App\Presenters\UploadedFilesPresenter;
+use Tests\TestCase;
+
+class UploadedFilesPresenterTest extends TestCase
+{
+    public function test_layout_includes_actions_column_by_default()
+    {
+        $layout = json_decode(UploadedFilesPresenter::dataTableLayout(), true);
+
+        $this->assertContains('available_actions', array_column($layout, 'field'));
+    }
+
+    public function test_layout_omits_actions_column_when_hidden()
+    {
+        $layout = json_decode(
+            UploadedFilesPresenter::dataTableLayout(['available_actions']),
+            true
+        );
+
+        $this->assertNotContains('available_actions', array_column($layout, 'field'));
+    }
+}


### PR DESCRIPTION
This adds an additional gate to still allow users who can see an asset to be able to see the asset model files (for example user's manuals that you wouldn't want to have to upload 1000 times for 1000 assets) but tightens the controls around uploading and deleting model files. 

I've also added some more helpful text explaining this behavior in the permissions matrix. 

Users who can VIEW assets will be able to VIEW BUT NOT MODIFY the model files for the asset model the asset belongs to. We weren't explaining that before, now we do.

This also removes the "Actions" column from the UI, since a user without permission to modify model files wouldn't ever see anything there anyway, so it's just a nicer UX.