### PR TITLE
Redirects: Fixed #15214 - return to index page with query string

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -1685,14 +1685,27 @@ class Helper
 
         // return to index
         if ($redirect_option == 'index') {
-            return match ($table) {
-                'Assets' => redirect()->route('hardware.index'),
-                'Users' => redirect()->route('users.index'),
-                'Licenses' => redirect()->route('licenses.index'),
-                'Accessories' => redirect()->route('accessories.index'),
-                'Components' => redirect()->route('components.index'),
-                'Consumables' => redirect()->route('consumables.index'),
+            $indexUrl = match ($table) {
+                'Assets' => route('hardware.index'),
+                'Users' => route('users.index'),
+                'Licenses' => route('licenses.index'),
+                'Accessories' => route('accessories.index'),
+                'Components' => route('components.index'),
+                'Consumables' => route('consumables.index'),
             };
+
+            // #15214: preserve query-string filters when the user came
+            // from a filtered view of the same index they're being sent
+            // back to (side-nav status filter, category filter, etc.).
+            // Without this the plain index route drops the caller's
+            // context and the user has to re-select their side-nav
+            // filter after every edit. $backUrl was already vetted for
+            // off-site hosts above.
+            if ($backUrl && parse_url($backUrl, PHP_URL_PATH) === parse_url($indexUrl, PHP_URL_PATH)) {
+                return redirect($backUrl);
+            }
+
+            return redirect($indexUrl);
         }
 
         // return to thing being assigned

--- a/tests/Unit/Helpers/HelperTest.php
+++ b/tests/Unit/Helpers/HelperTest.php
@@ -208,4 +208,90 @@ class HelperTest extends TestCase
             $this->assertEquals($data['route'], $redirect->getTargetUrl(), $scenario.'failed.');
         }
     }
+
+    public function test_get_redirect_option_preserves_query_filters_when_returning_to_index()
+    {
+        // #15214: a user editing an asset from `hardware?status_type=Deployed`
+        // should land back on that filtered view, not the plain
+        // hardware.index that drops the side-nav filter context.
+        Session::put('redirect_option', 'index');
+        Session::put('url.intended', route('hardware.index').'?status_type=Deployed');
+
+        $redirect = Helper::getRedirectOption((object) [], null, 'Assets');
+
+        $this->assertInstanceOf(RedirectResponse::class, $redirect);
+        $this->assertEquals(
+            route('hardware.index').'?status_type=Deployed',
+            $redirect->getTargetUrl(),
+        );
+    }
+
+    public function test_get_redirect_option_preserves_multiple_query_filters()
+    {
+        // Query string with more than one filter round-trips cleanly.
+        Session::put('redirect_option', 'index');
+        Session::put('url.intended', route('hardware.index').'?status_type=RTD&category_id=3');
+
+        $redirect = Helper::getRedirectOption((object) [], null, 'Assets');
+
+        $this->assertEquals(
+            route('hardware.index').'?status_type=RTD&category_id=3',
+            $redirect->getTargetUrl(),
+        );
+    }
+
+    public function test_get_redirect_option_falls_back_to_plain_index_when_no_referrer_query()
+    {
+        // When there's no filter to preserve, behavior matches the
+        // pre-#15214 code path.
+        Session::put('redirect_option', 'index');
+        Session::put('url.intended', route('hardware.index'));
+
+        $redirect = Helper::getRedirectOption((object) [], null, 'Assets');
+
+        $this->assertEquals(route('hardware.index'), $redirect->getTargetUrl());
+    }
+
+    public function test_get_redirect_option_ignores_referrer_pointing_at_a_different_path()
+    {
+        // If the referrer was the show page or the create form (not the
+        // index they'd be redirected to), don't smuggle it into the
+        // index redirect. Only same-path referrers are preserved.
+        Session::put('redirect_option', 'index');
+        Session::put('url.intended', route('hardware.show', 42));
+
+        $redirect = Helper::getRedirectOption((object) [], null, 'Assets');
+
+        $this->assertEquals(route('hardware.index'), $redirect->getTargetUrl());
+    }
+
+    public function test_get_redirect_option_ignores_offsite_referrer_when_returning_to_index()
+    {
+        // Off-site protection was already in place for the 'back'
+        // option (via the parse_url host check). Verify it also applies
+        // on the 'index' path so an attacker-controlled url.intended
+        // (see SamlController RelayState) can't smuggle an external URL
+        // into an index redirect.
+        Session::put('redirect_option', 'index');
+        Session::put('url.intended', 'https://evil.example.com/hardware?status_type=Deployed');
+
+        $redirect = Helper::getRedirectOption((object) [], null, 'Assets');
+
+        $this->assertEquals(route('hardware.index'), $redirect->getTargetUrl());
+    }
+
+    public function test_get_redirect_option_preserves_filters_for_other_entity_types_too()
+    {
+        // The #15214 fix lives in Helper::getRedirectOption so it covers
+        // every entity that routes through the redirect helper, not just
+        // Assets. Users/Licenses/etc. don't have side-nav filters today
+        // but might grow them, and generic ?category_id=... links are
+        // already common.
+        Session::put('redirect_option', 'index');
+        Session::put('url.intended', route('users.index').'?company_id=5');
+
+        $redirect = Helper::getRedirectOption((object) [], null, 'Users');
+
+        $this->assertEquals(route('users.index').'?company_id=5', $redirect->getTargetUrl());
+    }
 }


### PR DESCRIPTION
This just adds the functionality to remember the index filter the user might have had (i.e. in Users > Superusers filter) and redirects you back to the filtered result after making an edit to the object.

Fixed  #15214
