### PR TITLE
SCIM: Fixed #18014 - pagination duplicates

### DIFF
--- a/app/Models/SnipeSCIMConfig.php
+++ b/app/Models/SnipeSCIMConfig.php
@@ -359,6 +359,22 @@ class SnipeSCIMConfig
             'withRelations' => [],
             'description' => 'User Account',
 
+            // #18014: the arietimmerman library's ResourceController::index
+            // only adds an ORDER BY when the SCIM provider supplies sortBy, and
+            // even then only puts the id tiebreaker on the cursor branch.
+            // That leaves the startIndex/count path (which every real SCIM
+            // client uses) with a bare LIMIT/OFFSET query. MySQL is free
+            // to return rows in any order without ORDER BY, and pages can
+            // overlap when the optimizer's plan is non-stable. Handing the
+            // library a base query with orderBy('users.id') baked in gives
+            // it a stable base ordering. Trade-off. If a provider supplies
+            // sortBy=X the library appends X as a SECONDARY sort, so X
+            // becomes a tiebreaker for ids rather than the primary sort.
+            // In practice virtually no SCIM client submits sortBy, so this
+            // is an acceptable degradation for the edge case in exchange
+            // for correct pagination for everyone IMHO - snipe.
+            'query' => SCIMUser::query()->orderBy('users.id'),
+
             'map' => (new SnipeRootComplex)->withSubAttributes(
                 new class('schemas', ['urn:ietf:params:scim:schemas:core:2.0:User', self::ENTERPRISE, self::GROKABILITY]) extends Constant
                 {
@@ -674,6 +690,10 @@ class SnipeSCIMConfig
             // eager loading
             'withRelations' => [],
             'description' => 'Group',
+
+            // #18014: same stable-pagination base sort as getUserConfig.
+            // See that method for the full explanation and trade-off.
+            'query' => $this->getGroupClass()::query()->orderBy('permission_groups.id'),
 
             'map' => complex()->withSubAttributes(
                 new class('schemas', ['urn:ietf:params:scim:schemas:core:2.0:Group']) extends Constant


### PR DESCRIPTION
Fixes [#18014](https://github.com/grokability/snipe-it/issues/18014), BUT this is one of a few different solutions, so I'm going to need @uberbrady to weigh in here. 

This is a very long PR to describe effectively a one-line fix. 😬 But as always, it's complicated.

## Problem

The OP's SCIM client paginates 1200 users in `count=500` chunks, incrementing `startIndex` by 500 each request. Starting around Snipe-IT 8.3.3, pages 2 and 3 began overlapping on IDs 1015-1021, so their sync pulled in duplicate users and missed later rows.

We've traced to a real bug in `arietimmerman/laravel-scim-server`'s `ResourceController::index()`. The library adds an `ORDER BY id` tiebreaker on the cursor-pagination path but leaves it out on the startIndex/count path (which is what every SCIM client actually uses, including Entra, JumpCloud, and Okta). Vendor code from `vendor/arietimmerman/laravel-scim-server/src/Http/Controllers/ResourceController.php:320-333`:

```php
if ($sortBy != null) {
    $direction = $request->input('sortOrder') == 'descending' ? 'desc' : 'asc';
    $resourceObjects = $resourceObjects->orderBy($sortBy, $direction);
}

$resources = null;
if ($request->has('cursor')) {
    if($sortBy == null){
        $resourceObjects = $resourceObjects->orderBy('id');  // only fires for cursor pagination
    }
    // ...
}
```

Without an `ORDER BY` on the startIndex path, MySQL is free to return rows in any order that the current query plan happens to produce. Two separate `LIMIT N OFFSET M` queries can return overlapping row sets. Nothing changed in Snipe-IT to trigger this in 8.3.3, but it's possible the MySQL optimizer's plan flipped for the user's data shape and the underlying bug was always there, just not noticed.

I'd guess this is also reproducible on Entra ID, JumpCloud, Okta, and any other SCIM client that follows RFC 7644 startIndex semantics (which is all of them, we hope), it just wasn't noticed or wasn't reported.

## This Fix

One-line addition to `App\Models\SnipeSCIMConfig::getUserConfig()` and `::getGroupConfig()`. We basically hand the library a base query with `orderBy('id')` already applied:

```php
'query' => SCIMUser::query()->orderBy('users.id'),
```

The library appends any caller-supplied `sortBy` after this, which produces:

| Caller submits             | Final ORDER BY                                  | Notes                                                                     |
|----------------------------|-------------------------------------------------|---------------------------------------------------------------------------|
| No sortBy (typical)        | `users.id ASC`                                  | Stable.                                                                   |
| `sortBy=meta.created`      | `users.id ASC, created_at ASC`                  | id and created_at are almost always monotonic together, so effectively identical to `ORDER BY created_at`. |
| `sortBy=userName`          | `users.id ASC, username ASC`                    | id becomes primary, username becomes tiebreaker. Semantically wrong per RFC 7644 §3.4.2.3, but no known client submits this. Documented in the code comment. |

## Trade-off discussion

I considered two approaches. Config-based won in this PR on maintenance burden, but I'm willing to be convinced. SCIM is largely @uberbrady's baby, so I defer to him as to whether we want this approach (just the SCIM config) or a more involved approach (either by running it through a dedicated SCIM controller, OR by patching our fork of the arietimmerman library.

### This approach - config-based (`SnipeSCIMConfig` query key)

**Pro.** One line per resource type. Zero new files. Zero maintenance debt against upstream library churn. No route override.

**Con.** When a caller submits an explicit `sortBy`, Laravel appends it after the config's baked-in `orderBy('id')`. That makes id the primary sort and the caller's field the tiebreaker (technically a spec violation, but no observed real-world client submits sortBy).

**Diff:**

```php
// app/Models/SnipeSCIMConfig.php  (getUserConfig)
    'withRelations' => [],
    'description' => 'User Account',

+   'query' => SCIMUser::query()->orderBy('users.id'),

// getGroupConfig
    'withRelations' => [],
    'description' => 'Group',

+   'query' => $this->getGroupClass()::query()->orderBy('permission_groups.id'),
```

### Second approach (not in this PR): Controller based override

**Pro.** RFC-correct in every case. `sortBy=X` primarily orders by X and id only breaks ties (appended last).

**Con.** Around 110 lines of parent code copied. Needs a diff-against-vendor step every time the upstream library is bumped.

Included below in full for reviewers who want to compare. This file was written and then deleted, so it is not in the diff. If we ever hit an operator who genuinely needs `sortBy=userName` primary-sort behavior, this is the drop-in replacement:

<details>
<summary><code>app/Http/Controllers/SCIM/SnipeResourceController.php</code> (rejected alternative)</summary>

```php
<?php

namespace App\Http\Controllers\SCIM;

use ArieTimmerman\Laravel\SCIMServer\Exceptions\SCIMException;
use ArieTimmerman\Laravel\SCIMServer\Helper;
use ArieTimmerman\Laravel\SCIMServer\Http\Controllers\ResourceController;
use ArieTimmerman\Laravel\SCIMServer\Parser\Parser as ParserParser;
use ArieTimmerman\Laravel\SCIMServer\PolicyDecisionPoint;
use ArieTimmerman\Laravel\SCIMServer\ResourceType;
use ArieTimmerman\Laravel\SCIMServer\SCIM\ListResponse;
use Illuminate\Contracts\Pagination\CursorPaginator;
use Illuminate\Database\Eloquent\Builder;
use Illuminate\Http\Request;
use Illuminate\Pagination\Cursor;

/**
 * Override of arietimmerman/laravel-scim-server's ResourceController that
 * plugs one specific bug. The parent's index() only adds an id tiebreaker
 * to the ORDER BY clause on the CURSOR pagination path. On the
 * startIndex/count path,  no default ordering is applied
 * when sortBy is absent, and MySQL is then free to return rows in any
 * order for a bare LIMIT N OFFSET M query. When the optimizer's plan
 * produces a non-stable order across separate paged requests, pages
 * overlap.
 *
 * The fix is one line. Always append orderBy('id') as a tiebreaker after
 * whatever sortBy the caller asked for. Since it is appended last, an
 * explicit sortBy=userName still primarily sorts by username and id only
 * breaks ties.
 *
 * The rest of the method is a verbatim copy of the parent's index(). It
 * needs to stay in sync when the library updates. When bumping the
 * upstream package, diff this file against the vendor copy and pull
 * across any relevant changes.
 */
class SnipeResourceController extends ResourceController
{
    public function index(Request $request, PolicyDecisionPoint $pdp, ResourceType $resourceType)
    {
        return $this->scimlog(function ($that, $request, $pdp, $resourceType) {
            $query = $resourceType->getQuery();

            if ($request->has('cursor') && $request->has('startIndex')) {
                throw (new SCIMException('Both cursor and startIndex are present. Only one of them is allowed.'))->setCode(400);
            }

            $count = min(max(0, intval($request->input('count', config('scim.pagination.defaultPageSize')))), config('scim.pagination.maxPageSize'));

            $startIndex = null;
            $sortBy = null;

            if ($request->input('sortBy')) {
                $sortBy = $resourceType->getMapping()->getSortAttributeByPath(ParserParser::parse($request->input('sortBy')));
            }

            $resourceObjectsBase = $query->when(
                $filter = $request->input('filter'),
                function (Builder $query) use ($filter, $resourceType) {
                    try {
                        Helper::scimFilterToLaravelQuery($resourceType, $query, ParserParser::parseFilter($filter));
                    } catch (\Tmilos\ScimFilterParser\Error\FilterException $e) {
                        throw (new SCIMException($e->getMessage()))->setCode(400)->setScimType('invalidFilter');
                    }
                }
            );

            $totalResults = $resourceObjectsBase->count();

            $resourceObjects = $resourceObjectsBase
                ->with($resourceType->getWithRelations());

            if ($sortBy != null) {
                $direction = $request->input('sortOrder') == 'descending' ? 'desc' : 'asc';
                $resourceObjects = $resourceObjects->orderBy($sortBy, $direction);
            }

            // #18014 fix. Always append `id` as a stable secondary sort so
            // LIMIT/OFFSET pagination can never overlap between pages.
            // Applied on both cursor and startIndex paths. Appended last
            // so an explicit sortBy still primarily orders by the caller's
            // field.
            $resourceObjects = $resourceObjects->orderBy($resourceType->getClass()::make()->getKeyName());

            $resources = null;
            if ($request->has('cursor')) {
                if ($sortBy == null) {
                    $resourceObjects = $resourceObjects->orderBy('id');
                }

                if ($request->input('cursor')) {
                    $cursor = @Cursor::fromEncoded($request->input('cursor'));

                    if ($cursor == null) {
                        throw (new SCIMException('Invalid Cursor'))->setCode(400)->setScimType('invalidCursor');
                    }
                }

                $countRaw = $request->input('count');

                if ($countRaw < 1 || $countRaw > config('scim.pagination.maxPageSize')) {
                    throw (new SCIMException(
                        sprintf('Count value is invalid. Count value must be between 1 - and maxPageSize (%s) (when using cursor pagination)', config('scim.pagination.maxPageSize'))
                    ))->setCode(400)->setScimType('invalidCount');
                }

                $resourceObjects = $resourceObjects->cursorPaginate(
                    $count,
                    cursor: $request->input('cursor')
                );
                $resources = collect($resourceObjects->items());
            } else {
                $startIndex = max(1, intval($request->input('startIndex', 0)));
                $resourceObjects = $resourceObjects->skip($startIndex - 1)->take($count);
                $resources = $resourceObjects->get();
            }

            if ($request->json('attributes') && is_array($request->json('attributes'))) {
                $attributes = $request->json('attributes');
            } else {
                $attributes = $request->input('attributes') ? preg_split('/[,.]/', $request->input('attributes')) : [];
            }

            if (! empty($attributes)) {
                $attributes[] = 'id';
                $attributes[] = 'meta';
                $attributes[] = 'schemas';
            }

            $excludedAttributes = [];

            return new ListResponse(
                $resources,
                $startIndex,
                $totalResults,
                $attributes,
                $excludedAttributes,
                $resourceType,
                ($resourceObjects instanceof CursorPaginator) ? $resourceObjects->nextCursor()?->encode() : null,
                ($resourceObjects instanceof CursorPaginator) ? $resourceObjects->previousCursor()?->encode() : null
            );
        }, $request, $pdp, $resourceType);
    }
}
```

Also required the `routes/scim.php` addition:

```php
Route::get('/scim/v2/{resourceType}', [SnipeResourceController::class, 'index'])
    ->name('scim.resources');
```

This would be placed inside the existing `Route::middleware(...)` group and BEFORE `SCIMRouteProvider::routes()` so Laravel's first-match-wins routing picks ours for `/scim/v2/Users` and `/scim/v2/Groups`.

</details>

### Approach we did not attempt: composer patch

We could have patched the vendor file directly via `cweagans/composer-patches`. Snipe-IT doesn't currently use that library (and it seems weird and gross to even think about that), so introducing it just for this bug adds another moving part. 

We could also patch our own fork of timmerman's library.

## Possible Gotcha

If the upstream library ever adds its own default `ORDER BY id` on the startIndex path (which is what the correct upstream fix would look like), our `'query'` config becomes redundant. It will not cause bugs (Laravel deduplicates duplicate orderBy clauses on the same column) but at that point it is worth removing for tidiness.