### PR TITLE
Inline quantity stepper for consumables

### DIFF
--- a/app/Http/Controllers/Consumables/ConsumablesController.php
+++ b/app/Http/Controllers/Consumables/ConsumablesController.php
@@ -10,7 +10,9 @@ use App\Models\Company;
 use App\Models\Consumable;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\View\View;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Validator;
 
@@ -244,6 +246,62 @@ class ConsumablesController extends Controller
         $this->authorize($consumable);
 
         return view('consumables/view', compact('consumable'));
+    }
+
+    /**
+     * Nudge a consumable's quantity inline (from the toner dashboard or the
+     * info-panel stepper) without round-tripping the full edit form.
+     *
+     * Accepts either a relative `delta` (e.g. +1 / -1) or an absolute `qty`.
+     * The new value is clamped to never drop below what's already checked
+     * out and never below zero. The change saves through the normal model
+     * path, so ConsumableObserver records it in the activity log (who, when,
+     * and the old→new quantity) exactly like a full edit — no separate table
+     * needed; it shows on the consumable's History tab.
+     *
+     * @author [R. Christiansen]
+     */
+    public function adjustQuantity(Request $request, Consumable $consumable): JsonResponse
+    {
+        $this->authorize('update', $consumable);
+
+        $request->validate([
+            'delta' => 'sometimes|integer',
+            'qty' => 'sometimes|integer|min:0|max:99999',
+        ]);
+
+        $checkedOut = (int) $consumable->numCheckedOut();
+
+        if ($request->filled('qty')) {
+            $newQty = (int) $request->input('qty');
+        } else {
+            $newQty = (int) $consumable->qty + (int) $request->input('delta', 0);
+        }
+
+        // Floor at what's checked out (and never negative); ceiling at the
+        // column's max. Mirrors the edit form's `min:$checkedOut` guard.
+        $newQty = max($checkedOut, 0, $newQty);
+        $newQty = min($newQty, 99999);
+
+        $consumable->qty = $newQty;
+
+        if (! $consumable->save()) {
+            return response()->json([
+                'status' => 'error',
+                'messages' => $consumable->getErrors()->all(),
+            ], 422);
+        }
+
+        $remaining = (int) $consumable->numRemaining();
+        $min = (int) ($consumable->min_amt ?? 0);
+
+        return response()->json([
+            'status' => 'success',
+            'qty' => (int) $consumable->qty,
+            'remaining' => $remaining,
+            'min' => $min,
+            'state' => $remaining <= 0 ? 'red' : (($min > 0 && $remaining <= $min) ? 'yellow' : 'green'),
+        ]);
     }
 
     public function clone(Consumable $consumable): View

--- a/resources/lang/en-US/admin/consumables/general.php
+++ b/resources/lang/en-US/admin/consumables/general.php
@@ -9,4 +9,7 @@ return [
     'total' => 'Total',
     'update' => 'Update Consumable',
     'inventory_warning' => 'The inventory of this consumable is below the minimum amount of :min_count',
+    'qty_increase' => 'Add one',
+    'qty_decrease' => 'Remove one',
+    'qty_at_checkout_floor' => 'Already at the number checked out — can\'t go lower',
 ];

--- a/resources/views/blade/info-panel/index.blade.php
+++ b/resources/views/blade/info-panel/index.blade.php
@@ -163,8 +163,13 @@
 
         @if (method_exists($infoPanelObj, 'numRemaining'))
             <x-info-element icon_type="available" class="{{ ($infoPanelObj->numRemaining()) <= $infoPanelObj->min_amt ? 'text-danger' : 'text-success' }}" title="{{ trans('general.remaining') }}">
-                 {{ $infoPanelObj->numRemaining() }}
-                {{ trans('general.remaining') }}
+                @if ($infoPanelObj instanceof \App\Models\Consumable)
+                    {{ trans('general.remaining') }}
+                    <span class="pull-right"><x-qty-stepper :consumable="$infoPanelObj" /></span>
+                @else
+                     {{ $infoPanelObj->numRemaining() }}
+                    {{ trans('general.remaining') }}
+                @endif
             </x-info-element>
         @endif
 

--- a/resources/views/blade/qty-stepper.blade.php
+++ b/resources/views/blade/qty-stepper.blade.php
@@ -1,0 +1,148 @@
+@props([
+    'consumable',
+    'canEdit' => null,
+])
+
+{{--
+    Inline quantity control for a consumable. Shows the colored "remaining"
+    count (green / yellow / red, matching the toner dashboard) with a tall
+    up/down stepper split 50/50 down the right edge, sized to the counter so
+    the arrows are big enough to hit. Clicking nudges qty ±1 via
+    POST consumables.adjust-qty (AJAX) — no full edit-form round trip — and
+    every change lands in the consumable's activity log.
+
+    Reused on the /consumables toner cards and the consumable detail
+    info-panel "Remaining" row.
+--}}
+@php
+    $canEdit = $canEdit ?? (auth()->user()?->can('update', $consumable) ?? false);
+    $remaining = (int) $consumable->numRemaining();
+    $min = (int) ($consumable->min_amt ?? 0);
+    $state = $remaining <= 0 ? 'red' : (($min > 0 && $remaining <= $min) ? 'yellow' : 'green');
+@endphp
+
+<span class="qty-stepper qty-stepper--{{ $state }} {{ $canEdit ? 'is-editable' : '' }}"
+      data-qty-stepper
+      data-url="{{ route('consumables.adjust-qty', $consumable->id) }}"
+      data-min="{{ $min }}">
+    <span class="qty-stepper__value" data-qty-value aria-live="polite">{{ $remaining }}</span>
+    @if ($canEdit)
+        <span class="qty-stepper__nudge" role="group" aria-label="{{ $consumable->name }}">
+            <button type="button" class="qty-stepper__btn qty-stepper__btn--up" data-qty-delta="1"
+                    title="{{ trans('admin/consumables/general.qty_increase') }}"
+                    aria-label="{{ trans('admin/consumables/general.qty_increase') }}">
+                <i class="fa-solid fa-chevron-up" aria-hidden="true"></i>
+            </button>
+            <button type="button" class="qty-stepper__btn qty-stepper__btn--down" data-qty-delta="-1"
+                    title="{{ trans('admin/consumables/general.qty_decrease') }}"
+                    aria-label="{{ trans('admin/consumables/general.qty_decrease') }}">
+                <i class="fa-solid fa-chevron-down" aria-hidden="true"></i>
+            </button>
+        </span>
+    @endif
+</span>
+
+@once
+@push('css')
+<style>
+    .qty-stepper {
+        display: inline-flex;
+        align-items: stretch;
+        height: 38px;
+        line-height: 1;
+        border-radius: 3px;
+        overflow: hidden;
+        vertical-align: middle;
+        font-weight: bold;
+    }
+    .qty-stepper__value {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 46px;
+        padding: 0 10px;
+        color: #fff;
+        font-size: 15px;
+    }
+    .qty-stepper--green  .qty-stepper__value { background: #00a65a; }
+    .qty-stepper--yellow .qty-stepper__value { background: #f39c12; }
+    .qty-stepper--red    .qty-stepper__value { background: #dd4b39; }
+
+    /* Tall stepper, split 50/50 down the right edge of the counter. */
+    .qty-stepper__nudge {
+        display: flex;
+        flex-direction: column;
+        width: 30px;
+        flex: 0 0 30px;
+    }
+    .qty-stepper__btn {
+        flex: 1 1 50%;
+        min-height: 0;
+        padding: 0;
+        border: 0;
+        border-left: 1px solid rgba(255, 255, 255, 0.45);
+        background: rgba(0, 0, 0, 0.08);
+        color: #fff;
+        cursor: pointer;
+        font-size: 12px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: background 0.12s ease;
+    }
+    .qty-stepper__btn--up   { border-bottom: 1px solid rgba(255, 255, 255, 0.45); }
+    .qty-stepper__btn:hover { background: rgba(0, 0, 0, 0.22); }
+    .qty-stepper__btn:active { background: rgba(0, 0, 0, 0.34); }
+    .qty-stepper__btn:disabled { opacity: 0.5; cursor: default; }
+    .qty-stepper.is-busy { opacity: 0.6; }
+    .qty-stepper.is-busy .qty-stepper__btn { cursor: progress; }
+</style>
+@endpush
+
+<script>
+(function () {
+    if (window.__qtyStepperBound) return;
+    window.__qtyStepperBound = true;
+    var CSRF = "{{ csrf_token() }}";
+
+    document.addEventListener('click', function (e) {
+        var btn = e.target.closest ? e.target.closest('[data-qty-delta]') : null;
+        if (!btn) return;
+        var stepper = btn.closest('[data-qty-stepper]');
+        if (!stepper || stepper.classList.contains('is-busy')) return;
+
+        e.preventDefault();
+        stepper.classList.add('is-busy');
+
+        var body = new URLSearchParams();
+        body.set('delta', btn.getAttribute('data-qty-delta'));
+        body.set('_token', CSRF);
+
+        fetch(stepper.getAttribute('data-url'), {
+            method: 'POST',
+            headers: {
+                'X-CSRF-TOKEN': CSRF,
+                'X-Requested-With': 'XMLHttpRequest',
+                'Accept': 'application/json',
+                'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+            },
+            credentials: 'same-origin',
+            body: body.toString()
+        })
+        .then(function (r) { return r.ok ? r.json() : r.json().then(function (j) { throw j; }); })
+        .then(function (data) {
+            var valueEl = stepper.querySelector('[data-qty-value]');
+            if (valueEl) valueEl.textContent = data.remaining;
+            stepper.classList.remove('qty-stepper--green', 'qty-stepper--yellow', 'qty-stepper--red');
+            stepper.classList.add('qty-stepper--' + (data.state || 'green'));
+        })
+        .catch(function () {
+            // Leave the displayed value untouched on failure.
+        })
+        .then(function () {
+            stepper.classList.remove('is-busy');
+        });
+    });
+})();
+</script>
+@endonce

--- a/routes/web/consumables.php
+++ b/routes/web/consumables.php
@@ -20,6 +20,14 @@ Route::group(['prefix' => 'consumables', 'middleware' => ['auth']], function () 
     Route::get('{consumable}/clone',
         [Consumables\ConsumablesController::class, 'clone']
     )->name('consumables.clone.create');
+
+    // Inline quantity nudge from the consumable detail info-panel stepper.
+    // Adjusts qty by a delta (or sets an absolute value) and returns JSON,
+    // routing through the same Eloquent save the edit form uses so the
+    // change lands in the consumable's activity log (who + when + old->new).
+    Route::post('{consumable}/adjust-qty',
+        [Consumables\ConsumablesController::class, 'adjustQuantity']
+    )->name('consumables.adjust-qty');
     
 
 });

--- a/tests/Feature/Consumables/Ui/AdjustConsumableQuantityTest.php
+++ b/tests/Feature/Consumables/Ui/AdjustConsumableQuantityTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Feature\Consumables\Ui;
+
+use App\Models\Actionlog;
+use App\Models\Consumable;
+use App\Models\User;
+use Tests\TestCase;
+
+class AdjustConsumableQuantityTest extends TestCase
+{
+    public function test_requires_update_permission()
+    {
+        $consumable = Consumable::factory()->create(['qty' => 0]);
+
+        $this->actingAs(User::factory()->create())
+            ->post(route('consumables.adjust-qty', $consumable), ['delta' => 1])
+            ->assertForbidden();
+    }
+
+    public function test_increments_quantity_by_delta()
+    {
+        $consumable = Consumable::factory()->create(['qty' => 2]);
+        $user = User::factory()->editConsumables()->create();
+
+        $response = $this->actingAs($user)
+            ->post(route('consumables.adjust-qty', $consumable), ['delta' => 1]);
+
+        $response->assertOk()->assertJson(['status' => 'success', 'qty' => 3, 'remaining' => 3]);
+        $this->assertEquals(3, $consumable->fresh()->qty);
+    }
+
+    public function test_decrements_quantity_by_delta()
+    {
+        $consumable = Consumable::factory()->create(['qty' => 2]);
+        $user = User::factory()->editConsumables()->create();
+
+        $this->actingAs($user)
+            ->post(route('consumables.adjust-qty', $consumable), ['delta' => -1])
+            ->assertOk()->assertJson(['qty' => 1]);
+        $this->assertEquals(1, $consumable->fresh()->qty);
+    }
+
+    public function test_sets_absolute_quantity()
+    {
+        $consumable = Consumable::factory()->create(['qty' => 0]);
+        $user = User::factory()->editConsumables()->create();
+
+        $this->actingAs($user)
+            ->post(route('consumables.adjust-qty', $consumable), ['qty' => 12])
+            ->assertOk()->assertJson(['qty' => 12]);
+        $this->assertEquals(12, $consumable->fresh()->qty);
+    }
+
+    public function test_never_drops_below_what_is_checked_out()
+    {
+        $user = User::factory()->editConsumables()->create();
+        $consumable = Consumable::factory()->create(['qty' => 2]);
+        $consumable->users()->attach($consumable->id, ['consumable_id' => $consumable->id, 'assigned_to' => $user->id]);
+        $consumable->users()->attach($consumable->id, ['consumable_id' => $consumable->id, 'assigned_to' => $user->id]);
+        $this->assertEquals(2, $consumable->numCheckedOut());
+
+        // Trying to go to 0 (or below 2 checked out) clamps to 2.
+        $this->actingAs($user)
+            ->post(route('consumables.adjust-qty', $consumable), ['delta' => -5])
+            ->assertOk()->assertJson(['qty' => 2]);
+        $this->assertEquals(2, $consumable->fresh()->qty);
+    }
+
+    public function test_change_is_recorded_in_the_activity_log()
+    {
+        $consumable = Consumable::factory()->create(['qty' => 0]);
+        $user = User::factory()->editConsumables()->create();
+
+        $this->actingAs($user)
+            ->post(route('consumables.adjust-qty', $consumable), ['delta' => 1])
+            ->assertOk();
+
+        // ConsumableObserver logs an 'update' action with the changed qty,
+        // attributed to the acting user — the traceability Snipe already has.
+        $log = Actionlog::where('item_type', Consumable::class)
+            ->where('item_id', $consumable->id)
+            ->where('action_type', 'update')
+            ->latest('id')->first();
+
+        $this->assertNotNull($log, 'A qty nudge should write an update action log entry');
+        $this->assertEquals($user->id, $log->created_by);
+        $this->assertStringContainsString('qty', (string) $log->log_meta);
+    }
+}


### PR DESCRIPTION
### Description

Correcting a consumable count is a routine, high-frequency action — someone opens a fresh box, or a physical count disagrees with the system — and today it costs a full round trip through the edit form. This adds an inline up/down stepper to the "Remaining" row of the consumable info panel that nudges the quantity by one over AJAX and recolours green/yellow/red as it crosses the minimum-quantity threshold.

### Design notes

- **New `POST consumables/{consumable}/adjust-qty`** accepting either a relative `delta` or an absolute `qty`.
- **No new table, no loss of traceability.** The endpoint saves through the normal Eloquent path, so `ConsumableObserver` records the change in the activity log with who, when, and old→new — exactly as a full edit does. It shows up on the consumable's History tab with no extra work.
- **Clamped, not trusted.** The new value can never drop below what is already checked out (mirroring the edit form's `min` guard), never below zero, and never above the column maximum. The floor is enforced server-side regardless of what the client sends.
- **Authorised** via the existing `update` policy on the consumable.
- **`x-qty-stepper` is an anonymous component with self-contained CSS/JS**, so this needs no asset rebuild and adds nothing to the bundle.

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Added `tests/Feature/Consumables/Ui/AdjustConsumableQuantityTest.php` — 6 tests covering relative delta, absolute set, the checked-out floor, permission enforcement, and activity-log attribution. Full `tests/Feature/Consumables` suite passes — 43 tests, 164 assertions.

### Notes for reviewers

This is extracted from a larger internal change that also reordered the consumable detail tabs; I have deliberately left that out, since the tab order is a local preference rather than something to push on everyone. Only the stepper and its endpoint are here.
