### PR TITLE
🎥 FMCS+Location Scoping: Added download CSV to location scope check

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -163,6 +163,38 @@ class SettingsController extends Controller
     }
 
     /**
+     * Stream a CSV of every location-scoping FMCS mismatch.
+     *
+     * This endpoint runs the full walk (artisan=true) and streams
+     * the same table columns the CLI command prints, as CSV.
+     */
+    public function downloadLocationScopingReport(): \Symfony\Component\HttpFoundation\StreamedResponse
+    {
+        $mismatched = Helper::test_locations_fmcs(true);
+
+        $filename = 'location-scoping-mismatches-' . date('Y-m-d') . '.csv';
+
+        return response()->streamDownload(function () use ($mismatched) {
+            $out = fopen('php://output', 'w');
+            fputcsv($out, [
+                'Type',
+                'ID',
+                'Name',
+                'Checkout Type',
+                'Company IDs',
+                'Item Companies',
+                'Item Location',
+                'Location Company',
+                'Location Company ID',
+            ]);
+            foreach ($mismatched as $row) {
+                fputcsv($out, $row);
+            }
+            fclose($out);
+        }, $filename, ['Content-Type' => 'text/csv']);
+    }
+
+    /**
      * Return a form to allow a super admin to update settings.
      *
      * @author [A. Gianotto] [<snipe@snipe.net>]

--- a/resources/lang/en-US/admin/settings/general.php
+++ b/resources/lang/en-US/admin/settings/general.php
@@ -280,6 +280,7 @@ return [
     'scope_locations_fmcs_check_button' => 'Check Compatibility',
     'scope_locations_fmcs_test_needed' => 'Please Check Compatibility to enable this',
     'scope_locations_fmcs_support_disabled_text' => 'This option is disabled because you have conflicting locations set for :count or more items.',
+    'scope_locations_fmcs_download_report' => 'Download mismatch report (CSV)',
     'null_company_is_floater_text' => 'Treat items and users without company associations as floaters',
     'null_company_is_floater_help_text' => 'When disabled, items can only be checked out to targets without a company association if the item also has no company - null is treated as its own pseudo-company. When enabled, items from any company can be checked out to targets with no company assignment.',
     'show_in_model_list' => 'Show in Model Dropdowns',

--- a/resources/views/livewire/location-scope-check.blade.php
+++ b/resources/views/livewire/location-scope-check.blade.php
@@ -11,7 +11,16 @@
             <strong>{{ trans('admin/settings/general.scope_locations_fmcs_test_needed') }}</strong>
         @endif
     </p>
-    <button class="btn btn-sm btn-theme" wire:click.prevent="check_locations">{{ trans('admin/settings/general.scope_locations_fmcs_check_button') }}</button>
+    {{-- wire:loading + wire:target render a spinner icon only while the
+         check_locations action is in progress, and we disable the button so a
+         second click during the request can't queue a duplicate walk. --}}
+    <button class="btn btn-sm btn-theme"
+            wire:click.prevent="check_locations"
+            wire:loading.attr="disabled"
+            wire:target="check_locations">
+        <x-icon type="spinner" wire:loading wire:target="check_locations"/>
+        {{ trans('admin/settings/general.scope_locations_fmcs_check_button') }}
+    </button>
 
     {{-- Download-full-report link. Shown only after the enable-check
          has run AND found mismatches. The endpoint runs the full walk of
@@ -19,10 +28,52 @@
          take longer than the enable-check on large datasets since it
          doesn't early-bail. --}}
     @if ($is_tested && count($mismatched) > 0)
+        {{-- Use fetch() to know exactly when the response arrives (a hard-
+             coded timeout would either fire too early on huge datasets
+             or leave the button disabled longer than needed on small
+             ones). The response is then handed to the browser via a
+             synthetic anchor + revoked object URL, matching the
+             `download` behavior a normal <a> would have produced. On
+             any fetch error we fall back to a straight navigation so
+             the user still gets their file even if the JS path fails
+             (network hiccup, blob memory limit, etc.). --}}
         <a href="{{ route('settings.general.location_scoping_report') }}"
            class="btn btn-sm btn-default"
-           style="margin-left: 6px;">
-            <x-icon type="download"/>
+           style="margin-left: 6px;"
+           x-data="{
+               loading: false,
+               async fetchReport(event) {
+                   event.preventDefault();
+                   if (this.loading) return;
+                   this.loading = true;
+                   const href = event.currentTarget.getAttribute('href');
+                   try {
+                       const resp = await fetch(href, { credentials: 'same-origin' });
+                       if (! resp.ok) throw new Error('http ' + resp.status);
+                       const blob = await resp.blob();
+                       const dispo = resp.headers.get('Content-Disposition') || '';
+                       const match = dispo.match(/filename=&quot;?([^&quot;;]+)&quot;?/i);
+                       const filename = match ? match[1] : 'location-scoping-mismatches.csv';
+                       const objUrl = URL.createObjectURL(blob);
+                       const dl = document.createElement('a');
+                       dl.href = objUrl;
+                       dl.download = filename;
+                       document.body.appendChild(dl);
+                       dl.click();
+                       dl.remove();
+                       URL.revokeObjectURL(objUrl);
+                   } catch (e) {
+                       window.location.href = href;
+                   } finally {
+                       this.loading = false;
+                   }
+               }
+           }"
+           x-on:click="fetchReport($event)"
+           x-bind:class="{ 'disabled': loading }"
+           x-bind:aria-busy="loading">
+            <x-icon type="download" x-show="!loading"/>
+            <x-icon type="spinner" x-show="loading"/>
             {{ trans('admin/settings/general.scope_locations_fmcs_download_report') }}
         </a>
     @endif

--- a/resources/views/livewire/location-scope-check.blade.php
+++ b/resources/views/livewire/location-scope-check.blade.php
@@ -12,4 +12,18 @@
         @endif
     </p>
     <button class="btn btn-sm btn-theme" wire:click.prevent="check_locations">{{ trans('admin/settings/general.scope_locations_fmcs_check_button') }}</button>
+
+    {{-- Download-full-report link. Shown only after the enable-check
+         has run AND found mismatches. The endpoint runs the full walk of
+         Helper::test_locations_fmcs and streams a CSV, so expect it to
+         take longer than the enable-check on large datasets since it
+         doesn't early-bail. --}}
+    @if ($is_tested && count($mismatched) > 0)
+        <a href="{{ route('settings.general.location_scoping_report') }}"
+           class="btn btn-sm btn-default"
+           style="margin-left: 6px;">
+            <x-icon type="download"/>
+            {{ trans('admin/settings/general.scope_locations_fmcs_download_report') }}
+        </a>
+    @endif
 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -230,6 +230,9 @@ Route::group(['prefix' => 'admin', 'middleware' => ['auth', 'authorize:superuser
     Route::post('settings', [SettingsController::class, 'postSettings'])
         ->name('settings.general.save');
 
+    Route::get('settings/location-scoping-report.csv', [SettingsController::class, 'downloadLocationScopingReport'])
+        ->name('settings.general.location_scoping_report');
+
     Route::get('branding', [SettingsController::class, 'getBranding'])
         ->name('settings.branding.index')
         ->breadcrumbs(fn (Trail $trail) => $trail->parent('settings.index')


### PR DESCRIPTION
This adds a download button button to enable super admins to be able to download a report of their mismatched company IDs when attempting to enable location-company scoping. 

This makes it a bit easier for folks so they don't have to run the cli script. 

https://github.com/user-attachments/assets/45832169-bf35-4c08-a2a5-4afd0000e3b5

