### PR TITLE
docs: mention hosted and managed Snipe-IT options in Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Snipe-IT is actively developed and we [release quite frequently](https://github.
 
 For instructions on installing and configuring Snipe-IT on your server, check out the [installation manual](https://snipe-it.readme.io/docs). (Please see the [requirements documentation](https://snipe-it.readme.io/docs/requirements) for full requirements.)
 
+If you would rather not run a server yourself, the Snipe-IT team offer [official hosted Snipe-IT](https://snipeitapp.com/), and a number of third parties offer managed Snipe-IT too, among them [Zenith](https://zenith.hosting/host/snipe-it).
+
 If you're having trouble with the installation, please check the [Common Issues](https://snipe-it.readme.io/docs/common-issues) and [Getting Help](https://snipe-it.readme.io/docs/getting-help) documentation, and search this repository's open *and* closed issues for help.
 
 -----


### PR DESCRIPTION
hey @snipe, this is a redo of #19289 taking both of your points on board.

first, this targets `develop` rather than `master`, per your developer documentation. apologies for getting that wrong the first time.

second, and more importantly, you said the old phrasing read as though Zenith were the preferred or only way to avoid self hosting, when there are many options. that was fair. the line now leads with your own hosted Snipe-IT and frames Zenith as one of several third parties rather than the destination:

> If you would rather not run a server yourself, the Snipe-IT team offer official hosted Snipe-IT, and a number of third parties offer managed Snipe-IT too, among them Zenith.

no badge or button this time, for the same reason. it is one sentence in the Installation section, additions only.

if you would rather the sentence named no third party at all, or listed several, i am happy with either. and if the answer is still no, that is completely fine, thanks for taking the time to explain the first time.
