### PR TITLE
Quickscan Audit: Fixed #17143 - allow audit by asset tag *or* serial number

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -1409,18 +1409,56 @@ class AssetsController extends Controller
     public function checkinByTag(Request $request, $tag = null): JsonResponse
     {
         $this->authorize('checkin', Asset::class);
-        if ($tag == null && null !== ($request->input('asset_tag'))) {
-            $tag = $request->input('asset_tag');
-        }
-        $asset = Asset::where('asset_tag', $tag)->first();
+
+        $asset = $this->resolveCheckinAssetFromBody($request, $tag);
 
         if ($asset) {
             return $this->checkin($request, $asset->id);
         }
 
+        $displayKey = $tag
+            ?? $request->input('checkin_key')
+            ?? $request->input('asset_tag');
+
         return response()->json(Helper::formatStandardApiResponse('error', [
-            'asset' => e($tag),
-        ], 'Asset with tag '.e($tag).' not found'));
+            'asset' => e($displayKey),
+        ], 'Asset with tag '.e($displayKey).' not found'));
+    }
+
+    /**
+     * Body-based asset lookup for the quickscan-checkin path. Mirrors the
+     * audit-side resolveAuditAssetFromBody: prefer checkin_key +
+     * checkin_by_field (serial gated on unique_serial), fall back to the
+     * legacy `asset_tag` field, otherwise return null. The URL-bound tag
+     * path still wins when the caller uses the /bytag/{tag}/checkin route.
+     */
+    private function resolveCheckinAssetFromBody(Request $request, ?string $tag): ?Asset
+    {
+        if ($tag !== null) {
+            return Asset::where('asset_tag', $tag)->first();
+        }
+
+        $settings = Setting::getSettings();
+        $checkin_by_field = $request->input('checkin_by_field', 'asset_tag');
+        $checkin_key = $request->input('checkin_key', null);
+
+        if ($settings->unique_serial == '1' && $checkin_by_field === 'serial' && $checkin_key) {
+            return Asset::where('serial', '=', trim($checkin_key))->first();
+        }
+
+        if ($checkin_by_field === 'asset_tag' && $checkin_key) {
+            return Asset::where('asset_tag', '=', trim($checkin_key))->first();
+        }
+
+        // Legacy body-based lookup: kept so callers that still send
+        // `asset_tag` (e.g. the pre-serial quickscan-checkin blade, third-
+        // party integrations built against the older API shape) continue
+        // to work without change.
+        if ($request->filled('asset_tag')) {
+            return Asset::where('asset_tag', '=', $request->input('asset_tag'))->first();
+        }
+
+        return null;
     }
 
     /**

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -722,6 +722,8 @@ return [
     'optional' => 'OPTIONAL',
     'audit_by_field' => 'Audit by Field',
     'audit_by_field_help' => 'Auditing by scanning serial numbers is only an available option if serial numbers are required to be unique in the Admin Settings.',
+    'checkin_by_field' => 'Check in by Field',
+    'checkin_by_field_help' => 'Checking in by scanning serial numbers is only an available option if serial numbers are required to be unique in the Admin Settings.',
     'audit_key' => 'Asset',
 
     // Add form placeholders here

--- a/resources/views/hardware/quickscan-checkin.blade.php
+++ b/resources/views/hardware/quickscan-checkin.blade.php
@@ -29,15 +29,34 @@
                 <div class="box-body">
                     {{csrf_field()}}
 
-                    <!-- Asset Tag -->
-                    <div class="form-group {{ $errors->has('asset_tag') ? 'error' : '' }}">
-                        <label for="asset_tag" class="col-md-3 control-label" id="checkin_tag">{{ trans('general.asset_tag') }}</label>
+                    {{-- Look up by asset_tag or serial. Serial is only offered when the
+                         installation enforces unique serials, since checkin-by-serial would
+                         otherwise match ambiguously. Mirrors the audit-side quickscan flow. --}}
+                    <div class="form-group {{ $errors->has('checkin_by_field') ? 'error' : '' }}">
+                        <label for="checkin_by_field" class="col-md-3 control-label">{{ trans('general.checkin_by_field') }}</label>
+                        <div class="col-md-8">
+                            <select name="checkin_by_field" id="checkin_by_field" data-minimum-results-for-search="Infinity" style="width: 100% !important" class="form-control select2" aria-label="checkin_by_field" required>
+                                <option value="asset_tag">{{ trans('general.asset_tag') }}</option>
+                                <option value="serial" {{ ($snipeSettings->unique_serial != '1') ? 'disabled' : '' }}>{{ trans('general.serial_number') }}</option>
+                            </select>
+                            <x-form.error name="checkin_by_field" />
+
+                            <p class="help-block">
+                                <x-icon type="tip"/>
+                                {{ trans('general.checkin_by_field_help') }}
+                            </p>
+                        </div>
+                    </div>
+
+                    <!-- Asset Tag / Serial -->
+                    <div class="form-group {{ $errors->has('checkin_key') ? 'error' : '' }}">
+                        <label for="checkin_key" class="col-md-3 control-label" id="checkin_key_label">{{ trans('general.asset_tag') }}</label>
                         <div class="col-md-9">
                             <div class="input-group col-md-11 required">
-                                <input type="text" class="form-control" name="asset_tag" id="asset_tag" value="{{ old('asset_tag') }}" required>
+                                <input type="text" class="form-control" name="checkin_key" id="checkin_key" value="{{ old('checkin_key') }}" required>
 
                             </div>
-                            <x-form.error name="asset_tag" />
+                            <x-form.error name="checkin_key" />
                         </div>
                     </div>
 
@@ -133,6 +152,14 @@
 @section('moar_scripts')
     <script nonce="{{ csrf_token() }}">
 
+        $(document.body).on("change", "#checkin_by_field", function () {
+            $('label#checkin_key_label').text('{{ trans('general.asset_tag') }}');
+
+            if (this.value === 'serial') {
+                $('label#checkin_key_label').text('{{ trans('general.serial_number') }}');
+            }
+        });
+
         $("#checkin-form").submit(function (event) {
             $('#checkedin-div').show();
             $('#checkin-loader').show();
@@ -164,7 +191,7 @@
                     } else {
                         handlecheckinFail(data);
                     }
-                    $('input#asset_tag').val('');
+                    $('input#checkin_key').val('');
                 },
                 error: function (data) {
                     handlecheckinFail(data);
@@ -208,7 +235,7 @@
             $('#checkin-counter').html(y);
         }
 
-        $("#checkin_tag").focus();
+        $("#checkin_key").focus();
 
     </script>
 @stop

--- a/tests/Feature/Checkins/Api/AssetCheckinByTagTest.php
+++ b/tests/Feature/Checkins/Api/AssetCheckinByTagTest.php
@@ -63,4 +63,77 @@ class AssetCheckinByTagTest extends TestCase
 
         $this->assertEquals('My Asset Name', $asset->refresh()->name);
     }
+
+    // -------------------------------------------------------------------------
+    // Body-based checkin_key + checkin_by_field lookup (mirrors the audit path)
+    // -------------------------------------------------------------------------
+
+    public function test_asset_can_be_checked_in_by_asset_tag_via_checkin_key()
+    {
+        $asset = Asset::factory()->assignedToUser()->create();
+
+        $this->actingAsForApi(User::factory()->checkinAssets()->create())
+            ->postJson(route('api.asset.checkinbytag'), [
+                'checkin_key' => $asset->asset_tag,
+                'checkin_by_field' => 'asset_tag',
+            ])
+            ->assertOk()
+            ->assertStatusMessageIs('success');
+
+        $this->assertNull($asset->refresh()->assignedTo);
+    }
+
+    public function test_asset_can_be_checked_in_by_serial_when_unique_serial_is_enabled()
+    {
+        $this->settings->set(['unique_serial' => '1']);
+
+        $asset = Asset::factory()->assignedToUser()->create(['serial' => 'SN-CHECKIN-BY-SERIAL-1']);
+
+        $this->actingAsForApi(User::factory()->checkinAssets()->create())
+            ->postJson(route('api.asset.checkinbytag'), [
+                'checkin_key' => 'SN-CHECKIN-BY-SERIAL-1',
+                'checkin_by_field' => 'serial',
+            ])
+            ->assertOk()
+            ->assertStatusMessageIs('success');
+
+        $this->assertNull($asset->refresh()->assignedTo);
+    }
+
+    public function test_checkin_by_serial_is_refused_when_unique_serial_is_disabled()
+    {
+        // Guard rail: when serial uniqueness is not enforced, serial-based checkin
+        // must not resolve (matches the audit-side behavior).
+        $this->settings->set(['unique_serial' => '0']);
+
+        $asset = Asset::factory()->assignedToUser()->create(['serial' => 'SN-DISABLED-1']);
+
+        $this->actingAsForApi(User::factory()->checkinAssets()->create())
+            ->postJson(route('api.asset.checkinbytag'), [
+                'checkin_key' => 'SN-DISABLED-1',
+                'checkin_by_field' => 'serial',
+            ])
+            ->assertOk()
+            ->assertStatusMessageIs('error');
+
+        // Asset stays assigned because no lookup should have resolved it.
+        $this->assertNotNull($asset->refresh()->assignedTo);
+    }
+
+    public function test_legacy_asset_tag_body_field_still_works_for_backward_compat()
+    {
+        // Callers that predate the checkin_key convention (older integrations,
+        // the pre-serial quickscan-checkin blade) send `asset_tag` in the body.
+        // That path must keep working after the resolver refactor.
+        $asset = Asset::factory()->assignedToUser()->create();
+
+        $this->actingAsForApi(User::factory()->checkinAssets()->create())
+            ->postJson(route('api.asset.checkinbytag'), [
+                'asset_tag' => $asset->asset_tag,
+            ])
+            ->assertOk()
+            ->assertStatusMessageIs('success');
+
+        $this->assertNull($asset->refresh()->assignedTo);
+    }
 }


### PR DESCRIPTION
Same as we do for bulk checkin, this time for auditing. The audit by serial is only enabled if unique serial is enabled in the settings, since we wouldn't know which asset to audit if they were not unique.

Fixes #17143