### PR TITLE
Fixed MS Teams type error

### DIFF
--- a/app/Notifications/CheckinAccessoryNotification.php
+++ b/app/Notifications/CheckinAccessoryNotification.php
@@ -108,9 +108,9 @@ class CheckinAccessoryNotification extends Notification
                 ->title(trans('Accessory_Checkin_Notification'))
                 ->addStartGroupToSection('activityText')
                 ->fact(htmlspecialchars_decode($item->display_name), '', 'activityTitle')
-                ->fact(trans('mail.checked_into'), $item->location->name ? $item->location->name : '')
-                ->fact(trans('mail.Accessory_Checkin_Notification').' by ', $admin->display_name)
-                ->fact(trans('admin/consumables/general.remaining'), $item->numRemaining())
+                ->fact(trans('mail.checked_into'), $item->location?->name ?: '')
+                ->fact(trans('mail.Accessory_Checkin_Notification').' by ', (string) ($admin?->display_name ?? ''))
+                ->fact(trans('admin/consumables/general.remaining'), (string) $item->numRemaining())
                 ->fact(trans('mail.notes'), $note ?: '');
         }
 

--- a/app/Notifications/CheckinAssetNotification.php
+++ b/app/Notifications/CheckinAssetNotification.php
@@ -116,9 +116,9 @@ class CheckinAssetNotification extends Notification
                 ->title(trans('mail.Asset_Checkin_Notification', ['tag' => '']))
                 ->addStartGroupToSection('activityText')
                 ->fact(htmlspecialchars_decode($item->display_name), '', 'activityText')
-                ->fact(trans('mail.checked_into'), ($item->location) ? $item->location->name : '')
-                ->fact(trans('general.administrator'), $admin->display_name)
-                ->fact(trans('admin/hardware/form.status'), $item->status?->name)
+                ->fact(trans('mail.checked_into'), $item->location?->name ?: '')
+                ->fact(trans('general.administrator'), (string) ($admin?->display_name ?? ''))
+                ->fact(trans('admin/hardware/form.status'), (string) ($item->status?->name ?? ''))
                 ->fact(trans('mail.notes'), $note ?: '');
         }
 
@@ -139,13 +139,14 @@ class CheckinAssetNotification extends Notification
         $target = $this->target;
         $item = $this->item;
         $note = $this->note;
-//
+
+        //
         return GoogleChatMessage::create()
             ->to($this->settings->webhook_endpoint)
             ->card(
                 Card::create()
                     ->header(
-                        '<strong>' . trans('mail.Asset_Checkin_Notification', ['tag' => '']) . '</strong>' ?: '',
+                        '<strong>'.trans('mail.Asset_Checkin_Notification', ['tag' => '']).'</strong>' ?: '',
                         htmlspecialchars_decode($item->display_name) ?: '',
                     )
                     ->section(
@@ -153,7 +154,7 @@ class CheckinAssetNotification extends Notification
                             KeyValue::create(
                                 trans('mail.checked_into') ?: '',
                                 ($item->location) ? $item->location?->name : '',
-                                trans('admin/hardware/form.status') . ': ' . $item->status?->name
+                                trans('admin/hardware/form.status').': '.$item->status?->name
                             )->onClick(route('hardware.show', $item->id))
                         )
                     )

--- a/app/Notifications/CheckinComponentNotification.php
+++ b/app/Notifications/CheckinComponentNotification.php
@@ -119,9 +119,9 @@ class CheckinComponentNotification extends Notification
                 ->title(trans('mail.Component_checkin_notification'))
                 ->addStartGroupToSection('activityText')
                 ->fact(htmlspecialchars_decode($item->display_name), '', 'header')
-                ->fact(trans('mail.Component_checkin_notification').' by ', $admin->display_name ?: 'CLI tool')
-                ->fact(trans('mail.checkedin_from'), $target->display_name)
-                ->fact(trans('admin/consumables/general.remaining'), $item->numRemaining())
+                ->fact(trans('mail.Component_checkin_notification').' by ', $admin?->display_name ?: 'CLI tool')
+                ->fact(trans('mail.checkedin_from'), (string) ($target?->display_name ?? ''))
+                ->fact(trans('admin/consumables/general.remaining'), (string) $item->numRemaining())
                 ->fact(trans('mail.notes'), $note ?: '');
         }
 

--- a/app/Notifications/CheckinLicenseSeatNotification.php
+++ b/app/Notifications/CheckinLicenseSeatNotification.php
@@ -119,9 +119,9 @@ class CheckinLicenseSeatNotification extends Notification
                 ->title(trans('mail.License_Checkin_Notification'))
                 ->addStartGroupToSection('activityText')
                 ->fact(htmlspecialchars_decode($item->display_name), '', 'header')
-                ->fact(trans('mail.License_Checkin_Notification').' by ', $admin->display_name ?: 'CLI tool')
-                ->fact(trans('mail.checkedin_from'), $target->display_name)
-                ->fact(trans('admin/consumables/general.remaining'), $item->availCount()->count())
+                ->fact(trans('mail.License_Checkin_Notification').' by ', $admin?->display_name ?: 'CLI tool')
+                ->fact(trans('mail.checkedin_from'), (string) ($target?->display_name ?? ''))
+                ->fact(trans('admin/consumables/general.remaining'), (string) $item->availCount()->count())
                 ->fact(trans('mail.notes'), $note ?: '');
         }
 

--- a/app/Notifications/CheckoutAccessoryNotification.php
+++ b/app/Notifications/CheckoutAccessoryNotification.php
@@ -140,11 +140,11 @@ class CheckoutAccessoryNotification extends Notification
                 ->title(trans('mail.Accessory_Checkout_Notification'))
                 ->addStartGroupToSection('activityText')
                 ->fact(htmlspecialchars_decode($item->display_name), '', 'activityTitle')
-                ->fact(trans('mail.assigned_to'), $target->display_name)
+                ->fact(trans('mail.assigned_to'), (string) ($target?->display_name ?? ''))
                 ->fact(trans('general.qty'), (string) ($this->checkout_qty ?? 1))
                 ->fact(trans('mail.checkedout_from'), $item->location?->name ?: '')
-                ->fact(trans('mail.Accessory_Checkout_Notification').' by ', $admin->display_name)
-                ->fact(trans('admin/consumables/general.remaining'), $item->numRemaining())
+                ->fact(trans('mail.Accessory_Checkout_Notification').' by ', (string) ($admin?->display_name ?? ''))
+                ->fact(trans('admin/consumables/general.remaining'), (string) $item->numRemaining())
                 ->fact(trans('mail.notes'), $note ?: '');
         }
 

--- a/app/Notifications/CheckoutAssetNotification.php
+++ b/app/Notifications/CheckoutAssetNotification.php
@@ -129,9 +129,9 @@ class CheckoutAssetNotification extends Notification
                 ->type('success')
                 ->title(trans('mail.Asset_Checkout_Notification', ['tag' => '']))
                 ->addStartGroupToSection('activityText')
-                ->fact(trans('mail.assigned_to'), $target->display_name)
+                ->fact(trans('mail.assigned_to'), (string) ($target?->display_name ?? ''))
                 ->fact(htmlspecialchars_decode($item->display_name), '', 'activityText')
-                ->fact(trans('general.administrator'), $admin->display_name)
+                ->fact(trans('general.administrator'), (string) ($admin?->display_name ?? ''))
                 ->fact(trans('mail.notes'), $note ?: '');
         }
 

--- a/app/Notifications/CheckoutComponentNotification.php
+++ b/app/Notifications/CheckoutComponentNotification.php
@@ -115,9 +115,9 @@ class CheckoutComponentNotification extends Notification
                 ->title(trans('mail.Component_checkout_notification'))
                 ->addStartGroupToSection('activityText')
                 ->fact(htmlspecialchars_decode($item->display_name), '', 'activityTitle')
-                ->fact(trans('mail.Component_checkout_notification').' by ', $admin->display_name)
-                ->fact(trans('mail.assigned_to'), $target->display_name)
-                ->fact(trans('admin/consumables/general.remaining'), $item->numRemaining())
+                ->fact(trans('mail.Component_checkout_notification').' by ', (string) ($admin?->display_name ?? ''))
+                ->fact(trans('mail.assigned_to'), (string) ($target?->display_name ?? ''))
+                ->fact(trans('admin/consumables/general.remaining'), (string) $item->numRemaining())
                 ->fact(trans('mail.notes'), $note ?: '');
         }
 

--- a/app/Notifications/CheckoutConsumableNotification.php
+++ b/app/Notifications/CheckoutConsumableNotification.php
@@ -115,9 +115,9 @@ class CheckoutConsumableNotification extends Notification
                 ->title(trans('mail.Consumable_checkout_notification'))
                 ->addStartGroupToSection('activityText')
                 ->fact(htmlspecialchars_decode($item->display_name), '', 'activityTitle')
-                ->fact(trans('mail.Consumable_checkout_notification').' by ', $admin->display_name)
-                ->fact(trans('mail.assigned_to'), $target->display_name)
-                ->fact(trans('admin/consumables/general.remaining'), $item->numRemaining())
+                ->fact(trans('mail.Consumable_checkout_notification').' by ', (string) ($admin?->display_name ?? ''))
+                ->fact(trans('mail.assigned_to'), (string) ($target?->display_name ?? ''))
+                ->fact(trans('admin/consumables/general.remaining'), (string) $item->numRemaining())
                 ->fact(trans('mail.notes'), $note ?: '');
         }
 

--- a/app/Notifications/CheckoutLicenseSeatNotification.php
+++ b/app/Notifications/CheckoutLicenseSeatNotification.php
@@ -114,9 +114,9 @@ class CheckoutLicenseSeatNotification extends Notification
                 ->title(trans('mail.License_Checkout_Notification'))
                 ->addStartGroupToSection('activityText')
                 ->fact(htmlspecialchars_decode($item->display_name), '', 'activityTitle')
-                ->fact(trans('mail.License_Checkout_Notification').' by ', $admin->display_name)
-                ->fact(trans('mail.assigned_to'), $target->display_name)
-                ->fact(trans('admin/consumables/general.remaining'), $item->availCount()->count())
+                ->fact(trans('mail.License_Checkout_Notification').' by ', (string) ($admin?->display_name ?? ''))
+                ->fact(trans('mail.assigned_to'), (string) ($target?->display_name ?? ''))
+                ->fact(trans('admin/consumables/general.remaining'), (string) $item->availCount()->count())
                 ->fact(trans('mail.notes'), $note ?: '');
         }
 


### PR DESCRIPTION
Rollbar caught a `TypeError` on `MicrosoftTeamsMessage::fact()` from `CheckoutAccessoryNotification` line 144, where `$this->checkout_qty` was null and `fact()` is strict-typed `string $value`. Swept the same defensive coercion across all 9 checkout and checkin notification classes so no `->fact()` call site can hand it a null, int, or unresolved relation ever again.

Fixes `TypeError: NotificationChannels\MicrosoftTeams\MicrosoftTeamsMessage::fact(): Argument #2 ($value) must be of type string, null given, called in /snipe-it/app/Notifications/CheckoutAccessoryNotification.php on line 144`