### PR TITLE
SCIM: Fixed #19347 - added complex comparison for enterprise schemas

### DIFF
--- a/app/Models/SnipeSCIMConfig.php
+++ b/app/Models/SnipeSCIMConfig.php
@@ -15,6 +15,7 @@ use ArieTimmerman\Laravel\SCIMServer\Exceptions\SCIMException;
 use ArieTimmerman\Laravel\SCIMServer\Parser\Parser;
 use ArieTimmerman\Laravel\SCIMServer\Parser\Path;
 use ArieTimmerman\Laravel\SCIMServer\SCIM\Schema;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
 function a($name = null): Attribute
@@ -180,6 +181,34 @@ class SnipeRootComplex extends Complex
                 }
             }
         }
+    }
+
+    // #19347: Complex::applyComparison ignores the schema URN on the
+    // filter path and always falls back to the FIRST schema node (core).
+    // A filter like:
+    //   ?filter=urn:...enterprise:2.0:User:employeeNumber eq "1234567"
+    // parses with schema=<enterprise URN> and attributeNames=['employeeNumber'],
+    // but the library calls getSubNode('employeeNumber') on root, misses,
+    // then dispatches to getSchemaNode() (always core) which reports
+    // "Unknown path" since employeeNumber lives on the enterprise schema.
+    // Same shape of bug as the URN-blind add()/replace() routing above.
+    // If the path carries a schema URN and we have a schema node for it,
+    // dispatch the whole path there so its own applyComparison finds the
+    // attribute; otherwise defer to the library.
+    public function applyComparison(Builder &$query, Path $path, $parentAttribute = null)
+    {
+        $schemaUrn = $path->getAttributePath()?->path?->schema;
+
+        if ($schemaUrn !== null) {
+            $schemaNode = $this->getSubNode($schemaUrn);
+            if ($schemaNode instanceof AttributeSchema) {
+                $schemaNode->applyComparison($query, $path, $parentAttribute);
+
+                return;
+            }
+        }
+
+        parent::applyComparison($query, $path, $parentAttribute);
     }
 }
 

--- a/tests/Feature/Scim/UserFilterSchemaUrnTest.php
+++ b/tests/Feature/Scim/UserFilterSchemaUrnTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Feature\Scim;
+
+use App\Models\User;
+use Laravel\Passport\Passport;
+use Tests\TestCase;
+
+/**
+ * Regression for #19347: Azure Entra ID sends filter expressions with
+ * the fully-qualified schema URN prefixed onto the attribute name
+ * (RFC 7644 section 3.4.2.2), e.g.
+ *
+ *   GET /scim/v2/Users?filter=
+ *     urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:employeeNumber
+ *     eq "1234567"
+ *
+ * The upstream library's Complex::applyComparison drops the schema URN
+ * on the floor and always dispatches to the FIRST schema node (core),
+ * which reports "Unknown path" for any attribute defined on a non-core
+ * schema. SnipeRootComplex now intercepts these and routes to the
+ * correct schema node based on the URN.
+ *
+ * Note: filtering by relationship-backed extension attributes
+ * (department, location, company) is separately blocked by the
+ * library's default Attribute::applyComparison throwing "Comparison is
+ * not implemented" for MappedTable subclasses. That's a distinct gap
+ * from #19347 and is not covered here.
+ */
+class UserFilterSchemaUrnTest extends TestCase
+{
+    private const ENTERPRISE_URN = 'urn:ietf:params:scim:schemas:extension:enterprise:2.0:User';
+
+    private const CORE_URN = 'urn:ietf:params:scim:schemas:core:2.0:User';
+
+    public function test_filter_by_enterprise_employee_number_with_urn_prefix_finds_user(): void
+    {
+        Passport::actingAs(User::factory()->superuser()->create());
+        $target = User::factory()->create(['employee_num' => 'EMP-19347']);
+        User::factory()->create(['employee_num' => 'other']);
+
+        $filter = self::ENTERPRISE_URN.':employeeNumber eq "EMP-19347"';
+
+        $response = $this->getJson('/scim/v2/Users?filter='.urlencode($filter));
+
+        $response->assertOk();
+        $response->assertJsonPath('totalResults', 1);
+        $response->assertJsonPath('Resources.0.id', (string) $target->id);
+    }
+
+    public function test_filter_by_core_username_still_works_after_override(): void
+    {
+        // Sanity check that we haven't regressed the ordinary (no-URN,
+        // core-schema-implicit) filter path.
+        Passport::actingAs(User::factory()->superuser()->create());
+        $target = User::factory()->create(['username' => 'scim-filter-target']);
+        User::factory()->create();
+
+        $response = $this->getJson('/scim/v2/Users?filter='.urlencode('userName eq "scim-filter-target"'));
+
+        $response->assertOk();
+        $response->assertJsonPath('totalResults', 1);
+        $response->assertJsonPath('Resources.0.id', (string) $target->id);
+    }
+
+    public function test_filter_by_core_username_with_explicit_core_urn_prefix_works(): void
+    {
+        // Some clients qualify core-schema attributes with the core URN.
+        // Route via the same code path as enterprise.
+        Passport::actingAs(User::factory()->superuser()->create());
+        $target = User::factory()->create(['username' => 'scim-core-target']);
+        User::factory()->create();
+
+        $filter = self::CORE_URN.':userName eq "scim-core-target"';
+
+        $response = $this->getJson('/scim/v2/Users?filter='.urlencode($filter));
+
+        $response->assertOk();
+        $response->assertJsonPath('totalResults', 1);
+        $response->assertJsonPath('Resources.0.id', (string) $target->id);
+    }
+}


### PR DESCRIPTION
Azure Entra ID (and other SCIM clients following RFC 7644 section 3.4.2.2) send filter expressions with the fully-qualified schema URN prefixed onto the attribute name:

```
GET /scim/v2/Users?filter=urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:employeeNumber eq "1234567"
```

Snipe-IT returns 404 with:

```json
{
  "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
  "detail": "Unknown path: urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:employeeNumber eq \"1234567\", in object: urn:ietf:params:scim:schemas:core:2.0:User",
  "status": 404
}
```

Any Azure user-precedence rule that keys on `employeeNumber` (very common) trips this on every provision cycle. The bug has been latent since the enterprise and grokability extension schemas were added, it just never came up somehow.

The upstream library's `Complex::applyComparison` at `vendor/arietimmerman/laravel-scim-server/src/Attribute/Complex.php:288-302` ignores the schema URN on the parsed path and always dispatches to the FIRST schema node (which is core). The attribute lives on the enterprise _extension_ schema, so the _core_ schema reports "Unknown path" and 404s.

```php
} elseif ($path->getAttributePath() != null) {
    $attributeNames = $path?->getAttributePath()?->getAttributeNames() ?? [];

    if (!empty($attributeNames)) {
        $attribute = $this->getSubNode($attributeNames[0]);   // URN thrown away
        if ($attribute != null) { ... }
        elseif ($this->parent == null) {
            // this is the root node, check within the first (the default) schema node
            $this->getSchemaNode()->applyComparison($query, $path);   // always routes to core
        } else {
            throw new SCIMException('Unknown path: ' ...);
        }
    }
}
```

The URN is _on_ `$path->getAttributePath()->path->schema`, it's just never consulted. This is the same shape of bug that `SnipeRootComplex::add()` and `::replace()` already patched for PATCH/PUT operations (via `findInSchema`). GET filters never got the same razzle-dazzle.

This PR should fix this by overriding `applyComparison` on `SnipeRootComplex` to pick the URN off the path, look up the matching schema node, and dispatch the whole path there so its own `applyComparison` finds the attribute. Fall through to the library default when the path has no URN or the URN doesn't match a known schema.

`getSubNode($urn)` works because the `AttributeSchema` instances registered on the root are named after their URNs (`Schema::SCHEMA_USER`, `self::ENTERPRISE`, `self::GROKABILITY`), so lookup by URN string finds the right node directly.

## What this fix does NOT cover

Filtering by relationship-backed extension attributes (`department`, `location`, `company`) is _separately_ blocked by the library's default `Attribute::applyComparison` throwing "Comparison is not implemented" for anything that isn't a plain Eloquent column. Our `MappedTable` and `SCIMCompanyAttribute` subclasses would each need their own `applyComparison` to build the appropriate join or relationship subquery. That's a distinct gap from #19347 and out of scope here - and I'm not sure how often it comes up - but we can add it if it does.

Fixed #19347