### PR TITLE
FMCS+Floater Mode: Fixed #19394 - dropdowns in floater mode

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -633,7 +633,20 @@ class AssetsController extends Controller
             && ! auth()->user()->isSuperUser()) {
             $companyIds = array_values(array_filter(array_map('intval', explode(',', $request->input('companyId')))));
             if (! empty($companyIds)) {
-                $assets->whereIn('assets.company_id', $companyIds);
+                if (Setting::getSettings()->null_company_is_floater) {
+                    // Floater mode: include null-company (floater) assets too,
+                    // matching the "items from any company can be checked out
+                    // to targets with no company assignment" policy. Without
+                    // this the whereIn below hid all floaters from the
+                    // checkout dropdown while server-side canCheckoutTo still
+                    // permitted the checkout (#19394).
+                    $assets->where(function ($q) use ($companyIds) {
+                        $q->whereIn('assets.company_id', $companyIds)
+                            ->orWhereNull('assets.company_id');
+                    });
+                } else {
+                    $assets->whereIn('assets.company_id', $companyIds);
+                }
             }
         }
 

--- a/app/Http/Controllers/Api/LocationsController.php
+++ b/app/Http/Controllers/Api/LocationsController.php
@@ -488,7 +488,22 @@ class LocationsController extends Controller
         }
 
         if ((Setting::getSettings()->full_multiple_companies_support == '1') && $request->filled('companyId')) {
-            $locations->where('locations.company_id', '=', (int) $request->input('companyId'));
+            $companyId = (int) $request->input('companyId');
+
+            if (Setting::getSettings()->null_company_is_floater) {
+                // Floater mode: include null-company (floater) locations too,
+                // matching the "items from any company can be checked out
+                // to targets with no company assignment" policy. Without
+                // this the strict equality below hid all floaters from the
+                // checkout dropdown while the server-side canCheckoutTo
+                // still permitted the checkout (#19394).
+                $locations->where(function ($q) use ($companyId) {
+                    $q->where('locations.company_id', '=', $companyId)
+                        ->orWhereNull('locations.company_id');
+                });
+            } else {
+                $locations->where('locations.company_id', '=', $companyId);
+            }
         }
 
         $locations = $locations->orderBy('name', 'ASC')->get();

--- a/tests/Feature/Assets/Api/AssetsForSelectListTest.php
+++ b/tests/Feature/Assets/Api/AssetsForSelectListTest.php
@@ -139,4 +139,56 @@ class AssetsForSelectListTest extends TestCase
             ->assertResponseContainsInResults($assetA)
             ->assertResponseContainsInResults($assetB);
     }
+
+    /**
+     * #19394 regression: under FMCS + floater mode, a company-scoped user
+     * asking for assets narrowed by companyId should also see null-company
+     * (floater) assets in the results. This matches the documented rule
+     * that "items from any company can be checked out to targets with no
+     * company assignment" — server-side canCheckoutTo already permits the
+     * checkout, so the picker must not hide the target.
+     */
+    public function test_floater_assets_appear_in_selectlist_under_floater_mode_when_narrowed_by_company()
+    {
+        $this->settings->enableMultipleFullCompanySupport();
+        $this->settings->enableFloaterMode();
+
+        [$companyA, $companyB] = Company::factory()->count(2)->create();
+
+        $companyAsset = Asset::factory()->for($companyA)->create(['asset_tag' => 'FLOATER-CA']);
+        $otherCompanyAsset = Asset::factory()->for($companyB)->create(['asset_tag' => 'FLOATER-CB']);
+        $floaterAsset = Asset::factory()->create(['asset_tag' => 'FLOATER-NULL', 'company_id' => null]);
+
+        $actor = User::factory()->createAssets()->forCompany($companyA->id)->create();
+
+        $this->actingAsForApi($actor)
+            ->getJson(route('assets.selectlist', ['companyId' => $companyA->id]))
+            ->assertResponseContainsInResults($companyAsset)
+            ->assertResponseContainsInResults($floaterAsset)
+            ->assertResponseDoesNotContainInResults($otherCompanyAsset);
+    }
+
+    /**
+     * #19394 negative counterpart: under FMCS + strict mode (floater OFF),
+     * the companyId narrowing stays exact — null-company assets must NOT
+     * leak into the picker for a company-scoped caller. Otherwise turning
+     * floater mode off would silently still show floaters, breaking the
+     * "null is treated as its own pseudo-company" strict-mode contract.
+     */
+    public function test_floater_assets_are_hidden_in_selectlist_under_strict_mode_when_narrowed_by_company()
+    {
+        $this->settings->enableMultipleFullCompanySupport();
+        $this->settings->disableFloaterMode();
+
+        $companyA = Company::factory()->create();
+        $companyAsset = Asset::factory()->for($companyA)->create(['asset_tag' => 'STRICT-CA']);
+        $floaterAsset = Asset::factory()->create(['asset_tag' => 'STRICT-NULL', 'company_id' => null]);
+
+        $actor = User::factory()->createAssets()->forCompany($companyA->id)->create();
+
+        $this->actingAsForApi($actor)
+            ->getJson(route('assets.selectlist', ['companyId' => $companyA->id]))
+            ->assertResponseContainsInResults($companyAsset)
+            ->assertResponseDoesNotContainInResults($floaterAsset);
+    }
 }

--- a/tests/Feature/Assets/Ui/EncryptedCustomFieldFormDisclosureTest.php
+++ b/tests/Feature/Assets/Ui/EncryptedCustomFieldFormDisclosureTest.php
@@ -139,12 +139,17 @@ class EncryptedCustomFieldFormDisclosureTest extends TestCase
                 'SECRET-INSIDE-MARKDOWN-TEXTAREA',
             ],
             'date_picker' => [
+                // Intentionally-artificial dates that won't collide with
+                // real timestamps rendered elsewhere on the page (footer,
+                // recent-activity strings, "created N days ago" text,
+                // etc.). Any real date is at risk of matching an
+                // incidental page render on the day the suite runs.
                 ['element' => 'date_picker'],
-                '2026-07-29',
+                '1899-06-15',
             ],
             'datetime_picker' => [
                 ['element' => 'datetime_picker'],
-                '2026-07-29 13:37:00',
+                '1899-06-15 03:14:15',
             ],
             // Note: element='text' with format='DATE' or 'DATETIME' also render
             // decrypt chains in the template, but CustomField::canEncryptFor()

--- a/tests/Feature/Locations/Api/LocationsForSelectListTest.php
+++ b/tests/Feature/Locations/Api/LocationsForSelectListTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Locations\Api;
 
+use App\Models\Company;
 use App\Models\Location;
 use App\Models\User;
 use Illuminate\Testing\Fluent\AssertableJson;
@@ -123,5 +124,60 @@ class LocationsForSelectListTest extends TestCase
         $this->assertTrue($texts->contains('HQ'), 'Top-level location renders without indent prefix.');
         $this->assertTrue($texts->contains('-- DC1'), 'One-level-deep location gets a two-dash indent.');
         $this->assertTrue($texts->contains('---- Rack 1'), 'Two-levels-deep location gets a four-dash indent.');
+    }
+
+    /**
+     * #19394 regression: under FMCS + floater mode, a company-scoped user
+     * asking for locations narrowed by companyId should also see
+     * null-company (floater) locations. Matches the documented "items
+     * from any company can be checked out to targets with no company
+     * assignment" rule that server-side canCheckoutTo already enforces.
+     */
+    public function test_floater_locations_appear_in_selectlist_under_floater_mode_when_narrowed_by_company()
+    {
+        $this->settings->enableMultipleFullCompanySupport();
+        $this->settings->enableFloaterMode();
+
+        [$companyA, $companyB] = Company::factory()->count(2)->create();
+
+        $companyLocation = Location::factory()->create(['name' => 'FloaterModeLocA', 'company_id' => $companyA->id]);
+        $otherCompanyLocation = Location::factory()->create(['name' => 'FloaterModeLocB', 'company_id' => $companyB->id]);
+        $floaterLocation = Location::factory()->create(['name' => 'FloaterModeLocNull', 'company_id' => null]);
+
+        $actor = User::factory()->createUsers()->forCompany($companyA->id)->create();
+
+        $response = $this->actingAsForApi($actor)
+            ->getJson(route('api.locations.selectlist', ['companyId' => $companyA->id]))
+            ->assertOk();
+
+        $ids = collect($response->json('results'))->pluck('id')->all();
+        $this->assertContains($companyLocation->id, $ids, 'Same-company location must be visible.');
+        $this->assertContains($floaterLocation->id, $ids, 'Null-company (floater) location must be visible under floater mode.');
+        $this->assertNotContains($otherCompanyLocation->id, $ids, 'Other-company location must not leak in.');
+    }
+
+    /**
+     * #19394 negative counterpart: under FMCS + strict mode (floater OFF),
+     * the companyId narrowing must stay exact — null-company locations
+     * do not leak into the picker for a company-scoped caller.
+     */
+    public function test_floater_locations_are_hidden_in_selectlist_under_strict_mode_when_narrowed_by_company()
+    {
+        $this->settings->enableMultipleFullCompanySupport();
+        $this->settings->disableFloaterMode();
+
+        $companyA = Company::factory()->create();
+        $companyLocation = Location::factory()->create(['name' => 'StrictLocA', 'company_id' => $companyA->id]);
+        $floaterLocation = Location::factory()->create(['name' => 'StrictLocNull', 'company_id' => null]);
+
+        $actor = User::factory()->createUsers()->forCompany($companyA->id)->create();
+
+        $response = $this->actingAsForApi($actor)
+            ->getJson(route('api.locations.selectlist', ['companyId' => $companyA->id]))
+            ->assertOk();
+
+        $ids = collect($response->json('results'))->pluck('id')->all();
+        $this->assertContains($companyLocation->id, $ids);
+        $this->assertNotContains($floaterLocation->id, $ids, 'Null-company location must not appear under strict mode.');
     }
 }


### PR DESCRIPTION
Under FMCS + floater mode, the checkout target pickers for locations and assets applied a strict `where company_id = X` filter, hiding null-company (floater) targets even though the server-side `CompanyableTrait::canCheckoutTo` allowed the checkout. Users could not check company-owned items out to floater locations or assets despite the documented rule that "items from any company can be checked out to targets with no company assignment."

Users worked correctly already because `Company::scopeUsersByCompanyIds` does the floater expansion. This applies the same shape to the location and asset selectlists.

## Testing

- Enable FMCS + floater mode
- Create a company-owned asset
- Open its checkout form
- Confirm floater locations and floater assets now appear in the target pickers
- Disable floater mode, confirm floaters no longer appear (strict mode preserved)
- Verify same-company and other-company targets behave as before

Fixes #19394