### PR TITLE
Docker+Proxy: Fixed #6852 - Removed headers in trustedproxy config

### DIFF
--- a/config/trustedproxy.php
+++ b/config/trustedproxy.php
@@ -48,19 +48,18 @@ return [
     // 'proxies' => '*',
 
     /*
-     * Which headers to use to detect proxy-related data (For, Host, Proto, Port).
+     * Trusted forwarded-header list intentionally not configured here.
      *
-     * This key is intentionally not set here. app/Http/Middleware/TrustProxies.php
-     * already sets $headers on the middleware itself as a bitmask of the individual
-     * Illuminate\Http\Request::HEADER_X_FORWARDED_* constants (FOR, HOST, PORT,
-     * PROTO, AWS_ELB), which is what runtime uses. Prior versions of this file
-     * carried a commented-out example referencing HEADER_X_FORWARDED_ALL, but that
-     * constant was removed from Symfony (see symfony/symfony#38928) and uncommenting
-     * it produced a fatal "Undefined constant" error. See #6852.
+     * The runtime defaults trust X-Forwarded-For, X-Forwarded-Host,
+     * X-Forwarded-Port, X-Forwarded-Proto, and the AWS ELB set. This is
+     * the right answer for essentially every reverse-proxy deployment,
+     * so there is nothing to change under normal circumstances.
      *
-     * If you need to change which forwarded headers are trusted, edit the $headers
-     * property on App\Http\Middleware\TrustProxies rather than adding a 'headers'
-     * key here.
+     * Older versions of this file shipped a commented-out example
+     * referencing Illuminate\Http\Request::HEADER_X_FORWARDED_ALL. That
+     * constant was removed from Symfony (see symfony/symfony#38928) and
+     * uncommenting the example produced a fatal "Undefined constant"
+     * error. It has been removed to avoid the foot-gun. See #6852.
      *
      * @link https://symfony.com/doc/current/deployment/proxies.html
      */

--- a/config/trustedproxy.php
+++ b/config/trustedproxy.php
@@ -48,15 +48,21 @@ return [
     // 'proxies' => '*',
 
     /*
-     * Which headers to use to detect proxy related data (For, Host, Proto, Port)
+     * Which headers to use to detect proxy-related data (For, Host, Proto, Port).
      *
-     * Options include:
+     * This key is intentionally not set here. app/Http/Middleware/TrustProxies.php
+     * already sets $headers on the middleware itself as a bitmask of the individual
+     * Illuminate\Http\Request::HEADER_X_FORWARDED_* constants (FOR, HOST, PORT,
+     * PROTO, AWS_ELB), which is what runtime uses. Prior versions of this file
+     * carried a commented-out example referencing HEADER_X_FORWARDED_ALL, but that
+     * constant was removed from Symfony (see symfony/symfony#38928) and uncommenting
+     * it produced a fatal "Undefined constant" error. See #6852.
      *
-     * - Illuminate\Http\Request::HEADER_X_FORWARDED_ALL (use all x-forwarded-* headers to establish trust)
-     * - Illuminate\Http\Request::HEADER_FORWARDED (use the FORWARDED header to establish trust)
+     * If you need to change which forwarded headers are trusted, edit the $headers
+     * property on App\Http\Middleware\TrustProxies rather than adding a 'headers'
+     * key here.
      *
      * @link https://symfony.com/doc/current/deployment/proxies.html
      */
-    //    'headers' => Illuminate\Http\Request::HEADER_X_FORWARDED_ALL, //this is mostly handled already
 
 ];


### PR DESCRIPTION
This addresses part of the looooong-running Docker environment confusion in [#6852](https://github.com/grokability/snipe-it/issues/6852) (specifically the point flagged by [@mbenhuri-onepointbfg's last comment](https://github.com/grokability/snipe-it/issues/6852)).

## The Problem (fully re-stated to avoid future confusion)

`config/trustedproxy.php` shipped with a commented-out example that referenced `Illuminate\Http\Request::HEADER_X_FORWARDED_ALL`:

```php
//    'headers' => Illuminate\Http\Request::HEADER_X_FORWARDED_ALL, //this is mostly handled already
```

Symfony removed that constant when it split the individual X-Forwarded-* headers apart for CVE-related reasons (see [symfony/symfony#38928](https://github.com/symfony/symfony/pull/38928)). A Snipe-IT operator who reads the example, follows the "just uncomment this if you have proxy trouble" instinct, and drops that line into effect gets a fatal `Undefined constant Illuminate\Http\Request::HEADER_X_FORWARDED_ALL` and a hard 500 across the whole app.

Meanwhile the actual `app/Http/Middleware/TrustProxies.php` already sets the middleware's `$headers` property to a bitwise-OR combination of the individual constants that DO still exist:

```php
protected $headers =
    Request::HEADER_X_FORWARDED_FOR |
    Request::HEADER_X_FORWARDED_HOST |
    Request::HEADER_X_FORWARDED_PORT |
    Request::HEADER_X_FORWARDED_PROTO |
    Request::HEADER_X_FORWARDED_AWS_ELB;
```

So runtime is fine and nobody's currently broken. The config file just carries dead documentation with a foot-gun in it.

I removed the commented-out `HEADER_X_FORWARDED_ALL` line and replace the surrounding docblock with a pointer to the real place where forwarded-header trust is configured. The rest of the file (proxies + env) is unchanged.

The bulk of the _**37 comments**_ on #6852 are the same underlying misunderstanding rediscovered by different users over six years. `docker compose restart` reuses the existing container's environment, so a changed `.env` doesn't take effect until you recreate the container with `docker compose up -d`. 

That's a documentation problem on our end, not a code problem. Snipe-IT's env plumbing seems correct. The .env.example ships `APP_TRUSTED_PROXIES=192.168.1.1,10.0.0.1`, `config/trustedproxy.php` reads it correctly, and the middleware honors the resulting proxy list.

## Documentation Update (to-do, for me)

Add this to the docs on readme.io:


> ### Environment variable changes require a container **recreate**, not a restart
>
> `docker compose restart` (or `docker restart <container>`) reuses the existing container along with the environment it was originally created with. Editing your `.env` file and then running `docker compose restart` will NOT pick up the new values. This trips people up frequently on settings like `APP_TRUSTED_PROXIES`, `APP_URL`, `SECURE_COOKIES`, and any of the mail or database credentials.
>
> To load changed environment values, **recreate** the container:
>
> ```bash
> docker compose up -d
> ```
>
> Docker Compose will detect that the environment has changed and rebuild the container in place. Your data volumes are preserved. If you need to be extra explicit:
>
> ```bash
> docker compose down
> docker compose up -d
> ```
>
> The equivalent for a plain `docker run` workflow is to stop and remove the container and re-run it:
>
> ```bash
> docker stop snipeit
> docker rm snipeit
> docker run -d --env-file .env ... snipe/snipe-it
> ```
>
> Symptom to watch for: you edited `.env`, ran `docker compose restart`, and the setup page still complains about `APP_URL` or your proxy trust settings. That's this. Recreate the container.

If the upstream `fideloper/proxy` (which this config file's shape is derived from) or Laravel changes its config-reading conventions in a future major, revisit this file. Right now Laravel's `Illuminate\Http\Middleware\TrustProxies::setTrustedProxyIpAddresses` at line 69 does `$this->proxies() ?: config('trustedproxy.proxies')`, so both the middleware property AND this config file's `proxies` key are read paths and stay in sync. If that changes in the future though, some stuff could definitely break.
