### PR TITLE
Compare usernames case insensitively

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1307,17 +1307,18 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
      * @return string
      */
     /**
-     * Verify that a resolved local user's stored username byte-exactly matches
-     * the externally-supplied identifier. The MySQL/MariaDB default collation
-     * utf8mb4_unicode_ci folds accents and case, so `WHERE username = ?` on
-     * that engine can silently route 'snípeitreport3' or 'Admin' to the row
-     * for 'snipeitreport3' or 'admin'. Federated/SSO auth flows (SAML, LDAP,
-     * REMOTE_USER, Google OAuth) must call this after their username lookup
-     * so an attacker-controlled external identifier can't authenticate as a
-     * different local account. hash_equals runs in constant time so this
-     * check doesn't leak any timing signal.
+     * The MySQL/MariaDB default collation utf8mb4_unicode_ci folds accents
+     * and case, so `WHERE username = ?` on that engine can silently route
+     * 'snípeitreport3' (with an accent on the i) to the row for 'snipeitreport3'.
      *
-     * Returns the user when the strings match byte-for-byte, null otherwise.
+     * Federated/SSO auth flows (SAML, LDAP, REMOTE_USER, Google OAuth) must call
+     * this after their username lookup so an attacker-controlled external identifier
+     * can't authenticate as a different local account. hash_equals runs in constant
+     * time so this check doesn't leak any timing signal.
+     *
+     * Returns the user when the strings match byte-for-byte after lowercasing,
+     * null otherwise. (This was previously just bite-for-bite, but most IdPs are
+     * case-insensitive, so we normalize to lowercase before comparing.)
      */
     public static function verifyExactUsernameMatch(?self $user, string $expected): ?self
     {
@@ -1325,7 +1326,7 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
             return null;
         }
 
-        return hash_equals((string) $user->username, $expected) ? $user : null;
+        return hash_equals(mb_strtolower((string) $user->username), mb_strtolower($expected)) ? $user : null;
     }
 
     public static function generateEmailFromFullName($name)

--- a/resources/lang/en-US/auth/general.php
+++ b/resources/lang/en-US/auth/general.php
@@ -6,7 +6,6 @@ return [
     'reset_password' => 'Reset Password',
     'saml_login' => 'Login via SAML',
     'login' => 'Login',
-    'logn_help' => 'Some systems require case-sensitive usernames.',
     'login_prompt' => 'Please Login',
     'forgot_password' => 'I forgot my password',
     'ldap_reset_password' => 'Please click here to reset your LDAP password',

--- a/resources/lang/en-US/auth/message.php
+++ b/resources/lang/en-US/auth/message.php
@@ -3,7 +3,7 @@
 return [
 
     'account_already_exists' => 'An account with the this email already exists.',
-    'account_not_found' => 'The username or password is incorrect. Some systems require case-sensitive usernames.',
+    'account_not_found' => 'The username or password is incorrect.',
     'account_not_activated' => 'This user account is not activated.',
     'account_suspended' => 'This user account is suspended.',
 

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -63,9 +63,6 @@
                                             </label>
                                             <input class="form-control" placeholder="{{ trans('admin/users/table.username')  }}" name="username" type="text" id="username" autocomplete="{{ (config('auth.login_autocomplete') === true) ? 'on' : 'off'  }}" autocapitalize="off" spellcheck="false" autofocus>
                                             <x-form.error name="username" />
-                                            <x-form.help name="username">
-                                                <x-icon type="tip"/>
-                                                {{ trans('auth/general.logn_help') }}</x-form.help>
                                         </div>
 
 

--- a/tests/Unit/Models/User/VerifyExactUsernameMatchTest.php
+++ b/tests/Unit/Models/User/VerifyExactUsernameMatchTest.php
@@ -10,11 +10,15 @@ use Tests\TestCase;
  * guard against DB collation folding. The MySQL/MariaDB default collation
  * utf8mb4_unicode_ci treats snipeitreport3 and snípeitreport3 as equal, so
  * `WHERE username = ?` can return the wrong row for an attacker-controlled
- * external identifier. The helper is the byte-exact re-check every federated
- * auth callsite (SAML, LDAP, REMOTE_USER, Google OAuth) runs before trusting
- * the resolved local user. These tests instantiate the User model without
- * touching the DB because the helper is a pure function on the resolved row
- * plus the expected string.
+ * external identifier. The helper re-checks the resolved user's username
+ * against the caller-provided identifier every federated auth callsite
+ * (SAML, LDAP, REMOTE_USER, Google OAuth) runs before trusting the row.
+ * Comparison is case-insensitive (both sides lowercased) because most IdPs
+ * treat usernames case-insensitively and locking admins out on case-only
+ * mismatches was a real support burden. Everything else (accents, whitespace,
+ * unicode lookalikes) is still rejected. These tests instantiate the User
+ * model without touching the DB because the helper is a pure function on the
+ * resolved row plus the expected string.
  *
  * Original vulnerability report: whale120 (@whale120_tw), DEVCORE Internship
  * Program.
@@ -50,18 +54,27 @@ class VerifyExactUsernameMatchTest extends TestCase
         $this->assertNull(User::verifyExactUsernameMatch($user, 'snípeitreport3'));
     }
 
-    public function test_case_variant_is_rejected()
+    /**
+     * Deliberate compromise: most IdPs treat usernames case-insensitively,
+     * and admins were locking themselves out when the case in their IdP
+     * didn't match the case in their Snipe-IT user row. The helper now
+     * lowercases both sides before comparing, so `Admin` and `ADMIN` from
+     * a SAML/LDAP assertion resolve to the local `admin` row. Accent-,
+     * whitespace-, and lookalike-character folding are still rejected
+     * because those aren't handled by strtolower.
+     */
+    public function test_case_variant_matches()
     {
         $user = new User(['username' => 'admin']);
 
-        $this->assertNull(User::verifyExactUsernameMatch($user, 'Admin'));
+        $this->assertSame($user, User::verifyExactUsernameMatch($user, 'Admin'));
     }
 
-    public function test_uppercase_variant_is_rejected()
+    public function test_uppercase_variant_matches()
     {
         $user = new User(['username' => 'admin']);
 
-        $this->assertNull(User::verifyExactUsernameMatch($user, 'ADMIN'));
+        $this->assertSame($user, User::verifyExactUsernameMatch($user, 'ADMIN'));
     }
 
     /**


### PR DESCRIPTION
This loosens up some of the IdP username comparisons, since most IdP's are case-insensitive.