### PR TITLE
Removed orphaned API routes

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -247,13 +247,6 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'api-throttle:api']], fu
             ]
         )->name('api.components.history')->withTrashed();
 
-        Route::get('selectlist',
-            [
-                Api\ComponentsController::class,
-                'selectlist',
-            ]
-        )->name('api.components.selectlist');
-
         Route::get('{component}/assets',
             [
                 Api\ComponentsController::class,

--- a/routes/api.php
+++ b/routes/api.php
@@ -904,14 +904,6 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'api-throttle:api']], fu
                 'assets',
             ]
         )->name('api.models.assets');
-
-        Route::post('{id}/restore',
-            [
-                Api\AssetModelsController::class,
-                'restore',
-            ]
-        )->name('api.models.restore');
-
     });
 
     Route::resource('models',

--- a/routes/api.php
+++ b/routes/api.php
@@ -796,14 +796,6 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'api-throttle:api']], fu
             ]
         )->name('api.locations.selectlist');
 
-        // Users within a location
-        Route::get('{location}/users',
-            [
-                Api\LocationsController::class,
-                'getDataViewUsers',
-            ]
-        )->name('api.locations.viewusers');
-
         // Get list of assets with a default location
         Route::get('{location}/assets',
             [

--- a/routes/api.php
+++ b/routes/api.php
@@ -984,13 +984,6 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'api-throttle:api']], fu
             ]
         )->name('api.settings.ldaptestlogin');
 
-        Route::post('slacktest',
-            [
-                Api\SettingsController::class,
-                'slacktest',
-            ]
-        )->name('api.settings.slacktest');
-
         Route::post('mailtest',
             [
                 Api\SettingsController::class,

--- a/routes/api.php
+++ b/routes/api.php
@@ -1163,13 +1163,6 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'api-throttle:api']], fu
             ]
         )->name('api.user.eulas');
 
-        Route::get('list/{status?}',
-            [
-                Api\UsersController::class,
-                'getDatatable',
-            ]
-        )->name('api.users.list');
-
         Route::get('{user}/assets',
             [
                 Api\UsersController::class,


### PR DESCRIPTION
This PR removes five API routes which were never implemented.

All of these routes either can be duplicate an existing endpoint or are unused.

| Route | Handler (missing) | Why removed |
|-------|-------------------|-------------|
| `GET locations/{location}/users` | `LocationsController::getDataViewUsers` | The location page's Users tab loads via `api.users.index?location_id=` — the same pattern companies uses. Redundant. |
| `POST settings/slacktest` | `SettingsController::slacktest` | All webhook testing (Slack/Google/Teams) is handled by the `SlackSettingsForm` Livewire component, not an API route. Referenced nowhere. |
| `GET users/list/{status?}` | `UsersController::getDatatable` | Superseded by `api.users.index`. Referenced nowhere. |
| `POST models/{id}/restore` | `AssetModelsController::restore` | Model restore works via the web route `models.restore.store` → `getRestore()`. No API consumer. |
| `GET components/selectlist` | `ComponentsController::selectlist` | Components are never used as a select2/`data-endpoint` source anywhere in the UI. Referenced nowhere. |

> Note: We might want to actually re-add and implement the routes for restoring asset models and the component select list down the line.

> Note: I used Claude Code to sanity check removing these wouldn't cause issues and to generate this summary before I edited it.

---

[RB-21825]  
[RB-21826]
