### PR TITLE
Importer: Fixed FD-56712 - Guard against asset importer `created_by` null

### DIFF
--- a/app/Importer/AccessoryImporter.php
+++ b/app/Importer/AccessoryImporter.php
@@ -50,7 +50,7 @@ class AccessoryImporter extends ItemImporter
         }
         $this->log('No Matching Accessory, Creating a new one');
         $accessory = new Accessory;
-        $accessory->created_by = auth()->id();
+        $accessory->created_by = $this->created_by;
         $this->item['model_number'] = $this->findCsvMatch($row, 'model_number');
         $this->item['min_amt'] = $this->findCsvMatch($row, 'min_amt');
         $accessory->fill($this->sanitizeItemForStoring($accessory));

--- a/app/Importer/AssetImporter.php
+++ b/app/Importer/AssetImporter.php
@@ -102,6 +102,14 @@ class AssetImporter extends ItemImporter
         } else {
             $this->log('No Matching Asset, Creating a new one');
             $asset = new Asset;
+            // created_by is not in Asset's $fillable, so the value that
+            // ItemImporter::handle() puts on $this->item is stripped by
+            // sanitizeItemForStoring() before it reaches the model. Set
+            // it directly. Use $this->created_by (the property set by
+            // setCreatedBy() from both ItemImportRequest and
+            // ObjectImportCommand) rather than auth()->id() so CLI-run
+            // imports get the --user_id option value instead of null.
+            $asset->created_by = $this->created_by;
         }
 
         // If no status ID is found

--- a/app/Importer/AssetModelImporter.php
+++ b/app/Importer/AssetModelImporter.php
@@ -122,7 +122,7 @@ class AssetModelImporter extends ItemImporter
         } else {
             Log::debug('Creating model');
             $assetModel->fill($this->sanitizeItemForStoring($assetModel));
-            $assetModel->created_by = auth()->id();
+            $assetModel->created_by = $this->created_by;
         }
 
         if ($assetModel->save()) {

--- a/app/Importer/CategoryImporter.php
+++ b/app/Importer/CategoryImporter.php
@@ -60,7 +60,7 @@ class CategoryImporter extends ItemImporter
         } else {
             $this->log('No Matching Category, Create a new one');
             $category = new Category;
-            $category->created_by = auth()->id();
+            $category->created_by = $this->created_by;
         }
 
         // Pull the records from the CSV to determine their values

--- a/app/Importer/ComponentImporter.php
+++ b/app/Importer/ComponentImporter.php
@@ -49,7 +49,7 @@ class ComponentImporter extends ItemImporter
         }
         $this->log('No matching component, creating one');
         $component = new Component;
-        $component->created_by = auth()->id();
+        $component->created_by = $this->created_by;
         $component->fill($this->sanitizeItemForStoring($component));
 
         // This sets an attribute on the Loggable trait for the action log
@@ -68,7 +68,7 @@ class ComponentImporter extends ItemImporter
                 } else {
                     $component->assets()->attach($component->id, [
                         'component_id' => $component->id,
-                        'created_by' => auth()->id(),
+                        'created_by' => $this->created_by,
                         'created_at' => date('Y-m-d H:i:s'),
                         'assigned_qty' => 1, // Only assign the first one to the asset
                         'asset_id' => $asset->id,

--- a/app/Importer/ConsumableImporter.php
+++ b/app/Importer/ConsumableImporter.php
@@ -52,7 +52,7 @@ class ConsumableImporter extends ItemImporter
 
         $this->log('No matching consumable, creating one');
         $consumable = new Consumable;
-        $consumable->created_by = auth()->id();
+        $consumable->created_by = $this->created_by;
         $consumable->fill($this->sanitizeItemForStoring($consumable));
 
         // This sets an attribute on the Loggable trait for the action log

--- a/app/Importer/Importer.php
+++ b/app/Importer/Importer.php
@@ -347,7 +347,11 @@ abstract class Importer
             'display_name' => $this->findCsvMatch($row, 'display_name'),
             'email' => $this->findCsvMatch($row, 'email'),
             'manager_id' => '',
-            'department_id' => '',
+            // ItemImporter::handle() has already created the Department (if
+            // the CSV row had one) and stored its id on $this->item so it
+            // can flow through to the user record. Previously this value
+            // was hard-coded to '' and the Department was orphaned.
+            'department_id' => $this->item['department_id'] ?? '',
             'username' => $this->findCsvMatch($row, 'username'),
             'activated' => $this->fetchHumanBoolean($this->findCsvMatch($row, 'activated')),
             'remote' => $this->fetchHumanBoolean(($this->findCsvMatch($row, 'remote'))),
@@ -434,6 +438,13 @@ abstract class Importer
         $user->department_id = $user_array['department_id'] ?? null;
         $user->activated = 1;
         $user->password = $this->tempPassword;
+        // Use $this->created_by (set by setCreatedBy() from both
+        // ItemImportRequest for web imports and ObjectImportCommand for
+        // CLI imports) rather than auth()->id() so CLI-run imports get
+        // the --user_id option value instead of null. Without this,
+        // users minted as checkout targets during asset import land in
+        // the DB with a null created_by, breaking blame in the user list.
+        $user->created_by = $this->created_by;
 
         Log::debug('Creating a user with the following attributes: '.print_r($user_array, true));
 
@@ -576,25 +587,34 @@ abstract class Importer
      */
     public function createOrFetchDepartment($user_department_name)
     {
-        if ($user_department_name != '') {
-            $department = Department::where('name', '=', $user_department_name)->first();
-
-            if ($department) {
-                $this->log('A matching Department '.$user_department_name.' already exists');
-
-                return $department->id;
-            }
-
-            $department = new Department;
-            $department->name = $user_department_name;
-
-            if ($department->save()) {
-                $this->log('Department '.$user_department_name.' was created');
-
-                return $department->id;
-            }
-            $this->logError($department, 'Department');
+        // Explicit is_null check before the loose equality guard so a null
+        // input doesn't trigger PHP 8.x null-to-string deprecation warnings
+        // (the previous form was `!= ''` which coerces null to '' first).
+        if (is_null($user_department_name) || $user_department_name === '') {
+            return null;
         }
+
+        $department = Department::where('name', $user_department_name)->first();
+
+        if ($department) {
+            $this->log('A matching Department '.$user_department_name.' already exists');
+
+            return $department->id;
+        }
+
+        $department = new Department;
+        $department->name = $user_department_name;
+        // $this->created_by, not auth()->id(), so CLI-run imports
+        // attribute created_by to the --user_id option value rather
+        // than null.
+        $department->created_by = $this->created_by;
+
+        if ($department->save()) {
+            $this->log('Department '.$user_department_name.' was created');
+
+            return $department->id;
+        }
+        $this->logError($department, 'Department');
 
         return null;
     }

--- a/app/Importer/ItemImporter.php
+++ b/app/Importer/ItemImporter.php
@@ -82,7 +82,7 @@ class ItemImporter extends Importer
         $this->item['min_amt'] = $this->findCsvMatch($row, 'min_amt');
         $this->item['qty'] = $this->findCsvMatch($row, 'quantity');
         $this->item['requestable'] = $this->findCsvMatch($row, 'requestable');
-        $this->item['created_by'] = auth()->id();
+        $this->item['created_by'] = $this->created_by;
         $this->item['asset_tag'] = $this->findCsvMatch($row, 'asset_tag');
         $this->item['serial'] = $this->findCsvMatch($row, 'serial');
         $this->item['item_no'] = trim($this->findCsvMatch($row, 'item_no'));
@@ -256,7 +256,7 @@ class ItemImporter extends Importer
 
         $this->log('No Matching Model, Creating a new one');
         $asset_model = new AssetModel;
-        $asset_model->created_by = auth()->id();
+        $asset_model->created_by = $this->created_by;
         $item = $this->sanitizeItemForStoring($asset_model, $editingModel);
         $item['name'] = $asset_model_name;
         $item['model_number'] = $asset_modelNumber;
@@ -313,7 +313,7 @@ class ItemImporter extends Importer
         }
 
         $category = new Category;
-        $category->created_by = auth()->id();
+        $category->created_by = $this->created_by;
         $category->name = $asset_category;
         $category->category_type = $item_type;
 
@@ -353,7 +353,7 @@ class ItemImporter extends Importer
             return $company->id;
         }
         $company = new Company;
-        $company->created_by = auth()->id();
+        $company->created_by = $this->created_by;
         $company->name = $asset_company_name;
 
         if ($company->save()) {
@@ -425,7 +425,7 @@ class ItemImporter extends Importer
         }
         $this->log('Creating a new status');
         $status = new Statuslabel;
-        $status->created_by = auth()->id();
+        $status->created_by = $this->created_by;
         $status->name = trim($asset_statuslabel_name);
 
         $status->deployable = 1;
@@ -469,7 +469,7 @@ class ItemImporter extends Importer
         // Otherwise create a manufacturer.
         $manufacturer = new Manufacturer;
         $manufacturer->name = trim($item_manufacturer);
-        $manufacturer->created_by = auth()->id();
+        $manufacturer->created_by = $this->created_by;
 
         if ($manufacturer->save()) {
             $this->log('Manufacturer '.$manufacturer->name.' was created');
@@ -520,7 +520,7 @@ class ItemImporter extends Importer
         $location->city = '';
         $location->state = '';
         $location->country = '';
-        $location->created_by = auth()->id();
+        $location->created_by = $this->created_by;
 
         if ($location->save()) {
             $this->log('Location '.$asset_location.' was created');
@@ -558,7 +558,7 @@ class ItemImporter extends Importer
 
         $supplier = new Supplier;
         $supplier->name = $item_supplier;
-        $supplier->created_by = auth()->id();
+        $supplier->created_by = $this->created_by;
 
         if ($supplier->save()) {
             $this->log('Supplier '.$item_supplier.' was created');

--- a/app/Importer/LicenseImporter.php
+++ b/app/Importer/LicenseImporter.php
@@ -85,7 +85,7 @@ class LicenseImporter extends ItemImporter
             $license->update($this->sanitizeItemForUpdating($license));
         } else {
             $license->fill($this->sanitizeItemForStoring($license));
-            $license->created_by = auth()->id();
+            $license->created_by = $this->created_by;
         }
 
         // This sets an attribute on the Loggable trait for the action log
@@ -116,7 +116,7 @@ class LicenseImporter extends ItemImporter
                         ]));
                     } else {
                         $targetLicense->assigned_to = $checkout_target->id;
-                        $targetLicense->created_by = auth()->id();
+                        $targetLicense->created_by = $this->created_by;
                         if ($asset) {
                             $targetLicense->asset_id = $asset->id;
                         }
@@ -130,7 +130,7 @@ class LicenseImporter extends ItemImporter
                             'target' => trans('general.asset').' "'.$asset->display_name.'"',
                         ]));
                     } else {
-                        $targetLicense->created_by = auth()->id();
+                        $targetLicense->created_by = $this->created_by;
                         $targetLicense->asset_id = $asset->id;
                         $targetLicense->save();
                     }

--- a/app/Importer/LocationImporter.php
+++ b/app/Importer/LocationImporter.php
@@ -60,7 +60,7 @@ class LocationImporter extends ItemImporter
         } else {
             $this->log('No Matching Location, Create a new one');
             $location = new Location;
-            $location->created_by = auth()->id();
+            $location->created_by = $this->created_by;
         }
 
         // Pull the records from the CSV to determine their values

--- a/app/Importer/ManufacturerImporter.php
+++ b/app/Importer/ManufacturerImporter.php
@@ -60,7 +60,7 @@ class ManufacturerImporter extends ItemImporter
         } else {
             $this->log('No Matching Manufacturer, Create a new one');
             $manufacturer = new Manufacturer;
-            $manufacturer->created_by = auth()->id();
+            $manufacturer->created_by = $this->created_by;
         }
 
         // Pull the records from the CSV to determine their values

--- a/app/Importer/SupplierImporter.php
+++ b/app/Importer/SupplierImporter.php
@@ -60,7 +60,7 @@ class SupplierImporter extends ItemImporter
         } else {
             $this->log('No Matching Supplier, Create a new one');
             $supplier = new Supplier;
-            $supplier->created_by = auth()->id();
+            $supplier->created_by = $this->created_by;
         }
 
         // Pull the records from the CSV to determine their values

--- a/app/Importer/UserImporter.php
+++ b/app/Importer/UserImporter.php
@@ -4,7 +4,6 @@ namespace App\Importer;
 
 use App\Models\Asset;
 use App\Models\Company;
-use App\Models\Department;
 use App\Models\Location;
 use App\Models\Setting;
 use App\Models\User;
@@ -232,7 +231,7 @@ class UserImporter extends ItemImporter
         }
 
         $user = new User;
-        $user->created_by = auth()->id();
+        $user->created_by = $this->created_by;
 
         $user->fill($this->sanitizeItemForStoring($user));
 
@@ -269,44 +268,6 @@ class UserImporter extends ItemImporter
         }
 
         $this->logError($user, 'User');
-    }
-
-    /**
-     * Fetch an existing department, or create new if it doesn't exist
-     *
-     * @author Daniel Melzter
-     *
-     * @since 5.0
-     *
-     * @param  $department_name  string
-     * @return int id of department created/found
-     */
-    public function createOrFetchDepartment($department_name)
-    {
-        if (is_null($department_name) || $department_name == '') {
-            return null;
-        }
-
-        $department = Department::where(['name' => $department_name])->first();
-        if ($department) {
-            $this->log('A matching department '.$department_name.' already exists');
-
-            return $department->id;
-        }
-
-        $department = new Department;
-        $department->name = $department_name;
-        $department->created_by = $this->created_by;
-
-        if ($department->save()) {
-            $this->log('department '.$department_name.' was created');
-
-            return $department->id;
-        }
-
-        $this->logError($department, 'Department');
-
-        return null;
     }
 
     public function sendWelcome($send = true)

--- a/tests/Feature/Importing/AssetImportCreatedByTest.php
+++ b/tests/Feature/Importing/AssetImportCreatedByTest.php
@@ -31,7 +31,7 @@ class AssetImportCreatedByTest extends TestCase
     public function new_asset_created_via_import_records_the_importing_users_id_as_created_by(): void
     {
         $category = Category::factory()->create(['category_type' => 'asset']);
-        $location = Location::factory()->create();
+        Location::factory()->create();
         $statusLabel = Statuslabel::factory()->create();
         Company::factory()->create();
         AssetModel::factory()->for($category, 'category')->create(['name' => 'Import Test Model']);
@@ -146,7 +146,7 @@ class AssetImportCreatedByTest extends TestCase
         // that new user landed with created_by = null, matching the same
         // omission on the asset itself.
         $category = Category::factory()->create(['category_type' => 'asset']);
-        $location = Location::factory()->create();
+        Location::factory()->create();
         $statusLabel = Statuslabel::factory()->create();
         Company::factory()->create();
         AssetModel::factory()->for($category, 'category')->create(['name' => 'Auto User Test Model']);
@@ -198,7 +198,7 @@ class AssetImportCreatedByTest extends TestCase
         // through to the auto-created user (previously dropped on the
         // floor because createOrFetchUser hard-coded department_id to '').
         $category = Category::factory()->create(['category_type' => 'asset']);
-        $location = Location::factory()->create();
+        Location::factory()->create();
         $statusLabel = Statuslabel::factory()->create();
         Company::factory()->create();
         AssetModel::factory()->for($category, 'category')->create(['name' => 'Auto Dept Test Model']);

--- a/tests/Feature/Importing/AssetImportCreatedByTest.php
+++ b/tests/Feature/Importing/AssetImportCreatedByTest.php
@@ -1,0 +1,259 @@
+<?php
+
+namespace Tests\Feature\Importing;
+
+use App\Models\Asset;
+use App\Models\AssetModel;
+use App\Models\Category;
+use App\Models\Company;
+use App\Models\Department;
+use App\Models\Import;
+use App\Models\Location;
+use App\Models\Statuslabel;
+use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * Regression coverage for the "assets imported via CSV have blank created_by"
+ * bug. ItemImporter::handle() populated $this->item['created_by'] with
+ * auth()->id(), but sanitizeItemForStoring() then filtered the payload
+ * through $model->getFillable(), which does not include created_by on the
+ * Asset model. Every other importer (Category, Location, License, Supplier,
+ * User, etc.) worked around this by setting $model->created_by = auth()->id()
+ * directly on the model. Asset was the odd one out, and every asset created
+ * via the importer ended up with a null created_by column.
+ */
+class AssetImportCreatedByTest extends TestCase
+{
+    #[Test]
+    public function new_asset_created_via_import_records_the_importing_users_id_as_created_by(): void
+    {
+        $category = Category::factory()->create(['category_type' => 'asset']);
+        $location = Location::factory()->create();
+        $statusLabel = Statuslabel::factory()->create();
+        Company::factory()->create();
+        AssetModel::factory()->for($category, 'category')->create(['name' => 'Import Test Model']);
+
+        $importer = User::factory()->canImport()->create();
+
+        $csv = "asset tag,item name,category,status,model name\n";
+        $csv .= "CREATEDBY-001,Import Created Asset,{$category->name},{$statusLabel->name},Import Test Model\n";
+
+        $this->actingAsForApi($importer)
+            ->postJson(route('api.imports.store'), [
+                'files' => [
+                    $this->createFakeUploadedFile('createdby.csv', $csv),
+                ],
+            ])
+            ->assertSuccessful();
+
+        $import = Import::latest()->first();
+
+        $this->actingAsForApi($importer)
+            ->postJson(route('api.imports.importFile', $import->id), [
+                'import-type' => 'asset',
+                'column-mappings' => [
+                    'asset tag' => 'asset_tag',
+                    'item name' => 'item_name',
+                    'category' => 'category',
+                    'status' => 'status',
+                    'model name' => 'asset_model',
+                ],
+            ])
+            ->assertSuccessful();
+
+        $imported = Asset::where('asset_tag', 'CREATEDBY-001')->firstOrFail();
+
+        $this->assertSame(
+            $importer->id,
+            $imported->created_by,
+            'AssetImporter must set created_by to the id of the user running the import.'
+        );
+    }
+
+    #[Test]
+    public function updating_an_existing_asset_via_import_does_not_overwrite_created_by(): void
+    {
+        // Update path uses sanitizeItemForStoring(updating: true) which rejects
+        // empty values, so a null created_by from the item array cannot silently
+        // clobber the existing value. Pin the intended non-behavior explicitly
+        // so a future refactor cannot introduce a regression that would
+        // reassign every updated asset's created_by to the importer.
+        $category = Category::factory()->create(['category_type' => 'asset']);
+        $location = Location::factory()->create();
+        $statusLabel = Statuslabel::factory()->create();
+        $company = Company::factory()->create();
+        $assetModel = AssetModel::factory()->for($category, 'category')->create();
+
+        $originalOwner = User::factory()->create();
+
+        $asset = Asset::factory()
+            ->for($assetModel, 'model')
+            ->for($statusLabel, 'status')
+            ->for($location, 'defaultLoc')
+            ->for($company, 'company')
+            ->create([
+                'asset_tag' => 'CREATEDBY-002',
+                'name' => 'Existing Asset',
+                'created_by' => $originalOwner->id,
+            ]);
+
+        $importer = User::factory()->canImport()->create();
+
+        $csv = "asset tag,item name,category,status\n";
+        $csv .= "CREATEDBY-002,Renamed Via Import,{$category->name},{$statusLabel->name}\n";
+
+        $this->actingAsForApi($importer)
+            ->postJson(route('api.imports.store'), [
+                'files' => [
+                    $this->createFakeUploadedFile('createdby-update.csv', $csv),
+                ],
+            ])
+            ->assertSuccessful();
+
+        $import = Import::latest()->first();
+
+        $this->actingAsForApi($importer)
+            ->postJson(route('api.imports.importFile', $import->id), [
+                'import-type' => 'asset',
+                'import-update' => true,
+                'column-mappings' => [
+                    'asset tag' => 'asset_tag',
+                    'item name' => 'item_name',
+                    'category' => 'category',
+                    'status' => 'status',
+                ],
+            ])
+            ->assertSuccessful();
+
+        $asset->refresh();
+
+        $this->assertSame(
+            $originalOwner->id,
+            $asset->created_by,
+            'Import updates must not overwrite the existing created_by on an existing asset.'
+        );
+        $this->assertSame('Renamed Via Import', $asset->name, 'Sanity check: the update should still take effect on other fields.');
+    }
+
+    #[Test]
+    public function auto_created_checkout_target_user_records_created_by(): void
+    {
+        // Snipe-IT auto-creates the target user when an asset import row
+        // references a username that doesn't exist yet. Before the fix,
+        // that new user landed with created_by = null, matching the same
+        // omission on the asset itself.
+        $category = Category::factory()->create(['category_type' => 'asset']);
+        $location = Location::factory()->create();
+        $statusLabel = Statuslabel::factory()->create();
+        Company::factory()->create();
+        AssetModel::factory()->for($category, 'category')->create(['name' => 'Auto User Test Model']);
+
+        $importer = User::factory()->canImport()->create();
+
+        $csv = "asset tag,item name,category,status,model name,full name,username\n";
+        $csv .= "CREATEDBY-003,Import Asset Checkout,{$category->name},{$statusLabel->name},Auto User Test Model,Import Target User,import_target_user\n";
+
+        $this->actingAsForApi($importer)
+            ->postJson(route('api.imports.store'), [
+                'files' => [
+                    $this->createFakeUploadedFile('createdby-user.csv', $csv),
+                ],
+            ])
+            ->assertSuccessful();
+
+        $import = Import::latest()->first();
+
+        $this->actingAsForApi($importer)
+            ->postJson(route('api.imports.importFile', $import->id), [
+                'import-type' => 'asset',
+                'column-mappings' => [
+                    'asset tag' => 'asset_tag',
+                    'item name' => 'item_name',
+                    'category' => 'category',
+                    'status' => 'status',
+                    'model name' => 'asset_model',
+                    'full name' => 'full_name',
+                    'username' => 'username',
+                ],
+            ])
+            ->assertSuccessful();
+
+        $autoCreatedUser = User::where('username', 'import_target_user')->firstOrFail();
+
+        $this->assertSame(
+            $importer->id,
+            $autoCreatedUser->created_by,
+            'A user auto-created as the checkout target during an asset import must record the importing user as its creator.'
+        );
+    }
+
+    #[Test]
+    public function auto_created_department_records_created_by_and_attaches_to_the_auto_created_user(): void
+    {
+        // Two side-effects tied together: the department gets created
+        // (previously with null created_by), and its id gets propagated
+        // through to the auto-created user (previously dropped on the
+        // floor because createOrFetchUser hard-coded department_id to '').
+        $category = Category::factory()->create(['category_type' => 'asset']);
+        $location = Location::factory()->create();
+        $statusLabel = Statuslabel::factory()->create();
+        Company::factory()->create();
+        AssetModel::factory()->for($category, 'category')->create(['name' => 'Auto Dept Test Model']);
+
+        $importer = User::factory()->canImport()->create();
+
+        $csv = "asset tag,item name,category,status,model name,full name,username,department\n";
+        $csv .= "CREATEDBY-004,Import Dept Asset,{$category->name},{$statusLabel->name},Auto Dept Test Model,Dept Target User,dept_target_user,Import Test Department\n";
+
+        $this->actingAsForApi($importer)
+            ->postJson(route('api.imports.store'), [
+                'files' => [
+                    $this->createFakeUploadedFile('createdby-dept.csv', $csv),
+                ],
+            ])
+            ->assertSuccessful();
+
+        $import = Import::latest()->first();
+
+        $this->actingAsForApi($importer)
+            ->postJson(route('api.imports.importFile', $import->id), [
+                'import-type' => 'asset',
+                'column-mappings' => [
+                    'asset tag' => 'asset_tag',
+                    'item name' => 'item_name',
+                    'category' => 'category',
+                    'status' => 'status',
+                    'model name' => 'asset_model',
+                    'full name' => 'full_name',
+                    'username' => 'username',
+                    'department' => 'department',
+                ],
+            ])
+            ->assertSuccessful();
+
+        $autoCreatedDept = Department::where('name', 'Import Test Department')->firstOrFail();
+        $this->assertSame(
+            $importer->id,
+            $autoCreatedDept->created_by,
+            'A department auto-created during asset import must record the importing user as its creator.'
+        );
+
+        $autoCreatedUser = User::where('username', 'dept_target_user')->firstOrFail();
+        $this->assertSame(
+            $autoCreatedDept->id,
+            $autoCreatedUser->department_id,
+            'The department created for the CSV row must be linked to the auto-created checkout-target user (department propagation).'
+        );
+    }
+
+    protected function createFakeUploadedFile(string $filename, string $content): UploadedFile
+    {
+        $path = tempnam(sys_get_temp_dir(), 'csv');
+        file_put_contents($path, $content);
+
+        return new UploadedFile($path, $filename, 'text/csv', null, true);
+    }
+}


### PR DESCRIPTION
For some reason in the importer, we were handling `created_by` inconsistently. `created_by` is not a fillable or mappable field (on purpose - whoever is running the importer is the `created_by`, or if running via cli, the `--user-id` that gets passed). 

In most of the importer models, we were doing this half-right, using `$blah->created_by = auth()->id();` (which would have made it null from the cli importer, but most people don't use that, so I guess nobody noticed), but in the asset importer, it was being skipped since we weren't setting it explicitly.

This fixes that, switches all of the other `created_by` to use the cli-safe `$this->created_by` version instead of `$blah->created_by = auth()->id();`, and removes the duplicated `createOrFetchDepartment()` on the UserImporter. 
