### PR TITLE
SCIM: Return 400 instead of 500 when a client sends a filter-key body

### DIFF
--- a/app/Models/SnipeSCIMConfig.php
+++ b/app/Models/SnipeSCIMConfig.php
@@ -75,7 +75,7 @@ class SnipeRootComplex extends Complex
                 // the misconfiguration is on their end, versus the previous 500,
                 // which made it look like it was on our end.
                 if ($path->getAttributePath() === null) {
-                    throw new SCIMException('Cannot route SCIM key with no attribute path: ' . $key, 400);
+                    throw new SCIMException('Cannot route SCIM key with no attribute path: '.$key, 400);
                 }
 
                 $attributeNames = $path->getAttributePathAttributes();
@@ -147,7 +147,7 @@ class SnipeRootComplex extends Complex
                     // wild for misconfigured SCIM clients sending
                     // filter-key bodies to PUT /Users/{id}.
                     if ($path->getAttributePath() === null) {
-                        throw new SCIMException('Cannot route SCIM key with no attribute path: ' . $key, 400);
+                        throw new SCIMException('Cannot route SCIM key with no attribute path: '.$key, 400);
                     }
 
                     $attributeNames = $path->getAttributePathAttributes();
@@ -404,7 +404,7 @@ class SnipeSCIMConfig
                     {
                         protected function doRead(&$object, $attributes = [])
                         {
-                            if (!$object->email) {
+                            if (! $object->email) {
                                 return null;
                             }
 

--- a/app/Models/SnipeSCIMConfig.php
+++ b/app/Models/SnipeSCIMConfig.php
@@ -62,6 +62,22 @@ class SnipeRootComplex extends Complex
             $path = Parser::parse($key);
 
             if ($path->isNotEmpty()) {
+                // Path::isNotEmpty() returns true when EITHER the
+                // attribute-path OR the value-path is populated. A body
+                // key that's only a value-path filter expression (e.g.
+                // `emails[type eq "work"]`) makes it past this check
+                // but has getAttributePath() === null, which the
+                // library's shiftAttributePathAttributes() will null-
+                // deref on. Route-level replace/add here only
+                // dispatches by simple attribute name — a filter-key at
+                // this layer is a misconfigured SCIM client that we
+                // can't honor, and this will return a 400 so the user knows
+                // the misconfiguration is on their end, versus the previous 500,
+                // which made it look like it was on our end.
+                if ($path->getAttributePath() === null) {
+                    throw new SCIMException('Cannot route SCIM key with no attribute path: ' . $key, 400);
+                }
+
                 $attributeNames = $path->getAttributePathAttributes();
                 $schema = $path->getAttributePath()?->path?->schema;
                 $path = $path->shiftAttributePathAttributes();
@@ -123,6 +139,17 @@ class SnipeRootComplex extends Complex
             } else {
                 $path = Parser::parse($key);
                 if ($path->isNotEmpty()) {
+                    // See the matching guard in add() — isNotEmpty() lets
+                    // a value-path-only key through (e.g. emails[type eq
+                    // "work"]) but shiftAttributePathAttributes() null-
+                    // derefs on getAttributePath() when it's not present.
+                    // Trace: null-deref on Path.php:79 seen in the
+                    // wild for misconfigured SCIM clients sending
+                    // filter-key bodies to PUT /Users/{id}.
+                    if ($path->getAttributePath() === null) {
+                        throw new SCIMException('Cannot route SCIM key with no attribute path: ' . $key, 400);
+                    }
+
                     $attributeNames = $path->getAttributePathAttributes();
                     $path = $path->shiftAttributePathAttributes();
                     $subNode = $this->getSubNode($attributeNames[0] ?? $path->getAttributePath()?->path?->schema);
@@ -380,6 +407,7 @@ class SnipeSCIMConfig
                             if (!$object->email) {
                                 return null;
                             }
+
                             return [
                                 'value' => $object->email,
                                 'type' => 'work', // TODO - is this how we always have done it?
@@ -504,9 +532,9 @@ class SnipeSCIMConfig
                                 $address['primary'] = true;
                             }
                             if ($address) {
-                                return [(object) $address]; //cast-to-object forces "squiggly-brackets" in JSON
+                                return [(object) $address]; // cast-to-object forces "squiggly-brackets" in JSON
                             } else {
-                                return null; //this should remove the addresses block entirely
+                                return null; // this should remove the addresses block entirely
                             }
                         }
 

--- a/tests/Feature/Scim/ReplaceUserWithFilterKeyTest.php
+++ b/tests/Feature/Scim/ReplaceUserWithFilterKeyTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Feature\Scim;
+
+use App\Models\User;
+use Laravel\Passport\Passport;
+use Tests\TestCase;
+
+class ReplaceUserWithFilterKeyTest extends TestCase
+{
+    /**
+     * Regression for a Rollbar 500 traced back to a misconfigured SCIM
+     * client sending PUT /scim/v2/Users/{id} bodies whose keys are
+     * filter expressions (`emails[type eq "work"]`) instead of simple
+     * attribute names. The library's Path::shiftAttributePathAttributes()
+     * unconditionally calls ->getAttributePath()->shiftAttributeName();
+     * getAttributePath() is null when a key parses to a value-path-only
+     * expression, so the request crashed with:
+     *
+     *   Call to a member function shiftAttributeName() on null
+     *   in vendor/arietimmerman/laravel-scim-server/src/Parser/Path.php:79
+     *
+     * SnipeSCIMConfig::replace() (and its sibling ::add()) now guards
+     * that condition and throws a SCIMException — the client gets a
+     * HTTP 400 pointing at the bad key instead of a 500.
+     */
+    public function test_put_with_filter_expression_key_returns_400_not_500()
+    {
+        Passport::actingAs(User::factory()->superuser()->create());
+        $target = User::factory()->create();
+
+        $response = $this->putJson('/scim/v2/Users/'.$target->id, [
+            'schemas' => ['urn:ietf:params:scim:schemas:core:2.0:User'],
+            'userName' => $target->username,
+            // The bad key: a value-path filter expression as an attribute
+            // key. Reproduces the Path::shiftAttributeName-on-null crash.
+            'emails[type eq "work"]' => 'newaddress@example.com',
+        ]);
+
+        $response->assertStatus(400);
+    }
+}


### PR DESCRIPTION
`SnipeSCIMConfig::replace()` and `::add()` crashed with a null-dereference deep in the arietimmerman SCIM library when a client sent a `PUT /scim/v2/Users/{id}` (or matching PATCH `add`) whose body carried keys that were value-path filter expressions rather than plain attribute names:

```json
{
  "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
  "userName": "somebody",
  "emails[type eq \"work\"]": "new@example.com"
}
```

The bad key parses to a `Path` with a `valuePath` but no `attributePath`. `Path::isNotEmpty()` still returns true, but `Path::shiftAttributePathAttributes()` unconditionally calls `$this->getAttributePath()->shiftAttributeName()` and null-derefs, producing:

```
Call to a member function shiftAttributeName() on null
in vendor/arietimmerman/laravel-scim-server/src/Parser/Path.php:79
```

This surfaces as a 500 to the client and pages on-call. This PR guards both call sites in `SnipeSCIMConfig.php` and returns a helpful 400 instead.

## Changes

- `app/Models/SnipeSCIMConfig.php` — in both `SnipeRootComplex::add()` and `SnipeRootComplex::replace()`, guard the `shiftAttributePathAttributes()` call with an explicit `$path->getAttributePath() === null` check. When it hits, throw `SCIMException` with HTTP 400 and the offending key in the message.

## New tests

- `tests/Feature/Scim/ReplaceUserWithFilterKeyTest.php` — regression test that PUTs a filter-expression body key and asserts the response is `400`, not `500`.

## For users seeing this in their logs 

The client's SCIM configuration is putting a filter expression where an attribute name should be. After this change they get a `400 Bad Request` with the specific offending key in the message:

```
Cannot route SCIM key with no attribute path: emails[type eq "work"]
```

That's the string ou need to hunt down in their identity-provider mapping.