### PR TITLE
Consumable checkout: Fixed FD-56262 - use auth()->id instead of $user->id

### DIFF
--- a/app/Http/Controllers/Api/ConsumablesController.php
+++ b/app/Http/Controllers/Api/ConsumablesController.php
@@ -334,7 +334,11 @@ class ConsumablesController extends Controller
                 $consumable->users()->attach($consumable->id,
                     [
                         'consumable_id' => $consumable->id,
-                        'created_by' => $user->id,
+                        // The pivot's created_by is the operator recording the
+                        // checkout, not the checkout target. Sibling paths
+                        // (web ConsumableCheckoutController, web + API
+                        // ComponentCheckoutController) all key off auth()->id().
+                        'created_by' => auth()->id(),
                         'assigned_to' => $request->input('assigned_to'),
                         'note' => $request->input('note'),
                     ]

--- a/tests/Feature/Checkouts/Api/ConsumableCheckoutTest.php
+++ b/tests/Feature/Checkouts/Api/ConsumableCheckoutTest.php
@@ -90,6 +90,36 @@ class ConsumableCheckoutTest extends TestCase
         });
     }
 
+    public function test_pivot_row_created_by_is_the_actor_not_the_target()
+    {
+        // Regression: previously the pivot's created_by was set to $user->id
+        // (the checkout target), so audit surfaces that read consumables_users
+        // (e.g. "who checked this consumable out to me") would show the target
+        // as their own creator. The action_logs stream separately recorded the
+        // correct actor, which is why the pivot bug survived.
+        $consumable = Consumable::factory()->create();
+        $actor = User::factory()->checkoutConsumables()->create();
+        $target = User::factory()->create();
+
+        $this->actingAsForApi($actor)
+            ->postJson(route('api.consumables.checkout', $consumable), [
+                'assigned_to' => $target->id,
+                'note' => 'created_by attribution regression',
+            ]);
+
+        $this->assertDatabaseHas('consumables_users', [
+            'consumable_id' => $consumable->id,
+            'assigned_to' => $target->id,
+            'created_by' => $actor->id,
+        ]);
+
+        $this->assertDatabaseMissing('consumables_users', [
+            'consumable_id' => $consumable->id,
+            'assigned_to' => $target->id,
+            'created_by' => $target->id,
+        ]);
+    }
+
     public function test_action_log_created_upon_checkout()
     {
         $consumable = Consumable::factory()->create();


### PR DESCRIPTION
Switched to using the auth() user for consumable API checkouts, added tests