### PR TITLE
Fix character encoding when importing CSV (#19414)

### DIFF
--- a/app/Http/Controllers/Api/ImportController.php
+++ b/app/Http/Controllers/Api/ImportController.php
@@ -88,15 +88,28 @@ class ImportController extends Controller
                 if (! ini_get('auto_detect_line_endings')) {
                     ini_set('auto_detect_line_endings', '1');
                 }
-                if (function_exists('iconv')) {
+                if (function_exists('iconv') || function_exists('mb_convert_encoding')) {
                     $file_contents = $file->getContent(); // TODO - this *does* load the whole file in RAM, but we need that to be able to 'iconv' it?
                     $encoding = $detector->getEncoding($file_contents);
                     \Log::debug("Discovered encoding: $encoding in uploaded CSV");
+
+                    if (! mb_check_encoding($file_contents, 'UTF-8')) {
+                        $detected = mb_detect_encoding($file_contents, ['UTF-8', 'GBK', 'GB2312', 'GB18030', 'BIG5', 'SJIS', 'EUC-JP', 'EUC-KR', 'Windows-1252', 'ISO-8859-1'], true);
+                        if ($detected && strcasecmp($detected, 'UTF-8') !== 0) {
+                            $encoding = $detected;
+                            \Log::debug("Fallback detected encoding: $encoding in uploaded CSV");
+                        }
+                    }
+
                     $reader = null;
-                    if (strcasecmp($encoding, 'UTF-8') != 0) {
+                    if ($encoding && strcasecmp($encoding, 'UTF-8') != 0) {
                         $transliterated = false;
                         try {
-                            $transliterated = iconv(strtoupper($encoding), 'UTF-8', $file_contents);
+                            if (function_exists('iconv')) {
+                                $transliterated = @iconv(strtoupper($encoding), 'UTF-8//IGNORE', $file_contents);
+                            } elseif (function_exists('mb_convert_encoding')) {
+                                $transliterated = mb_convert_encoding($file_contents, 'UTF-8', $encoding);
+                            }
                         } catch (\Exception $e) {
                             $transliterated = false; // blank out the partially-decoded string
 

--- a/app/Importer/Importer.php
+++ b/app/Importer/Importer.php
@@ -140,7 +140,40 @@ abstract class Importer
         }
         // By default the importer passes a url to the file.
         // However, for testing we also support passing a string directly
+        $contents = null;
         if (is_file($file)) {
+            $contents = file_get_contents($file);
+        } else {
+            $contents = $file;
+        }
+
+        if ($contents !== false && ! mb_check_encoding($contents, 'UTF-8')) {
+            $encoding = null;
+            if (class_exists('\Onnov\DetectEncoding\EncodingDetector')) {
+                $detector = new \Onnov\DetectEncoding\EncodingDetector;
+                $encoding = $detector->getEncoding($contents);
+            }
+            if (! $encoding || strcasecmp($encoding, 'UTF-8') === 0 || ! mb_check_encoding($contents, 'UTF-8')) {
+                $detected = mb_detect_encoding($contents, ['UTF-8', 'GBK', 'GB2312', 'GB18030', 'BIG5', 'SJIS', 'EUC-JP', 'EUC-KR', 'Windows-1252', 'ISO-8859-1'], true);
+                if ($detected) {
+                    $encoding = $detected;
+                }
+            }
+            if ($encoding && strcasecmp($encoding, 'UTF-8') !== 0) {
+                if (function_exists('iconv')) {
+                    $converted = @iconv(strtoupper($encoding), 'UTF-8//IGNORE', $contents);
+                    if ($converted !== false) {
+                        $contents = $converted;
+                    }
+                } elseif (function_exists('mb_convert_encoding')) {
+                    $contents = mb_convert_encoding($contents, 'UTF-8', $encoding);
+                }
+            }
+        }
+
+        if ($contents !== null) {
+            $this->csv = Reader::createFromString($contents);
+        } elseif (is_file($file)) {
             $this->csv = Reader::createFromPath($file);
         } else {
             $this->csv = Reader::createFromString($file);
@@ -265,7 +298,12 @@ abstract class Importer
 
         // $this->log("Custom Key: ${key}");
         if (array_key_exists($key, $array)) {
-            $val = Encoding::toUTF8(trim($array[$key]));
+            $trimmed = trim($array[$key]);
+            if (mb_check_encoding($trimmed, 'UTF-8')) {
+                $val = $trimmed;
+            } else {
+                $val = Encoding::toUTF8($trimmed);
+            }
         }
 
         // $this->log("${key}: ${val}");


### PR DESCRIPTION
Summary

This PR fixes the character encoding issue that caused non-UTF-8 characters to appear garbled (mojibake) after importing CSV files.

Changes

* Added automatic detection for multiple CSV encodings, including **GBK, GB2312, GB18030, Big5, Shift_JIS, EUC-JP, EUC-KR, and Windows-1252**, when the input is not valid UTF-8.
* Automatically converts detected non-UTF-8 CSV content to **UTF-8** before parsing and storing the data.
* Updated `findCsvMatch()` in `app/Importer/Importer.php` to preserve existing UTF-8 multi-byte characters and prevent double encoding.

Testing

* Imported CSV files encoded in UTF-8 and non-UTF-8 formats.
* Verified that Chinese and other multi-byte characters are imported and displayed correctly without becoming garbled.
* Confirmed that UTF-8 encoded CSV files continue to import correctly.
