### PR TITLE
Added case-sensitivity note for login

### DIFF
--- a/resources/lang/en-US/auth/general.php
+++ b/resources/lang/en-US/auth/general.php
@@ -6,6 +6,7 @@ return [
     'reset_password' => 'Reset Password',
     'saml_login' => 'Login via SAML',
     'login' => 'Login',
+    'logn_help' => 'Some systems require case-sensitive usernames.',
     'login_prompt' => 'Please Login',
     'forgot_password' => 'I forgot my password',
     'ldap_reset_password' => 'Please click here to reset your LDAP password',

--- a/resources/lang/en-US/auth/message.php
+++ b/resources/lang/en-US/auth/message.php
@@ -3,7 +3,7 @@
 return [
 
     'account_already_exists' => 'An account with the this email already exists.',
-    'account_not_found' => 'The username or password is incorrect.',
+    'account_not_found' => 'The username or password is incorrect. Some systems require case-sensitive usernames.',
     'account_not_activated' => 'This user account is not activated.',
     'account_suspended' => 'This user account is suspended.',
 

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -63,6 +63,9 @@
                                             </label>
                                             <input class="form-control" placeholder="{{ trans('admin/users/table.username')  }}" name="username" type="text" id="username" autocomplete="{{ (config('auth.login_autocomplete') === true) ? 'on' : 'off'  }}" autocapitalize="off" spellcheck="false" autofocus>
                                             <x-form.error name="username" />
+                                            <x-form.help name="username">
+                                                <x-icon type="tip"/>
+                                                {{ trans('auth/general.logn_help') }}</x-form.help>
                                         </div>
 
 


### PR DESCRIPTION
This adds a note about case-sensitivity to the login page. This relates to the fix in 2304066d79 (which is related to the not-yet-published [SA](https://github.com/grokability/snipe-it/security/advisories/GHSA-w3vv-5wxh-xg4h), where we had to make usernames case-sensitive for non-local users.

I've opted not to check for LDAP login/SAML/etc, since that would be an information disclosure on login. Everybody gets the same message, regardless of what their login type is. 

<img width="380" height="407" alt="Screenshot 2026-07-20 at 3 43 12 PM" src="https://github.com/user-attachments/assets/a3de379b-8ee3-498c-a51b-b3dd30346b3a" />
